### PR TITLE
Makefile: cleanup ocamldoc binaries (was: cleanup build artifacts during bootstrap)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2053,6 +2053,8 @@ manpages:
 	$(MAKE) -C api_docgen man
 
 partialclean::
+	rm -f ocamldoc/ocamldoc ocamldoc/ocamldoc.exe
+	rm -f ocamldoc/ocamldoc.opt ocamldoc/ocamldoc.opt.exe
 	rm -f ocamldoc/\#*\#
 	rm -f ocamldoc/*.cm[aiotx] ocamldoc/*.cmxa ocamldoc/*.cmti \
 	  ocamldoc/*.a ocamldoc/*.lib ocamldoc/*.o ocamldoc/*.obj


### PR DESCRIPTION
@clef-men reported to me today that a certain kind of compiler changes reproductibly results in a segfault during `make bootstrap`. This happens when we need a bootstrap because the changes are mutating the format of .cmi or .cmo files.

The `bootstrap` rule first does a `make coreboot`, which builds the new compiler from the boot compiler and stdlib, and then `make all` to rebuild the whole distribution. But at this point, the build may encounter old build artifacts lying around from the *old* compiler, and their .cmi and .cmo format is incompatible with the new compiler. In particular, calling `make manpages` rebuilds and then calls `ocamldoc` (possibly using dynamic linking?), and apparently this can result in segfaults.

The proposed fix is to have `make bootstrap` run `make partialclean` between `make coreboot` and `make all`, to remove all build artifacts that may come from the previous bootstrap compiler.

(cc @dra27 and @shindere, maybe @shym?)

(I also thought about adding this `partialclean` step at the end of `coreboot`, but @clef-men suggested to keep `coreboot` as simple as possible at the risk of being lower-level and less safe to use, which sounds reasonable. The issue here is that the current behavior gets non-expert users confused, they think that they did something wrong.)

## Detailed reproduction instructions

Step 0: in a clean repository, run `make -j` to build everything.

Step 1: apply the following path to OCaml sources, which modifies the format of types stored in .cmi files (it shifts almost all non-constant constructors by one):

```diff
--- i/typing/types.ml
+++ w/typing/types.ml
@@ -33,6 +33,7 @@ and type_expr = transient_expr
 
 and type_desc =
     Tvar of string option
+  | Tneverused of unit
   | Tarrow of arg_label * type_expr * type_expr * commutable
   | Ttuple of type_expr list
   | Tconstr of Path.t * type_expr list * abbrev_memo ref
diff --git i/typing/types.mli w/typing/types.mli
index afe9e111fe6..e12cd1b0ead 100644
--- i/typing/types.mli
+++ w/typing/types.mli
@@ -66,6 +66,8 @@ type type_desc =
   (** [Tvar (Some "a")] ==> ['a] or ['_a]
       [Tvar None]       ==> [_] *)
 
+  | Tneverused of unit
+
   | Tarrow of arg_label * type_expr * type_expr * commutable
   (** [Tarrow (Nolabel,      e1, e2, c)] ==> [e1    -> e2]
       [Tarrow (Labelled "l", e1, e2, c)] ==> [l:e1  -> e2]
```

Step 2: build and bootstrap the modified compiler. This requires OCAMLPARAM="_,w=-8" to silence warnings about non-exhaustive matches.

    OCAMLPARAM="_,w=-8" make -j coreall
    OCAMLPARAM="_,w=-8" make -j coreboot
    
At this point, you have a modified compiler with *incompatible* .cmi files.

Step 3: try to build the manpages

    OCAMLPARAM="_,w=-8" make -j manpages

Observed output, at some point:

```
make[2]: *** [Makefile:43: build/libref/float.odoc] Segmentation fault
```
