### PR TITLE
stdlib: add a format_text function for text-like format strings

### DIFF
--- a/Changes
+++ b/Changes
@@ -216,7 +216,8 @@ Working version
   Bär)
 
 - #13569: add a `Format.format_text` which adds break hints to format literals.
-  (Florian Angeletti, review by Daniel Bünzli and Gabriel Scherer)
+  (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
+   and Gabriel Scherer)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -215,6 +215,9 @@ Working version
   (Yves Ndiaye and Nicolás Ojeda Bär, review by Daniel Bünzli and Nicolás Ojeda
   Bär)
 
+- #13569: add a `Format.format_text` which adds break hints to format literals.
+  (Florian Angeletti, review by Daniel Bünzli and Gabriel Scherer)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/stdlib/camlinternalFormatBasics.ml
+++ b/stdlib/camlinternalFormatBasics.ml
@@ -688,3 +688,62 @@ fun fmt1 fmt2 -> match fmt1 with
 
   | End_of_format ->
     fmt2
+
+
+type neutral_concat =
+  { f:
+      'a 'b 'c 'd 'e 'f. [`String of string | `Char of char ] ->
+      ('a,'b,'c,'d,'e,'f) fmt -> ('a,'b,'c,'d,'e,'f) fmt
+  }
+
+let rec string_concat_map: type a b c d e f.
+   neutral_concat -> (a,b,c,d,e,f) fmt -> (a,b,c,d,e,f) fmt =
+  fun f -> function
+  | String (pad, rest) -> String (pad, string_concat_map f rest)
+  | Caml_string (pad, rest) -> Caml_string (pad, string_concat_map f rest)
+
+  | Int (iconv, pad, prec, rest) ->
+    Int (iconv, pad, prec,  string_concat_map f rest)
+  | Int32 (iconv, pad, prec, rest) ->
+    Int32 (iconv, pad, prec,  string_concat_map f rest)
+  | Nativeint (iconv, pad, prec, rest) ->
+    Nativeint (iconv, pad, prec,  string_concat_map f rest)
+  | Int64 (iconv, pad, prec, rest) ->
+    Int64 (iconv, pad, prec,  string_concat_map f rest)
+  | Float (fconv, pad, prec, rest) ->
+    Float (fconv, pad, prec,  string_concat_map f rest)
+
+  | Char (rest) -> Char (string_concat_map f rest)
+  | Caml_char rest ->
+    Caml_char ( string_concat_map f rest)
+  | Bool (pad, rest) -> Bool (pad,  string_concat_map f rest)
+  | Alpha rest -> Alpha (string_concat_map f rest)
+  | Theta rest -> Theta (string_concat_map f rest)
+  | Custom (arity, fc, rest) ->
+    Custom (arity, fc,  string_concat_map f rest)
+  | Reader rest -> Reader (string_concat_map f rest)
+  | Flush rest -> Flush (string_concat_map f rest)
+
+  | String_literal (str, rest) -> f.f (`String str) (string_concat_map f rest)
+  | Char_literal (chr, rest) ->
+      f.f (`Char chr) (string_concat_map f rest)
+  | Format_arg (pad, fmtty, rest) ->
+    Format_arg   (pad, fmtty, string_concat_map f rest)
+  | Format_subst (pad, fmtty, rest) ->
+    Format_subst (pad, fmtty, string_concat_map f rest)
+
+  | Scan_char_set (width_opt, char_set, rest) ->
+    Scan_char_set (width_opt, char_set, string_concat_map f rest)
+  | Scan_get_counter (counter, rest) ->
+    Scan_get_counter (counter,string_concat_map f rest)
+  | Scan_next_char (rest) ->
+    Scan_next_char (string_concat_map f rest)
+  | Ignored_param (ign, rest) ->
+    Ignored_param (ign, string_concat_map f rest)
+
+  | Formatting_lit (fmting_lit, rest) ->
+    Formatting_lit (fmting_lit, string_concat_map f rest)
+  | Formatting_gen (fmting_gen, rest) ->
+    Formatting_gen (fmting_gen, string_concat_map f rest)
+
+  | End_of_format -> End_of_format

--- a/stdlib/camlinternalFormatBasics.mli
+++ b/stdlib/camlinternalFormatBasics.mli
@@ -325,3 +325,15 @@ val concat_fmt :
     ('a, 'b, 'c, 'd, 'e, 'f) fmt ->
     ('f, 'b, 'c, 'e, 'g, 'h) fmt ->
     ('a, 'b, 'c, 'd, 'g, 'h) fmt
+
+type neutral_concat =
+  { f:
+      'a 'b 'c 'd 'e 'f. [`String of string | `Char of char ] ->
+      ('a,'b,'c,'d,'e,'f) fmt -> ('a,'b,'c,'d,'e,'f) fmt
+  }
+
+val string_concat_map:
+  neutral_concat ->
+   ('a, 'b, 'c, 'd, 'e, 'f) fmt -> ('a, 'b, 'c, 'd, 'e, 'f) fmt
+(** Helper function for splitting format string and char literal.
+    @since 5.4 *)

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1351,6 +1351,50 @@ let pp_print_text ppf s =
   done;
   if !left <> len then flush ()
 
+(* To format free-flowing text *)
+let format_text fmt6 =
+  let open CamlinternalFormatBasics in
+  let Format(fmt,s) = fmt6 in
+  let cons_substring ~first ~last s fmt =
+    if first = last then fmt
+    else String_literal(String.sub s first (last-first),fmt) in
+  let cons_space ~spaces fmt = Formatting_lit (Break("",spaces,0), fmt) in
+  let cons ~first ~last s ~spaces fmt =
+    cons_substring ~first ~last s (cons_space ~spaces fmt)
+  in
+  let rec skip_spaces len s pos =
+    if pos >= len || s.[pos] <> ' ' then pos
+    else skip_spaces len s (pos+1)
+  in
+  let rec split len s pos fmt =
+    if pos >= len then fmt
+    else
+      let space = String.index_from_opt s pos ' ' in
+      let newline = String.index_from_opt s pos '\n' in
+      match space, newline with
+      | None, None -> cons_substring ~first:pos ~last:len s fmt
+      | Some last, None ->
+          let after_spaces = skip_spaces len s (last+1) in
+          let spaces = after_spaces - last in
+          cons ~first:pos ~last s ~spaces (split len s after_spaces fmt)
+      | Some last, Some l when last < l ->
+          let after_spaces = skip_spaces len s (last+1) in
+          let spaces = after_spaces - last in
+        cons ~first:pos ~last s ~spaces (split len s after_spaces fmt)
+      | _, Some last ->
+          let after_spaces = skip_spaces len s (last+1) in
+          let spaces = after_spaces - last - 1 in
+          cons ~first:pos ~last s ~spaces (split len s after_spaces fmt)
+  in
+  let concat s fmt = match s with
+    | `Char ' ' -> cons_space ~spaces:1 fmt
+    | `Char '\n' -> cons_space ~spaces:2 fmt
+    | `Char c -> Char_literal(c,fmt)
+    | `String s -> split (String.length s) s 0 fmt in
+  let fmt = string_concat_map {f=concat} fmt in
+  Format(fmt,s)
+
+
 let pp_print_option ?(none = fun _ () -> ()) pp_v ppf = function
 | None -> none ppf ()
 | Some v -> pp_v ppf v

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1354,37 +1354,44 @@ let pp_print_text ppf s =
 (* To format free-flowing text *)
 let format_text fmt6 =
   let open CamlinternalFormatBasics in
-  let Format(fmt,s) = fmt6 in
-  let cons_substring ~first ~last s fmt =
-    if first = last then fmt
-    else String_literal(String.sub s first (last-first),fmt) in
+  let Format(fmt,_) = fmt6 in
   let cons_space ~spaces fmt = Formatting_lit (Break("",spaces,0), fmt) in
-  let cons ~first ~last s ~spaces fmt =
-    cons_substring ~first ~last s (cons_space ~spaces fmt)
+  let rec skip_char len s char pos =
+    if pos >= len || s.[pos] <> char then pos
+    else skip_char len s char (pos+1)
   in
-  let rec skip_spaces len s pos =
-    if pos >= len || s.[pos] <> ' ' then pos
-    else skip_spaces len s (pos+1)
-  in
-  let rec split len s pos fmt =
+  let[@tail_mod_cons] rec split len s pos fmt =
     if pos >= len then fmt
     else
       let space = String.index_from_opt s pos ' ' in
       let newline = String.index_from_opt s pos '\n' in
-      match space, newline with
-      | None, None -> cons_substring ~first:pos ~last:len s fmt
-      | Some last, None ->
-          let after_spaces = skip_spaces len s (last+1) in
-          let spaces = after_spaces - last in
-          cons ~first:pos ~last s ~spaces (split len s after_spaces fmt)
-      | Some last, Some l when last < l ->
-          let after_spaces = skip_spaces len s (last+1) in
-          let spaces = after_spaces - last in
-        cons ~first:pos ~last s ~spaces (split len s after_spaces fmt)
-      | _, Some last ->
-          let after_spaces = skip_spaces len s (last+1) in
-          let spaces = after_spaces - last - 1 in
-          cons ~first:pos ~last s ~spaces (split len s after_spaces fmt)
+      let first = match space, newline with
+        | Some x, Some y -> Some (min x y)
+        | None, x | x, None -> x
+      in
+      match first with
+      | None ->
+          String_literal(String.sub s pos (len-pos), fmt)
+      | Some sep ->
+          let after_newlines = skip_char len s '\n' sep in
+          let after_spaces = skip_char len s ' ' after_newlines in
+          let newlines = after_newlines - sep in
+          let spaces = after_spaces - after_newlines in
+          match newlines, spaces with
+          | (0|1), spaces ->
+              String_literal(
+                String.sub s pos (sep-pos),
+                cons (Break("",newlines+spaces,0)) len s after_spaces fmt
+              )
+          | _, _ ->
+              String_literal(
+                String.sub s pos (sep-pos),
+                paragraph len s after_spaces fmt
+              )
+  and[@tail_mod_cons] paragraph len s pos fmt =
+    Formatting_lit (Force_newline, cons Force_newline len s pos fmt)
+  and[@tail_mod_cons] cons break len s pos fmt =
+    Formatting_lit (break, split len s pos fmt)
   in
   let concat s fmt = match s with
     | `Char ' ' -> cons_space ~spaces:1 fmt
@@ -1392,7 +1399,7 @@ let format_text fmt6 =
     | `Char c -> Char_literal(c,fmt)
     | `String s -> split (String.length s) s 0 fmt in
   let fmt = string_concat_map {f=concat} fmt in
-  Format(fmt,s)
+  Format(fmt, CamlinternalFormat.string_of_fmt fmt)
 
 
 let pp_print_option ?(none = fun _ () -> ()) pp_v ppf = function

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1378,15 +1378,12 @@ let format_text fmt6 =
       | Some sep ->
           let before = String.sub s pos (sep-pos) in
           let pos, spaces, newlines = skip_and_count_whites 0 0 len s sep in
-          match newlines, spaces with
-          | (0|1), spaces ->
-              let break = Break("", max spaces 1, 0) in
-              String_literal(before, cons ~repeat:1 break len s pos fmt)
-          | bl, _ ->
-              String_literal(
-                before,
-                cons ~repeat:bl Force_newline len s pos fmt
-              )
+          let repeat, break =
+            match newlines, spaces with
+            | (0|1), spaces -> 1, Break("", max spaces 1, 0)
+            | bl, _ -> bl, Force_newline
+          in
+          String_literal(before, cons ~repeat break len s pos fmt)
   and[@tail_mod_cons] cons ~repeat break len s pos fmt =
     if repeat = 0 then
       split len s pos fmt

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1270,8 +1270,8 @@ val pp_print_text : formatter -> string -> unit
 *)
 
 val format_text: ('a,'b,'c,'d,'e,'f) format6 -> ('a,'b,'c,'d,'e,'f) format6
-(** [text fmt] replaces spaces and newlines in the format string literal [fmt]
-    with hint breaks or forced newlines:
+(** [format_text fmt] replaces spaces and newlines in the format string literal
+    [fmt] with hint breaks or forced newlines:
   - Blank lines (lines made only of spaces ([U+0020])) are replaced by ["\@n"].
   - Sequences of spaces and a newline ([U+000A]) preceding a blank line are
     replaced by ["\@n"]: blank lines remain blank lines in the output.

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1271,7 +1271,15 @@ val pp_print_text : formatter -> string -> unit
 
 val format_text: ('a,'b,'c,'d,'e,'f) format6 -> ('a,'b,'c,'d,'e,'f) format6
 (** [text fmt] replaces spaces and newlines in the format string literal [fmt]
-    with hint breaks.
+    with hint breaks or forced newlines:
+- Only ascii spaces ([" " = "\u{20}"]) and linefeeds ["\n" = "\u{A}"] are
+  replaced. In particular, this means that non-breaking spaces (for instance
+  ["\u{A0}"]) are left unchanged.
+- [0<=k<=1] newlines followed by [n] spaces are converted to a [@;<0 (k+n)>]
+  break hint (when [k+n>=1]).
+- Two and more newlines followed by spaces are converted to two forced
+  newlines ["@\n@\n"].
+- Newlines can be inserted with ["@\n"].
   @since 5.4
 *)
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1269,6 +1269,13 @@ val pp_print_text : formatter -> string -> unit
   @since 4.02
 *)
 
+val format_text: ('a,'b,'c,'d,'e,'f) format6 -> ('a,'b,'c,'d,'e,'f) format6
+(** [text fmt] replaces spaces and newlines in the format string literal [fmt]
+    with hint breaks.
+  @since 5.4
+*)
+
+
 val pp_print_option :
   ?none:(formatter -> unit -> unit) ->
   (formatter -> 'a -> unit) -> (formatter -> 'a option -> unit)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1272,15 +1272,14 @@ val pp_print_text : formatter -> string -> unit
 val format_text: ('a,'b,'c,'d,'e,'f) format6 -> ('a,'b,'c,'d,'e,'f) format6
 (** [text fmt] replaces spaces and newlines in the format string literal [fmt]
     with hint breaks or forced newlines:
-- Only ascii spaces ([" " = "\u{20}"]) and linefeeds ["\n" = "\u{A}"] are
-  replaced. In particular, this means that non-breaking spaces (for instance
-  ["\u{A0}"]) are left unchanged.
-- [0<=k<=1] newlines followed by [n] spaces are converted to a [@;<0 (k+n)>]
-  break hint (when [k+n>=1]).
-- Two and more newlines followed by spaces are converted to two forced
-  newlines ["@\n@\n"].
-- Newlines can be inserted with ["@\n"].
-  @since 5.4
+  - Blank lines (lines made only of spaces ([U+0020])) are replaced by ["\@n"].
+  - Sequences of spaces and a newline ([U+000A]) preceding a blank line are
+    replaced by ["\@n"]: blank lines remain blank lines in the output.
+  - Remaining sequences made of [k] spaces and newlines are replaced
+    by ["@;<0 k'>"] where [k' = max 1 k] is at least [1].
+  - Breaks can be avoided using non-breaking space characters ([U+00A0]).
+  - Lines can be forced by using ["@\n"]
+@since 5.4
 *)
 
 

--- a/testsuite/tests/lib-format/format_text.ml
+++ b/testsuite/tests/lib-format/format_text.ml
@@ -1,0 +1,64 @@
+(* TEST
+expect;
+*)
+
+let test n =
+  let open Format in
+  set_geometry ~max_indent:(n-2) ~margin:n;
+  printf (format_text
+            "@[<v>@[qualibus @[in@] @[tenebris@] vitae quantisque periclis@] \
+             @[degitur hoc aevi quod cumquest! nonne videre@] \
+             @[nihil aliud sibinaturam latrare, nisi ut qui@] \
+             @[corpore seiunctus dolor absit, mente fruatur@] \
+             @[iucundo sensu cura semota metuque?@] %s@]@."
+         )
+    "De rerum natura, Lucretius"
+[%%expect {|
+val test : int -> unit = <fun>
+|}]
+
+
+let () = test 20
+[%%expect {|
+qualibus in
+tenebris vitae
+quantisque periclis
+degitur hoc aevi
+quod cumquest!
+nonne videre
+nihil aliud
+sibinaturam
+latrare, nisi ut
+qui
+corpore seiunctus
+dolor absit, mente
+fruatur
+iucundo sensu cura
+semota metuque?
+De rerum natura, Lucretius
+|}]
+
+
+let () = test 40
+[%%expect {|
+qualibus in tenebris vitae quantisque
+periclis
+degitur hoc aevi quod cumquest! nonne
+videre
+nihil aliud sibinaturam latrare, nisi
+ut qui
+corpore seiunctus dolor absit, mente
+fruatur
+iucundo sensu cura semota metuque?
+De rerum natura, Lucretius
+|}]
+
+let () = test 80
+[%%expect {|
+qualibus in tenebris vitae quantisque periclis
+degitur hoc aevi quod cumquest! nonne videre
+nihil aliud sibinaturam latrare, nisi ut qui
+corpore seiunctus dolor absit, mente fruatur
+iucundo sensu cura semota metuque?
+De rerum natura, Lucretius
+|}]

--- a/testsuite/tests/lib-format/format_text.ml
+++ b/testsuite/tests/lib-format/format_text.ml
@@ -2,6 +2,34 @@
 expect;
 *)
 
+let () =
+  Format.set_geometry ~max_indent:28 ~margin:30;
+  Format.printf (
+    Format.format_text
+      "@[\
+A first paragraph containing
+a newline and some characters.
+
+A second paragraph,
+split from the first one by a new line,
+and with few more newlines inside.
+
+The end.@]@."
+         )
+
+[%%expect {|
+A first paragraph containing
+a newline and some
+characters.
+
+A second paragraph, split
+from the first one by a new
+line, and with few more
+newlines inside.
+
+The end.
+|}]
+
 let test n =
   let open Format in
   set_geometry ~max_indent:(n-2) ~margin:n;


### PR DESCRIPTION
When converting warning messages to `Format_doc.t`, it was quite annoying to add formatting hints on every space in text paragraphs, for instance:
```ocaml
        "This primitive declaration uses type %a,@ whose@ representation@ \
         may be either boxed or unboxed.@ Without@ an@ annotation@ to@ \
         indicate@ which@ representation@ is@ intended,@ the@ boxed@ \
         representation@ has@ been@ selected@ by@ default.@ This@ default@ \
         choice@ may@ change@ in@ future@ versions@ of@ the@ compiler,@ \
         breaking@ the@ primitive@ implementation.@ You@ should@ explicitly@ \
         annotate@ the@ declaration@ of@ %a@ with@ %a@ or@ %a,@ so@ that@ its@ \
         external@ interface@ remains@ stable@ in@ the future."
```

In order to remove this annoyance, this PR propose to add a `format_text` function which replaces spaces and newlines ([' '] and ['\n']) with formatting hints in *format string* literals. This means that with this new function, one can write

```ocaml
Format.format_text
        "This primitive declaration uses type %a, whose representation \
         may be either boxed or unboxed. Without an annotation to \
         indicate which representation is intended, the boxed \
         representation has been selected by default. This default \
         choice may change in future versions of the compiler, \
         breaking the primitive implementation. You should explicitly \
         annotate the declaration of %a with %a or %a, so that its \
         external interface remains stable in the future."
```
and obtain a better version of the formatted string literal above.

Compared to `pp_print_string`, `format_text`  is less efficient (it may allocate a copy of the string) but it does not require to separate the text contents from the specifiers, formatting tags and other formatting hints making it easier
to use in many context.