### PR TITLE
error messages: composable formatting for warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,9 @@ Working version
   code is no longer printed as "..." to avoid confusion with OCaml strings.
   (Florian Angeletti, review by Richard Eisenberg)
 
+- #13568, composable formatting for warning and alert messages
+  (Florian Angeletti, review by Richard Eisenberg)
+
 - #13587: Enable native backend on x86_64 GNU/Hurd.
   (Samuel Thibault, review by Antonin Décimo, Sébastien Hinderer and Miod
    Vallat)

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -746,7 +746,7 @@ let batch_mode_printer : report_printer =
   let pp_footnote ppf f =
     Option.iter (Format.fprintf ppf "@,%a" pp_txt) f
   in
-  let old_format self ppf report =
+  let error_format self ppf report =
     Format.fprintf ppf "@[<v>%a%a%a: %a@[%a@]%a%a%a@]@."
       Format.pp_open_tbox ()
       (self.pp_main_loc self report) report.main.loc
@@ -757,7 +757,7 @@ let batch_mode_printer : report_printer =
       pp_footnote report.footnote
       Format.pp_close_tbox ()
   in
-  let new_format self ppf report =
+  let warning_format self ppf report =
     Format.fprintf ppf "@[<v>%a@[<b 2>%a: %a@]%a%a@]@."
       (self.pp_main_loc self report) report.main.loc
       (self.pp_report_kind self report) report.kind
@@ -772,8 +772,8 @@ let batch_mode_printer : report_printer =
       | Report_warning _
       | Report_warning_as_error _
       | Report_alert _ | Report_alert_as_error _ ->
-          new_format self ppf report
-      | Report_error -> old_format self ppf report
+          warning_format self ppf report
+      | Report_error -> error_format self ppf report
     in
     (* Make sure we keep [num_loc_lines] updated.
        The tabulation box is here to give submessage the option

--- a/testsuite/tests/asmcomp/0001-test.compilers.reference
+++ b/testsuite/tests/asmcomp/0001-test.compilers.reference
@@ -1,2 +1,2 @@
 File "0001-test.ml", line 1:
-Warning 24 [bad-module-name]: bad source file name: "0001-test" is not a valid module name.
+Warning 24 [bad-module-name]: bad source file name: 0001-test is not a valid module name.

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -59,8 +59,7 @@ File "morematch.ml", lines 1050-1053, characters 8-10:
 1052 |   | B (`B,`D) -> 1
 1053 |   | C -> 2
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-A `D
+  Here is an example of a case that is not matched: A `D
 
 File "morematch.ml", line 1084, characters 5-51:
 1084 |   |  _, _, _, _, _, A, _, _, _, _, B, _, _, _, _, _ -> "11"

--- a/testsuite/tests/basic-more/pr10338.compilers.reference
+++ b/testsuite/tests/basic-more/pr10338.compilers.reference
@@ -2,4 +2,4 @@ File "pr10338.ml", line 7, characters 21-65:
 7 | let f ?(s="hello") = function x when (print_endline s; true) -> x;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-All clauses in this pattern-matching are guarded.
+  All clauses in this pattern-matching are guarded.

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -5,8 +5,7 @@ File "robustmatch.ml", lines 33-37, characters 6-23:
 36 |       | _,  AB, B -> ()
 37 |       | _, MAB, B -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(AB, MAB, A)
+  Here is an example of a case that is not matched: (AB, MAB, A)
 
 File "robustmatch.ml", lines 43-47, characters 4-21:
 43 | ....match t1, t2, x with
@@ -15,48 +14,42 @@ File "robustmatch.ml", lines 43-47, characters 4-21:
 46 |     | _,  AB, B -> ()
 47 |     | _, MAB, B -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(AB, MAB, A)
+  Here is an example of a case that is not matched: (AB, MAB, A)
 
 File "robustmatch.ml", lines 54-56, characters 4-27:
 54 | ....match r1, r2, a with
 55 |     | R1, _, 0 -> ()
 56 |     | _, R2, "coucou" -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, 1)
+  Here is an example of a case that is not matched: (R1, R1, 1)
 
 File "robustmatch.ml", lines 64-66, characters 4-27:
 64 | ....match r1, r2, a with
 65 |     | R1, _, A -> ()
 66 |     | _, R2, "coucou" -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, (B|C))
+  Here is an example of a case that is not matched: (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 69-71, characters 4-20:
 69 | ....match r1, r2, a with
 70 |     | _, R2, "coucou" -> ()
 71 |     | R1, _, A -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, (B|C))
+  Here is an example of a case that is not matched: (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 74-76, characters 4-20:
 74 | ....match r1, r2, a with
 75 |     | _, R2, "coucou" -> ()
 76 |     | R1, _, _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, "")
+  Here is an example of a case that is not matched: (R2, R2, "")
 
 File "robustmatch.ml", lines 85-87, characters 4-20:
 85 | ....match r1, r2, a with
 86 |     | R1, _, A -> ()
 87 |     | _, R2, X -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, (B|C))
+  Here is an example of a case that is not matched: (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 90-93, characters 4-20:
 90 | ....match r1, r2, a with
@@ -64,40 +57,35 @@ File "robustmatch.ml", lines 90-93, characters 4-20:
 92 |     | _, R2, X -> ()
 93 |     | R1, _, _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, (Y|Z))
+  Here is an example of a case that is not matched: (R2, R2, (Y|Z))
 
 File "robustmatch.ml", lines 96-98, characters 4-20:
 96 | ....match r1, r2, a with
 97 |     | R1, _, _ -> ()
 98 |     | _, R2, X -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, (Y|Z))
+  Here is an example of a case that is not matched: (R2, R2, (Y|Z))
 
 File "robustmatch.ml", lines 107-109, characters 4-20:
 107 | ....match r1, r2, a with
 108 |     | R1, _, A -> ()
 109 |     | _, R2, X -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, (B|C))
+  Here is an example of a case that is not matched: (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 129-131, characters 4-20:
 129 | ....match r1, r2, a with
 130 |     | R1, _, A -> ()
 131 |     | _, R2, X -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, B)
+  Here is an example of a case that is not matched: (R1, R1, B)
 
 File "robustmatch.ml", lines 151-153, characters 4-20:
 151 | ....match r1, r2, a with
 152 |     | R1, _, A -> ()
 153 |     | _, R2, X -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, B)
+  Here is an example of a case that is not matched: (R1, R1, B)
 
 File "robustmatch.ml", lines 156-159, characters 4-20:
 156 | ....match r1, r2, a with
@@ -105,24 +93,21 @@ File "robustmatch.ml", lines 156-159, characters 4-20:
 158 |     | _, R2, X -> ()
 159 |     | R1, _, _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, Y)
+  Here is an example of a case that is not matched: (R2, R2, Y)
 
 File "robustmatch.ml", lines 162-164, characters 4-20:
 162 | ....match r1, r2, a with
 163 |     | R1, _, _ -> ()
 164 |     | _, R2, X -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, Y)
+  Here is an example of a case that is not matched: (R2, R2, Y)
 
 File "robustmatch.ml", lines 167-169, characters 4-20:
 167 | ....match r1, r2, a with
 168 |     | R1, _, C -> ()
 169 |     | _, R2, Y -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, A)
+  Here is an example of a case that is not matched: (R1, R1, A)
 
 File "robustmatch.ml", lines 176-179, characters 4-20:
 176 | ....match r1, r2, a with
@@ -130,16 +115,14 @@ File "robustmatch.ml", lines 176-179, characters 4-20:
 178 |     | R2, _, [||] -> ()
 179 |     | _, R1, 1 -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, [| _ |])
+  Here is an example of a case that is not matched: (R2, R2, [| _ |])
 
 File "robustmatch.ml", lines 182-184, characters 4-23:
 182 | ....match r1, r2, a with
 183 |     | R1, _, _ -> ()
 184 |     | _, R2, [||] -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, [| _ |])
+  Here is an example of a case that is not matched: (R2, R2, [| _ |])
 
 File "robustmatch.ml", lines 187-190, characters 4-20:
 187 | ....match r1, r2, a with
@@ -147,8 +130,7 @@ File "robustmatch.ml", lines 187-190, characters 4-20:
 189 |     | R1, _, 0 -> ()
 190 |     | R1, _, _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, [| _ |])
+  Here is an example of a case that is not matched: (R2, R2, [| _ |])
 
 File "robustmatch.ml", lines 200-203, characters 4-19:
 200 | ....match r1, r2, a with
@@ -156,71 +138,64 @@ File "robustmatch.ml", lines 200-203, characters 4-19:
 202 |     | R1, _, 0 -> ()
 203 |     | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type repr.
+  It will remain exhaustive when constructors are added to type repr.
 
 File "robustmatch.ml", lines 210-212, characters 4-27:
 210 | ....match r1, r2, a with
 211 |     | R1, _, 'c' -> ()
 212 |     | _, R2, "coucou" -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, 'a')
+  Here is an example of a case that is not matched: (R1, R1, 'a')
 
 File "robustmatch.ml", lines 219-221, characters 4-27:
 219 | ....match r1, r2, a with
 220 |     | R1, _, `A -> ()
 221 |     | _, R2, "coucou" -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, `B)
+  Here is an example of a case that is not matched: (R1, R1, `B)
 
 File "robustmatch.ml", lines 228-230, characters 4-37:
 228 | ....match r1, r2, a with
 229 |     | R1, _, (3, "") -> ()
 230 |     | _, R2, (1, "coucou", 'a') -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, (3, "*"))
+  Here is an example of a case that is not matched: (R1, R1, (3, "*"))
 
 File "robustmatch.ml", lines 239-241, characters 4-51:
 239 | ....match r1, r2, a with
 240 |     | R1, _, { x = 3; y = "" } -> ()
 241 |     | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, {x=3; y="*"})
+  Here is an example of a case that is not matched: (R1, R1, {x=3; y="*"})
 
 File "robustmatch.ml", lines 244-246, characters 4-36:
 244 | ....match r1, r2, a with
 245 |     | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
 246 |     | _, R1, { x = 3; y = "" } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, {a=1; b="coucou"; c='b'})
+  Here is an example of a case that is not matched:
+    (R2, R2, {a=1; b="coucou"; c='b'})
 
 File "robustmatch.ml", lines 253-255, characters 4-20:
 253 | ....match r1, r2, a with
 254 |     | R1, _, (3, "") -> ()
 255 |     | _, R2, 1 -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, (3, "*"))
+  Here is an example of a case that is not matched: (R1, R1, (3, "*"))
 
 File "robustmatch.ml", lines 263-265, characters 4-20:
 263 | ....match r1, r2, a with
 264 |     | R1, _, { x = 3; y = "" } -> ()
 265 |     | _, R2, 1 -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, {x=3; y="*"})
+  Here is an example of a case that is not matched: (R1, R1, {x=3; y="*"})
 
 File "robustmatch.ml", lines 272-274, characters 4-20:
 272 | ....match r1, r2, a with
 273 |     | R1, _, lazy 1 -> ()
 274 |     | _, R2, 1 -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R1, R1, lazy 0)
+  Here is an example of a case that is not matched: (R1, R1, lazy 0)
 
 File "robustmatch.ml", lines 281-284, characters 4-24:
 281 | ....match r1, r2, a with
@@ -228,5 +203,4 @@ File "robustmatch.ml", lines 281-284, characters 4-24:
 283 |     | _, R2, "coucou" -> ()
 284 |     | _, R2, "foo" -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(R2, R2, "")
+  Here is an example of a case that is not matched: (R2, R2, "")

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -40,8 +40,7 @@ Lines 1-3, characters 0-20:
 2 | | { x = 3 } -> ()
 3 | | { x = None } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x=Some _}
+  Here is an example of a case that is not matched: "{x=Some _}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;
@@ -56,8 +55,7 @@ Lines 1-3, characters 0-18:
 2 | | { x = None } -> ()
 3 | | { x = "" } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x="*"}
+  Here is an example of a case that is not matched: "{x="*"}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;
@@ -72,8 +70,7 @@ Lines 1-3, characters 0-18:
 2 | | { x = None } -> ()
 3 | | { x = `X } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x=`AnyOtherTag}
+  Here is an example of a case that is not matched: "{x=`AnyOtherTag}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;
@@ -88,8 +85,7 @@ Lines 1-3, characters 0-17:
 2 | | { x = [||] } -> ()
 3 | | { x = 3 } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x=0}
+  Here is an example of a case that is not matched: "{x=0}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;
@@ -104,8 +100,7 @@ Lines 1-3, characters 0-17:
 2 | | { x = `X } -> ()
 3 | | { x = 3 } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x=0}
+  Here is an example of a case that is not matched: "{x=0}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;
@@ -120,8 +115,7 @@ Lines 1-3, characters 0-17:
 2 | | { x = `X "lol" } -> ()
 3 | | { x = 3 } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x=0}
+  Here is an example of a case that is not matched: "{x=0}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;
@@ -138,8 +132,7 @@ Lines 1-4, characters 0-17:
 3 | | { x = None } -> ()
 4 | | { x = 3 } -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{x=0}
+  Here is an example of a case that is not matched: "{x=0}"
 
 Exception: Assert_failure ("", 1, 12).
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -720,8 +720,9 @@ val bad_location : 'a GADT_ordering.is_point -> 'a -> int = <fun>
 Line 4, characters 11-19:
 4 |       let+ Is_point = is_point
                ^^^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering GADT_ordering.point and a as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "GADT_ordering.point" and "a" as equal.
+  But the knowledge of these types is not principal.
 
 Line 5, characters 11-19:
 5 |       and+ { x; y } = a in

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -587,7 +587,8 @@ val let_not_principal : unit = ()
 Line 3, characters 9-10:
 3 |     let+ A = A.A in
              ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val let_not_principal : unit = ()
 |}];;
@@ -617,7 +618,8 @@ val and_not_principal : A.t -> A.t -> unit = <fun>
 Line 5, characters 11-12:
 5 |       and+ A = y in
                ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val and_not_principal : A.t -> A.t -> unit = <fun>
 |}];;
@@ -721,8 +723,8 @@ Line 4, characters 11-19:
 4 |       let+ Is_point = is_point
                ^^^^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering
-  "GADT_ordering.point" and "a" as equal.
-  But the knowledge of these types is not principal.
+  "GADT_ordering.point" and "a" as equal. But the knowledge of these types is not
+  principal.
 
 Line 5, characters 11-19:
 5 |       and+ { x; y } = a in

--- a/testsuite/tests/lexing/escape.ocaml.reference
+++ b/testsuite/tests/lexing/escape.ocaml.reference
@@ -2,9 +2,9 @@ Line 7, characters 15-17:
 7 | let invalid = "\99" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
-Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r, ...). Did you check the list of OCaml escape sequences?
-To get a backslash character, escape it with a second backslash: \\.
+  Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+  Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
 
 val invalid : string = "\\99"
 Line 1, characters 15-19:
@@ -19,18 +19,18 @@ Line 1, characters 15-17:
 1 | let invalid = "\o77" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
-Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r, ...). Did you check the list of OCaml escape sequences?
-To get a backslash character, escape it with a second backslash: \\.
+  Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+  Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
 
 val invalid : string = "\\o77"
 Line 1, characters 15-17:
 1 | let invalid = "\o99" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
-Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r, ...). Did you check the list of OCaml escape sequences?
-To get a backslash character, escape it with a second backslash: \\.
+  Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+  Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
 
 val invalid : string = "\\o99"
 

--- a/testsuite/tests/lexing/uchar_esc.ocaml.reference
+++ b/testsuite/tests/lexing/uchar_esc.ocaml.reference
@@ -26,18 +26,18 @@ Line 1, characters 21-23:
 1 | let no_hex_digits = "\u{}" ;;
                          ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
-Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r, ...). Did you check the list of OCaml escape sequences?
-To get a backslash character, escape it with a second backslash: \\.
+  Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+  Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
 
 val no_hex_digits : string = "\\u{}"
 Line 1, characters 25-27:
 1 | let illegal_hex_digit = "\u{u}" ;;
                              ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
-Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r, ...). Did you check the list of OCaml escape sequences?
-To get a backslash character, escape it with a second backslash: \\.
+  Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+  Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
 
 val illegal_hex_digit : string = "\\u{u}"
 

--- a/testsuite/tests/local-functions/non_local.compilers.reference
+++ b/testsuite/tests/local-functions/non_local.compilers.reference
@@ -1,4 +1,5 @@
 File "non_local.ml", line 21, characters 16-25:
 21 |   let[@local] f y = x + y in
                      ^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: This function cannot be compiled into a static continuation
+Warning 55 [inlining-impossible]: Cannot inline:
+  This function cannot be compiled into a static continuation

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -22,8 +22,7 @@ Lines 8-11, characters 4-16:
 10 |     | Some false -> ()
 11 |     | None -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some true
+  Here is an example of a case that is not matched: "Some true"
 
 val test_match_exhaustiveness : unit -> unit = <fun>
 |}]
@@ -41,8 +40,7 @@ Lines 2-4, characters 4-30:
 3 |     | Some false -> ()
 4 |     | None | exception _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some true
+  Here is an example of a case that is not matched: "Some true"
 
 val test_match_exhaustiveness_nest1 : unit -> unit = <fun>
 |}]
@@ -60,8 +58,7 @@ Lines 2-4, characters 4-16:
 3 |     | Some false | exception _ -> ()
 4 |     | None -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some true
+  Here is an example of a case that is not matched: "Some true"
 
 val test_match_exhaustiveness_nest2 : unit -> unit = <fun>
 |}]
@@ -81,8 +78,7 @@ Lines 2-5, characters 4-30:
 4 |     | Some false | exception _ -> ()
 5 |     | None | exception _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some true
+  Here is an example of a case that is not matched: "Some true"
 
 Line 4, characters 29-30:
 4 |     | Some false | exception _ -> ()

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -35,10 +35,10 @@ Lines 4-8, characters 2-32:
 6 |   | {a = _;     b = None} -> 1
 7 |   | {a = _;     b = _} when (x.b <- None; false) -> 2
 8 |   | {a = true;  b = Some y} -> y
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 (let
   (f/281 =
      (function x/283 : int
@@ -99,10 +99,10 @@ Lines 2-5, characters 2-32:
 3 |   | {a = false; b = _} -> 0
 4 |   | {a = _;     b = None} -> 1
 5 |   | {a = true;  b = Some y} -> y
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 (let
   (f/298 =
      (function x/299 : int
@@ -141,10 +141,10 @@ Lines 2-6, characters 2-13:
 4 |   | _ when (r := None; false) -> 1
 5 |   | Some { contents = Some n } -> n
 6 |   | None -> 3
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 (let
   (f/305 =
      (function r/306 : int
@@ -272,10 +272,10 @@ Lines 2-6, characters 2-13:
 4 |   | _ when (r := ((), None); false) -> 1
 5 |   | Some { contents = ((), Some n) } -> n
 6 |   | None -> 3
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 (let
   (deep/342 =
      (function r/344 : int

--- a/testsuite/tests/messages/precise_locations.ml
+++ b/testsuite/tests/messages/precise_locations.ml
@@ -86,7 +86,7 @@ end);;
 Line 2, characters 0-9:
 2 | open List
     ^^^^^^^^^
-Error (warning 33 [unused-open]): unused open Stdlib.List.
+Error (warning 33 [unused-open]): unused open "Stdlib.List".
 |}];;
 
 type unknown += Foo;;

--- a/testsuite/tests/no-alias-deps/aliases.compilers.reference
+++ b/testsuite/tests/no-alias-deps/aliases.compilers.reference
@@ -6,5 +6,6 @@ Warning 49 [no-cmi-file]: no cmi file was found in path for module A
 File "aliases.ml", line 18, characters 12-13:
 18 | module B' = B (* broken b.cmi *)
                  ^
-Warning 49 [no-cmi-file]: no valid cmi file was found in path for module B. b.cmi
+Warning 49 [no-cmi-file]: no valid cmi file was found in path for module B.
+  b.cmi
 is not a compiled interface

--- a/testsuite/tests/syntactic-arity/max_arity.compilers.reference
+++ b/testsuite/tests/syntactic-arity/max_arity.compilers.reference
@@ -2,4 +2,4 @@ File "max_arity.ml", line 154, characters 8-12:
 154 | let _ = f ();;
               ^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.

--- a/testsuite/tests/tmc/other_features.ml
+++ b/testsuite/tests/tmc/other_features.ml
@@ -22,8 +22,8 @@ Lines 6-11, characters 30-40:
  9 |     | C (a, b) ->
 10 |         let map' l = map f l in
 11 |         C (map' a, (map' [@tailcall]) b)
-Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
-but is never applied in TMC position.
+Warning 71 [unused-tmc-attribute]: This function is marked "@tail_mod_cons"
+  but is never applied in TMC position.
 
 Line 11, characters 19-39:
 11 |         C (map' a, (map' [@tailcall]) b)

--- a/testsuite/tests/tmc/partial_application.compilers.reference
+++ b/testsuite/tests/tmc/partial_application.compilers.reference
@@ -2,4 +2,4 @@ File "partial_application.ml", line 7, characters 26-36:
 7 | let[@tail_mod_cons] rec f () () = ()
                               ^^^^^^^^^^
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
-but is never applied in TMC position.
+  but is never applied in TMC position.

--- a/testsuite/tests/tmc/tupled_function_calls.native.reference
+++ b/testsuite/tests/tmc/tupled_function_calls.native.reference
@@ -6,7 +6,7 @@ File "tupled_function_calls.ml", lines 16-21, characters 46-57:
 20 |       let pair = (f, xs) in
 21 |       f x :: (tupled_map_not_direct[@tailcall true]) pair
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
-but is never applied in TMC position.
+  but is never applied in TMC position.
 
 File "tupled_function_calls.ml", line 21, characters 13-57:
 21 |       f x :: (tupled_map_not_direct[@tailcall true]) pair

--- a/testsuite/tests/tmc/usage_warnings.ml
+++ b/testsuite/tests/tmc/usage_warnings.ml
@@ -19,20 +19,19 @@ let[@tail_mod_cons] rec flatten = function
 Line 3, characters 17-40:
 3 |   | xs :: xss -> append xs (flatten xss)
                      ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 72 [tmc-breaks-tailcall]: This call
-is in tail-modulo-cons position in a TMC function,
-but the function called is not itself specialized for TMC,
-so the call will not be transformed into a tail call.
-Please either mark the called function with the [@tail_mod_cons]
-attribute, or mark this call with the [@tailcall false] attribute
-to make its non-tailness explicit.
+Warning 72 [tmc-breaks-tailcall]: This call is in tail-modulo-cons position
+  in a TMC function, but the function called is not itself specialized for
+  TMC, so the call will not be transformed into a tail call.
+  Please either mark the called function with the "[@tail_mod_cons]" attribute,
+  or mark this call with the "[@tailcall false]" attribute to make its
+  non-tailness explicit.
 
 Lines 1-3, characters 34-40:
 1 | ..................................function
 2 |   | [] -> []
 3 |   | xs :: xss -> append xs (flatten xss)
-Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
-but is never applied in TMC position.
+Warning 71 [unused-tmc-attribute]: This function is marked "@tail_mod_cons"
+  but is never applied in TMC position.
 
 val flatten : 'a list list -> 'a list = <fun>
 |}]
@@ -65,13 +64,12 @@ let[@tail_mod_cons] rec flatten = function
 Line 10, characters 9-30:
 10 |       in append_flatten xs xss
               ^^^^^^^^^^^^^^^^^^^^^
-Warning 72 [tmc-breaks-tailcall]: This call
-is in tail-modulo-cons position in a TMC function,
-but the function called is not itself specialized for TMC,
-so the call will not be transformed into a tail call.
-Please either mark the called function with the [@tail_mod_cons]
-attribute, or mark this call with the [@tailcall false] attribute
-to make its non-tailness explicit.
+Warning 72 [tmc-breaks-tailcall]: This call is in tail-modulo-cons position
+  in a TMC function, but the function called is not itself specialized for
+  TMC, so the call will not be transformed into a tail call.
+  Please either mark the called function with the "[@tail_mod_cons]" attribute,
+  or mark this call with the "[@tailcall false]" attribute to make its
+  non-tailness explicit.
 
 Lines 1-10, characters 34-30:
  1 | ..................................function
@@ -84,8 +82,8 @@ Lines 1-10, characters 34-30:
  8 |             (* incorrect: this call to append_flatten is not transformed *)
  9 |             x :: append_flatten xs xss
 10 |       in append_flatten xs xss
-Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
-but is never applied in TMC position.
+Warning 71 [unused-tmc-attribute]: This function is marked "@tail_mod_cons"
+  but is never applied in TMC position.
 
 val flatten : 'a list list -> 'a list = <fun>
 |}]
@@ -111,13 +109,12 @@ let rec flatten = function
 Line 13, characters 12-23:
 13 |             flatten xss
                  ^^^^^^^^^^^
-Warning 72 [tmc-breaks-tailcall]: This call
-is in tail-modulo-cons position in a TMC function,
-but the function called is not itself specialized for TMC,
-so the call will not be transformed into a tail call.
-Please either mark the called function with the [@tail_mod_cons]
-attribute, or mark this call with the [@tailcall false] attribute
-to make its non-tailness explicit.
+Warning 72 [tmc-breaks-tailcall]: This call is in tail-modulo-cons position
+  in a TMC function, but the function called is not itself specialized for
+  TMC, so the call will not be transformed into a tail call.
+  Please either mark the called function with the "[@tail_mod_cons]" attribute,
+  or mark this call with the "[@tailcall false]" attribute to make its
+  non-tailness explicit.
 
 val flatten : 'a list list -> 'a list = <fun>
 |}]
@@ -166,13 +163,12 @@ Lines 20-23, characters 10-27:
 21 |             (* no [@tailcall false]: this should warn that
 22 |                the call becomes non-tailcall in the TMC version. *)
 23 |             (filter_1 f xs)
-Warning 72 [tmc-breaks-tailcall]: This call
-is in tail-modulo-cons position in a TMC function,
-but the function called is not itself specialized for TMC,
-so the call will not be transformed into a tail call.
-Please either mark the called function with the [@tail_mod_cons]
-attribute, or mark this call with the [@tailcall false] attribute
-to make its non-tailness explicit.
+Warning 72 [tmc-breaks-tailcall]: This call is in tail-modulo-cons position
+  in a TMC function, but the function called is not itself specialized for
+  TMC, so the call will not be transformed into a tail call.
+  Please either mark the called function with the "[@tail_mod_cons]" attribute,
+  or mark this call with the "[@tailcall false]" attribute to make its
+  non-tailness explicit.
 
 module Tail_calls_to_non_specialized_functions :
   sig
@@ -250,13 +246,12 @@ end
 Line 16, characters 13-56:
 16 |         then (graft[@tailcall]) (* this should warn *) n
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 72 [tmc-breaks-tailcall]: This call
-is in tail-modulo-cons position in a TMC function,
-but the function called is not itself specialized for TMC,
-so the call will not be transformed into a tail call.
-Please either mark the called function with the [@tail_mod_cons]
-attribute, or mark this call with the [@tailcall false] attribute
-to make its non-tailness explicit.
+Warning 72 [tmc-breaks-tailcall]: This call is in tail-modulo-cons position
+  in a TMC function, but the function called is not itself specialized for
+  TMC, so the call will not be transformed into a tail call.
+  Please either mark the called function with the "[@tail_mod_cons]" attribute,
+  or mark this call with the "[@tailcall false]" attribute to make its
+  non-tailness explicit.
 
 Line 17, characters 17-67:
 17 |         else Tau ((graft[@tailcall]) (* this should also warn *) n)

--- a/testsuite/tests/tool-ocamlc-open/tool-ocamlc-open-error.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-open/tool-ocamlc-open-error.compilers.reference
@@ -1,5 +1,5 @@
 File "tool-ocamlc-open-error.ml", line 1:
-Warning 24 [bad-module-name]: bad source file name: "Tool-ocamlc-open-error" is not a valid module name.
+Warning 24 [bad-module-name]: bad source file name: Tool-ocamlc-open-error is not a valid module name.
 
 File "command line argument: -open "F("", line 1, characters 1-2:
 Error: Syntax error

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -9,8 +9,8 @@
 #   * Line 2, characters 6-9:
 2 | 750;; (*) comment-start warning after semicolon must be displayed once
           ^^^
-Warning 1 [comment-start]: this `(*' is the start of a comment.
-Hint: Did you forget spaces when writing the infix operator `( * )'?
+Warning 1 [comment-start]: this (* is the start of a comment.
+  Hint: Did you forget spaces when writing the infix operator ( * )?
 
 - : int = 750
 #   Line 2, characters 9-11:
@@ -27,8 +27,7 @@ Error: The constructor true has type bool
 2 | match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)
     ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-0
+  Here is an example of a case that is not matched: 0
 
 Exception: Match_failure ("//toplevel//", 2, 0).
 - : int = 16
@@ -38,8 +37,7 @@ Line 2, characters 5-27:
 2 | 18;; match 19 with 20 -> ();; 21;; (* Warning + run-time error in 2nd phrase. *)
          ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-0
+  Here is an example of a case that is not matched: 0
 
 Exception: Match_failure ("//toplevel//", 2, 5).
 - : int = 21
@@ -47,24 +45,21 @@ Exception: Match_failure ("//toplevel//", 2, 5).
 2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
           ^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-0
+  Here is an example of a case that is not matched: 0
 
 val f : int -> unit = <fun>
 Line 2, characters 22-24:
 2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
                           ^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-0
+  Here is an example of a case that is not matched: 0
 
 val f : int -> unit = <fun>
 Line 2, characters 38-40:
 2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
                                           ^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-0
+  Here is an example of a case that is not matched: 0
 
 val f : int -> unit = <fun>
 #   * * *   

--- a/testsuite/tests/tool-toplevel/pr7060.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr7060.compilers.reference
@@ -4,8 +4,7 @@ Line 1, characters 18-54:
 1 | let print_t out = function A -> Format.fprintf out "A";;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-B
+  Here is an example of a case that is not matched: B
 
 val print_t : Format.formatter -> t -> unit = <fun>
 - : t =

--- a/testsuite/tests/typing-deprecated/alerts.ml
+++ b/testsuite/tests/typing-deprecated/alerts.ml
@@ -269,20 +269,20 @@ end
 Line 2, characters 13-25:
 2 |   val x: int [@@alert 42]
                  ^^^^^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'alert'.
-Invalid payload
+Warning 47 [attribute-payload]: illegal payload for attribute "alert".
+  Invalid payload
 
 Line 3, characters 13-29:
 3 |   val y: int [@@alert bla 42]
                  ^^^^^^^^^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'alert'.
-Invalid payload
+Warning 47 [attribute-payload]: illegal payload for attribute "alert".
+  Invalid payload
 
 Line 4, characters 13-28:
 4 |   val z: int [@@alert "bla"]
                  ^^^^^^^^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'alert'.
-Ill-formed list of alert settings
+Warning 47 [attribute-payload]: illegal payload for attribute "alert".
+  Ill-formed list of alert settings
 
 module X : sig val x : int val y : int val z : int end
 |}]

--- a/testsuite/tests/typing-deprecated/deprecated.ml
+++ b/testsuite/tests/typing-deprecated/deprecated.ml
@@ -653,8 +653,7 @@ Line 1, characters 4-31:
 1 | let ([][@ocaml.ppwarning "XX"]) = []
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-_::_
+  Here is an example of a case that is not matched: "_::_"
 |}]
 let[@ocaml.warning "-8-22"] ([][@ocaml.ppwarning "XX"]) = []
 ;;

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -241,8 +241,8 @@ type b = Unique
 Line 7, characters 8-14:
 7 | let x = Unique;;
             ^^^^^^
-Warning 41 [ambiguous-name]: Unique belongs to several types: b M.s t a
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "Unique" belongs to several types: "b""M.s""t""a".
+  The first one was selected. Please disambiguate if this is wrong.
 
 val x : b = Unique
 |}]

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -241,7 +241,7 @@ type b = Unique
 Line 7, characters 8-14:
 7 | let x = Unique;;
             ^^^^^^
-Warning 41 [ambiguous-name]: "Unique" belongs to several types: "b""M.s""t""a".
+Warning 41 [ambiguous-name]: "Unique" belongs to several types: "b" "M.s" "t" "a".
   The first one was selected. Please disambiguate if this is wrong.
 
 val x : b = Unique

--- a/testsuite/tests/typing-extensions/floatarray.ml
+++ b/testsuite/tests/typing-extensions/floatarray.ml
@@ -66,7 +66,8 @@ val f : Float.Array.t -> unit = <fun>
 Line 4, characters 4-8:
 4 |   | [||] -> ()
         ^^^^
-Warning 18 [not-principal]: this type-based array disambiguation is not principal.
+Warning 18 [not-principal]: this type-based array disambiguation is not
+  principal.
 
 val f : Float.Array.t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -309,9 +309,9 @@ Line 3, characters 8-26:
             ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched:
-    "*extension*
-Matching over values of extensible variant types (the *extension* above)
-must include a wild card pattern in order to be exhaustive."
+    "*extension*"
+    Matching over values of extensible variant types (the *extension* above)
+    must include a wild card pattern in order to be exhaustive.
 
 val f : foo -> unit = <fun>
 |}]
@@ -331,9 +331,9 @@ Lines 1-4, characters 8-11:
 4 |   | [] -> 2
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched:
-    "*extension*::[]
-Matching over values of extensible variant types (the *extension* above)
-must include a wild card pattern in order to be exhaustive."
+    "*extension*::[]"
+    Matching over values of extensible variant types (the *extension* above)
+    must include a wild card pattern in order to be exhaustive.
 
 val f : foo list -> int = <fun>
 |}]
@@ -355,9 +355,9 @@ Line 1, characters 8-62:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched:
-    "*extension*
-Matching over values of extensible variant types (the *extension* above)
-must include a wild card pattern in order to be exhaustive."
+    "*extension*"
+    Matching over values of extensible variant types (the *extension* above)
+    must include a wild card pattern in order to be exhaustive.
 
 val f : t -> string = <fun>
 |}]

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -308,10 +308,10 @@ Line 3, characters 8-26:
 3 | let f = function Foo -> ()
             ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-*extension*
+  Here is an example of a case that is not matched:
+    "*extension*
 Matching over values of extensible variant types (the *extension* above)
-must include a wild card pattern in order to be exhaustive.
+must include a wild card pattern in order to be exhaustive."
 
 val f : foo -> unit = <fun>
 |}]
@@ -330,10 +330,10 @@ Lines 1-4, characters 8-11:
 3 |   | _::_::_ -> 3
 4 |   | [] -> 2
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-*extension*::[]
+  Here is an example of a case that is not matched:
+    "*extension*::[]
 Matching over values of extensible variant types (the *extension* above)
-must include a wild card pattern in order to be exhaustive.
+must include a wild card pattern in order to be exhaustive."
 
 val f : foo list -> int = <fun>
 |}]
@@ -354,10 +354,10 @@ Line 1, characters 8-62:
 1 | let f = function IPair (i, j) -> Format.sprintf "(%d, %d)" i j ;;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-*extension*
+  Here is an example of a case that is not matched:
+    "*extension*
 Matching over values of extensible variant types (the *extension* above)
-must include a wild card pattern in order to be exhaustive.
+must include a wild card pattern in order to be exhaustive."
 
 val f : t -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -16,8 +16,7 @@ Lines 6-7, characters 2-13:
 6 | ..match tag with
 7 |   | Bool -> x
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Int
+  Here is an example of a case that is not matched: "Int"
 
 val fbool : 't -> 't ty -> 't = <fun>
 |}];;
@@ -33,8 +32,7 @@ Lines 2-3, characters 2-16:
 2 | ..match tag with
 3 |   | Int -> x > 0
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Bool
+  Here is an example of a case that is not matched: "Bool"
 
 val fint : 't -> 't ty -> bool = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -55,8 +55,7 @@ Line 6, characters 2-20:
 6 |   let None = y in () ;;
       ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some A
+  Here is an example of a case that is not matched: "Some A"
 
 val g : M.j t option -> unit = <fun>
 |}]
@@ -83,8 +82,7 @@ Line 9, characters 2-20:
 9 |   let None = y in () ;;
       ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some A
+  Here is an example of a case that is not matched: "Some A"
 
 val g : M.j t option -> unit = <fun>
 |}]
@@ -110,8 +108,7 @@ Line 9, characters 2-20:
 9 |   let None = y in () ;;
       ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some A
+  Here is an example of a case that is not matched: "Some A"
 
 val g : 'a M.j t option -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -18,8 +18,7 @@ Lines 7-9, characters 43-24:
 8 |     | One, One -> "two"
 9 |     | Two, Two -> "four"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(One, Two)
+  Here is an example of a case that is not matched: "(One, Two)"
 
 module Add :
   (T : sig type two end) ->

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -34,8 +34,7 @@ Lines 12-16, characters 2-36:
 15 |   | Leq, Bool x, Bool y -> Bool (x <= y)
 16 |   | Add, Int x, Int y -> Int (x + y)
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(Eq, Int _, _)
+  Here is an example of a case that is not matched: "(Eq, Int _, _)"
 
 val eval : ('a, 'b, 'c) binop -> 'a constant -> 'b constant -> 'c constant =
   <fun>

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -16,8 +16,7 @@ Lines 7-8, characters 47-21:
 7 | ...............................................match l, r with
 8 |     | A, B -> "f A B"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(A, A)
+  Here is an example of a case that is not matched: "(A, A)"
 
 module F :
   (S : sig type 'a t end) ->
@@ -44,8 +43,7 @@ Lines 10-11, characters 15-21:
 10 | ...............match l, r with
 11 |     | A, B -> "f A B"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(A, A)
+  Here is an example of a case that is not matched: "(A, A)"
 
 module F :
   (S : sig type 'a t end) ->

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -29,8 +29,7 @@ Lines 16-17, characters 39-16:
 16 | .......................................function
 17 |   | Any -> "Any"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 val f : (M.s, [ `A | `B ]) t -> string = <fun>
 Exception: Match_failure ("", 16, 39).
@@ -60,8 +59,7 @@ Lines 12-13, characters 49-16:
 12 | .................................................function
 13 |   | Any -> "Any"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 val f : (N.s, < a : int; b : bool >) t -> string = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr5997.ml
+++ b/testsuite/tests/typing-gadts/pr5997.ml
@@ -26,8 +26,7 @@ Line 16, characters 0-33:
 16 | match M.comp with | Diff -> false;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 Exception: Match_failure ("", 16, 0).
 |}];;
@@ -50,8 +49,7 @@ Line 11, characters 0-33:
 11 | match M.comp with | Diff -> false;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 Exception: Match_failure ("", 11, 0).
 |}];;

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -25,8 +25,7 @@ Lines 8-9, characters 52-13:
 8 | ....................................................function
 9 |    | B s -> s
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-A
+  Here is an example of a case that is not matched: "A"
 
 module M :
   (A : sig module type T end) (B : sig module type T end) ->

--- a/testsuite/tests/typing-gadts/pr6993_bad.ml
+++ b/testsuite/tests/typing-gadts/pr6993_bad.ml
@@ -21,8 +21,7 @@ Line 2, characters 36-66:
 2 | let f : ('a list, 'a) eqp -> unit = function N s -> print_string s;;
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Y
+  Here is an example of a case that is not matched: "Y"
 
 val f : ('a list, 'a) eqp -> unit = <fun>
 module rec A : sig type t = B.t list end

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -15,8 +15,7 @@ Line 5, characters 9-39:
 5 | let get1 (Cons (x, _) : (_ * 'a, 'a) t) = x ;; (* warn, cf PR#6993 *)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Nil
+  Here is an example of a case that is not matched: "Nil"
 
 val get1 : ('b * 'a, 'a) t -> 'b = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr7234.ml
+++ b/testsuite/tests/typing-gadts/pr7234.ml
@@ -12,8 +12,7 @@ Line 3, characters 15-36:
 3 | let f (type a) (Neq n : (a, a t) eq) = n;;   (* warn! *)
                    ^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 val f : ('a, 'a t) eq -> int = <fun>
 |}];;
@@ -26,8 +25,7 @@ Line 2, characters 16-39:
 2 |  let f (type a) (Neq n : (a, a T.t) eq) = n  (* warn! *)
                     ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 module F : (T : sig type _ t end) -> sig val f : ('a, 'a T.t) eq -> int end
 |}];;

--- a/testsuite/tests/typing-gadts/pr7269.ml
+++ b/testsuite/tests/typing-gadts/pr7269.ml
@@ -15,8 +15,7 @@ Line 4, characters 6-28:
 4 | let f (T (`Other msg) : s t) = print_string msg;;
           ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-T (`Conj _)
+  Here is an example of a case that is not matched: "T (`Conj _)"
 
 val f : s t -> unit = <fun>
 Exception: Match_failure ("", 4, 6).
@@ -44,8 +43,7 @@ Line 11, characters 12-59:
 11 | let () = M.(match x with T (`Other msg) -> print_string msg);; (* warn *)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-T (`Conj _)
+  Here is an example of a case that is not matched: "T (`Conj _)"
 
 Exception: Match_failure ("", 11, 12).
 |}];;
@@ -77,8 +75,7 @@ Line 13, characters 25-37:
 13 | let () = M.(e { ex = fun (`Other msg) -> print_string msg });; (* warn *)
                               ^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`Conj _
+  Here is an example of a case that is not matched: "`Conj _"
 
 Exception: Match_failure ("", 13, 25).
 |}];;

--- a/testsuite/tests/typing-gadts/pr7390.ml
+++ b/testsuite/tests/typing-gadts/pr7390.ml
@@ -25,8 +25,7 @@ Line 2, characters 6-23:
 2 |   fun (Either (Y a, N)) -> a;;
           ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Either (N, Y _)
+  Here is an example of a case that is not matched: "Either (N, Y _)"
 
 val f : filled either -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/pr7432.ml
+++ b/testsuite/tests/typing-gadts/pr7432.ml
@@ -25,8 +25,7 @@ Line 2, characters 2-30:
 2 |   function `R {silly} -> silly
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`L Refl
+  Here is an example of a case that is not matched: "`L Refl"
 
 val f : [ `L of (s, t) eql | `R of silly ] -> 'a = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/pr9019.ml
+++ b/testsuite/tests/typing-gadts/pr9019.ml
@@ -37,8 +37,7 @@ Lines 4-8, characters 2-18:
 7 |   | _,  AB, B -> 3
 8 |   | _, MAB, B -> 4
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(AB, MAB, A)
+  Here is an example of a case that is not matched: "(AB, MAB, A)"
 
 val f : 'x M.t -> 'x M.t -> 'x -> int = <fun>
 |}]
@@ -170,8 +169,7 @@ Lines 9-11, characters 2-37:
 10 |   | Not_A, A_or_B, `B i -> print_int i
 11 |   | _, A_or_B, `A s -> print_string s
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(A, A_or_B, `B _)
+  Here is an example of a case that is not matched: "(A, A_or_B, `B _)"
 
 val f : 'x a -> 'x a_or_b -> 'x -> unit = <fun>
 |}]
@@ -202,8 +200,8 @@ Lines 9-11, characters 2-18:
 10 |   | B, `B String_option, Some s -> print_string s
 11 |   | A, `A, _ -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(B, `B String_option, None)
+  Here is an example of a case that is not matched:
+    "(B, `B String_option, None)"
 
 val f : ('x, 'y ty) b -> 'x -> 'y -> unit = <fun>
 |}]
@@ -223,8 +221,7 @@ Line 2, characters 18-44:
 2 | let f (x : _ a) = match x with `A None -> ();;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`A (Some _)
+  Here is an example of a case that is not matched: "`A (Some _)"
 
 val f : 'a option a -> unit = <fun>
 |}]
@@ -235,8 +232,7 @@ Line 1, characters 23-47:
 1 | let f (x : [> `A] a) = match x with `A `B -> ();;
                            ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`A `A
+  Here is an example of a case that is not matched: "`A `A"
 
 val f : [< `A | `B > `A ] a -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -23,8 +23,7 @@ Line 1, characters 8-35:
 1 | let f = function Sigma (M, A) -> ();;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Sigma (M, B)
+  Here is an example of a case that is not matched: "Sigma (M, B)"
 
 val f : dyn -> unit = <fun>
 |}];;
@@ -48,14 +47,14 @@ val f : 'a t -> 'a -> int = <fun>
 Line 4, characters 4-10:
 4 |   | IntLit, n -> n+1
         ^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering int and a as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  int" and "a" as equal. But the knowledge of these types is not principal.
 
 Line 5, characters 4-11:
 5 |   | BoolLit, b -> 1
         ^^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering bool and a as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  bool" and "a" as equal. But the knowledge of these types is not principal.
 
 val f : 'a t -> 'a -> int = <fun>
 |}]
@@ -72,8 +71,8 @@ val f : 'a t -> 'a -> int = <fun>
 Line 4, characters 4-10:
 4 |   | IntLit, n -> n+1
         ^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering int and a as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  int" and "a" as equal. But the knowledge of these types is not principal.
 
 val f : 'a t -> 'a -> int = <fun>
 |}]
@@ -141,8 +140,9 @@ val f1 : unit ab M.t -> bool = <fun>
 Line 4, characters 4-7:
 4 |   | MAB -> false;;
         ^^^
-Warning 18 [not-principal]: typing this pattern requires considering unit M.mab and unit ab as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "unit M.mab" and "unit ab" as equal.
+  But the knowledge of these types is not principal.
 
 val f1 : unit ab M.t -> bool = <fun>
 |}]
@@ -158,14 +158,15 @@ val f2 : 'x M.t -> bool = <fun>
 Line 4, characters 4-6:
 4 |   | AB -> true
         ^^
-Warning 18 [not-principal]: typing this pattern requires considering unit ab and x as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  unit ab" and "x" as equal. But the knowledge of these types is not principal.
 
 Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
-Warning 18 [not-principal]: typing this pattern requires considering unit M.mab and x as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "unit M.mab" and "x" as equal.
+  But the knowledge of these types is not principal.
 
 val f2 : 'x M.t -> bool = <fun>
 |}]
@@ -182,8 +183,9 @@ val f3 : unit ab M.t -> bool = <fun>
 Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
-Warning 18 [not-principal]: typing this pattern requires considering unit M.mab and unit ab as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "unit M.mab" and "unit ab" as equal.
+  But the knowledge of these types is not principal.
 
 val f3 : unit ab M.t -> bool = <fun>
 |}]
@@ -210,8 +212,9 @@ val g2 : ('x, int option) eq -> 'x -> int option = <fun>
 Line 3, characters 7-11:
 3 |    let Refl = e in x;;
            ^^^^
-Warning 18 [not-principal]: typing this pattern requires considering x and int option as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  x" and "int option" as equal.
+  But the knowledge of these types is not principal.
 
 val g2 : ('x, int option) eq -> 'x -> int option = <fun>
 |}]
@@ -242,8 +245,8 @@ let () =
 Line 3, characters 27-28:
 3 |   | [ { a = 3; _ } ; { b = F; _ }] -> ()
                                ^
-Warning 18 [not-principal]: typing this pattern requires considering Foo.t and int as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  Foo.t" and "int" as equal. But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -277,8 +280,8 @@ let () =
 Line 3, characters 26-31:
 3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering int and Foo.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -291,8 +294,8 @@ let () =
 Line 3, characters 12-17:
 3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
                 ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering int and Foo.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 (* Unify with 'a first *)
@@ -312,8 +315,8 @@ let () =
 Line 3, characters 26-31:
 3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering int and Foo.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -325,8 +328,8 @@ let () =
 Line 3, characters 12-17:
 3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
                 ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering int and Foo.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 
@@ -357,8 +360,8 @@ val foo : M.t foo -> M.t = <fun>
 Line 3, characters 18-23:
 3 |   | { x = x; eq = Refl3 } -> x
                       ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 val foo : M.t foo -> M.t = <fun>
 |}]
@@ -373,8 +376,8 @@ val foo : int foo -> int = <fun>
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 val foo : int foo -> int = <fun>
 |}]
@@ -395,8 +398,8 @@ Error: This pattern matches values of type "N.t foo"
 Line 3, characters 26-31:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 Line 3, characters 4-33:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
@@ -417,8 +420,8 @@ val foo : string foo -> string = <fun>
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
-But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering "
+  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 val foo : string foo -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -47,14 +47,14 @@ val f : 'a t -> 'a -> int = <fun>
 Line 4, characters 4-10:
 4 |   | IntLit, n -> n+1
         ^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  int" and "a" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "a" as equal. But the knowledge of these types is not principal.
 
 Line 5, characters 4-11:
 5 |   | BoolLit, b -> 1
         ^^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  bool" and "a" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "bool" and "a" as equal. But the knowledge of these types is not principal.
 
 val f : 'a t -> 'a -> int = <fun>
 |}]
@@ -71,8 +71,8 @@ val f : 'a t -> 'a -> int = <fun>
 Line 4, characters 4-10:
 4 |   | IntLit, n -> n+1
         ^^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  int" and "a" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "a" as equal. But the knowledge of these types is not principal.
 
 val f : 'a t -> 'a -> int = <fun>
 |}]
@@ -141,8 +141,8 @@ Line 4, characters 4-7:
 4 |   | MAB -> false;;
         ^^^
 Warning 18 [not-principal]: typing this pattern requires considering
-  "unit M.mab" and "unit ab" as equal.
-  But the knowledge of these types is not principal.
+  "unit M.mab" and "unit ab" as equal. But the knowledge of these types is not
+  principal.
 
 val f1 : unit ab M.t -> bool = <fun>
 |}]
@@ -158,15 +158,15 @@ val f2 : 'x M.t -> bool = <fun>
 Line 4, characters 4-6:
 4 |   | AB -> true
         ^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  unit ab" and "x" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "unit ab" and "x" as equal. But the knowledge of these types is not principal.
 
 Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
 Warning 18 [not-principal]: typing this pattern requires considering
-  "unit M.mab" and "x" as equal.
-  But the knowledge of these types is not principal.
+  "unit M.mab" and "x" as equal. But the knowledge of these types is not
+  principal.
 
 val f2 : 'x M.t -> bool = <fun>
 |}]
@@ -184,8 +184,8 @@ Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
 Warning 18 [not-principal]: typing this pattern requires considering
-  "unit M.mab" and "unit ab" as equal.
-  But the knowledge of these types is not principal.
+  "unit M.mab" and "unit ab" as equal. But the knowledge of these types is not
+  principal.
 
 val f3 : unit ab M.t -> bool = <fun>
 |}]
@@ -212,9 +212,9 @@ val g2 : ('x, int option) eq -> 'x -> int option = <fun>
 Line 3, characters 7-11:
 3 |    let Refl = e in x;;
            ^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  x" and "int option" as equal.
-  But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "x" and "int option" as equal. But the knowledge of these types is not
+  principal.
 
 val g2 : ('x, int option) eq -> 'x -> int option = <fun>
 |}]
@@ -245,8 +245,8 @@ let () =
 Line 3, characters 27-28:
 3 |   | [ { a = 3; _ } ; { b = F; _ }] -> ()
                                ^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  Foo.t" and "int" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "Foo.t" and "int" as equal. But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -280,8 +280,8 @@ let () =
 Line 3, characters 26-31:
 3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -294,8 +294,8 @@ let () =
 Line 3, characters 12-17:
 3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
                 ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 (* Unify with 'a first *)
@@ -315,8 +315,8 @@ let () =
 Line 3, characters 26-31:
 3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -328,8 +328,8 @@ let () =
 Line 3, characters 12-17:
 3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
                 ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  int" and "Foo.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "Foo.t" as equal. But the knowledge of these types is not principal.
 |}]
 
 
@@ -360,8 +360,8 @@ val foo : M.t foo -> M.t = <fun>
 Line 3, characters 18-23:
 3 |   | { x = x; eq = Refl3 } -> x
                       ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 val foo : M.t foo -> M.t = <fun>
 |}]
@@ -376,8 +376,8 @@ val foo : int foo -> int = <fun>
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 val foo : int foo -> int = <fun>
 |}]
@@ -398,8 +398,8 @@ Error: This pattern matches values of type "N.t foo"
 Line 3, characters 26-31:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 Line 3, characters 4-33:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
@@ -420,8 +420,8 @@ val foo : string foo -> string = <fun>
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering "
-  M.t" and "N.t" as equal. But the knowledge of these types is not principal.
+Warning 18 [not-principal]: typing this pattern requires considering
+  "M.t" and "N.t" as equal. But the knowledge of these types is not principal.
 
 val foo : string foo -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/syntactic-arity.ml
+++ b/testsuite/tests/typing-gadts/syntactic-arity.ml
@@ -33,8 +33,8 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This expression has type "'a -> 'b"
        but an expression was expected of type "string"
-  Hint: This function application is partial,
-  maybe some arguments are missing.
+  Hint: This function application is partial, maybe some arguments
+  are missing.
 |}];;
 
 (* And the fully polymorphic definition is rejected. *)
@@ -91,8 +91,7 @@ Line 5, characters 16-48:
 5 | let ok (type a) (Eq : (a, int -> int) eq_or_not) : a =
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Neq
+  Here is an example of a case that is not matched: "Neq"
 
 val ok : ('a -> 'b, int -> int) eq_or_not -> 'a -> 'b = <fun>
 |}];;
@@ -105,8 +104,7 @@ Line 2, characters 6-38:
 2 |   fun (Eq : (a, int -> int) eq_or_not) x -> x + 1;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Neq
+  Here is an example of a case that is not matched: "Neq"
 
 Line 2, characters 2-49:
 2 |   fun (Eq : (a, int -> int) eq_or_not) x -> x + 1;;

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -107,16 +107,14 @@ Lines 11-12, characters 6-19:
 11 | ......function
 12 |         | C2 x -> x
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-C1 _
+  Here is an example of a case that is not matched: "C1 _"
 
 Lines 24-26, characters 6-30:
 24 | ......function
 25 |         | Foo _ , Foo _ -> true
 26 |         | Bar _, Bar _ -> true
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(Foo _, Bar _)
+  Here is an example of a case that is not matched: "(Foo _, Bar _)"
 
 module Nonexhaustive :
   sig
@@ -163,15 +161,13 @@ Line 2, characters 10-18:
 2 |   class c (Some x) = object method x : int = x end
               ^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-None
+  Here is an example of a case that is not matched: "None"
 
 Line 4, characters 10-18:
 4 |   class d (Just x) = object method x : int = x end
               ^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Nothing
+  Here is an example of a case that is not matched: "Nothing"
 
 module PR6862 :
   sig
@@ -200,7 +196,7 @@ Line 4, characters 43-44:
 4 |   let g : int t -> int = function I -> 1 | _ -> 2 (* warn *)
                                                ^
 Warning 56 [unreachable-case]: this match case is unreachable.
-Consider replacing it with a refutation case '<pat> -> .'
+  Consider replacing it with a refutation case "<pat> -> ."
 
 module PR6220 :
   sig
@@ -269,8 +265,7 @@ Lines 8-9, characters 4-33:
 8 | ....match x with
 9 |     | String s -> print_endline s.................
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Any
+  Here is an example of a case that is not matched: "Any"
 
 module PR6801 :
   sig
@@ -933,8 +928,7 @@ Lines 2-8, characters 2-16:
 7 |   | TA, D 0 -> -1
 8 |   | TA, D z -> z
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(TE TC, D [| 0. |])
+  Here is an example of a case that is not matched: "(TE TC, D [| 0. |])"
 
 val f : 'a ty -> 'a t -> int = <fun>
 |}];;
@@ -998,8 +992,8 @@ Lines 4-10, characters 2-29:
  9 |   | {left=TA; right=D 0} -> -1
 10 |   | {left=TA; right=D z} -> z
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{left=TE TC; right=D [| 0. |]}
+  Here is an example of a case that is not matched:
+    "{left=TE TC; right=D [| 0. |]}"
 
 val f : 'a ty -> 'a t -> int = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -61,8 +61,7 @@ Lines 5-7, characters 39-23:
 6 |   | BoolLit, false -> false
 7 |   | IntLit , 6 -> false
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(BoolLit, true)
+  Here is an example of a case that is not matched: "(BoolLit, true)"
 
 val check : 's t * 's -> bool = <fun>
 |}];;
@@ -80,8 +79,7 @@ Lines 3-5, characters 45-38:
 4 |   | {fst = BoolLit; snd = false} -> false
 5 |   | {fst = IntLit ; snd =  6} -> false
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{fst=BoolLit; snd=true}
+  Here is an example of a case that is not matched: "{fst=BoolLit; snd=true}"
 
 val check : ('s t, 's) pair -> bool = <fun>
 |}];;

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -73,8 +73,7 @@ Lines 5-7, characters 4-7:
 6 |     | `A -> ()
 7 |     end
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`B
+  Here is an example of a case that is not matched: "`B"
 
 val f : t -> unit = <fun>
 |}]
@@ -130,8 +129,7 @@ Lines 5-7, characters 4-7:
 6 |     | `A -> ()
 7 |     end
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`B
+  Here is an example of a case that is not matched: "`B"
 
 val f : t -> unit = <fun>
 |}]
@@ -151,8 +149,7 @@ Lines 5-7, characters 4-7:
 6 |     | `A -> ()
 7 |     end
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`B
+  Here is an example of a case that is not matched: "`B"
 
 val f : t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -158,8 +158,7 @@ Line 6, characters 23-57:
 6 | let () = print_endline (match PR6505b.x with `Bar s -> s);; (* fails *)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`Foo _
+  Here is an example of a case that is not matched: "`Foo _"
 
 Exception: Match_failure ("", 6, 23).
 |}]

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -38,7 +38,7 @@ Line 3, characters 2-20:
 3 |   { x with lbl = 4 }
       ^^^^^^^^^^^^^^^^^^
 Warning 23 [useless-record-with]: all the fields are explicitly listed in this record:
-the 'with' clause is useless.
+  the "with" clause is useless.
 
 val after_a : M.r = {M.lbl = 4}
 |}]
@@ -571,8 +571,7 @@ Lines 1-3, characters 8-10:
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{contents=B}
+  Here is an example of a case that is not matched: "{contents=B}"
 
 val t : M.t ref -> unit = <fun>
 |}, Principal{|
@@ -586,8 +585,7 @@ Lines 1-3, characters 8-10:
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{contents=B}
+  Here is an example of a case that is not matched: "{contents=B}"
 
 val t : M.t ref -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -53,7 +53,8 @@ val b : unit = ()
 Line 3, characters 7-18:
 3 |   x := { lbl = 4 }
            ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 val b : unit = ()
 |}]
@@ -119,7 +120,8 @@ val h : M.r -> unit = <fun>
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
@@ -157,7 +159,8 @@ val j : M.r -> unit = <fun>
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
@@ -214,7 +217,8 @@ val n : M.r ref -> unit = <fun>
 Line 4, characters 17-28:
 4 |   | { contents = { lbl = _ } } -> ()
                      ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
@@ -252,7 +256,8 @@ val p : M.r ref -> unit = <fun>
 Line 4, characters 17-28:
 4 |   | { contents = { lbl = _ } } -> ()
                      ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
@@ -294,7 +299,8 @@ val s : M.r ref -> unit = <fun>
 Line 4, characters 9-20:
 4 |     x := { lbl = 4 }
              ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 val s : M.r ref -> unit = <fun>
 |}]
@@ -309,7 +315,8 @@ val t : M.r ref -> unit = <fun>
 Line 3, characters 9-20:
 3 |     x := { lbl = 4 }
              ^^^^^^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 val t : M.r ref -> unit = <fun>
 |}]
@@ -360,7 +367,8 @@ val b : unit = ()
 Line 3, characters 7-8:
 3 |   x := B
            ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val b : unit = ()
 |}]
@@ -405,7 +413,8 @@ val h : M.t -> unit = <fun>
 Line 4, characters 4-5:
 4 |   | B -> ()
         ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val h : M.t -> unit = <fun>
 |}]
@@ -433,7 +442,8 @@ val j : M.t -> unit = <fun>
 Line 4, characters 4-5:
 4 |   | B -> ()
         ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val j : M.t -> unit = <fun>
 |}]
@@ -485,7 +495,8 @@ val n : M.t ref -> unit = <fun>
 Line 4, characters 17-18:
 4 |   | { contents = A } -> ()
                      ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
@@ -523,7 +534,8 @@ val p : M.t ref -> unit = <fun>
 Line 4, characters 17-18:
 4 |   | { contents = A } -> ()
                      ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
@@ -556,7 +568,8 @@ val s : M.t ref -> unit = <fun>
 Line 4, characters 9-10:
 4 |     x := A
              ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val s : M.t ref -> unit = <fun>
 |}]
@@ -578,7 +591,8 @@ val t : M.t ref -> unit = <fun>
 Line 3, characters 9-10:
 3 |     x := B
              ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 Lines 1-3, characters 8-10:
 1 | ........function

--- a/testsuite/tests/typing-misc/empty_variant.ml
+++ b/testsuite/tests/typing-misc/empty_variant.ml
@@ -58,8 +58,7 @@ Lines 16-17, characters 8-18:
 16 | ........match abc with
 17 |         | A _ -> 1
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-C ()
+  Here is an example of a case that is not matched: "C ()"
 
 val f : unit -> unit = <fun>
 |}]
@@ -74,8 +73,7 @@ Line 3, characters 22-42:
 3 | let g (x:nothing t) = match x with A -> ()
                           ^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-C
+  Here is an example of a case that is not matched: "C"
 
 val g : nothing t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -314,8 +314,7 @@ Line 47, characters 4-11:
 47 | let Some v' = undyn int_vec_vec d
          ^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-None
+  Here is an example of a case that is not matched: "None"
 
 val v' : int Vec.t Vec.t = <abstr>
 |}]
@@ -346,8 +345,7 @@ Line 17, characters 2-30:
 17 |   let Vec Int = vec_ty in Refl
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Vec (Vec Int)
+  Here is an example of a case that is not matched: "Vec (Vec Int)"
 
 val eq_int_any : unit -> (int, 'a) eq = <fun>
 |}]

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -10,7 +10,7 @@ val f : x:int -> int = <fun>
 Line 2, characters 5-6:
 2 | f ?x:0;;
          ^
-Warning 43 [nonoptional-label]: the label x is not optional.
+Warning 43 [nonoptional-label]: the label "x" is not optional.
 
 - : int = 1
 |}];;

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -75,16 +75,15 @@ Line 9, characters 0-41:
 9 | function (`A|`B), _ -> 0 | _,(`A|`B) -> 1;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(`AnyOtherTag, `AnyOtherTag)
+  Here is an example of a case that is not matched:
+    "(`AnyOtherTag, `AnyOtherTag)"
 
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line 10, characters 0-29:
 10 | function `B,1 -> 1 | _,1 -> 2;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(_, 0)
+  Here is an example of a case that is not matched: "(_, 0)"
 
 Line 10, characters 21-24:
 10 | function `B,1 -> 1 | _,1 -> 2;;
@@ -96,8 +95,7 @@ Line 11, characters 0-29:
 11 | function 1,`B -> 1 | 1,_ -> 2;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(0, _)
+  Here is an example of a case that is not matched: "(0, _)"
 
 Line 11, characters 21-24:
 11 | function 1,`B -> 1 | 1,_ -> 2;;
@@ -145,8 +143,7 @@ Line 2, characters 0-24:
 2 | function (`A x : t) -> x;;
     ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-`<some private tag>
+  Here is an example of a case that is not matched: "`<some private tag>"
 
 - : t -> string = <fun>
 |}]
@@ -157,8 +154,8 @@ Line 1, characters 8-76:
 1 | let f = function `AnyOtherTag, _ -> 1 | _, (`AnyOtherTag|`AnyOtherTag') -> 2;;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(`AnyOtherTag', `AnyOtherTag'')
+  Here is an example of a case that is not matched:
+    "(`AnyOtherTag', `AnyOtherTag'')"
 
 val f : [> `AnyOtherTag ] * [> `AnyOtherTag | `AnyOtherTag' ] -> int = <fun>
 |}]

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -396,9 +396,9 @@ module Foo : sig type info = { doc : unit; } type t = { info : info; } end
 Line 5, characters 38-41:
 5 | let add_extra_info arg = arg.Foo.info.doc
                                           ^^^
-Warning 40 [name-out-of-scope]: doc was selected from type Foo.info.
-It is not visible in the current scope, and will not
-be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: "doc" was selected from type "Foo.info".
+  It is not visible in the current scope, and will not be selected
+  if the type becomes unknown.
 
 val add_extra_info : Foo.t -> unit = <fun>
 |}]
@@ -419,9 +419,9 @@ module Bar : sig end
 Line 8, characters 38-41:
 8 | let add_extra_info arg = arg.Foo.info.doc
                                           ^^^
-Warning 40 [name-out-of-scope]: doc was selected from type Bar/2.info.
-It is not visible in the current scope, and will not
-be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: "doc" was selected from type "Bar/2.info".
+  It is not visible in the current scope, and will not be selected
+  if the type becomes unknown.
 
 val add_extra_info : Foo.t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -171,7 +171,7 @@ Line 1, characters 8-44:
 1 | let r = { (assert false) with contents = 1 } ;;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 23 [useless-record-with]: all the fields are explicitly listed in this record:
-the 'with' clause is useless.
+  the "with" clause is useless.
 
 Exception: Assert_failure ("", 1, 10).
 |}]

--- a/testsuite/tests/typing-modules/generative.ml
+++ b/testsuite/tests/typing-modules/generative.ml
@@ -51,7 +51,7 @@ Line 3, characters 14-24:
 3 | module M2 = F(struct end);; (* accepted with a warning *)
                   ^^^^^^^^^^
 Warning 73 [generative-application-expects-unit]: A generative functor
-should be applied to '()'; using '(struct end)' is deprecated.
+  should be applied to "()"; using "(struct end)" is deprecated.
 
 module M2 : S
 |}];;

--- a/testsuite/tests/typing-objects-bugs/pr7284_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr7284_bad.compilers.reference
@@ -2,5 +2,4 @@ File "pr7284_bad.ml", line 35, characters 30-62:
 35 |    let f : X.v1 wit -> unit = function V1 s -> print_endline s
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-V2 _
+  Here is an example of a case that is not matched: V2 _

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -290,8 +290,8 @@ end;;
 Line 3, characters 2-36:
 3 |   inherit printable_point y as super
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 13 [instance-variable-override]: the following instance variables are overridden by the class printable_point :
-  x
+Warning 13 [instance-variable-override]: the following instance variables
+  are overridden by the class "printable_point": "x"
 
 class printable_color_point :
   int ->

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -483,24 +483,24 @@ end;;
 Line 3, characters 2-13:
 3 |   inherit c 5
       ^^^^^^^^^^^
-Warning 13 [instance-variable-override]: the following instance variables are overridden by the class c :
-  x
+Warning 13 [instance-variable-override]: the following instance variables
+  are overridden by the class "c": "x"
 
 Line 4, characters 6-7:
 4 |   val y = 3
           ^
-Warning 13 [instance-variable-override]: the instance variable y is overridden.
+Warning 13 [instance-variable-override]: the instance variable "y" is overridden.
 
 Line 6, characters 2-13:
 6 |   inherit d 7
       ^^^^^^^^^^^
-Warning 13 [instance-variable-override]: the following instance variables are overridden by the class d :
-  t z
+Warning 13 [instance-variable-override]: the following instance variables
+  are overridden by the class "d": "t""z"
 
 Line 7, characters 6-7:
 7 |   val u = 3
           ^
-Warning 13 [instance-variable-override]: the instance variable u is overridden.
+Warning 13 [instance-variable-override]: the instance variable "u" is overridden.
 
 class e :
   unit ->
@@ -993,7 +993,7 @@ class c = object
 Line 4, characters 17-23:
 4 |       method n = self#m
                      ^^^^^^
-Warning 17 [undeclared-virtual-method]: the virtual method m is not declared.
+Warning 17 [undeclared-virtual-method]: the virtual method "m" is not declared.
 
 class c : object method m : int method n : int end
 |}];;
@@ -1159,8 +1159,8 @@ val has_foo : < foo : 'a; .. > -> unit = <fun>
 Line 3, characters 10-75:
 3 | class c = object (self) method private foo = 5 initializer has_foo self end;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
- foo.
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "foo".
 
 class c : object method foo : int end
 |}];;

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -495,7 +495,7 @@ Line 6, characters 2-13:
 6 |   inherit d 7
       ^^^^^^^^^^^
 Warning 13 [instance-variable-override]: the following instance variables
-  are overridden by the class "d": "t""z"
+  are overridden by the class "d": "t" "z"
 
 Line 7, characters 6-7:
 7 |   val u = 3

--- a/testsuite/tests/typing-objects/field_kind.ml
+++ b/testsuite/tests/typing-objects/field_kind.ml
@@ -29,8 +29,8 @@ Lines 2-5, characters 2-5:
 3 |     method private x = 3
 4 |     method m : type a. a t -> 's -> a = fun Int other -> (other#x : int)
 5 |   end..
-Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
- x.
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "x".
 
 val o' : < m : 'a. 'a t -> 'b -> 'a; x : int > as 'b = <obj>
 val aargh : unit = ()
@@ -47,8 +47,8 @@ Lines 2-5, characters 2-5:
 3 |     method private x = 3
 4 |     method m : 's -> int = fun other -> (other#x : int)
 5 |   end..
-Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
- x.
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "x".
 
 val o2 : < m : 'a -> int; x : int > as 'a = <obj>
 |}]
@@ -68,8 +68,8 @@ Lines 2-6, characters 2-5:
 4 |     method m : 's -> int = fun other ->
 5 |       let module M = struct let other = other end in (M.other#x : int)
 6 |   end..
-Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
- x.
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "x".
 
 val o3 : < m : 'a -> int; x : int > as 'a = <obj>
 val aargh : unit = ()

--- a/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
@@ -1,13 +1,13 @@
 File "pervasives_leitmotiv.ml", line 1:
-Warning 63 [erroneous-printed-signature]: The printed interface differs from the inferred interface.
-The inferred interface contained items which could not be printed
-properly due to name collisions between identifiers.
-File "pervasives_leitmotiv.ml", lines 10-12, characters 0-3:
+Warning 63 [erroneous-printed-signature]: The printed interface differs from
+  the inferred interface. The inferred interface contained items which could
+  not be printed properly due to name collisions between identifiers.
+  File "pervasives_leitmotiv.ml", lines 10-12, characters 0-3:
   Definition of module Stdlib
 File "_none_", line 1:
   Definition of module Stdlib/2
-Beware that this warning is purely informational and will not catch
-all instances of erroneous printed interface.
+  Beware that this warning is purely informational and will not catch all
+  instances of erroneous printed interface.
 type fpclass = A
 module Stdlib : sig type fpclass = B end
 val f : fpclass -> Stdlib.fpclass -> Stdlib/2.fpclass

--- a/testsuite/tests/typing-ocamlc-i/pr4791.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr4791.compilers.reference
@@ -1,12 +1,12 @@
 File "pr4791.ml", line 1:
-Warning 63 [erroneous-printed-signature]: The printed interface differs from the inferred interface.
-The inferred interface contained items which could not be printed
-properly due to name collisions between identifiers.
-File "pr4791.ml", line 11, characters 2-12:
+Warning 63 [erroneous-printed-signature]: The printed interface differs from
+  the inferred interface. The inferred interface contained items which could
+  not be printed properly due to name collisions between identifiers.
+  File "pr4791.ml", line 11, characters 2-12:
   Definition of type t
 File "pr4791.ml", line 8, characters 0-10:
   Definition of type t/2
-Beware that this warning is purely informational and will not catch
-all instances of erroneous printed interface.
+  Beware that this warning is purely informational and will not catch all
+  instances of erroneous printed interface.
 type t = A
 module B : sig type t = B val f : t/2 -> t end

--- a/testsuite/tests/typing-ocamlc-i/pr6323.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr6323.compilers.reference
@@ -1,13 +1,13 @@
 File "pr6323.ml", line 1:
-Warning 63 [erroneous-printed-signature]: The printed interface differs from the inferred interface.
-The inferred interface contained items which could not be printed
-properly due to name collisions between identifiers.
-File "pr6323.ml", line 15, characters 2-24:
+Warning 63 [erroneous-printed-signature]: The printed interface differs from
+  the inferred interface. The inferred interface contained items which could
+  not be printed properly due to name collisions between identifiers.
+  File "pr6323.ml", line 15, characters 2-24:
   Definition of type t
 File "pr6323.ml", line 8, characters 0-26:
   Definition of type t/2
-Beware that this warning is purely informational and will not catch
-all instances of erroneous printed interface.
+  Beware that this warning is purely informational and will not catch all
+  instances of erroneous printed interface.
 type 'a t = B of 'a t list
 val foo : 'a -> 'b t list -> 'c t list
 module DT :

--- a/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
@@ -1,12 +1,12 @@
 File "pr7402.ml", line 1:
-Warning 63 [erroneous-printed-signature]: The printed interface differs from the inferred interface.
-The inferred interface contained items which could not be printed
-properly due to name collisions between identifiers.
-File "pr7402.ml", lines 14-16, characters 0-5:
+Warning 63 [erroneous-printed-signature]: The printed interface differs from
+  the inferred interface. The inferred interface contained items which could
+  not be printed properly due to name collisions between identifiers.
+  File "pr7402.ml", lines 14-16, characters 0-5:
   Definition of module M
 File "pr7402.ml", lines 8-11, characters 0-3:
   Definition of module M/2
-Beware that this warning is purely informational and will not catch
-all instances of erroneous printed interface.
+  Beware that this warning is purely informational and will not catch all
+  instances of erroneous printed interface.
 module M : sig type t val v : t end
 module F : sig module M : sig val v : M.t end val v : M/2.t end

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -53,8 +53,7 @@ Lines 1-4, characters 0-24:
 3 | | {pv=5::_} -> "int"
 4 | | {pv=true::_} -> "bool"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{pv=false::_}
+  Here is an example of a case that is not matched: "{pv=false::_}"
 
 - : string = "OK"
 |}];;
@@ -71,8 +70,7 @@ Lines 1-4, characters 0-20:
 3 | | {pv=true::_} -> "bool"
 4 | | {pv=5::_} -> "int"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{pv=0::_}
+  Here is an example of a case that is not matched: "{pv=0::_}"
 
 - : string = "OK"
 |}];;
@@ -1110,8 +1108,8 @@ val f : unit -> c = <fun>
 Line 4, characters 11-60:
 4 | let f () = object method private n = 1 method m = {<>}#n end;;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
- n.
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "n".
 
 val f : unit -> < m : int; n : int > = <fun>
 Line 5, characters 27-39:

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -304,7 +304,8 @@ class ['a] ostream1 :
 Line 8, characters 4-16:
 8 |     self#tl#fold ~f ~init:(f self#hd init)
         ^^^^^^^^^^^^
-Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
 
 class ['a] ostream1 :
   hd:'a ->
@@ -1284,21 +1285,24 @@ val f : < m : 'a. 'a -> 'a > -> < m : 'a. 'a -> 'a > = <fun>
 Line 2, characters 9-16:
 2 | fun x -> (f x)#m;; (* Warning 18 *)
              ^^^^^^^
-Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
 
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 val f : < m : 'a. 'a -> 'a > * 'b -> < m : 'a. 'a -> 'a > = <fun>
 Line 4, characters 9-20:
 4 | fun x -> (f (x,x))#m;; (* Warning 18 *)
              ^^^^^^^^^^^
-Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
 
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 val f : < m : 'a. 'a -> 'a > -> < m : 'a. 'a -> 'a > array = <fun>
 Line 6, characters 9-20:
 6 | fun x -> (f x).(0)#m;; (* Warning 18 *)
              ^^^^^^^^^^^
-Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
 
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 |}];;
@@ -1328,13 +1332,15 @@ val just : 'a option -> 'a = <fun>
 Line 4, characters 42-62:
 4 | let f x = let l = [Some x; (None : u)] in (just(List.hd l))#id;;
                                               ^^^^^^^^^^^^^^^^^^^^
-Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
 
 val f : c -> 'a -> 'a = <fun>
 Line 7, characters 36-47:
 7 |   let x = List.hd [Some x; none] in (just x)#id;;
                                         ^^^^^^^^^^^
-Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
 
 val g : c -> 'a -> 'a = <fun>
 val h : < id : 'a; .. > -> 'a = <fun>

--- a/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
@@ -41,8 +41,7 @@ Lines 4-5, characters 2-38:
 4 | ..match [] with
 5 |   | _::_ -> (x :> [`A | `C] Element.t)
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-[]
+  Here is an example of a case that is not matched: "[]"
 
 val f : [ `A ] Element.t -> [ `A | `C ] Element.t = <fun>
 |}];;

--- a/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
@@ -18,7 +18,8 @@ val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 Line 5, characters 49-50:
 5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
                                                      ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 |}]
@@ -34,7 +35,8 @@ val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 Line 5, characters 49-50:
 5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
                                                      ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 |}]

--- a/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
+++ b/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
@@ -2,8 +2,7 @@ File "b_bad.ml", lines 13-14, characters 29-28:
 13 | .............................function
 14 |     A.X s -> print_endline s
 Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Y
+  Here is an example of a case that is not matched: Y
 
 File "b_bad.ml", line 18, characters 11-14:
 18 | let () = f A.y

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -761,14 +761,13 @@ type i = I of int
 Line 2, characters 0-34:
 2 | external id : i -> i = "%identity";;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 61 [unboxable-type-in-prim-decl]: This primitive declaration uses type i, whose representation
-may be either boxed or unboxed. Without an annotation to indicate
-which representation is intended, the boxed representation has been
-selected by default. This default choice may change in future
-versions of the compiler, breaking the primitive implementation.
-You should explicitly annotate the declaration of i
-with [@@boxed] or [@@unboxed], so that its external interface
-remains stable in the future.
+Warning 61 [unboxable-type-in-prim-decl]: This primitive declaration uses type "i",
+  whose representation may be either boxed or unboxed. Without an annotation
+  to indicate which representation is intended, the boxed representation has
+  been selected by default. This default choice may change in future versions
+  of the compiler, breaking the primitive implementation. You should
+  explicitly annotate the declaration of "i" with "[@@boxed]" or "[@@unboxed]", so
+  that its external interface remains stable in the future.
 
 external id : i -> i = "%identity"
 |}];;
@@ -782,26 +781,24 @@ type j = J of int
 Line 3, characters 0-34:
 3 | external id : i -> j = "%identity";;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 61 [unboxable-type-in-prim-decl]: This primitive declaration uses type i, whose representation
-may be either boxed or unboxed. Without an annotation to indicate
-which representation is intended, the boxed representation has been
-selected by default. This default choice may change in future
-versions of the compiler, breaking the primitive implementation.
-You should explicitly annotate the declaration of i
-with [@@boxed] or [@@unboxed], so that its external interface
-remains stable in the future.
+Warning 61 [unboxable-type-in-prim-decl]: This primitive declaration uses type "i",
+  whose representation may be either boxed or unboxed. Without an annotation
+  to indicate which representation is intended, the boxed representation has
+  been selected by default. This default choice may change in future versions
+  of the compiler, breaking the primitive implementation. You should
+  explicitly annotate the declaration of "i" with "[@@boxed]" or "[@@unboxed]", so
+  that its external interface remains stable in the future.
 
 Line 3, characters 0-34:
 3 | external id : i -> j = "%identity";;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 61 [unboxable-type-in-prim-decl]: This primitive declaration uses type j, whose representation
-may be either boxed or unboxed. Without an annotation to indicate
-which representation is intended, the boxed representation has been
-selected by default. This default choice may change in future
-versions of the compiler, breaking the primitive implementation.
-You should explicitly annotate the declaration of j
-with [@@boxed] or [@@unboxed], so that its external interface
-remains stable in the future.
+Warning 61 [unboxable-type-in-prim-decl]: This primitive declaration uses type "j",
+  whose representation may be either boxed or unboxed. Without an annotation
+  to indicate which representation is intended, the boxed representation has
+  been selected by default. This default choice may change in future versions
+  of the compiler, breaking the primitive implementation. You should
+  explicitly annotate the declaration of "j" with "[@@boxed]" or "[@@unboxed]", so
+  that its external interface remains stable in the future.
 
 external id : i -> j = "%identity"
 |}];;

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -27,10 +27,11 @@ let ambiguous_typical_example = function
 Line 2, characters 4-29:
 2 |   | ((Val x, _) | (_, Val x)) when x < 0 -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable x appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "x" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 |}]
@@ -97,10 +98,11 @@ let ambiguous__y = function
 Line 2, characters 4-43:
 2 |   | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable y appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 |}]
@@ -131,10 +133,11 @@ let ambiguous__x_y = function
 Line 2, characters 4-43:
 2 |   | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable y appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
@@ -147,10 +150,11 @@ let ambiguous__x_y_z = function
 Line 2, characters 4-43:
 2 |   | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variables y, z appear in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variables "y", "z" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
@@ -181,10 +185,11 @@ let ambiguous__in_depth = function
 Line 2, characters 4-40:
 2 |   | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable x appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "x" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
@@ -215,10 +220,11 @@ let ambiguous__first_orpat = function
 Lines 2-3, characters 4-58:
 2 | ....`A ((`B (Some x, _) | `B (_, Some x)),
 3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable x appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "x" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__first_orpat :
   [> `A of
@@ -236,10 +242,11 @@ let ambiguous__second_orpat = function
 Lines 2-3, characters 4-42:
 2 | ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
 3 |         (`C (Some y, _) | `C (_, Some y))).................
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable y appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__second_orpat :
   [> `A of
@@ -332,10 +339,11 @@ let ambiguous__amoi a = match a with
 Lines 2-3, characters 2-17:
 2 | ..X (Z x,Y (y,0))
 3 | | X (Z y,Y (x,_))
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variables x, y appear in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variables "x", "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__amoi : amoi -> int = <fun>
 |}]
@@ -355,10 +363,11 @@ let ambiguous__module_variable x b =  match x with
 Lines 2-3, characters 4-24:
 2 | ....(module M:S),_,(1,_)
 3 |   | _,(module M:S),(_,1)...................
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable M appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "M" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
@@ -373,7 +382,7 @@ let not_ambiguous__module_variable x b =  match x with
 Line 2, characters 12-13:
 2 |   | (module M:S),_,(1,_)
                 ^
-Warning 60 [unused-module]: unused module M.
+Warning 60 [unused-module]: unused module "M".
 
 val not_ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
@@ -395,23 +404,24 @@ let ambiguous_xy_but_not_ambiguous_z g = function
 Line 2, characters 4-5:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^
-Warning 41 [ambiguous-name]: A belongs to several types: t2 t
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "A" belongs to several types: "t2""t".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Lines 1-3, characters 41-10:
 1 | .........................................function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type t2.
+  It will remain exhaustive when constructors are added to type "t2".
 
 Line 2, characters 4-56:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variables x, y appear in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variables "x", "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
@@ -419,35 +429,36 @@ val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
 Line 2, characters 4-5:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^
-Warning 41 [ambiguous-name]: A belongs to several types: t2 t
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "A" belongs to several types: "t2""t".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Line 2, characters 24-25:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
                             ^
-Warning 41 [ambiguous-name]: A belongs to several types: t2 t
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "A" belongs to several types: "t2""t".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Line 2, characters 42-43:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
                                               ^
-Warning 41 [ambiguous-name]: B belongs to several types: t2 t
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "B" belongs to several types: "t2""t".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Lines 1-3, characters 41-10:
 1 | .........................................function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type t2.
+  It will remain exhaustive when constructors are added to type "t2".
 
 Line 2, characters 4-56:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variables x, y appear in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variables "x", "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
@@ -506,10 +517,11 @@ let guarded_ambiguity = function
 Line 3, characters 4-29:
 3 |   | ((Val y, _) | (_, Val y)) when y < 0 -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable y appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "y" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val guarded_ambiguity : expr * expr -> unit = <fun>
 |}]
@@ -538,10 +550,11 @@ let cmp (pred : a -> bool) (x : a alg) (y : a alg) =
 Line 4, characters 4-29:
 4 |   | ((Val x, _) | (_, Val x)) when pred x -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable x appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(see manual section 13.5.4)
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under
+  guard; variable "x" appears in different places in different or-pattern
+  alternatives.
+  Only the first match will be used to evaluate the guard expression.
+  (see manual section 13.5.4)
 
 val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -404,7 +404,7 @@ let ambiguous_xy_but_not_ambiguous_z g = function
 Line 2, characters 4-5:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^
-Warning 41 [ambiguous-name]: "A" belongs to several types: "t2""t".
+Warning 41 [ambiguous-name]: "A" belongs to several types: "t2" "t".
   The first one was selected. Please disambiguate if this is wrong.
 
 Lines 1-3, characters 41-10:
@@ -429,19 +429,19 @@ val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
 Line 2, characters 4-5:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^
-Warning 41 [ambiguous-name]: "A" belongs to several types: "t2""t".
+Warning 41 [ambiguous-name]: "A" belongs to several types: "t2" "t".
   The first one was selected. Please disambiguate if this is wrong.
 
 Line 2, characters 24-25:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
                             ^
-Warning 41 [ambiguous-name]: "A" belongs to several types: "t2""t".
+Warning 41 [ambiguous-name]: "A" belongs to several types: "t2" "t".
   The first one was selected. Please disambiguate if this is wrong.
 
 Line 2, characters 42-43:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
                                               ^
-Warning 41 [ambiguous-name]: "B" belongs to several types: "t2""t".
+Warning 41 [ambiguous-name]: "B" belongs to several types: "t2" "t".
   The first one was selected. Please disambiguate if this is wrong.
 
 Lines 1-3, characters 41-10:

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -20,7 +20,7 @@ Line 1, characters 8-22:
 1 | let _ = Array.get [||];;
             ^^^^^^^^^^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 
 - : int -> 'a = <fun>
 |}]
@@ -35,7 +35,7 @@ Line 1, characters 16-32:
 1 | let () = ignore (Array.get [||]);;
                     ^^^^^^^^^^^^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 |}]
 
 
@@ -50,7 +50,7 @@ Line 1, characters 21-35:
 1 | let _ = if true then Array.get [||] else (fun _ -> 12);;
                          ^^^^^^^^^^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 
 - : int -> int = <fun>
 |}]
@@ -74,7 +74,7 @@ Line 1, characters 18-23:
 1 | let f x = let _ = x.r 1 in ();;
                       ^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 
 val f : t -> unit = <fun>
 |}]
@@ -88,7 +88,7 @@ Line 2, characters 6-10:
 2 | match f 42 with
           ^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 
 - : unit = ()
 |}]
@@ -103,7 +103,7 @@ Line 2, characters 6-10:
 2 | match f 42 with
           ^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 
 - : unit = ()
 |}]
@@ -148,6 +148,6 @@ Line 2, characters 10-15:
               ^^^^^
 Error: This expression has type "int -> int"
        but an expression was expected of type "int"
-  Hint: This function application is partial,
-  maybe some arguments are missing.
+  Hint: This function application is partial, maybe some arguments
+  are missing.
 |}]

--- a/testsuite/tests/typing-warnings/disable_warnings_classes.ml
+++ b/testsuite/tests/typing-warnings/disable_warnings_classes.ml
@@ -17,7 +17,7 @@ end;;
 Line 8, characters 8-9:
 8 |     let y = 5 in ()
             ^
-Warning 26 [unused-var]: unused variable y.
+Warning 26 [unused-var]: unused variable "y".
 
 class c : object val a : unit val x : unit end
 |}];;
@@ -36,7 +36,7 @@ end;;
 Line 8, characters 8-9:
 8 |     let y = 5 in ()
             ^
-Warning 26 [unused-var]: unused variable y.
+Warning 26 [unused-var]: unused variable "y".
 
 class c : object method a : unit method x : unit end
 |}];;
@@ -55,7 +55,7 @@ end;;
 Line 8, characters 8-9:
 8 |     let y = 5 in ()
             ^
-Warning 26 [unused-var]: unused variable y.
+Warning 26 [unused-var]: unused variable "y".
 
 class c : object  end
 |}];;
@@ -85,7 +85,7 @@ end;;
 Line 4, characters 8-9:
 4 |     let b = 5 in ()
             ^
-Warning 26 [unused-var]: unused variable b.
+Warning 26 [unused-var]: unused variable "b".
 
 class c : object val a : unit val x : unit end
 |}];;

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -345,8 +345,8 @@ Lines 1-4, characters 8-28:
 4 |   | Some x when x <= 0 -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched:
-    "Some _
-(However, some guarded clause may match this value.)"
+    "Some _"
+    (However, some guarded clause may match this value.)
 
 val f : int option -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -12,8 +12,7 @@ Lines 1-3, characters 8-23:
 2 |     None, None -> 1
 3 |   | Some _, Some _ -> 2..
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(None, Some _)
+  Here is an example of a case that is not matched: "(None, Some _)"
 
 val f : 'a option * 'b option -> int = <fun>
 |}]
@@ -36,13 +35,13 @@ Line 1, characters 20-48:
 1 | let f (x : int t) = match x with A -> 1 | _ -> 2;; (* warn *)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type t.
+  It will remain exhaustive when constructors are added to type "t".
 
 Line 1, characters 42-43:
 1 | let f (x : int t) = match x with A -> 1 | _ -> 2;; (* warn *)
                                               ^
 Warning 56 [unreachable-case]: this match case is unreachable.
-Consider replacing it with a refutation case '<pat> -> .'
+  Consider replacing it with a refutation case "<pat> -> ."
 
 val f : int t -> int = <fun>
 |}]
@@ -53,7 +52,7 @@ Line 1, characters 53-54:
 1 | let f (x : unit t option) = match x with None -> 1 | _ -> 2 ;; (* warn? *)
                                                          ^
 Warning 56 [unreachable-case]: this match case is unreachable.
-Consider replacing it with a refutation case '<pat> -> .'
+  Consider replacing it with a refutation case "<pat> -> ."
 
 val f : unit t option -> int = <fun>
 |}]
@@ -64,7 +63,7 @@ Line 1, characters 53-59:
 1 | let f (x : unit t option) = match x with None -> 1 | Some _ -> 2 ;; (* warn *)
                                                          ^^^^^^
 Warning 56 [unreachable-case]: this match case is unreachable.
-Consider replacing it with a refutation case '<pat> -> .'
+  Consider replacing it with a refutation case "<pat> -> ."
 
 val f : unit t option -> int = <fun>
 |}]
@@ -80,8 +79,7 @@ Line 1, characters 27-49:
 1 | let f (x : int t option) = match x with None -> 1;; (* warn *)
                                ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some A
+  Here is an example of a case that is not matched: "Some A"
 
 val f : int t option -> int = <fun>
 |}]
@@ -101,8 +99,8 @@ Line 1, characters 49-68:
 1 | let f : (int t box pair * bool) option -> unit = function None -> ();;
                                                      ^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some ({left=Box A; right=Box A}, _)
+  Here is an example of a case that is not matched:
+    "Some ({left=Box A; right=Box A}, _)"
 
 val f : (int t box pair * bool) option -> unit = <fun>
 |}]
@@ -118,8 +116,7 @@ Line 1, characters 8-39:
 1 | let f = function {left=Box 0; _ } -> ();;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{left=Box 1; _ }
+  Here is an example of a case that is not matched: "{left=Box 1; _ }"
 
 val f : int box pair -> unit = <fun>
 |}]
@@ -130,8 +127,7 @@ Line 1, characters 8-47:
 1 | let f = function {left=Box 0;right=Box 1} -> ();;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-{left=Box 0; right=Box 0}
+  Here is an example of a case that is not matched: "{left=Box 0; right=Box 0}"
 
 val f : int box pair -> unit = <fun>
 |}]
@@ -188,8 +184,7 @@ Line 1, characters 33-51:
 1 | let f : (A.a, A.b) cmp -> unit = function Any -> ()
                                      ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Eq
+  Here is an example of a case that is not matched: "Eq"
 
 val f : (A.a, A.b) cmp -> unit = <fun>
 |}]
@@ -242,8 +237,7 @@ Line 2, characters 2-24:
 2 |   function None -> false
       ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some (PlusS _)
+  Here is an example of a case that is not matched: "Some (PlusS _)"
 
 val harder : (zero succ, zero succ, zero succ) plus option -> bool = <fun>
 |}]
@@ -320,7 +314,7 @@ Line 1, characters 12-42:
 1 | let f x y = match 1 with 1 when x = y -> 1;;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-All clauses in this pattern-matching are guarded.
+  All clauses in this pattern-matching are guarded.
 
 val f : 'a -> 'a -> int = <fun>
 |}]
@@ -332,8 +326,7 @@ Line 1, characters 8-37:
 1 | let f = function {contents=_}, 0 -> 0;;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-({ _ }, 1)
+  Here is an example of a case that is not matched: "({ _ }, 1)"
 
 val f : 'a ref * int -> int = <fun>
 |}]
@@ -351,9 +344,9 @@ Lines 1-4, characters 8-28:
 3 |   | Some x when x > 0 -> ()
 4 |   | Some x when x <= 0 -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some _
-(However, some guarded clause may match this value.)
+  Here is an example of a case that is not matched:
+    "Some _
+(However, some guarded clause may match this value.)"
 
 val f : int option -> unit = <fun>
 |}]
@@ -388,8 +381,7 @@ Lines 20-22, characters 45-49:
 21 | | A, A, A, A -> ()
 22 | | (A|B), (A|B), (A|B), A (*missing B here*) -> ()
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-((A|B), (A|B), (A|B), B)
+  Here is an example of a case that is not matched: "((A|B), (A|B), (A|B), B)"
 
 module Single_row_optim :
   sig type t = A | B val non_exhaustive : t * t * t * t -> unit end

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -10,12 +10,12 @@ end;;
 Line 2, characters 20-26:
 2 |   module M = struct type t end  (* unused type t *)
                         ^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 Line 3, characters 2-8:
 3 |   open M  (* unused open *)
       ^^^^^^
-Warning 33 [unused-open]: unused open M.
+Warning 33 [unused-open]: unused open "M".
 
 module T1 : sig end
 |}]
@@ -40,17 +40,18 @@ end;;
 Line 4, characters 2-8:
 4 |   open M (* used by line below; shadow constructor A *)
       ^^^^^^
-Warning 45 [open-shadow-label-constructor]: this open statement shadows the constructor A (which is later used)
+Warning 45 [open-shadow-label-constructor]: this open statement shadows the
+  constructor "A" (which is later used)
 
 Line 2, characters 2-13:
 2 |   type t0 = A  (* unused type and constructor *)
       ^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t0.
+Warning 34 [unused-type-declaration]: unused type "t0".
 
 Line 2, characters 12-13:
 2 |   type t0 = A  (* unused type and constructor *)
                 ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 module T3 : sig end
 |}]
@@ -65,17 +66,17 @@ end;;
 Line 3, characters 20-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                         ^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 Line 3, characters 29-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                                  ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 Line 4, characters 2-8:
 4 |   open M (* unused open; no shadowing (A below refers to the one in t0) *)
       ^^^^^^
-Warning 33 [unused-open]: unused open M.
+Warning 33 [unused-open]: unused open "M".
 
 module T4 : sig end
 |}]
@@ -90,17 +91,18 @@ end;;
 Line 4, characters 2-8:
 4 |   open M (* shadow constructor A *)
       ^^^^^^
-Warning 45 [open-shadow-label-constructor]: this open statement shadows the constructor A (which is later used)
+Warning 45 [open-shadow-label-constructor]: this open statement shadows the
+  constructor "A" (which is later used)
 
 Line 2, characters 2-13:
 2 |   type t0 = A (* unused type and constructor *)
       ^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t0.
+Warning 34 [unused-type-declaration]: unused type "t0".
 
 Line 2, characters 12-13:
 2 |   type t0 = A (* unused type and constructor *)
                 ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 module T5 : sig end
 |}]
@@ -114,12 +116,12 @@ end;;
 Line 2, characters 20-26:
 2 |   module M = struct type t end  (* unused type t *)
                         ^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 Line 3, characters 2-9:
 3 |   open! M  (* unused open *)
       ^^^^^^^
-Warning 66 [unused-open-bang]: unused open! M.
+Warning 66 [unused-open-bang]: unused open! "M".
 
 module T1_bis : sig end
 |}]
@@ -143,12 +145,12 @@ end;;
 Line 2, characters 2-13:
 2 |   type t0 = A  (* unused type and constructor *)
       ^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t0.
+Warning 34 [unused-type-declaration]: unused type "t0".
 
 Line 2, characters 12-13:
 2 |   type t0 = A  (* unused type and constructor *)
                 ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 module T3_bis : sig end
 |}]
@@ -163,17 +165,17 @@ end;;
 Line 3, characters 20-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                         ^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 Line 3, characters 29-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                                  ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 Line 4, characters 2-9:
 4 |   open! M (* unused open; no shadowing (A below refers to the one in t0) *)
       ^^^^^^^
-Warning 66 [unused-open-bang]: unused open! M.
+Warning 66 [unused-open-bang]: unused open! "M".
 
 module T4_bis : sig end
 |}]
@@ -188,12 +190,12 @@ end;;
 Line 2, characters 2-13:
 2 |   type t0 = A (* unused type and constructor *)
       ^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t0.
+Warning 34 [unused-type-declaration]: unused type "t0".
 
 Line 2, characters 12-13:
 2 |   type t0 = A (* unused type and constructor *)
                 ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 module T5_bis : sig end
 |}]

--- a/testsuite/tests/typing-warnings/pr5892.ml
+++ b/testsuite/tests/typing-warnings/pr5892.ml
@@ -18,8 +18,7 @@ Line 1, characters 31-52:
 1 | let f : label choice -> bool = function Left -> true;; (* warn *)
                                    ^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Right
+  Here is an example of a case that is not matched: "Right"
 
 val f : CamlinternalOO.label choice -> bool = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -27,8 +27,8 @@ A
 Line 1, characters 0-1:
 1 | A
     ^
-Warning 41 [ambiguous-name]: A belongs to several types: a exn
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "A" belongs to several types: "a""exn".
+  The first one was selected. Please disambiguate if this is wrong.
 
 - : a = A
 |}]
@@ -39,8 +39,8 @@ raise A
 Line 1, characters 6-7:
 1 | raise A
           ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Exception: A.
 |}]
@@ -57,8 +57,8 @@ function Not_found -> 1 | A -> 2 | _ -> 3
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 - : exn -> int = <fun>
 |}, Principal{|
@@ -70,8 +70,8 @@ Warning 18 [not-principal]: this type-based constructor disambiguation is not pr
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 - : exn -> int = <fun>
 |}]
@@ -82,14 +82,14 @@ try raise A with A -> 2
 Line 1, characters 10-11:
 1 | try raise A with A -> 2
               ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 1, characters 17-18:
 1 | try raise A with A -> 2
                      ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 - : int = 2
 |}]

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -27,7 +27,7 @@ A
 Line 1, characters 0-1:
 1 | A
     ^
-Warning 41 [ambiguous-name]: "A" belongs to several types: "a""exn".
+Warning 41 [ambiguous-name]: "A" belongs to several types: "a" "exn".
   The first one was selected. Please disambiguate if this is wrong.
 
 - : a = A

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -65,7 +65,8 @@ Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3

--- a/testsuite/tests/typing-warnings/pr7085.ml
+++ b/testsuite/tests/typing-warnings/pr7085.ml
@@ -32,8 +32,7 @@ Line 17, characters 5-35:
 17 |      match M.is_t () with None -> 0
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some (Is Eq)
+  Here is an example of a case that is not matched: "Some (Is Eq)"
 
 module Make : (M : T) -> sig val f : unit -> int end
 |}]

--- a/testsuite/tests/typing-warnings/pr7115.ml
+++ b/testsuite/tests/typing-warnings/pr7115.ml
@@ -16,7 +16,7 @@ end;;
 Line 2, characters 10-11:
 2 |   let _f ~x (* x unused argument *) = function
               ^
-Warning 27 [unused-var-strict]: unused variable x.
+Warning 27 [unused-var-strict]: unused variable "x".
 
 module X1 : sig end
 |}]
@@ -30,7 +30,7 @@ end;;
 Line 2, characters 6-7:
 2 |   let x = 42 (* unused value *)
           ^
-Warning 32 [unused-value-declaration]: unused value x.
+Warning 32 [unused-value-declaration]: unused value "x".
 
 module X2 : sig end
 |}]
@@ -46,12 +46,12 @@ end;;
 Line 2, characters 24-25:
 2 |   module O = struct let x = 42 (* unused *) end
                             ^
-Warning 32 [unused-value-declaration]: unused value x.
+Warning 32 [unused-value-declaration]: unused value "x".
 
 Line 3, characters 2-8:
 3 |   open O (* unused open *)
       ^^^^^^
-Warning 33 [unused-open]: unused open O.
+Warning 33 [unused-open]: unused open "O".
 
 module X3 : sig end
 |}]

--- a/testsuite/tests/typing-warnings/pr7261.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7261.compilers.reference
@@ -5,7 +5,8 @@ Error: Syntax error
 Line 2, characters 35-49:
 2 |     Foo: 'b * 'b -> foo constraint 'b = [> `Bla ];;
                                        ^^^^^^^^^^^^^^
-Warning 62 [constraint-on-gadt]: Type constraints do not apply to GADT cases of variant types.
+Warning 62 [constraint-on-gadt]: Type constraints do not apply to GADT cases
+  of variant types.
 
 type foo = Foo : 'b * 'b -> foo
 

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -23,7 +23,7 @@ end = C;;
 Line 2, characters 2-8:
 2 |   open A
       ^^^^^^
-Warning 33 [unused-open]: unused open A.
+Warning 33 [unused-open]: unused open "A".
 
 module rec C : sig end
 |}]
@@ -41,13 +41,12 @@ Line 5, characters 10-14:
 5 |       let None = None
               ^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some _
+  Here is an example of a case that is not matched: "Some _"
 
 Line 4, characters 6-12:
 4 |       open A
           ^^^^^^
-Warning 33 [unused-open]: unused open A.
+Warning 33 [unused-open]: unused open "A".
 
 module rec D : sig module M : sig module X : sig end end end
 |}]

--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -22,7 +22,7 @@ end
 Line 5, characters 8-9:
 5 |     let x = 13
             ^
-Warning 32 [unused-value-declaration]: unused value x.
+Warning 32 [unused-value-declaration]: unused value "x".
 
 module M : sig module F2 : U -> U end
 |}]
@@ -41,7 +41,7 @@ end
 Line 5, characters 8-9:
 5 |     let x = 13
             ^
-Warning 32 [unused-value-declaration]: unused value x.
+Warning 32 [unused-value-declaration]: unused value "x".
 
 module N : sig module F2 : U -> U end
 |}]
@@ -52,7 +52,7 @@ module F (X : sig type t type s end) = struct type t = X.t end
 Line 1, characters 25-31:
 1 | module F (X : sig type t type s end) = struct type t = X.t end
                              ^^^^^^
-Warning 34 [unused-type-declaration]: unused type s.
+Warning 34 [unused-type-declaration]: unused type "s".
 
 module F : (X : sig type t type s end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -25,31 +25,31 @@ end;;
 Line 3, characters 19-20:
 3 |   let f1 (r:t) = r.x (* ok *)
                        ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
                                  ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 21-22:
 7 |     match r with {x; y} -> y + y (* ok *)
                          ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
-Warning 27 [unused-var-strict]: unused variable x.
+Warning 27 [unused-var-strict]: unused variable "x".
 
 module OK :
   sig val f1 : M1.t -> int val f2 : M1.t -> int val f3 : M1.t -> int end
@@ -57,8 +57,8 @@ module OK :
 Line 3, characters 19-20:
 3 |   let f1 (r:t) = r.x (* ok *)
                        ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
@@ -68,25 +68,25 @@ Warning 18 [not-principal]: this type-based field disambiguation is not principa
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
                                  ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 21-22:
 7 |     match r with {x; y} -> y + y (* ok *)
                          ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
-Warning 27 [unused-var-strict]: unused variable x.
+Warning 27 [unused-var-strict]: unused variable "x".
 
 module OK :
   sig val f1 : M1.t -> int val f2 : M1.t -> int val f3 : M1.t -> int end
@@ -100,8 +100,9 @@ end;; (* fails *)
 Line 3, characters 25-31:
 3 |   let f r = match r with {x; y} -> y + y
                              ^^^^^^
-Warning 41 [ambiguous-name]: these field labels belong to several types: M1.u M1.t
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: these field labels belong to several types:
+    "M1.u""M1.t".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Line 3, characters 35-36:
 3 |   let f r = match r with {x; y} -> y + y
@@ -120,33 +121,33 @@ end;; (* fails for -principal *)
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 6, characters 11-12:
 6 |        {x; y} -> y + y
                ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
-Warning 27 [unused-var-strict]: unused variable x.
+Warning 27 [unused-var-strict]: unused variable "x".
 
 module F2 : sig val f : M1.t -> int end
 |}, Principal{|
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 6, characters 11-12:
 6 |        {x; y} -> y + y
                ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 6, characters 7-13:
 6 |        {x; y} -> y + y
@@ -156,7 +157,7 @@ Warning 18 [not-principal]: this type-based record disambiguation is not princip
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
-Warning 27 [unused-var-strict]: unused variable x.
+Warning 27 [unused-var-strict]: unused variable "x".
 
 module F2 : sig val f : M1.t -> int end
 |}]
@@ -174,8 +175,8 @@ let f (r:M.t) = r.M.x;; (* ok *)
 Line 1, characters 18-21:
 1 | let f (r:M.t) = r.M.x;; (* ok *)
                       ^^^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 val f : M.t -> int = <fun>
 |}]
@@ -184,15 +185,15 @@ let f (r:M.t) = r.x;; (* warning *)
 Line 1, characters 18-19:
 1 | let f (r:M.t) = r.x;; (* warning *)
                       ^
-Warning 40 [name-out-of-scope]: x was selected from type M.t.
-It is not visible in the current scope, and will not
-be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: "x" was selected from type "M.t".
+  It is not visible in the current scope, and will not be selected
+  if the type becomes unknown.
 
 Line 1, characters 18-19:
 1 | let f (r:M.t) = r.x;; (* warning *)
                       ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 val f : M.t -> int = <fun>
 |}]
@@ -201,15 +202,15 @@ let f ({x}:M.t) = x;; (* warning *)
 Line 1, characters 8-9:
 1 | let f ({x}:M.t) = x;; (* warning *)
             ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 1, characters 7-10:
 1 | let f ({x}:M.t) = x;; (* warning *)
            ^^^
-Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
-not visible in the current scope: x.
-They will not be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: this record of type "M.t" contains fields that
+  are not visible in the current scope: "x".
+  They will not be selected if the type becomes unknown.
 
 val f : M.t -> int = <fun>
 |}]
@@ -235,13 +236,13 @@ end;;
 Line 4, characters 20-21:
 4 |   let f (r:M.t) = r.x
                         ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 2-8:
 3 |   open N
       ^^^^^^
-Warning 33 [unused-open]: unused open N.
+Warning 33 [unused-open]: unused open "N".
 
 module OK : sig val f : M.t -> int end
 |}]
@@ -287,15 +288,15 @@ end;; (* ok *)
 Line 3, characters 9-10:
 3 |   let f {x;z} = x,z
              ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 8-13:
 3 |   let f {x;z} = x,z
             ^^^^^
-Warning 9 [missing-record-field-pattern]: the following labels are not bound in this record pattern:
-y
-Either bind these labels explicitly or add '; _' to the pattern.
+Warning 9 [missing-record-field-pattern]: the following labels are not bound
+  in this record pattern: "y".
+  Either bind these labels explicitly or add "; _" to the pattern.
 
 module OK : sig val f : M.u -> bool * char end
 |}]
@@ -307,8 +308,8 @@ end;; (* fail for missing label *)
 Line 3, characters 11-12:
 3 |   let r = {x=true;z='z'}
                ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 10-24:
 3 |   let r = {x=true;z='z'}
@@ -325,14 +326,14 @@ end;; (* ok *)
 Line 4, characters 11-12:
 4 |   let r = {x=3; y=true}
                ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 4, characters 16-17:
 4 |   let r = {x=3; y=true}
                     ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 module OK :
   sig
@@ -393,14 +394,14 @@ let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
 Line 1, characters 8-28:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
             ^^^^^^^^^^^^^^^^^^^^
-Warning 41 [ambiguous-name]: x belongs to several types: MN.bar MN.foo
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "x" belongs to several types: "MN.bar""MN.foo".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Line 1, characters 8-28:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
             ^^^^^^^^^^^^^^^^^^^^
-Warning 41 [ambiguous-name]: y belongs to several types: NM.foo NM.bar
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: "y" belongs to several types: "NM.foo""NM.bar".
+  The first one was selected. Please disambiguate if this is wrong.
 
 Line 1, characters 19-23:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
@@ -430,8 +431,8 @@ end;;
 Line 3, characters 37-38:
 3 |   let f r = ignore (r: foo); {r with x = 2; z = 3}
                                          ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 44-45:
 3 |   let f r = ignore (r: foo); {r with x = 2; z = 3}
@@ -459,8 +460,8 @@ end;;
 Line 3, characters 38-39:
 3 |   let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                           ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 45-46:
 3 |   let f r = ignore (r: foo); { r with x = 3; a = 4 }
@@ -477,14 +478,14 @@ end;;
 Line 3, characters 11-12:
 3 |   let r = {x=1; y=2}
                ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 16-17:
 3 |   let r = {x=1; y=2}
                     ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 4, characters 18-19:
 4 |   let r: other = {x=1; y=2}
@@ -541,8 +542,8 @@ class f (_ : 'a) (_ : 'a) = object end;;
 Line 1, characters 12-13:
 1 | class g = f A;; (* ok *)
                 ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 class g : f
 class f : 'a -> 'a -> object  end
@@ -552,22 +553,22 @@ class g = f (A : t) A;; (* warn with -principal *)
 Line 1, characters 13-14:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                  ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                         ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 class g : f
 |}, Principal{|
 Line 1, characters 13-14:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                  ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
@@ -577,8 +578,8 @@ Warning 18 [not-principal]: this type-based constructor disambiguation is not pr
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                         ^
-Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 class g : f
 |}]
@@ -598,13 +599,13 @@ end;;
 Line 7, characters 15-16:
 7 |   let y : t = {x = 0}
                    ^
-Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 6, characters 2-8:
 6 |   open M  (* this open is unused, it isn't reported as shadowing 'x' *)
       ^^^^^^
-Warning 33 [unused-open]: unused open M.
+Warning 33 [unused-open]: unused open "M".
 
 module Shadow1 :
   sig
@@ -625,13 +626,15 @@ end;;
 Line 6, characters 2-8:
 6 |   open M  (* this open shadows label 'x' *)
       ^^^^^^
-Warning 45 [open-shadow-label-constructor]: this open statement shadows the label x (which is later used)
+Warning 45 [open-shadow-label-constructor]: this open statement shadows the
+  label "x" (which is later used)
 
 Line 7, characters 10-18:
 7 |   let y = {x = ""}
               ^^^^^^^^
-Warning 41 [ambiguous-name]: these field labels belong to several types: M.s t
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: these field labels belong to several types:
+    "M.s""t".
+  The first one was selected. Please disambiguate if this is wrong.
 
 module Shadow2 :
   sig
@@ -653,8 +656,8 @@ end;;
 Line 5, characters 37-40:
 5 |   let f (u : u) = match u with `Key {loc} -> loc
                                          ^^^
-Warning 42 [disambiguated-name]: this use of loc relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "loc" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 module P6235 :
   sig
@@ -679,8 +682,8 @@ end;;
 Line 7, characters 11-14:
 7 |     |`Key {loc} -> loc
                ^^^
-Warning 42 [disambiguated-name]: this use of loc relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "loc" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 module P6235' :
   sig
@@ -693,8 +696,8 @@ module P6235' :
 Line 7, characters 11-14:
 7 |     |`Key {loc} -> loc
                ^^^
-Warning 42 [disambiguated-name]: this use of loc relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "loc" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 7, characters 10-15:
 7 |     |`Key {loc} -> loc
@@ -739,56 +742,56 @@ module M : sig type t = { x : int; y : char; } end
 Line 2, characters 27-28:
 2 | let f (x : M.t) = { x with y = 'a' }
                                ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 2, characters 18-36:
 2 | let f (x : M.t) = { x with y = 'a' }
                       ^^^^^^^^^^^^^^^^^^
-Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
-not visible in the current scope: y.
-They will not be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: this record of type "M.t" contains fields that
+  are not visible in the current scope: "y".
+  They will not be selected if the type becomes unknown.
 
 val f : M.t -> M.t = <fun>
 Line 3, characters 27-28:
 3 | let g (x : M.t) = { x with y = 'a' } :: []
                                ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 3, characters 18-36:
 3 | let g (x : M.t) = { x with y = 'a' } :: []
                       ^^^^^^^^^^^^^^^^^^
-Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
-not visible in the current scope: y.
-They will not be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: this record of type "M.t" contains fields that
+  are not visible in the current scope: "y".
+  They will not be selected if the type becomes unknown.
 
 val g : M.t -> M.t list = <fun>
 Line 4, characters 27-28:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                                ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 4, characters 18-36:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                       ^^^^^^^^^^^^^^^^^^
-Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
-not visible in the current scope: y.
-They will not be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: this record of type "M.t" contains fields that
+  are not visible in the current scope: "y".
+  They will not be selected if the type becomes unknown.
 
 Line 4, characters 49-50:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                                                      ^
-Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
-it will not compile with OCaml 4.00 or earlier.
+Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
+  disambiguation, it will not compile with OCaml 4.00 or earlier.
 
 Line 4, characters 40-58:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                                             ^^^^^^^^^^^^^^^^^^
-Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
-not visible in the current scope: y.
-They will not be selected if the type becomes unknown.
+Warning 40 [name-out-of-scope]: this record of type "M.t" contains fields that
+  are not visible in the current scope: "y".
+  They will not be selected if the type becomes unknown.
 
 val h : M.t -> M.t list = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -63,7 +63,8 @@ Warning 42 [disambiguated-name]: this use of "x" relies on type-directed
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
                                  ^
-Warning 18 [not-principal]: this type-based field disambiguation is not principal.
+Warning 18 [not-principal]: this type-based field disambiguation is not
+  principal.
 
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
@@ -152,7 +153,8 @@ Warning 42 [disambiguated-name]: this use of "y" relies on type-directed
 Line 6, characters 7-13:
 6 |        {x; y} -> y + y
            ^^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
@@ -573,7 +575,8 @@ Warning 42 [disambiguated-name]: this use of "A" relies on type-directed
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                         ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
 
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
@@ -702,7 +705,8 @@ Warning 42 [disambiguated-name]: this use of "loc" relies on type-directed
 Line 7, characters 10-15:
 7 |     |`Key {loc} -> loc
               ^^^^^
-Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+Warning 18 [not-principal]: this type-based record disambiguation is not
+  principal.
 
 module P6235' :
   sig

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -101,7 +101,7 @@ Line 3, characters 25-31:
 3 |   let f r = match r with {x; y} -> y + y
                              ^^^^^^
 Warning 41 [ambiguous-name]: these field labels belong to several types:
-    "M1.u""M1.t".
+    "M1.u" "M1.t".
   The first one was selected. Please disambiguate if this is wrong.
 
 Line 3, characters 35-36:
@@ -394,13 +394,13 @@ let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
 Line 1, characters 8-28:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
             ^^^^^^^^^^^^^^^^^^^^
-Warning 41 [ambiguous-name]: "x" belongs to several types: "MN.bar""MN.foo".
+Warning 41 [ambiguous-name]: "x" belongs to several types: "MN.bar" "MN.foo".
   The first one was selected. Please disambiguate if this is wrong.
 
 Line 1, characters 8-28:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
             ^^^^^^^^^^^^^^^^^^^^
-Warning 41 [ambiguous-name]: "y" belongs to several types: "NM.foo""NM.bar".
+Warning 41 [ambiguous-name]: "y" belongs to several types: "NM.foo" "NM.bar".
   The first one was selected. Please disambiguate if this is wrong.
 
 Line 1, characters 19-23:
@@ -633,7 +633,7 @@ Line 7, characters 10-18:
 7 |   let y = {x = ""}
               ^^^^^^^^
 Warning 41 [ambiguous-name]: these field labels belong to several types:
-    "M.s""t".
+    "M.s" "t".
   The first one was selected. Please disambiguate if this is wrong.
 
 module Shadow2 :

--- a/testsuite/tests/typing-warnings/unused_functor_parameter.ml
+++ b/testsuite/tests/typing-warnings/unused_functor_parameter.ml
@@ -8,7 +8,7 @@ module Foo(Unused : sig end) = struct end;;
 Line 1, characters 11-17:
 1 | module Foo(Unused : sig end) = struct end;;
                ^^^^^^
-Warning 60 [unused-module]: unused module Unused.
+Warning 60 [unused-module]: unused module "Unused".
 
 module Foo : (Unused : sig end) -> sig end
 |}]
@@ -18,7 +18,7 @@ module type S = functor (Unused : sig end) -> sig end;;
 Line 1, characters 25-31:
 1 | module type S = functor (Unused : sig end) -> sig end;;
                              ^^^^^^
-Warning 67 [unused-functor-parameter]: unused functor parameter Unused.
+Warning 67 [unused-functor-parameter]: unused functor parameter "Unused".
 
 module type S = (Unused : sig end) -> sig end
 |}]
@@ -30,7 +30,7 @@ end;;
 Line 2, characters 12-18:
 2 |   module M (Unused : sig end) : sig end
                 ^^^^^^
-Warning 67 [unused-functor-parameter]: unused functor parameter Unused.
+Warning 67 [unused-functor-parameter]: unused functor parameter "Unused".
 
 module type S = sig module M : (Unused : sig end) -> sig end end
 |}]

--- a/testsuite/tests/typing-warnings/unused_recmodule.ml
+++ b/testsuite/tests/typing-warnings/unused_recmodule.ml
@@ -26,7 +26,7 @@ end;;
 Line 14, characters 4-10:
 14 |     type t
          ^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 module M : sig end
 |}];;

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -12,7 +12,7 @@ end
 Line 3, characters 2-19:
 3 |   type unused = int
       ^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 module Unused : sig end
 |}]
@@ -27,7 +27,7 @@ end
 Line 4, characters 2-27:
 4 |   type nonrec unused = used
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 module Unused_nonrec : sig end
 |}]
@@ -41,12 +41,12 @@ end
 Line 3, characters 2-27:
 3 |   type unused = A of unused
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 Line 3, characters 16-27:
 3 |   type unused = A of unused
                     ^^^^^^^^^^^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 module Unused_rec : sig end
 |}]
@@ -73,7 +73,7 @@ end
 Line 4, characters 11-12:
 4 |   type t = T
                ^
-Warning 37 [unused-constructor]: unused constructor T.
+Warning 37 [unused-constructor]: unused constructor "T".
 
 module Unused_constructor : sig type t end
 |}]
@@ -91,8 +91,8 @@ end
 Line 5, characters 11-12:
 5 |   type t = T
                ^
-Warning 37 [unused-constructor]: constructor T is never used to build values.
-(However, this constructor appears in patterns.)
+Warning 37 [unused-constructor]: constructor "T" is never used to build values.
+  (However, this constructor appears in patterns.)
 
 module Unused_constructor_outside_patterns :
   sig type t val nothing : t -> unit end
@@ -108,8 +108,8 @@ end
 Line 4, characters 11-12:
 4 |   type t = T
                ^
-Warning 37 [unused-constructor]: constructor T is never used to build values.
-Its type is exported as a private type.
+Warning 37 [unused-constructor]: constructor "T" is never used to build values.
+  Its type is exported as a private type.
 
 module Unused_constructor_exported_private : sig type t = private T end
 |}]
@@ -137,7 +137,7 @@ end
 Line 4, characters 19-20:
 4 |   type t = private T
                        ^
-Warning 37 [unused-constructor]: unused constructor T.
+Warning 37 [unused-constructor]: unused constructor "T".
 
 module Unused_private_constructor : sig type t end
 |}]
@@ -185,7 +185,7 @@ end
 Line 3, characters 2-26:
 3 |   exception Nobody_uses_me
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 38 [unused-extension]: unused exception Nobody_uses_me
+Warning 38 [unused-extension]: unused exception "Nobody_uses_me"
 
 module Unused_exception : sig end
 |}]
@@ -201,7 +201,7 @@ end
 Line 5, characters 12-26:
 5 |   type t += Nobody_uses_me
                 ^^^^^^^^^^^^^^
-Warning 38 [unused-extension]: unused extension constructor Nobody_uses_me
+Warning 38 [unused-extension]: unused extension constructor "Nobody_uses_me"
 
 module Unused_extension_constructor : sig type t = .. end
 |}]
@@ -217,7 +217,7 @@ end
 Line 5, characters 59-75:
 5 |   type t += Dont_warn_on_me [@warning "-unused-extension"] | Nobody_uses_me
                                                                ^^^^^^^^^^^^^^^^
-Warning 38 [unused-extension]: unused extension constructor Nobody_uses_me
+Warning 38 [unused-extension]: unused extension constructor "Nobody_uses_me"
 
 module Unused_extension_disabled_warning : sig type t = .. end
 |}]
@@ -235,8 +235,8 @@ end
 Line 4, characters 2-32:
 4 |   exception Nobody_constructs_me
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 38 [unused-extension]: exception Nobody_constructs_me is never used to build values.
-(However, this constructor appears in patterns.)
+Warning 38 [unused-extension]: exception "Nobody_constructs_me" is never used
+  to build values. (However, this constructor appears in patterns.)
 
 module Unused_exception_outside_patterns : sig val falsity : exn -> bool end
 |}]
@@ -256,8 +256,8 @@ end
 Line 6, characters 12-27:
 6 |   type t += Noone_builds_me
                 ^^^^^^^^^^^^^^^
-Warning 38 [unused-extension]: extension constructor Noone_builds_me is never used to build values.
-(However, this constructor appears in patterns.)
+Warning 38 [unused-extension]: extension constructor "Noone_builds_me" is never used
+  to build values. (However, this constructor appears in patterns.)
 
 module Unused_extension_outside_patterns :
   sig type t = .. val falsity : t -> bool end
@@ -273,8 +273,8 @@ end
 Line 4, characters 2-23:
 4 |   exception Private_exn
       ^^^^^^^^^^^^^^^^^^^^^
-Warning 38 [unused-extension]: exception Private_exn is never used to build values.
-It is exported or rebound as a private extension.
+Warning 38 [unused-extension]: exception "Private_exn" is never used to build
+  values. It is exported or rebound as a private extension.
 
 module Unused_exception_exported_private :
   sig type exn += private Private_exn end
@@ -292,8 +292,8 @@ end
 Line 6, characters 12-23:
 6 |   type t += Private_ext
                 ^^^^^^^^^^^
-Warning 38 [unused-extension]: extension constructor Private_ext is never used to build values.
-It is exported or rebound as a private extension.
+Warning 38 [unused-extension]: extension constructor "Private_ext" is never used
+  to build values. It is exported or rebound as a private extension.
 
 module Unused_extension_exported_private :
   sig type t = .. type t += private Private_ext end
@@ -324,7 +324,7 @@ end
 Line 5, characters 20-31:
 5 |   type t += private Private_ext
                         ^^^^^^^^^^^
-Warning 38 [unused-extension]: unused extension constructor Private_ext
+Warning 38 [unused-extension]: unused extension constructor "Private_ext"
 
 module Unused_private_extension : sig type t end
 |}]
@@ -361,7 +361,7 @@ end;;
 Line 3, characters 11-12:
 3 |   type t = A [@@warning "-34"]
                ^
-Warning 37 [unused-constructor]: unused constructor A.
+Warning 37 [unused-constructor]: unused constructor "A".
 
 module Unused_type_disable_warning : sig end
 |}]
@@ -374,7 +374,7 @@ end;;
 Line 3, characters 2-30:
 3 |   type t = A [@@warning "-37"]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 module Unused_constructor_disable_warning : sig end
 |}]
@@ -387,12 +387,12 @@ end;;
 Line 3, characters 2-33:
 3 |   type t = A [@warning "-37"] | B
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 Line 3, characters 30-33:
 3 |   type t = A [@warning "-37"] | B
                                   ^^^
-Warning 37 [unused-constructor]: unused constructor B.
+Warning 37 [unused-constructor]: unused constructor "B".
 
 module Unused_constructor_disable_one_warning : sig end
 |}]
@@ -406,12 +406,12 @@ end;;
 Line 2, characters 13-21:
 2 |   type t = { a : int; b : int }
                  ^^^^^^^^
-Warning 69 [unused-field]: unused record field a.
+Warning 69 [unused-field]: unused record field "a".
 
 Line 2, characters 22-29:
 2 |   type t = { a : int; b : int }
                           ^^^^^^^
-Warning 69 [unused-field]: unused record field b.
+Warning 69 [unused-field]: unused record field "b".
 
 module Unused_record : sig end
 |}]
@@ -425,8 +425,8 @@ end;;
 Line 2, characters 13-20:
 2 |   type t = { a : int }
                  ^^^^^^^
-Warning 69 [unused-field]: record field a is never read.
-(However, this field is used to build or mutate values.)
+Warning 69 [unused-field]: record field "a" is never read.
+  (However, this field is used to build or mutate values.)
 
 module Unused_field : sig end
 |}]
@@ -442,8 +442,8 @@ end;;
 Line 2, characters 22-30:
 2 |   type t = { a : int; b : int; c : int }
                           ^^^^^^^^
-Warning 69 [unused-field]: record field b is never read.
-(However, this field is used to build or mutate values.)
+Warning 69 [unused-field]: record field "b" is never read.
+  (However, this field is used to build or mutate values.)
 
 module Unused_field : sig end
 |}]
@@ -458,7 +458,7 @@ end;;
 Line 2, characters 22-37:
 2 |   type t = { a : int; mutable b : int }
                           ^^^^^^^^^^^^^^^
-Warning 69 [unused-field]: mutable record field b is never mutated.
+Warning 69 [unused-field]: mutable record field "b" is never mutated.
 
 module Unused_mutable_field : sig end
 |}]
@@ -494,7 +494,7 @@ end;;
 Line 4, characters 22-37:
 4 |   type t = { a : int; mutable b : int }
                           ^^^^^^^^^^^^^^^
-Warning 69 [unused-field]: mutable record field b is never mutated.
+Warning 69 [unused-field]: mutable record field "b" is never mutated.
 
 module Unused_mutable_field_exported_private :
   sig type t = private { a : int; mutable b : int; } end
@@ -508,7 +508,7 @@ end;;
 Line 3, characters 2-56:
 3 |   type t = { a: int; b:int } [@@warning "-unused-field"]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 module Unused_field_disable_warning : sig end
 |}]
@@ -521,12 +521,12 @@ end;;
 Line 3, characters 2-55:
 3 |   type t = { a: int [@warning "-unused-field"]; b:int }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type t.
+Warning 34 [unused-type-declaration]: unused type "t".
 
 Line 3, characters 48-53:
 3 |   type t = { a: int [@warning "-unused-field"]; b:int }
                                                     ^^^^^
-Warning 69 [unused-field]: unused record field b.
+Warning 69 [unused-field]: unused record field "b".
 
 module Unused_field_disable_one_warning : sig end
 |}]
@@ -538,7 +538,7 @@ let u (type unused) = ()
 Line 1, characters 12-18:
 1 | let u (type unused) = ()
                 ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val u : unit = ()
 |}]
@@ -548,7 +548,7 @@ let u = fun (type unused) -> ()
 Line 1, characters 18-24:
 1 | let u = fun (type unused) -> ()
                       ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val u : unit = ()
 |}]
@@ -558,7 +558,7 @@ let u : type unused. unit = ()
 Line 1, characters 13-19:
 1 | let u : type unused. unit = ()
                  ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val u : unit = ()
 |}]
@@ -568,7 +568,7 @@ let f (type unused) x = x
 Line 1, characters 12-18:
 1 | let f (type unused) x = x
                 ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val f : 'a -> 'a = <fun>
 |}]
@@ -578,7 +578,7 @@ let f = fun (type unused) x -> x
 Line 1, characters 18-24:
 1 | let f = fun (type unused) x -> x
                       ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val f : 'a -> 'a = <fun>
 |}]
@@ -588,7 +588,7 @@ let f = fun (type unused) x -> x
 Line 1, characters 18-24:
 1 | let f = fun (type unused) x -> x
                       ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val f : 'a -> 'a = <fun>
 |}]
@@ -598,7 +598,7 @@ let f (type used unused) (x : used) = x
 Line 1, characters 17-23:
 1 | let f (type used unused) (x : used) = x
                      ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val f : 'used -> 'used = <fun>
 |}]
@@ -609,7 +609,7 @@ let f = fun (type used unused) (x : used) -> x
 Line 1, characters 23-29:
 1 | let f = fun (type used unused) (x : used) -> x
                            ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val f : 'used -> 'used = <fun>
 |}]
@@ -620,7 +620,7 @@ let f : type used unused. used -> used = fun x -> x
 Line 1, characters 18-24:
 1 | let f : type used unused. used -> used = fun x -> x
                       ^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused.
+Warning 34 [unused-type-declaration]: unused type "unused".
 
 val f : 'used -> 'used = <fun>
 |}]
@@ -630,12 +630,12 @@ let f (type unused1 unused2) x = x
 Line 1, characters 12-19:
 1 | let f (type unused1 unused2) x = x
                 ^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused1.
+Warning 34 [unused-type-declaration]: unused type "unused1".
 
 Line 1, characters 20-27:
 1 | let f (type unused1 unused2) x = x
                         ^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused2.
+Warning 34 [unused-type-declaration]: unused type "unused2".
 
 val f : 'a -> 'a = <fun>
 |}]
@@ -646,12 +646,12 @@ let f = fun (type unused1 unused2) x -> x
 Line 1, characters 18-25:
 1 | let f = fun (type unused1 unused2) x -> x
                       ^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused1.
+Warning 34 [unused-type-declaration]: unused type "unused1".
 
 Line 1, characters 26-33:
 1 | let f = fun (type unused1 unused2) x -> x
                               ^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused2.
+Warning 34 [unused-type-declaration]: unused type "unused2".
 
 val f : 'a -> 'a = <fun>
 |}]
@@ -662,12 +662,12 @@ let f : type unused1 unused2. 'a -> 'a = fun x -> x
 Line 1, characters 13-20:
 1 | let f : type unused1 unused2. 'a -> 'a = fun x -> x
                  ^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused1.
+Warning 34 [unused-type-declaration]: unused type "unused1".
 
 Line 1, characters 21-28:
 1 | let f : type unused1 unused2. 'a -> 'a = fun x -> x
                          ^^^^^^^
-Warning 34 [unused-type-declaration]: unused type unused2.
+Warning 34 [unused-type-declaration]: unused type "unused2".
 
 val f : 'a -> 'a = <fun>
 |}]

--- a/testsuite/tests/warnings/w01.compilers.reference
+++ b/testsuite/tests/warnings/w01.compilers.reference
@@ -7,14 +7,13 @@ File "w01.ml", line 20, characters 0-3:
 20 | f 1; f 1;;
      ^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
+  maybe some arguments are missing.
 
 File "w01.ml", line 30, characters 4-5:
 30 | let 1 = 1;;
          ^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-0
+  Here is an example of a case that is not matched: 0
 
 File "w01.ml", line 35, characters 0-1:
 35 | 1; 1;;

--- a/testsuite/tests/warnings/w03.compilers.reference
+++ b/testsuite/tests/warnings/w03.compilers.reference
@@ -6,4 +6,4 @@ Alert deprecated: A
 File "w03.ml", line 17, characters 15-25:
 17 | exception B [@@deprecated]
                     ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated attribute cannot appear in this context

--- a/testsuite/tests/warnings/w04.compilers.reference
+++ b/testsuite/tests/warnings/w04.compilers.reference
@@ -3,4 +3,4 @@ File "w04.ml", lines 21-23, characters 10-8:
 22 | | A -> 0
 23 | | _ -> 1
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type t.
+  It will remain exhaustive when constructors are added to type t.

--- a/testsuite/tests/warnings/w04_failure.compilers.reference
+++ b/testsuite/tests/warnings/w04_failure.compilers.reference
@@ -4,7 +4,7 @@ File "w04_failure.ml", lines 20-23, characters 2-17:
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type repr.
+  It will remain exhaustive when constructors are added to type repr.
 
 File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
@@ -12,7 +12,7 @@ File "w04_failure.ml", lines 20-23, characters 2-17:
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type ab.
+  It will remain exhaustive when constructors are added to type ab.
 
 File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
@@ -20,4 +20,4 @@ File "w04_failure.ml", lines 20-23, characters 2-17:
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
-It will remain exhaustive when constructors are added to type xy.
+  It will remain exhaustive when constructors are added to type xy.

--- a/testsuite/tests/warnings/w06.compilers.reference
+++ b/testsuite/tests/warnings/w06.compilers.reference
@@ -1,9 +1,11 @@
 File "w06.ml", line 16, characters 9-12:
 16 | let () = foo 2
               ^^^
-Warning 6 [labels-omitted]: label bar was omitted in the application of this function.
+Warning 6 [labels-omitted]: label bar was omitted in the application of this
+  function.
 
 File "w06.ml", line 17, characters 9-12:
 17 | let () = bar 4 2
               ^^^
-Warning 6 [labels-omitted]: labels foo, baz were omitted in the application of this function.
+Warning 6 [labels-omitted]: labels foo, baz were omitted in the application
+  of this function.

--- a/testsuite/tests/warnings/w26_alias.ml
+++ b/testsuite/tests/warnings/w26_alias.ml
@@ -13,7 +13,7 @@ type t = { x : int; y : int; }
 Line 6, characters 21-22:
 6 | let sum ({ x; y } as t) = x + y
                          ^
-Warning 26 [unused-var]: unused variable t.
+Warning 26 [unused-var]: unused variable "t".
 
 val sum : t -> int = <fun>
 |}]

--- a/testsuite/tests/warnings/w44.ml
+++ b/testsuite/tests/warnings/w44.ml
@@ -14,7 +14,8 @@ let g f = f (); M.(f ());;
 Line 1, characters 16-17:
 1 | let g f = f (); M.(f ());;
                     ^
-Warning 44 [open-shadow-identifier]: this open statement shadows the value identifier f (which is later used)
+Warning 44 [open-shadow-identifier]: this open statement shadows the
+  value identifier "f" (which is later used)
 
 val g : (unit -> 'a) -> int = <fun>
 |}]

--- a/testsuite/tests/warnings/w45.compilers.reference
+++ b/testsuite/tests/warnings/w45.compilers.reference
@@ -7,7 +7,7 @@ Warning 45 [open-shadow-label-constructor]: this open statement shadows the
 File "w45.ml", line 26, characters 14-15:
 26 |   let _ = (A, X) (* X belongs to several types *)
                    ^
-Warning 41 [ambiguous-name]: X belongs to several types: T2.sT1.s.
+Warning 41 [ambiguous-name]: X belongs to several types: T2.s T1.s.
   The first one was selected. Please disambiguate if this is wrong.
 
 File "w45.ml", line 23, characters 2-9:

--- a/testsuite/tests/warnings/w45.compilers.reference
+++ b/testsuite/tests/warnings/w45.compilers.reference
@@ -1,13 +1,14 @@
 File "w45.ml", line 24, characters 2-9:
 24 |   open T2 (* shadow X, which is later used; but not A, see #6762 *)
        ^^^^^^^
-Warning 45 [open-shadow-label-constructor]: this open statement shadows the constructor X (which is later used)
+Warning 45 [open-shadow-label-constructor]: this open statement shadows the
+  constructor X (which is later used)
 
 File "w45.ml", line 26, characters 14-15:
 26 |   let _ = (A, X) (* X belongs to several types *)
                    ^
-Warning 41 [ambiguous-name]: X belongs to several types: T2.s T1.s
-The first one was selected. Please disambiguate if this is wrong.
+Warning 41 [ambiguous-name]: X belongs to several types: T2.sT1.s.
+  The first one was selected. Please disambiguate if this is wrong.
 
 File "w45.ml", line 23, characters 2-9:
 23 |   open T1 (* unused open *)

--- a/testsuite/tests/warnings/w47_inline.compilers.reference
+++ b/testsuite/tests/warnings/w47_inline.compilers.reference
@@ -11,40 +11,41 @@ Warning 26 [unused-var]: unused variable f3.
 File "w47_inline.ml", line 15, characters 23-29:
 15 | let d = (fun x -> x) [@inline malformed attribute] (* rejected *)
                             ^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
-It must be either 'never', 'always', 'hint' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute inline.
+  It must be either 'never', 'always', 'hint' or empty
 
 File "w47_inline.ml", line 16, characters 23-29:
 16 | let e = (fun x -> x) [@inline malformed_attribute] (* rejected *)
                             ^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
-It must be either 'never', 'always', 'hint' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute inline.
+  It must be either 'never', 'always', 'hint' or empty
 
 File "w47_inline.ml", line 17, characters 23-29:
 17 | let f = (fun x -> x) [@inline : malformed_attribute] (* rejected *)
                             ^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
-It must be either 'never', 'always', 'hint' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute inline.
+  It must be either 'never', 'always', 'hint' or empty
 
 File "w47_inline.ml", line 18, characters 23-29:
 18 | let g = (fun x -> x) [@inline ? malformed_attribute] (* rejected *)
                             ^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
-It must be either 'never', 'always', 'hint' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute inline.
+  It must be either 'never', 'always', 'hint' or empty
 
 File "w47_inline.ml", line 23, characters 15-22:
 23 | let k x = (a [@inlined malformed]) x (* rejected *)
                     ^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'inlined'.
-It must be either 'never', 'always', 'hint' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute inlined.
+  It must be either 'never', 'always', 'hint' or empty
 
 File "w47_inline.ml", line 31, characters 7-12:
 31 |   let[@local malformed] f3 x = x (* bad payload *) in
             ^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'local'.
-It must be either 'never', 'always', 'maybe' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute local.
+  It must be either 'never', 'always', 'maybe' or empty
 
 File "w47_inline.ml", line 32, characters 17-26:
 32 |   let[@local] f4 x = 2 * x (* not local *) in
                       ^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: This function cannot be compiled into a static continuation
+Warning 55 [inlining-impossible]: Cannot inline:
+  This function cannot be compiled into a static continuation

--- a/testsuite/tests/warnings/w47_ppwarning.compilers.reference
+++ b/testsuite/tests/warnings/w47_ppwarning.compilers.reference
@@ -1,20 +1,20 @@
 File "w47_ppwarning.ml", line 10, characters 12-25:
 10 | let x1 = 42 [@@ppwarning]
                  ^^^^^^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'ppwarning'.
-A single string literal is expected
+Warning 47 [attribute-payload]: illegal payload for attribute ppwarning.
+  A single string literal is expected
 
 File "w47_ppwarning.ml", line 13, characters 12-37:
 13 | let x2 = 42 [@@ppwarning "foo" "bar"]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'ppwarning'.
-A single string literal is expected
+Warning 47 [attribute-payload]: illegal payload for attribute ppwarning.
+  A single string literal is expected
 
 File "w47_ppwarning.ml", line 16, characters 12-28:
 16 | let x3 = 42 [@@ppwarning 84]
                  ^^^^^^^^^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'ppwarning'.
-A single string literal is expected
+Warning 47 [attribute-payload]: illegal payload for attribute ppwarning.
+  A single string literal is expected
 
 File "w47_ppwarning.ml", line 19, characters 25-30:
 19 | let x4 = 42 [@@ppwarning "foo"]

--- a/testsuite/tests/warnings/w51.ml
+++ b/testsuite/tests/warnings/w51.ml
@@ -73,8 +73,8 @@ let rec test x = (test[@tailcall foobar]) x;;
 Line 1, characters 24-32:
 1 | let rec test x = (test[@tailcall foobar]) x;;
                             ^^^^^^^^
-Warning 47 [attribute-payload]: illegal payload for attribute 'tailcall'.
-Only an optional boolean literal is supported.
+Warning 47 [attribute-payload]: illegal payload for attribute "tailcall".
+  Only an optional boolean literal is supported.
 
 val test : 'a -> 'b = <fun>
 |}]

--- a/testsuite/tests/warnings/w52.ml
+++ b/testsuite/tests/warnings/w52.ml
@@ -8,9 +8,10 @@ let () = try () with Invalid_argument "Any" -> ();;
 Line 1, characters 38-43:
 1 | let () = try () with Invalid_argument "Any" -> ();;
                                           ^^^^^
-Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
-this constructor's arguments. They are only for information
-and may change in future versions. (see manual section 13.5.3)
+Warning 52 [fragile-literal-pattern]: Code should not depend on the actual
+  values of this constructor's arguments.
+  They are only for information and may change in future versions.
+  (see manual section 13.5.3)
 |}];;
 
 let () = try () with Match_failure ("Any",_,_) -> ();;
@@ -18,9 +19,10 @@ let () = try () with Match_failure ("Any",_,_) -> ();;
 Line 1, characters 35-46:
 1 | let () = try () with Match_failure ("Any",_,_) -> ();;
                                        ^^^^^^^^^^^
-Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
-this constructor's arguments. They are only for information
-and may change in future versions. (see manual section 13.5.3)
+Warning 52 [fragile-literal-pattern]: Code should not depend on the actual
+  values of this constructor's arguments.
+  They are only for information and may change in future versions.
+  (see manual section 13.5.3)
 |}];;
 
 let () = try () with Match_failure (_,0,_) -> ();;
@@ -28,9 +30,10 @@ let () = try () with Match_failure (_,0,_) -> ();;
 Line 1, characters 35-42:
 1 | let () = try () with Match_failure (_,0,_) -> ();;
                                        ^^^^^^^
-Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
-this constructor's arguments. They are only for information
-and may change in future versions. (see manual section 13.5.3)
+Warning 52 [fragile-literal-pattern]: Code should not depend on the actual
+  values of this constructor's arguments.
+  They are only for information and may change in future versions.
+  (see manual section 13.5.3)
 |}];;
 
 type t =
@@ -53,9 +56,10 @@ let f = function
 Line 2, characters 7-17:
 2 | | Warn "anything" -> ()
            ^^^^^^^^^^
-Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
-this constructor's arguments. They are only for information
-and may change in future versions. (see manual section 13.5.3)
+Warning 52 [fragile-literal-pattern]: Code should not depend on the actual
+  values of this constructor's arguments.
+  They are only for information and may change in future versions.
+  (see manual section 13.5.3)
 
 val f : t -> unit = <fun>
 |}];;
@@ -67,9 +71,10 @@ let g = function
 Line 2, characters 8-10:
 2 | | Warn' 0n -> ()
             ^^
-Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
-this constructor's arguments. They are only for information
-and may change in future versions. (see manual section 13.5.3)
+Warning 52 [fragile-literal-pattern]: Code should not depend on the actual
+  values of this constructor's arguments.
+  They are only for information and may change in future versions.
+  (see manual section 13.5.3)
 
 val g : t -> unit = <fun>
 |}];;
@@ -95,9 +100,10 @@ let j = function
 Line 2, characters 7-34:
 2 | | Deep (_ :: _ :: ("deep",_) :: _) -> ()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
-this constructor's arguments. They are only for information
-and may change in future versions. (see manual section 13.5.3)
+Warning 52 [fragile-literal-pattern]: Code should not depend on the actual
+  values of this constructor's arguments.
+  They are only for information and may change in future versions.
+  (see manual section 13.5.3)
 
 val j : t -> unit = <fun>
 |}];;

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -1,909 +1,909 @@
 File "w53.ml", line 12, characters 16-21:
 12 |   val x : int [@alert foo "foo"] (* rejected *)
                      ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53.ml", line 18, characters 6-11:
 18 |   [@@@alert foo "foo"] (* rejected *)
            ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53.ml", line 22, characters 14-19:
 22 |   let x = 5 [@alert foo "foo"] (* rejected *)
                    ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53.ml", line 24, characters 16-21:
 24 |   let y = 10 [@@alert foo "foo"] (* rejected *)
                      ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53.ml", line 26, characters 6-11:
 26 |   [@@@alert foo "foo"] (* rejected *)
            ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53.ml", line 34, characters 24-29:
 34 |   type t1 = { x : int [@boxed] } (* rejected *)
                              ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 36, characters 16-21:
 36 |   val x : int [@boxed] (* rejected *)
                      ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 40, characters 17-22:
 40 |   val y : int [@@boxed] (* rejected *)
                       ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 42, characters 6-11:
 42 |   [@@@boxed] (* rejected *)
            ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 46, characters 16-21:
 46 |   let x = (42 [@boxed], 84) (* rejected *)
                      ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 48, characters 16-21:
 48 |   let y = 10 [@@boxed] (* rejected *)
                      ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 50, characters 6-11:
 50 |   [@@@boxed] (* rejected *)
            ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the boxed attribute cannot appear in this context
 
 File "w53.ml", line 57, characters 16-26:
 57 |   val x : int [@deprecated] (* rejected *)
                      ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated attribute cannot appear in this context
 
 File "w53.ml", line 63, characters 6-16:
 63 |   [@@@deprecated] (* rejected *)
            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated attribute cannot appear in this context
 
 File "w53.ml", line 67, characters 14-24:
 67 |   let x = 5 [@deprecated] (* rejected *)
                    ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated attribute cannot appear in this context
 
 File "w53.ml", line 69, characters 16-26:
 69 |   let y = 10 [@@deprecated] (* rejected *)
                      ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated attribute cannot appear in this context
 
 File "w53.ml", line 71, characters 6-16:
 71 |   [@@@deprecated] (* rejected *)
            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated attribute cannot appear in this context
 
 File "w53.ml", line 76, characters 19-37:
 76 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
                         ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 78, characters 16-34:
 78 |   val x : int [@deprecated_mutable] (* rejected *)
                      ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 80, characters 21-39:
 80 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
                           ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 84, characters 24-42:
 84 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
                              ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 86, characters 17-35:
 86 |   val y : int [@@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 88, characters 6-24:
 88 |   [@@@deprecated_mutable] (* rejected *)
            ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 92, characters 14-32:
 92 |   let x = 5 [@deprecated_mutable] (* rejected *)
                    ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 94, characters 16-34:
 94 |   let y = 10 [@@deprecated_mutable] (* rejected *)
                      ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 96, characters 6-24:
 96 |   [@@@deprecated_mutable] (* rejected *)
            ^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the deprecated_mutable attribute cannot appear in this context
 
 File "w53.ml", line 101, characters 32-46:
 101 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
                                       ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 103, characters 16-30:
 103 |   val x : int [@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 105, characters 20-34:
 105 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
                           ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 107, characters 17-31:
 107 |   val y : int [@@explicit_arity] (* rejected *)
                        ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 109, characters 6-20:
 109 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 113, characters 14-28:
 113 |   let x = 5 [@explicit_arity] (* rejected *)
                     ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 115, characters 16-30:
 115 |   let y = 10 [@@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 117, characters 6-20:
 117 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the explicit_arity attribute cannot appear in this context
 
 File "w53.ml", line 122, characters 18-27:
 122 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 126, characters 16-25:
 126 |   val x : int [@immediate] (* rejected *)
                       ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 127, characters 17-26:
 127 |   val x : int [@@immediate] (* rejected *)
                        ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 129, characters 6-15:
 129 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 130, characters 6-17:
 130 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate64 attribute cannot appear in this context
 
 File "w53.ml", line 134, characters 15-24:
 134 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                      ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 134, characters 32-43:
 134 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                                       ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate64 attribute cannot appear in this context
 
 File "w53.ml", line 135, characters 21-30:
 135 |   let y = (4, 42) [@@immediate] (* rejected *)
                            ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 136, characters 21-32:
 136 |   let z = (4, 42) [@@immediate64] (* rejected *)
                            ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate64 attribute cannot appear in this context
 
 File "w53.ml", line 138, characters 18-27:
 138 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 142, characters 6-15:
 142 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate attribute cannot appear in this context
 
 File "w53.ml", line 143, characters 6-17:
 143 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the immediate64 attribute cannot appear in this context
 
 File "w53.ml", line 148, characters 25-31:
 148 |   type t1 = int -> int [@inline] (* rejected *)
                                ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 149, characters 26-32:
 149 |   type t2 = int -> int [@@inline] (* rejected *)
                                 ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 150, characters 25-32:
 150 |   type t3 = int -> int [@inlined] (* rejected *)
                                ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 151, characters 26-33:
 151 |   type t4 = int -> int [@@inlined] (* rejected *)
                                 ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 153, characters 24-30:
 153 |   val f1 : int -> int [@inline] (* rejected *)
                               ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 154, characters 25-31:
 154 |   val f2 : int -> int [@@inline] (* rejected *)
                                ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 155, characters 24-31:
 155 |   val f3 : int -> int [@inlined] (* rejected *)
                               ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 156, characters 25-32:
 156 |   val f4 : int -> int [@@inlined] (* rejected *)
                                ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 158, characters 53-59:
 158 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
                                                            ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 159, characters 54-60:
 159 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
                                                             ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 161, characters 6-12:
 161 |   [@@@inline] (* rejected *)
             ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 162, characters 6-13:
 162 |   [@@@inlined] (* rejected *)
             ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 166, characters 16-22:
 166 |   let h x = x [@inline] (* rejected *)
                       ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 167, characters 16-28:
 167 |   let h x = x [@ocaml.inline] (* rejected *)
                       ^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inline attribute cannot appear in this context
 
 File "w53.ml", line 169, characters 16-23:
 169 |   let i x = x [@inlined] (* rejected *)
                       ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 170, characters 16-29:
 170 |   let j x = x [@ocaml.inlined] (* rejected *)
                       ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inlined attribute cannot appear in this context
 
 File "w53.ml", line 173, characters 18-25:
 173 |   let l x = h x [@inlined] (* rejected *)
                         ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 181, characters 27-33:
 181 |   module C = struct end [@@inline] (* rejected *)
                                  ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 182, characters 28-40:
 182 |   module C' = struct end [@@ocaml.inline] (* rejected *)
                                   ^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inline attribute cannot appear in this context
 
 File "w53.ml", line 183, characters 27-34:
 183 |   module D = struct end [@@inlined] (* rejected *)
                                  ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 184, characters 28-41:
 184 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
                                   ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inlined attribute cannot appear in this context
 
 File "w53.ml", line 188, characters 18-24:
 188 |   module G = (A [@inline])(struct end) (* rejected *)
                         ^^^^^^
-Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inline attribute cannot appear in this context
 
 File "w53.ml", line 189, characters 19-31:
 189 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
                          ^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inline attribute cannot appear in this context
 
 File "w53.ml", line 193, characters 24-31:
 193 |   module I = Set.Make [@inlined] (* rejected *)
                               ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 194, characters 25-38:
 194 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
                                ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inlined attribute cannot appear in this context
 
 File "w53.ml", line 196, characters 25-32:
 196 |   module J = Set.Make [@@inlined] (* rejected *)
                                ^^^^^^^
-Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the inlined attribute cannot appear in this context
 
 File "w53.ml", line 197, characters 26-39:
 197 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
                                 ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.inlined attribute cannot appear in this context
 
 File "w53.ml", line 202, characters 21-28:
 202 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 203, characters 19-26:
 203 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 204, characters 19-26:
 204 |   val x : int64 [@@noalloc] (* rejected *)
                          ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 206, characters 24-31:
 206 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 206, characters 46-53:
 206 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 211, characters 21-28:
 211 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 212, characters 19-26:
 212 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 213, characters 25-32:
 213 |   let x : int64 = 42L [@@noalloc] (* rejected *)
                                ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 215, characters 24-31:
 215 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 215, characters 46-53:
 215 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the noalloc attribute cannot appear in this context
 
 File "w53.ml", line 244, characters 21-29:
 244 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 245, characters 19-27:
 245 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 246, characters 16-24:
 246 |   val x : int [@tailcall] (* rejected *)
                       ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 248, characters 35-43:
 248 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 250, characters 6-14:
 250 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 254, characters 21-29:
 254 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 255, characters 19-27:
 255 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 257, characters 16-24:
 257 |   let m x = x [@tailcall] (* rejected *)
                       ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 258, characters 16-30:
 258 |   let n x = x [@ocaml.tailcall] (* rejected *)
                       ^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "ocaml.tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the ocaml.tailcall attribute cannot appear in this context
 
 File "w53.ml", line 261, characters 18-26:
 261 |   let q x = m x [@tailcall] (* rejected *)
                         ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 263, characters 35-43:
 263 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 265, characters 6-14:
 265 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tailcall attribute cannot appear in this context
 
 File "w53.ml", line 270, characters 24-31:
 270 |   type t1 = { x : int [@unboxed] } (* rejected *)
                               ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 272, characters 16-23:
 272 |   val x : int [@unboxed] (* rejected *)
                       ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 276, characters 17-24:
 276 |   val y : int [@@unboxed] (* rejected *)
                        ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 280, characters 6-13:
 280 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 284, characters 16-23:
 284 |   let x = (42 [@unboxed], 84) (* rejected *)
                       ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 286, characters 16-23:
 286 |   let y = 10 [@@unboxed] (* rejected *)
                       ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 290, characters 6-13:
 290 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unboxed attribute cannot appear in this context
 
 File "w53.ml", line 295, characters 21-29:
 295 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the untagged attribute cannot appear in this context
 
 File "w53.ml", line 296, characters 19-27:
 296 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the untagged attribute cannot appear in this context
 
 File "w53.ml", line 297, characters 17-25:
 297 |   val x : int [@@untagged] (* rejected *)
                        ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the untagged attribute cannot appear in this context
 
 File "w53.ml", line 304, characters 21-29:
 304 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the untagged attribute cannot appear in this context
 
 File "w53.ml", line 305, characters 19-27:
 305 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the untagged attribute cannot appear in this context
 
 File "w53.ml", line 306, characters 22-30:
 306 |   let x : int = 42 [@@untagged] (* rejected *)
                             ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the untagged attribute cannot appear in this context
 
 File "w53.ml", line 314, characters 24-32:
 314 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 315, characters 27-35:
 315 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 317, characters 23-31:
 317 |   val f : int -> int [@unrolled 42] (* rejected *)
                              ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 318, characters 24-32:
 318 |   val g : int -> int [@@unrolled 42] (* rejected *)
                               ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 320, characters 39-47:
 320 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 322, characters 6-14:
 322 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 326, characters 8-16:
 326 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
               ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 333, characters 24-32:
 333 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 334, characters 27-35:
 334 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 336, characters 22-30:
 336 |   let rec f x = f x [@unrolled 42] (* rejected *)
                             ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 337, characters 23-31:
 337 |   let rec f x = f x [@@unrolled 42] (* rejected *)
                              ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 339, characters 39-47:
 339 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 341, characters 6-14:
 341 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the unrolled attribute cannot appear in this context
 
 File "w53.ml", line 390, characters 25-48:
 390 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 394, characters 16-39:
 394 |   val x : int [@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 396, characters 21-44:
 396 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 398, characters 17-40:
 398 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 400, characters 6-29:
 400 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 406, characters 25-48:
 406 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 408, characters 14-37:
 408 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 410, characters 16-39:
 410 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 412, characters 6-29:
 412 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the warn_on_literal_pattern attribute cannot appear in this context
 
 File "w53.ml", line 421, characters 21-25:
 421 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 422, characters 19-23:
 422 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 423, characters 19-23:
 423 |   val x : int64 [@@poll error] (* rejected *)
                          ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 425, characters 24-28:
 425 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                               ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 425, characters 49-53:
 425 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                                                        ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 427, characters 39-43:
 427 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 431, characters 21-25:
 431 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 432, characters 19-23:
 432 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 433, characters 25-29:
 433 |   let x : int64 = 42L [@@poll error] (* rejected *)
                                ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 436, characters 24-28:
 436 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                               ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 436, characters 49-53:
 436 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                                                        ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 438, characters 39-43:
 438 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the poll attribute cannot appear in this context
 
 File "w53.ml", line 443, characters 21-31:
 443 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 444, characters 19-29:
 444 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 445, characters 19-29:
 445 |   val x : int64 [@@specialise] (* rejected *)
                          ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 447, characters 24-34:
 447 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 447, characters 49-59:
 447 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 449, characters 39-49:
 449 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 453, characters 21-31:
 453 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 454, characters 19-29:
 454 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 455, characters 25-35:
 455 |   let x : int64 = 42L [@@specialise] (* rejected *)
                                ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 457, characters 16-26:
 457 |   let g x = (f[@specialise]) x (* rejected *)
                       ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 459, characters 24-34:
 459 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 459, characters 49-59:
 459 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 461, characters 39-49:
 461 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialise attribute cannot appear in this context
 
 File "w53.ml", line 466, characters 21-32:
 466 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 467, characters 19-30:
 467 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 468, characters 19-30:
 468 |   val x : int64 [@@specialised] (* rejected *)
                          ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 470, characters 24-35:
 470 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 470, characters 50-61:
 470 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 472, characters 39-50:
 472 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 476, characters 21-32:
 476 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 477, characters 19-30:
 477 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 478, characters 25-36:
 478 |   let x : int64 = 42L [@@specialised] (* rejected *)
                                ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 479, characters 8-19:
 479 |   let [@specialised] f x = x (* rejected *)
               ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 482, characters 24-35:
 482 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 482, characters 50-61:
 482 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 484, characters 39-50:
 484 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the specialised attribute cannot appear in this context
 
 File "w53.ml", line 489, characters 21-34:
 489 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 490, characters 19-32:
 490 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 491, characters 19-32:
 491 |   val x : int64 [@@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 493, characters 24-37:
 493 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 493, characters 52-65:
 493 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 496, characters 39-52:
 496 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 500, characters 21-34:
 500 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 501, characters 19-32:
 501 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 502, characters 25-38:
 502 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
                                ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 504, characters 16-29:
 504 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
                       ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 506, characters 24-37:
 506 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 506, characters 52-65:
 506 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 509, characters 39-52:
 509 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the tail_mod_cons attribute cannot appear in this context
 
 File "w53.ml", line 515, characters 10-15:
 515 |       [@@@alert foo "foo"] (* rejected *)
                 ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53_across_cmi.compilers.reference
+++ b/testsuite/tests/warnings/w53_across_cmi.compilers.reference
@@ -1,32 +1,32 @@
 File "w53_without_cmi.ml", line 6, characters 4-9:
 6 | [@@@alert xyz "xyz"] (* rejected *)
         ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53_without_cmi.ml", line 9, characters 6-11:
 9 |   [@@@alert foo "foo"] (* rejected *)
           ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53_with_cmi.mli", line 6, characters 4-9:
 6 | [@@@alert xyz "xyz"] (* rejected *)
         ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53_with_cmi.ml", line 1, characters 4-9:
 1 | [@@@alert foo "foo"] (* rejected *)
         ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53_with_cmi.ml", line 2, characters 4-9:
 2 | [@@@alert bar "bar"] (* rejected *)
         ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 
 File "w53_with_cmi.ml", line 6, characters 4-9:
 6 | [@@@alert xyz "xyz"] (* rejected *)
         ^^^^^
-Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 File "w53_across_cmi.ml", line 17, characters 5-20:
 17 | open W53_without_cmi
           ^^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w54.compilers.reference
+++ b/testsuite/tests/warnings/w54.compilers.reference
@@ -1,19 +1,23 @@
 File "w54.ml", line 12, characters 33-39:
 12 | let f = (fun x -> x) [@inline] [@inline never]
                                       ^^^^^^
-Warning 54 [duplicated-attribute]: the "inline" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the inline attribute is used more than once
+  on this expression
 
 File "w54.ml", line 13, characters 51-63:
 13 | let g = (fun x -> x) [@inline] [@something_else] [@ocaml.inline]
                                                         ^^^^^^^^^^^^
-Warning 54 [duplicated-attribute]: the "ocaml.inline" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the ocaml.inline attribute is used more than once
+  on this expression
 
 File "w54.ml", line 15, characters 26-39:
 15 | let h x = (g [@inlined] [@ocaml.inlined never]) x
                                ^^^^^^^^^^^^^
-Warning 54 [duplicated-attribute]: the "ocaml.inlined" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the ocaml.inlined attribute is used more than once
+  on this expression
 
 File "w54.ml", line 19, characters 0-43:
 19 | let i = ((fun x -> x) [@inline]) [@@inline]
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 54 [duplicated-attribute]: the "inline" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the inline attribute is used more than once
+  on this expression

--- a/testsuite/tests/warnings/w55.flambda.reference
+++ b/testsuite/tests/warnings/w55.flambda.reference
@@ -1,14 +1,17 @@
 File "w55.ml", line 33, characters 10-26:
 33 | let h x = (j [@inlined]) x
                ^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: [@inlined] attributes may not be used on partial applications
+Warning 55 [inlining-impossible]: Cannot inline:
+  [@inlined] attributes may not be used on partial applications
 
 File "w55.ml", line 29, characters 10-27:
 29 | let i x = (!r [@inlined]) x
                ^^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+Warning 55 [inlining-impossible]: Cannot inline:
+  [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
 
 File "w55.ml", line 39, characters 12-30:
 39 | let b x y = (a [@inlined]) x y
                  ^^^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+Warning 55 [inlining-impossible]: Cannot inline:
+  [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)

--- a/testsuite/tests/warnings/w55.native.reference
+++ b/testsuite/tests/warnings/w55.native.reference
@@ -1,7 +1,8 @@
 File "w55.ml", line 25, characters 10-26:
 25 | let g x = (f [@inlined]) x
                ^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: Function information unavailable
+Warning 55 [inlining-impossible]: Cannot inline:
+  Function information unavailable
 
 File "w55.ml", line 29, characters 10-27:
 29 | let i x = (!r [@inlined]) x
@@ -21,9 +22,11 @@ Warning 55 [inlining-impossible]: Cannot inline: Over-application
 File "w55.ml", line 39, characters 12-30:
 39 | let b x y = (a [@inlined]) x y
                  ^^^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: Function information unavailable
+Warning 55 [inlining-impossible]: Cannot inline:
+  Function information unavailable
 
 File "w55.ml", line 42, characters 10-26:
 42 | let d x = (c [@inlined]) x
                ^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: Function information unavailable
+Warning 55 [inlining-impossible]: Cannot inline:
+  Function information unavailable

--- a/testsuite/tests/warnings/w58.native.reference
+++ b/testsuite/tests/warnings/w58.native.reference
@@ -1,2 +1,3 @@
 File "_none_", line 1:
-Warning 58 [no-cmx-file]: no cmx file was found in path for module Module_without_cmx, and its interface was not compiled with -opaque
+Warning 58 [no-cmx-file]: no cmx file was found in path for module
+  Module_without_cmx, and its interface was not compiled with -opaque

--- a/testsuite/tests/warnings/w59.flambda.reference
+++ b/testsuite/tests/warnings/w59.flambda.reference
@@ -1,34 +1,34 @@
 File "w59.ml", line 47, characters 2-43:
 47 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
-in this source file.  Such assignments may generate incorrect code 
-when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
+  was detected in this source file. Such assignments may generate
+  incorrect code when using Flambda.
 
 File "w59.ml", line 48, characters 2-43:
 48 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
-in this source file.  Such assignments may generate incorrect code 
-when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
+  was detected in this source file. Such assignments may generate
+  incorrect code when using Flambda.
 
 File "w59.ml", line 49, characters 2-43:
 49 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
-in this source file.  Such assignments may generate incorrect code 
-when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
+  was detected in this source file. Such assignments may generate
+  incorrect code when using Flambda.
 
 File "w59.ml", line 50, characters 2-43:
 50 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
-in this source file.  Such assignments may generate incorrect code 
-when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
+  was detected in this source file. Such assignments may generate
+  incorrect code when using Flambda.
 
 File "w59.ml", line 57, characters 2-7:
 57 |   set o
        ^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
-in this source file.  Such assignments may generate incorrect code 
-when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
+  was detected in this source file. Such assignments may generate
+  incorrect code when using Flambda.

--- a/testsuite/tests/warnings/w59.flambda.reference
+++ b/testsuite/tests/warnings/w59.flambda.reference
@@ -1,34 +1,34 @@
 File "w59.ml", line 47, characters 2-43:
 47 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
-  was detected in this source file. Such assignments may generate
-  incorrect code when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment
+  to a non-mutable value was detected in this source file. Such assignments
+  may generate incorrect code when using Flambda.
 
 File "w59.ml", line 48, characters 2-43:
 48 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
-  was detected in this source file. Such assignments may generate
-  incorrect code when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment
+  to a non-mutable value was detected in this source file. Such assignments
+  may generate incorrect code when using Flambda.
 
 File "w59.ml", line 49, characters 2-43:
 49 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
-  was detected in this source file. Such assignments may generate
-  incorrect code when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment
+  to a non-mutable value was detected in this source file. Such assignments
+  may generate incorrect code when using Flambda.
 
 File "w59.ml", line 50, characters 2-43:
 50 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
-  was detected in this source file. Such assignments may generate
-  incorrect code when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment
+  to a non-mutable value was detected in this source file. Such assignments
+  may generate incorrect code when using Flambda.
 
 File "w59.ml", line 57, characters 2-7:
 57 |   set o
        ^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value
-  was detected in this source file. Such assignments may generate
-  incorrect code when using Flambda.
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment
+  to a non-mutable value was detected in this source file. Such assignments
+  may generate incorrect code when using Flambda.

--- a/testsuite/tests/warnings/w74.ml
+++ b/testsuite/tests/warnings/w74.ml
@@ -22,10 +22,10 @@ Lines 1-5, characters 34-31:
 3 | | (_, r) when (r.contents <- true; false) -> assert false
 4 | | (false, _) -> ()
 5 | | (_, {contents = false}) -> ()
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 
 val f : bool * bool ref -> unit = <fun>
 |}];;
@@ -41,10 +41,10 @@ Lines 1-4, characters 34-31:
 2 | | (true, {contents = true}) -> ()
 3 | | (false, _) -> ()
 4 | | (_, {contents = false}) -> ()
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 
 val g : bool * bool ref -> unit = <fun>
 |}];;
@@ -76,10 +76,10 @@ Lines 2-6, characters 2-33:
 4 |   | (_, r) when (r.contents <- true; false) -> assert false
 5 |   | (false, _) -> ()
 6 |   | (_, {contents = false}) -> ()
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 
 val f : bool * bool ref -> unit = <fun>
 |}];;
@@ -96,10 +96,10 @@ Lines 1-5, characters 34-31:
 3 | | (_, r) when (r.contents <- true; false) -> assert false
 4 | | (false, _) -> ()
 5 | | (_, {contents = false}) -> ()
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
+Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
+  partial, even if it appears to be total. It may generate a "Match_failure"
+  exception. This typically occurs due to complex matches on mutable fields.
+  (see manual section 13.5.5)
 
 val f : bool * bool ref -> unit = <fun>
 |}];;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1883,25 +1883,27 @@ let do_check_partial ~pred loc casel pss = match pss with
     match counter_examples () with
     | Seq.Nil -> Total
     | Seq.Cons (v, _rest) ->
-      if Warnings.is_active (Warnings.Partial_match "") then begin
-        let errmsg =
-          let doc = ref Format_doc.Doc.empty in
-          let fmt = Format_doc.formatter doc in
-          Format_doc.fprintf fmt "@[<v>%a" Printpat.top_pretty v;
-          if do_match (initial_only_guarded casel) [v] then
-            Format_doc.fprintf fmt
-              "@,(However, some guarded clause may match this value.)";
-          if contains_extension v then
-            Format_doc.fprintf fmt
-              "@,@[Matching over values of extensible variant types \
-               (the *extension* above)@,\
-               must include a wild card pattern@ in order to be exhaustive.@]"
-          ;
-          Format_doc.fprintf fmt "@]";
-          Format_doc.(asprintf "%a" pp_doc) !doc
-        in
-        Location.prerr_warning loc (Warnings.Partial_match errmsg)
-      end;
+      if Warnings.is_active (Warnings.Partial_match Format_doc.Doc.empty) then
+        begin
+          let errmsg =
+            let doc = ref Format_doc.Doc.empty in
+            let fmt = Format_doc.formatter doc in
+            Format_doc.fprintf fmt "@[<v>%a"
+              (Misc.Style.as_inline_code Printpat.top_pretty) v;
+            if do_match (initial_only_guarded casel) [v] then
+              Format_doc.fprintf fmt
+                "@,(However, some guarded clause may match this value.)";
+            if contains_extension v then
+              Format_doc.fprintf fmt
+                "@,@[Matching over values of extensible variant types \
+                 (the *extension* above)@,\
+                 must include a wild card pattern@ in order to be exhaustive.@]"
+            ;
+            Format_doc.fprintf fmt "@]";
+            !doc
+          in
+          Location.prerr_warning loc (Warnings.Partial_match errmsg)
+        end;
       Partial
 
 (*****************)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -970,10 +970,10 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
             let msg =
               Format_doc.doc_printf
                 "typing this pattern requires considering@ %a@ and@ %a@ as \
-                equal.@,\
+                equal.@ \
                 But the knowledge of these types"
-                    Printtyp.Doc.type_expr t1
-                    Printtyp.Doc.type_expr t2
+                    (Style.as_inline_code Printtyp.Doc.type_expr) t1
+                    (Style.as_inline_code Printtyp.Doc.type_expr) t2
             in
             Location.prerr_warning loc (Warnings.Not_principal msg);
             raise Warn_only_once)
@@ -6540,8 +6540,8 @@ let report_partial_application = function
       match get_desc tr.Errortrace.got.Errortrace.expanded with
       | Tarrow _ ->
           [ Location.msg
-              "@[@{<hint>Hint@}: This function application is partial,@ \
-               maybe some arguments are missing.@]" ]
+              "@[@{<hint>Hint@}:@ This function application is partial,@ \
+               maybe@ some@ arguments@ are missing.@]" ]
       | _ -> []
     end
   | None -> []

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -969,9 +969,9 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
           if not (fully_generic t1 && fully_generic t2) then
             let msg =
               Format_doc.doc_printf
-                "typing this pattern requires considering@ %a@ and@ %a@ as \
-                equal.@ \
-                But the knowledge of these types"
+                "typing this pattern requires considering@ @[%a@]@ and@ \
+                 @[%a@]@ as@ equal.@ \
+                 But@ the@ knowledge@ of@ these@ types"
                     (Style.as_inline_code Printtyp.Doc.type_expr) t1
                     (Style.as_inline_code Printtyp.Doc.type_expr) t2
             in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -889,6 +889,7 @@ module Style = struct
     pp_close_stag ppf ()
 
   let inline_code ppf s = as_inline_code Format_doc.pp_print_string ppf s
+  let hint ppf = Format_doc.fprintf ppf "@{<hint>Hint@}"
 
   (* either prints the tag of [s] or delegates to [or_else] *)
   let mark_open_tag ~or_else s =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -507,6 +507,7 @@ module Style : sig
     inline_code: tag_style;
   }
 
+  val hint: Format_doc.formatter -> unit
   val as_inline_code: 'a Format_doc.printer -> 'a Format_doc.printer
   val inline_code: string Format_doc.printer
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -42,7 +42,7 @@ type t =
   | Ignored_partial_application             (*  5 *)
   | Labels_omitted of string list           (*  6 *)
   | Method_override of string list          (*  7 *)
-  | Partial_match of string                 (*  8 *)
+  | Partial_match of Format_doc.t           (*  8 *)
   | Missing_record_field_pattern of string  (*  9 *)
   | Non_unit_statement                      (* 10 *)
   | Redundant_case                          (* 11 *)
@@ -920,11 +920,13 @@ let message = function
         Style.inline_code cname
         space_inline_list slist
   | Method_override [] -> assert false
-  | Partial_match "" -> msg "this pattern-matching is not exhaustive."
-  | Partial_match s ->
+  | Partial_match doc ->
+      if doc = Format_doc.Doc.empty then
+        msg "this pattern-matching is not exhaustive."
+     else
       msg "this pattern-matching is not exhaustive.@ \
            @[Here is an example of a case that is not matched:@;<1 2>%a@]"
-        Style.inline_code s
+        Format_doc.pp_doc doc
   | Missing_record_field_pattern s ->
       msg "the following labels are not bound@ in@ this@ \
            record@ pattern:@;<1 2>%a.@ \

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -879,291 +879,376 @@ let () = ignore @@ parse_options true defaults_warn_error
 let () =
   List.iter (set_alert ~error:false ~enable:false) default_disabled_alerts
 
+module Fmt = Format_doc
+module Style = Misc.Style
+let msg = Fmt.doc_printf
+let comma_inline_list = Fmt.(pp_print_list ~pp_sep:comma Style.inline_code)
+let space_inline_list ppf l =
+  Fmt.fprintf ppf "@[%a@]" (Fmt.pp_print_list Style.inline_code) l
+let expand ppf s = if s = "" then () else Fmt.fprintf ppf "@ %s" s
+
 let message = function
   | Comment_start ->
-      "this `(*' is the start of a comment.\n\
-       Hint: Did you forget spaces when writing the infix operator `( * )'?"
-  | Comment_not_end -> "this is not the end of a comment."
+      msg
+        "this %a is the start of a comment.@ \
+         %t: Did you forget spaces when writing the infix operator %a?"
+        Style.inline_code "(*"
+        Style.hint
+        Style.inline_code "( * )"
+  | Comment_not_end -> msg "this is not the end of a comment."
   | Fragile_match "" ->
-      "this pattern-matching is fragile."
+      msg "this pattern-matching is fragile."
   | Fragile_match s ->
-      "this pattern-matching is fragile.\n\
-       It will remain exhaustive when constructors are added to type " ^ s ^ "."
+      msg "this pattern-matching is fragile.@ \
+           It will remain exhaustive when constructors are added to type %a."
+        Style.inline_code s
   | Ignored_partial_application ->
-      "this function application is partial,\n\
-       maybe some arguments are missing."
+      msg "this function application is partial,@ \
+           maybe@ some@ arguments@ are@ missing."
   | Labels_omitted [] -> assert false
   | Labels_omitted [l] ->
-     "label " ^ l ^ " was omitted in the application of this function."
+      msg "label %a@ was omitted@ in@ the@ application@ of@ this@ function."
+        Style.inline_code l
   | Labels_omitted ls ->
-     "labels " ^ String.concat ", " ls ^
-       " were omitted in the application of this function."
+      msg "labels %a@ were omitted@ in@ the@ application@ of@ this@ function."
+        comma_inline_list ls
   | Method_override [lab] ->
-      "the method " ^ lab ^ " is overridden."
+      msg "the method %a is overridden."
+        Style.inline_code lab
   | Method_override (cname :: slist) ->
-      String.concat " "
-        ("the following methods are overridden by the class"
-         :: cname  :: ":\n " :: slist)
+      msg "the following methods are overridden@ by@ the@ class@ %a:@;<1 2>%a"
+        Style.inline_code cname
+        space_inline_list slist
   | Method_override [] -> assert false
-  | Partial_match "" -> "this pattern-matching is not exhaustive."
+  | Partial_match "" -> msg "this pattern-matching is not exhaustive."
   | Partial_match s ->
-      "this pattern-matching is not exhaustive.\n\
-       Here is an example of a case that is not matched:\n" ^ s
+      msg "this pattern-matching is not exhaustive.@ \
+           @[Here is an example of a case that is not matched:@;<1 2>%a@]"
+        Style.inline_code s
   | Missing_record_field_pattern s ->
-      "the following labels are not bound in this record pattern:\n" ^ s ^
-      "\nEither bind these labels explicitly or add '; _' to the pattern."
+      msg "the following labels are not bound@ in@ this@ \
+           record@ pattern:@;<1 2>%a.@ \
+           @[Either bind these labels explicitly or add %a to the pattern.@]"
+        Style.inline_code s
+        Style.inline_code "; _"
   | Non_unit_statement ->
-      "this expression should have type unit."
-  | Redundant_case -> "this match case is unused."
-  | Redundant_subpat -> "this sub-pattern is unused."
+      msg "this expression should have type unit."
+  | Redundant_case -> msg "this match case is unused."
+  | Redundant_subpat -> msg "this sub-pattern is unused."
   | Instance_variable_override [lab] ->
-      "the instance variable " ^ lab ^ " is overridden."
+      msg "the instance variable %a is overridden."
+        Style.inline_code lab
   | Instance_variable_override (cname :: slist) ->
-      String.concat " "
-        ("the following instance variables are overridden by the class"
-         :: cname  :: ":\n " :: slist)
+      msg
+        "the following instance variables@ are overridden@ \
+         by the class %a:@;<1 2>%a"
+        Style.inline_code cname
+        space_inline_list slist
   | Instance_variable_override [] -> assert false
   | Illegal_backslash ->
-    "illegal backslash escape in string.\n\
-    Hint: Single backslashes \\ are reserved for escape sequences\n\
-    (\\n, \\r, ...). Did you check the list of OCaml escape sequences?\n\
-    To get a backslash character, escape it with a second backslash: \\\\."
+      msg "illegal backslash escape in string.@ \
+           %t: Single backslashes %a are reserved for escape sequences@ \
+           (%a, %a, ...).@ Did you check the list of OCaml escape sequences?@ \
+           To get a backslash character, escape it with a second backslash: %a."
+        Style.hint
+        Style.inline_code {|\|}
+        Style.inline_code {|\n|}
+        Style.inline_code {|\r|}
+        Style.inline_code {|\\|}
   | Implicit_public_methods l ->
-      "the following private methods were made public implicitly:\n "
-      ^ String.concat " " l ^ "."
-  | Unerasable_optional_argument -> "this optional argument cannot be erased."
-  | Undeclared_virtual_method m -> "the virtual method "^m^" is not declared."
-  | Not_principal msg ->
-      Format_doc.asprintf "%a is not principal."
-        Format_doc.pp_doc msg
-  | Non_principal_labels s -> s^" without principality."
-  | Ignored_extra_argument -> "this argument will not be used by the function."
+      msg
+        "the following private methods@ were@ made@ public@ \
+         implicitly:@;<1 2>%a."
+        space_inline_list l
+  | Unerasable_optional_argument ->
+      msg "this optional argument cannot be erased."
+  | Undeclared_virtual_method m ->
+      msg "the virtual method %a is not declared."
+        Style.inline_code m
+  | Not_principal emsg ->
+      msg "%a is not principal." Fmt.pp_doc emsg
+  | Non_principal_labels s -> msg "%s without principality." s
+  | Ignored_extra_argument ->
+      msg "this argument will not be used by the function."
   | Nonreturning_statement ->
-      "this statement never returns (or has an unsound type.)"
-  | Preprocessor s -> s
+      msg "this statement never returns (or has an unsound type.)"
+  | Preprocessor s -> msg "%s" s
   | Useless_record_with ->
-      "all the fields are explicitly listed in this record:\n\
-       the 'with' clause is useless."
+      msg "all the fields are explicitly listed in this record:@ \
+           the %a clause is useless."
+        Style.inline_code "with"
   | Bad_module_name (modname) ->
-      "bad source file name: \"" ^ modname ^ "\" is not a valid module name."
+      msg "bad source file name: %a is not a valid module name."
+        Style.inline_code modname
   | All_clauses_guarded ->
-      "this pattern-matching is not exhaustive.\n\
-       All clauses in this pattern-matching are guarded."
-  | Unused_var v | Unused_var_strict v -> "unused variable " ^ v ^ "."
+      msg "this pattern-matching is not exhaustive.@ \
+           All clauses in this pattern-matching are guarded."
+  | Unused_var v | Unused_var_strict v ->
+      msg "unused variable %a."
+        Style.inline_code v
   | Wildcard_arg_to_constant_constr ->
-     "wildcard pattern given as argument to a constant constructor"
+      msg "wildcard pattern given as argument to a constant constructor"
   | Eol_in_string ->
-     "unescaped end-of-line in a string constant\n\
-      (non-portable behavior before OCaml 5.2)"
+      msg "unescaped end-of-line in a string constant@ \
+           (non-portable behavior before OCaml 5.2)"
   | Duplicate_definitions (kind, cname, tc1, tc2) ->
-      Printf.sprintf "the %s %s is defined in both types %s and %s."
-        kind cname tc1 tc2
-  | Unused_value_declaration v -> "unused value " ^ v ^ "."
-  | Unused_open s -> "unused open " ^ s ^ "."
-  | Unused_open_bang s -> "unused open! " ^ s ^ "."
-  | Unused_type_declaration s -> "unused type " ^ s ^ "."
-  | Unused_for_index s -> "unused for-loop index " ^ s ^ "."
-  | Unused_ancestor s -> "unused ancestor variable " ^ s ^ "."
-  | Unused_constructor (s, Unused) -> "unused constructor " ^ s ^ "."
+      msg "the %s %a is defined in both types %a and %a."
+        kind
+        Style.inline_code cname
+        Style.inline_code tc1
+        Style.inline_code tc2
+  | Unused_value_declaration v ->
+      msg "unused value %a." Style.inline_code v
+  | Unused_open s -> msg "unused open %a." Style.inline_code s
+  | Unused_open_bang s -> msg "unused open! %a." Style.inline_code s
+  | Unused_type_declaration s -> msg "unused type %a." Style.inline_code s
+  | Unused_for_index s -> msg "unused for-loop index %a." Style.inline_code s
+  | Unused_ancestor s -> msg "unused ancestor variable %a." Style.inline_code s
+  | Unused_constructor (s, Unused) ->
+      msg "unused constructor %a." Style.inline_code s
   | Unused_constructor (s, Not_constructed) ->
-      "constructor " ^ s ^
-      " is never used to build values.\n\
-        (However, this constructor appears in patterns.)"
-  | Unused_constructor (s, Only_exported_private) ->
-      "constructor " ^ s ^
-      " is never used to build values.\n\
-        Its type is exported as a private type."
-  | Unused_extension (s, is_exception, complaint) ->
-     let kind =
-       if is_exception then "exception" else "extension constructor" in
-     let name = kind ^ " " ^ s in
-     begin match complaint with
-       | Unused -> "unused " ^ name
-       | Not_constructed ->
-          name ^
-          " is never used to build values.\n\
+      msg "constructor %a is never used to build values.@ \
            (However, this constructor appears in patterns.)"
-       | Only_exported_private ->
-          name ^
-          " is never used to build values.\n\
-            It is exported or rebound as a private extension."
-     end
+        Style.inline_code s
+  | Unused_constructor (s, Only_exported_private) ->
+      msg "constructor %a is never used to build values.@ \
+           Its type is exported as a private type."
+        Style.inline_code s
+  | Unused_extension (s, is_exception, complaint) ->
+      let kind =
+        if is_exception then "exception" else "extension constructor" in
+      begin match complaint with
+      | Unused -> msg "unused %s %a" kind Style.inline_code s
+      | Not_constructed ->
+          msg
+            "%s %a is never used@ to@ build@ values.@ \
+             (However, this constructor appears in patterns.)"
+            kind Style.inline_code s
+      | Only_exported_private ->
+          msg
+            "%s %a is never used@ to@ build@ values.@ \
+             It is exported or rebound as a private extension."
+            kind Style.inline_code s
+      end
   | Unused_rec_flag ->
-      "unused rec flag."
+      msg "unused rec flag."
   | Name_out_of_scope (ty, [nm], false) ->
-      nm ^ " was selected from type " ^ ty ^
-      ".\nIt is not visible in the current scope, and will not \n\
-       be selected if the type becomes unknown."
+      msg "%a was selected from type %a.@ \
+           @[It is not visible in the current scope,@ and@ will@ not@ \
+           be@ selected@ if the type becomes unknown@]."
+        Style.inline_code nm
+        Style.inline_code ty
   | Name_out_of_scope (_, _, false) -> assert false
   | Name_out_of_scope (ty, slist, true) ->
-      "this record of type "^ ty ^" contains fields that are \n\
-       not visible in the current scope: "
-      ^ String.concat " " slist ^ ".\n\
-       They will not be selected if the type becomes unknown."
+      msg "this record of type %a@ contains@ fields@ that@ are@ \
+           not@ visible in the current scope:@;<1 2>%a.@ \
+           @[They will not be selected@ if the type@ becomes@ unknown.@]"
+        Style.inline_code ty
+        space_inline_list slist
   | Ambiguous_name ([s], tl, false, expansion) ->
-      s ^ " belongs to several types: " ^ String.concat " " tl ^
-      "\nThe first one was selected. Please disambiguate if this is wrong."
-      ^ expansion
+      msg "%a belongs to several types:@;<1 2>%a.@ \
+           The first one was selected.@ \
+           @[Please disambiguate@ if@ this@ is wrong.%a@]"
+        Style.inline_code s
+        space_inline_list tl
+        expand expansion
   | Ambiguous_name (_, _, false, _ ) -> assert false
   | Ambiguous_name (_slist, tl, true, expansion) ->
-      "these field labels belong to several types: " ^
-      String.concat " " tl ^
-      "\nThe first one was selected. Please disambiguate if this is wrong."
-      ^ expansion
+      msg "these field labels belong to several types:@;<1 2>%a.@ \
+           @[The first one was selected.@ \
+           Please disambiguate@ if@ this@ is@ wrong.%a@]"
+        space_inline_list tl
+        expand expansion
   | Disambiguated_name s ->
-      "this use of " ^ s ^ " relies on type-directed disambiguation,\n\
-       it will not compile with OCaml 4.00 or earlier."
+      msg "this use of %a@ relies@ on@ type-directed@ disambiguation,@ \
+           @[it@ will@ not@ compile@ with@ OCaml@ 4.00@ or@ earlier.@]"
+        Style.inline_code s
   | Nonoptional_label s ->
-      "the label " ^ s ^ " is not optional."
+      msg "the label %a is not optional."
+        Style.inline_code s
   | Open_shadow_identifier (kind, s) ->
-      Printf.sprintf
-        "this open statement shadows the %s identifier %s (which is later used)"
-        kind s
+      msg
+        "this open statement shadows@ the@ %s identifier@ %a@ \
+         (which is later used)"
+        kind Style.inline_code s
   | Open_shadow_label_constructor (kind, s) ->
-      Printf.sprintf
-        "this open statement shadows the %s %s (which is later used)"
-        kind s
+      msg
+        "this open statement shadows@ the@ %s %a@ (which is later used)"
+        kind Style.inline_code s
   | Bad_env_variable (var, s) ->
-      Printf.sprintf "illegal environment variable %s : %s" var s
+      msg "illegal environment variable %a : %s"
+        Style.inline_code var
+        s
   | Attribute_payload (a, s) ->
-      Printf.sprintf "illegal payload for attribute '%s'.\n%s" a s
+      msg "illegal payload for attribute %a.@ %s"
+        Style.inline_code a
+        s
   | Eliminated_optional_arguments sl ->
-      Printf.sprintf "implicit elimination of optional argument%s %s"
+      msg "implicit elimination@ of optional argument%s@ %a"
         (if List.length sl = 1 then "" else "s")
-        (String.concat ", " sl)
+        comma_inline_list sl
   | No_cmi_file(name, None) ->
-      "no cmi file was found in path for module " ^ name
-  | No_cmi_file(name, Some msg) ->
-      Printf.sprintf
-        "no valid cmi file was found in path for module %s. %s"
-        name msg
+      msg "no cmi file was found@ in path for module %a"
+        Style.inline_code name
+  | No_cmi_file(name, Some wmsg) ->
+      msg
+        "no valid cmi file was found@ in path for module %a.@ %s"
+        Style.inline_code name
+        wmsg
   | Unexpected_docstring unattached ->
-      if unattached then "unattached documentation comment (ignored)"
-      else "ambiguous documentation comment"
+      if unattached then msg "unattached documentation comment (ignored)"
+      else msg "ambiguous documentation comment"
   | Wrong_tailcall_expectation b ->
-      Printf.sprintf "expected %s"
+      msg "expected %s"
         (if b then "tailcall" else "non-tailcall")
   | Fragile_literal_pattern ->
       let[@manual.ref "ss:warn52"] ref_manual = [ 13; 5; 3 ] in
-      Format.asprintf
-        "Code should not depend on the actual values of\n\
-         this constructor's arguments. They are only for information\n\
-         and may change in future versions. %a"
-        (Format_doc.compat Misc.print_see_manual) ref_manual
+      msg
+        "Code should not depend@ on@ the@ actual@ values of@ \
+         this@ constructor's arguments.@ @[They are only for@ information@ \
+         and@ may@ change@ in@ future versions.@ %a@]"
+        Misc.print_see_manual ref_manual
   | Unreachable_case ->
-      "this match case is unreachable.\n\
-       Consider replacing it with a refutation case '<pat> -> .'"
+      msg "this match case is unreachable.@ \
+           Consider replacing it with a refutation case %a"
+        Style.inline_code "<pat> -> ."
   | Misplaced_attribute attr_name ->
-      Printf.sprintf "the %S attribute cannot appear in this context" attr_name
+      msg "the %a attribute cannot appear in this context"
+        Style.inline_code attr_name
   | Duplicated_attribute attr_name ->
-      Printf.sprintf "the %S attribute is used more than once on this \
-          expression"
-        attr_name
+      msg "the %a attribute is used more than once@ on@ this@ \
+           expression"
+        Style.inline_code attr_name
   | Inlining_impossible reason ->
-      Printf.sprintf "Cannot inline: %s" reason
+      msg "Cannot inline:@ %s" reason
   | Ambiguous_var_in_pattern_guard vars ->
       let[@manual.ref "ss:warn57"] ref_manual = [ 13; 5; 4 ] in
       let vars = List.sort String.compare vars in
       let vars_explanation =
-        let in_different_places =
-          "in different places in different or-pattern alternatives"
-        in
         match vars with
         | [] -> assert false
-        | [x] -> "variable " ^ x ^ " appears " ^ in_different_places
+        | [x] ->
+            Fmt.dprintf
+              "variable %a appears in@ different@ places@ in@ \
+               different@ or-pattern@ alternatives."
+              Style.inline_code x
         | _::_ ->
-            let vars = String.concat ", " vars in
-            "variables " ^ vars ^ " appear " ^ in_different_places
+            Fmt.dprintf
+              "variables %a appears in@ different@ places@ in@ \
+               different@ or-pattern@ alternatives."
+              comma_inline_list vars
       in
-      Format.asprintf
-        "Ambiguous or-pattern variables under guard;\n\
-         %s.\n\
-         Only the first match will be used to evaluate the guard expression.\n\
-         %a"
-        vars_explanation (Format_doc.compat Misc.print_see_manual) ref_manual
+      msg
+        "Ambiguous or-pattern variables under@ guard;@ \
+         %t@ \
+         @[Only the first match will be used to evaluate@ \
+         the@ guard@ expression.@ %a@]"
+        vars_explanation
+        Misc.print_see_manual ref_manual
   | No_cmx_file name ->
-      Printf.sprintf
-        "no cmx file was found in path for module %s, \
-         and its interface was not compiled with -opaque" name
+      msg
+        "no cmx file was found@ in@ path@ for@ module@ %a,@ \
+         and@ its@ interface@ was@ not@ compiled@ with %a"
+        Style.inline_code name
+        Style.inline_code "-opaque"
   | Flambda_assignment_to_non_mutable_value ->
-      "A potential assignment to a non-mutable value was detected \n\
-        in this source file.  Such assignments may generate incorrect code \n\
-        when using Flambda."
-  | Unused_module s -> "unused module " ^ s ^ "."
+      msg
+        "A potential assignment to a non-mutable value@ was@ detected@ \
+         in@ this@ source@ file.@ \
+         Such@ assignments@ may@ generate@ incorrect code@ \
+         when@ using@ Flambda."
+  | Unused_module s -> msg "unused module %a." Style.inline_code s
   | Unboxable_type_in_prim_decl t ->
-      Printf.sprintf
-        "This primitive declaration uses type %s, whose representation\n\
-         may be either boxed or unboxed. Without an annotation to indicate\n\
-         which representation is intended, the boxed representation has been\n\
-         selected by default. This default choice may change in future\n\
-         versions of the compiler, breaking the primitive implementation.\n\
-         You should explicitly annotate the declaration of %s\n\
-         with [@@boxed] or [@@unboxed], so that its external interface\n\
-         remains stable in the future." t t
+      msg
+        "This primitive declaration uses type %a,@ whose@ representation@ \
+         may be either boxed or unboxed.@ Without@ an@ annotation@ to@ \
+         indicate@ which@ representation@ is@ intended,@ the@ boxed@ \
+         representation@ has@ been@ selected@ by@ default.@ This@ default@ \
+         choice@ may@ change@ in@ future@ versions@ of@ the@ compiler,@ \
+         breaking@ the@ primitive@ implementation.@ You@ should@ explicitly@ \
+         annotate@ the@ declaration@ of@ %a@ with@ %a@ or@ %a,@ so@ that@ its@ \
+         external@ interface@ remains@ stable@ in@ the future."
+        Style.inline_code t
+        Style.inline_code t
+        Style.inline_code "[@@boxed]"
+        Style.inline_code "[@@unboxed]"
   | Constraint_on_gadt ->
-      "Type constraints do not apply to GADT cases of variant types."
+      msg "Type constraints do not apply to@ GADT@ cases@ of@ variant types."
   | Erroneous_printed_signature s ->
-      "The printed interface differs from the inferred interface.\n\
-       The inferred interface contained items which could not be printed\n\
-       properly due to name collisions between identifiers.\n"
-     ^ s
-     ^ "\nBeware that this warning is purely informational and will not catch\n\
-        all instances of erroneous printed interface."
+      msg
+        "The printed@ interface@ differs@ from@ the@ inferred@ interface.@ \
+         The@ inferred@ interface@ contained@ items@ which@ could@ not@ be@ \
+         printed@ properly@ due@ to@ name@ collisions@ between@ identifiers.@ \
+         %s@ \
+         Beware@ that@ this@ warning@ is@ purely@ informational@ and@ will@ \
+         not@ catch@ all@ instances@ of@ erroneous@ printed@ interface."
+        s
   | Unsafe_array_syntax_without_parsing ->
-     "option -unsafe used with a preprocessor returning a syntax tree"
+      msg "option@ %a@ used with a preprocessor returning@ a@ syntax tree"
+        Style.inline_code "-unsafe"
   | Redefining_unit name ->
-      Printf.sprintf
-        "This type declaration is defining a new '()' constructor\n\
-         which shadows the existing one.\n\
-         Hint: Did you mean 'type %s = unit'?" name
-  | Unused_functor_parameter s -> "unused functor parameter " ^ s ^ "."
+      let def ppf name = Fmt.fprintf ppf "type %s = unit" name in
+      msg
+        "This type declaration is@ defining@ a new %a constructor@ \
+         which@ shadows@ the@ existing@ one.@ \
+         %t: Did you mean %a?"
+        Style.inline_code "()"
+        Style.hint
+        (Style.as_inline_code def) name
+  | Unused_functor_parameter s ->
+      msg "unused functor parameter %a." Style.inline_code s
   | Match_on_mutable_state_prevent_uncurry ->
-    "This pattern depends on mutable state.\n\
-     It prevents the remaining arguments from being uncurried, which will \
-     cause additional closure allocations."
-  | Unused_field (s, Unused) -> "unused record field " ^ s ^ "."
+      msg
+        "This pattern depends on@ mutable@ state.@ It prevents@ the@ \
+         remaining@ arguments@ from@ being@ uncurried,@ which will@ cause@ \
+         additional@ closure@ allocations."
+  | Unused_field (s, Unused) ->
+      msg "unused record field %a." Style.inline_code s
   | Unused_field (s, Not_read) ->
-      "record field " ^ s ^
-      " is never read.\n\
-        (However, this field is used to build or mutate values.)"
+      msg "record field %a is never read.@ \
+           (However, this field is used to build or mutate values.)"
+        Style.inline_code s
   | Unused_field (s, Not_mutated) ->
-      "mutable record field " ^ s ^
-      " is never mutated."
+      msg "mutable record field %a is never mutated."
+        Style.inline_code s
   | Missing_mli ->
-    "Cannot find interface file."
+      msg "Cannot find interface file."
   | Unused_tmc_attribute ->
-      "This function is marked @tail_mod_cons\n\
-       but is never applied in TMC position."
+      msg "This function is marked %a@ \
+           but is never applied in TMC position."
+        Style.inline_code "@tail_mod_cons"
   | Tmc_breaks_tailcall ->
-      "This call\n\
-       is in tail-modulo-cons position in a TMC function,\n\
-       but the function called is not itself specialized for TMC,\n\
-       so the call will not be transformed into a tail call.\n\
-       Please either mark the called function with the [@tail_mod_cons]\n\
-       attribute, or mark this call with the [@tailcall false] attribute\n\
-       to make its non-tailness explicit."
+      msg "This call@ is@ in@ tail-modulo-cons@ position@ in@ a@ TMC@ \
+           function,@ but@ the@ function@ called@ is@ not@ itself@ \
+           specialized@ for@ TMC,@ so@ the@ call@ will@ not@ be@ transformed@ \
+           into@ a@ tail@ call.@ \
+           @[Please@ either@ mark@ the@ called@ function@ with@ the %a@ \
+           attribute,@ or@ mark@ this@ call@ with@ the@ %a@ attribute@ to@ \
+           make@ its@ non-tailness@ explicit.@]"
+        Style.inline_code "[@tail_mod_cons]"
+        Style.inline_code "[@tailcall false]"
   | Generative_application_expects_unit ->
-      "A generative functor\n\
-       should be applied to '()'; using '(struct end)' is deprecated."
+      msg "A generative functor@ \
+           should be applied@ to@ %a;@ using@ %a@ is deprecated."
+        Style.inline_code "()"
+        Style.inline_code "(struct end)"
   | Degraded_to_partial_match ->
       let[@manual.ref "ss:warn74"] ref_manual = [ 13; 5; 5 ] in
-      Format.asprintf
-        "This pattern-matching is compiled \n\
-         as partial, even if it appears to be total. \
-         It may generate a Match_failure\n\
-         exception. This typically occurs due to \
-         complex matches on mutable fields.\n\
-         %a"
-        (Format_doc.compat Misc.print_see_manual) ref_manual
+      msg
+        "This pattern-matching@ is@ compiled@ as@ partial,@ even@ if@ it@ \
+         appears@ to@ be@ total.@ It@ may@ generate@ a@ %a@ exception.@ This@ \
+         typically@ occurs@ due@ to@ complex@ matches@ on@ mutable@ fields.@ %a"
+        Style.inline_code "Match_failure"
+        Misc.print_see_manual ref_manual
 ;;
 
 let nerrors = ref 0
 
 type reporting_information =
   { id : string
-  ; message : string
+  ; message : Fmt.doc
   ; is_error : bool
-  ; sub_locs : (loc * string) list;
+  ; sub_locs : (loc * Fmt.doc) list;
   }
 
 let id_name w =
@@ -1192,7 +1277,7 @@ let report_alert (alert : alert) =
   | true ->
       let is_error = alert_is_error alert in
       if is_error then incr nerrors;
-      let message = Misc.normalise_eol alert.message in
+      let message = msg "%s" (Misc.normalise_eol alert.message) in
        (* Reduce \r\n to \n:
            - Prevents any \r characters being printed on Unix when processing
              Windows sources
@@ -1202,8 +1287,8 @@ let report_alert (alert : alert) =
       let sub_locs =
         if not alert.def.loc_ghost && not alert.use.loc_ghost then
           [
-            alert.def, "Definition";
-            alert.use, "Expected signature";
+            alert.def, msg "Definition";
+            alert.use, msg "Expected signature";
           ]
         else
           []

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -884,7 +884,8 @@ module Style = Misc.Style
 let msg = Fmt.doc_printf
 let comma_inline_list = Fmt.(pp_print_list ~pp_sep:comma Style.inline_code)
 let space_inline_list ppf l =
-  Fmt.fprintf ppf "@[%a@]" (Fmt.pp_print_list Style.inline_code) l
+  let pp_sep = Fmt.pp_print_space in
+  Fmt.fprintf ppf "@[%a@]" (Fmt.pp_print_list ~pp_sep Style.inline_code) l
 let expand ppf s = if s = "" then () else Fmt.fprintf ppf "@ %s" s
 
 let message = function

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -969,7 +969,7 @@ let message = function
       msg "the virtual method %a is not declared."
         Style.inline_code m
   | Not_principal emsg ->
-      msg "%a is not principal." Fmt.pp_doc emsg
+      msg "%a@ is@ not@ principal." Fmt.pp_doc emsg
   | Non_principal_labels s -> msg "%s without principality." s
   | Ignored_extra_argument ->
       msg "this argument will not be used by the function."

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -1156,9 +1156,9 @@ let message = function
         Style.inline_code "-opaque"
   | Flambda_assignment_to_non_mutable_value ->
       msg
-        "A potential assignment to a non-mutable value@ was@ detected@ \
+        "A potential@ assignment@ to@ a@ non-mutable@ value@ was@ detected@ \
          in@ this@ source@ file.@ \
-         Such@ assignments@ may@ generate@ incorrect code@ \
+         Such@ assignments@ may@ generate@ incorrect@ code@ \
          when@ using@ Flambda."
   | Unused_module s -> msg "unused module %a." Style.inline_code s
   | Unboxable_type_in_prim_decl t ->

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -139,9 +139,9 @@ val defaults_warn_error : string
 
 type reporting_information =
   { id : string
-  ; message : string
+  ; message : Format_doc.t
   ; is_error : bool
-  ; sub_locs : (loc * string) list;
+  ; sub_locs : (loc * Format_doc.t) list;
   }
 
 val report : t -> [ `Active of reporting_information | `Inactive ]

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -47,7 +47,7 @@ type t =
   | Ignored_partial_application             (*  5 *)
   | Labels_omitted of string list           (*  6 *)
   | Method_override of string list          (*  7 *)
-  | Partial_match of string                 (*  8 *)
+  | Partial_match of Format_doc.t           (*  8 *)
   | Missing_record_field_pattern of string  (*  9 *)
   | Non_unit_statement                      (* 10 *)
   | Redundant_case                          (* 11 *)


### PR DESCRIPTION
This PR enables composable formatting for warning messages.

Before this PR warning messages were rendered as strings before being sent to the error report printer.
Consequently, warning messages could not really use styling nor formatting hints in a reliable way.

This PR switches warning messages to render to `Format_doc.t` rather than string (like error messages) to enable both options. 

A painful source of complexity for this PR as described in #12965 is that the format used for error message reports

```
──────────────────
  Location
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
  Header │ Main
         │ msg
         │
         │
┈┈┈┈┈┈┈┈┈╧════════
Suberrors
──────────────────
```
does not work well for warnings because the width of the header for warning is unbounded and often quite large. 

To solve this formatting issue, this PR takes the alternative path of implementing a new format for warnings and alerts

```
───────────────────
  Location
───────────────────
  Header ┊ Main msg
┈┈┈┈┈┈┈┈┈┘
  ┊ 
  ┊
  ┊
  ┊
──╧════════════════
Suberrors
───────────────────
```

while keeping the old format for error messages. I expect this to be a (temporarily?) work-around to decouple the formatting of warnings from the change of format for all error messages.
