### PR TITLE
Use explicit units in time quantities, `Unix.select` fix on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -167,6 +167,10 @@ Working version
   (Romain Beauxis, review by Gabriel Scherer and Antonin Décimo)
 
 - #13576: Introduce internal helpers to convert between time representations.
+  On Windows, prevent erroneously waiting for an unbounded time in Unix.select
+  if more than 64 file descriptors per lists are watched, or if watching
+  non-socket file descriptors, and a timeout longer than $2^{32}$ milliseconds
+  is used. Cap the timeout to $2^{32}$ milliseconds.
   (Antonin Décimo, review by Gabriel Scherer and Miod Vallat)
 
 ### Tools:

--- a/Changes
+++ b/Changes
@@ -166,6 +166,9 @@ Working version
 - #13504, #13625: Add `Thread.set_current_thread_name`.
   (Romain Beauxis, review by Gabriel Scherer and Antonin Décimo)
 
+- #13576: Introduce internal helpers to convert between time representations.
+  (Antonin Décimo, review by Gabriel Scherer and Miod Vallat)
+
 ### Tools:
 
 - #12019: ocamlc: add `align_double` and `align_int64` to `ocamlc -config`

--- a/otherlibs/unix/access.c
+++ b/otherlibs/unix/access.c
@@ -13,11 +13,11 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
-#define CAML_INTERNALS
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -167,4 +167,40 @@ extern void caml_unix_clear_cloexec(int fd, const char * cmdname, value arg);
 #define EXECV_CAST
 #endif
 
+#ifdef CAML_INTERNALS
+#include <time.h>
+#include <math.h>
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
+
+Caml_inline struct timespec caml_timespec_of_sec(double sec)
+{
+  double int_sec, frac_sec;
+  frac_sec = modf(sec, &int_sec);
+  return (struct timespec)
+    { .tv_sec  = (time_t) int_sec,
+#if __STDC_VERSION__ >= 202311L
+      .tv_nsec = (typeof((struct timespec){0}.tv_nsec))
+#else
+      .tv_nsec = (long)
+#endif
+        (frac_sec * NSEC_PER_SEC) };
+}
+
+Caml_inline struct timeval caml_timeval_of_sec(double sec)
+{
+  double int_sec, frac_sec;
+  frac_sec = modf(sec, &int_sec);
+  return (struct timeval)
+#ifdef _WIN32
+    { .tv_sec  = (long) int_sec,
+      .tv_usec = (long) (frac_sec * USEC_PER_SEC) };
+#else
+    { .tv_sec  = (time_t) int_sec,
+      .tv_usec = (suseconds_t) (frac_sec * USEC_PER_SEC) };
+#endif
+}
+#endif  /* CAML_INTERNALS */
+
 #endif /* CAML_UNIXSUPPORT_H */

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -13,12 +13,12 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #define _GNU_SOURCE  /* helps to find execvpe() */
 #include <string.h>
 #include <errno.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
-#define CAML_INTERNALS
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 

--- a/otherlibs/unix/gettimeofday_unix.c
+++ b/otherlibs/unix/gettimeofday_unix.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
@@ -24,7 +25,7 @@ double caml_unix_gettimeofday_unboxed(value unit)
 {
   struct timeval tp;
   gettimeofday(&tp, NULL);
-  return ((double) tp.tv_sec + (double) tp.tv_usec / 1e6);
+  return ((double) tp.tv_sec + (double) tp.tv_usec / USEC_PER_SEC);
 }
 
 CAMLprim value caml_unix_gettimeofday(value unit)

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -13,13 +13,11 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <time.h>
-
-#define CAML_INTERNALS
 #include <caml/winsupport.h>
-
 #include "caml/unixsupport.h"
 
 double caml_unix_gettimeofday_unboxed(value unit)

--- a/otherlibs/unix/itimer.c
+++ b/otherlibs/unix/itimer.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
@@ -24,20 +25,20 @@
 #include <math.h>
 #include <sys/time.h>
 
-static void caml_unix_set_timeval(struct timeval * tv, double d)
+static void caml_unix_set_timeval(struct timeval * tv, double sec)
 {
-  double integr, frac;
-  frac = modf(d, &integr);
-  /* Round time up so that if d is small but not 0, we end up with
+  double int_sec, frac_sec;
+  frac_sec = modf(sec, &int_sec);
+  /* Round time up so that if [sec] is small but not 0, we end up with
      a non-0 timeval. */
-  tv->tv_sec = integr;
-  tv->tv_usec = ceil(1e6 * frac);
-  if (tv->tv_usec >= 1000000) { tv->tv_sec++; tv->tv_usec = 0; }
+  tv->tv_sec = int_sec;
+  tv->tv_usec = ceil(frac_sec * USEC_PER_SEC);
+  if (tv->tv_usec >= USEC_PER_SEC) { tv->tv_sec++; tv->tv_usec = 0; }
 }
 
 static value caml_unix_convert_itimer(struct itimerval *tp)
 {
-#define Get_timeval(tv) (double) tv.tv_sec + (double) tv.tv_usec / 1e6
+#define Get_timeval(tv) (double) tv.tv_sec + (double) tv.tv_usec / USEC_PER_SEC
   value res = caml_alloc_small(Double_wosize * 2, Double_array_tag);
   Store_double_flat_field(res, 0, Get_timeval(tp->it_interval));
   Store_double_flat_field(res, 1, Get_timeval(tp->it_value));

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -1067,7 +1067,8 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       if (tm_sec >= 0.0)
         {
-          tm_msec = (DWORD)(tm_sec * MSEC_PER_SEC);
+          double msec = tm_sec * MSEC_PER_SEC;
+          tm_msec = msec < INFINITE ? (DWORD) msec : INFINITE - 1;
           DEBUG_PRINT("Will wait %d ms", tm_msec);
         }
       else

--- a/otherlibs/unix/sleep_win32.c
+++ b/otherlibs/unix/sleep_win32.c
@@ -13,15 +13,16 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
 
-CAMLprim value caml_unix_sleep(value t)
+CAMLprim value caml_unix_sleep(value sec)
 {
-  DWORD ms = (DWORD)(Double_val(t) * 1e3);
+  DWORD msec = (DWORD) (Double_val(sec) * MSEC_PER_SEC);
   caml_enter_blocking_section();
-  Sleep(ms);
+  Sleep(msec);
   caml_leave_blocking_section();
   return Val_unit;
 }

--- a/otherlibs/unix/sockopt_unix.c
+++ b/otherlibs/unix/sockopt_unix.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -214,7 +215,7 @@ CAMLexport value caml_unix_getsockopt_aux(const char * name,
     break;
   case TYPE_TIMEVAL:
     res = caml_copy_double((double) optval.tv.tv_sec
-                           + (double) optval.tv.tv_usec / 1e6);
+                           + (double) optval.tv.tv_usec / USEC_PER_SEC);
     break;
   case TYPE_UNIX_ERROR:
     if (optval.i == 0) {
@@ -236,7 +237,6 @@ CAMLexport value caml_unix_setsockopt_aux(const char * name,
 {
   union option_value optval;
   socklen_param_type optsize;
-  double f;
 
   switch (ty) {
   case TYPE_BOOL:
@@ -251,10 +251,8 @@ CAMLexport value caml_unix_setsockopt_aux(const char * name,
       optval.lg.l_linger = Int_val(Some_val(val));
     break;
   case TYPE_TIMEVAL:
-    f = Double_val(val);
+    optval.tv = caml_timeval_of_sec(Double_val(val));
     optsize = sizeof(optval.tv);
-    optval.tv.tv_sec = (int) f;
-    optval.tv.tv_usec = (int) (1e6 * (f - optval.tv.tv_sec));
     break;
   case TYPE_UNIX_ERROR:
   default:

--- a/otherlibs/unix/sockopt_win32.c
+++ b/otherlibs/unix/sockopt_win32.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <errno.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -152,7 +153,7 @@ CAMLexport value caml_unix_getsockopt_aux(const char * name,
     break;
   case TYPE_TIMEVAL:
     res = caml_copy_double((double) optval.tv.tv_sec
-                           + (double) optval.tv.tv_usec / 1e6);
+                           + (double) optval.tv.tv_usec / USEC_PER_SEC);
     break;
   case TYPE_UNIX_ERROR:
     if (optval.i == 0) {
@@ -174,7 +175,6 @@ CAMLexport value caml_unix_setsockopt_aux(const char * name,
 {
   union option_value optval;
   socklen_param_type optsize;
-  double f;
 
   switch (ty) {
   case TYPE_BOOL:
@@ -189,10 +189,8 @@ CAMLexport value caml_unix_setsockopt_aux(const char * name,
       optval.lg.l_linger = Int_val(Some_val(val));
     break;
   case TYPE_TIMEVAL:
-    f = Double_val(val);
+    optval.tv = caml_timeval_of_sec(Double_val(val));
     optsize = sizeof(optval.tv);
-    optval.tv.tv_sec = (int) f;
-    optval.tv.tv_usec = (int) (1e6 * (f - optval.tv.tv_sec));
     break;
   case TYPE_UNIX_ERROR:
   default:

--- a/otherlibs/unix/stat_unix.c
+++ b/otherlibs/unix/stat_unix.c
@@ -60,7 +60,7 @@ static double stat_timestamp(time_t sec, long nsec)
   double s = (double) sec;
   /* The conversion of nsec to fraction of seconds can round.
      Still, we have 0 <= n < 1.0. */
-  double n = (double) nsec / 1e9;
+  double n = (double) nsec / NSEC_PER_SEC;
   /* The sum s + n can round up, hence s <= t + <= s + 1.0 */
   double t = s + n;
   /* Detect the "round up to s + 1" case and decrease t so that

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -75,8 +75,8 @@ static const int file_kind_table[] = {
 static double stat_timestamp(__time64_t tm)
 {
   /* Split the timestamp into seconds and remaining 100ns units */
-  __int64 sec = tm / 10000000;  /* 10^7 */
-  int n100sec = tm % 10000000;
+  __int64 sec = tm / (NSEC_PER_SEC / 100);  /* 10^7 */
+  int n100sec = tm % (NSEC_PER_SEC / 100);
   /* The conversion of sec to FP is exact for the foreseeable future.
      (It starts rounding when sec > 2^53, i.e. in 285 million years.) */
   double s = (double) sec;

--- a/otherlibs/unix/times_unix.c
+++ b/otherlibs/unix/times_unix.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
@@ -36,14 +37,14 @@ CAMLprim value caml_unix_times(value unit)
 
   getrusage (RUSAGE_SELF, &ru);
   Store_double_flat_field(res, 0,
-                          ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);
+    ru.ru_utime.tv_sec + (double) ru.ru_utime.tv_usec / USEC_PER_SEC);
   Store_double_flat_field(res, 1,
-                          ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
+    ru.ru_stime.tv_sec + (double) ru.ru_stime.tv_usec / USEC_PER_SEC);
   getrusage (RUSAGE_CHILDREN, &ru);
   Store_double_flat_field(res, 2,
-                          ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);
+    ru.ru_utime.tv_sec + (double) ru.ru_utime.tv_usec / USEC_PER_SEC);
   Store_double_flat_field(res, 3,
-                          ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
+    ru.ru_stime.tv_sec + (double) ru.ru_stime.tv_usec / USEC_PER_SEC);
   return res;
 
 #else

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1097,7 +1097,11 @@ val select :
    The result is composed of three sets of descriptors: those ready
    for reading (first component), ready for writing (second component),
    and over which an exceptional condition is pending (third
-   component). *)
+   component).
+
+   On Windows, if one of descriptor lists exceeds [FD_SETSIZE] elements
+   (64 by default), or if at least one non-socket file descriptor is
+   used, the maximal timeout is capped to 2{^32} milliseconds. *)
 
 (** {1 Locking} *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1097,7 +1097,11 @@ val select :
    The result is composed of three sets of descriptors: those ready
    for reading (first component), ready for writing (second component),
    and over which an exceptional condition is pending (third
-   component). *)
+   component).
+
+   On Windows, if one of descriptor lists exceeds [FD_SETSIZE] elements
+   (64 by default), or if at least one non-socket file descriptor is
+   used, the maximal timeout is capped to 2{^32} milliseconds. *)
 
 (** {1 Locking} *)
 

--- a/otherlibs/unix/utimes_unix.c
+++ b/otherlibs/unix/utimes_unix.c
@@ -40,10 +40,8 @@ CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
   if (at == 0.0 && mt == 0.0) {
     t = (struct timeval *) NULL;
   } else {
-    tv[0].tv_sec = at;
-    tv[0].tv_usec = (at - tv[0].tv_sec) * 1000000;
-    tv[1].tv_sec = mt;
-    tv[1].tv_usec = (mt - tv[1].tv_sec) * 1000000;
+    tv[0] = caml_timeval_of_sec(at);
+    tv[1] = caml_timeval_of_sec(mt);
     t = tv;
   }
   p = caml_stat_strdup(String_val(path));

--- a/otherlibs/unix/utimes_win32.c
+++ b/otherlibs/unix/utimes_win32.c
@@ -59,9 +59,9 @@ CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
     lastModificationTime.ul = lastAccessTime.ul;
   } else {
     lastAccessTime.ul =
-      (ULONGLONG)(at * 10000000.0) + CAML_NT_EPOCH_100ns_TICKS;
+      (ULONGLONG)(at * (NSEC_PER_SEC / 100)) + CAML_NT_EPOCH_100ns_TICKS;
     lastModificationTime.ul =
-      (ULONGLONG)(mt * 10000000.0) + CAML_NT_EPOCH_100ns_TICKS;
+      (ULONGLONG)(mt * (NSEC_PER_SEC / 100)) + CAML_NT_EPOCH_100ns_TICKS;
   }
   caml_enter_blocking_section();
   res = SetFileTime(hFile, NULL, &lastAccessTime.ft, &lastModificationTime.ft);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -771,6 +771,26 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #define CAML_GENSYM_2(name, l) CAML_GENSYM_3(name, l)
 #define CAML_GENSYM(name) CAML_GENSYM_2(name, __LINE__)
 
+#define MSEC_PER_SEC  UINT64_C(1000)
+#define USEC_PER_SEC  UINT64_C(1000000)
+#define NSEC_PER_USEC UINT64_C(1000)
+#define NSEC_PER_MSEC UINT64_C(1000000)
+#define NSEC_PER_SEC  UINT64_C(1000000000)
+
+#include <time.h>
+
+Caml_inline struct timespec caml_timespec_of_nsec(uint64_t nsec)
+{
+  return (struct timespec)
+    { .tv_sec = (time_t) (nsec / NSEC_PER_SEC),
+#if __STDC_VERSION__ >= 202311L
+      .tv_nsec = (typeof((struct timespec){0}.tv_nsec))
+#else
+      .tv_nsec = (long)
+#endif
+        (nsec % NSEC_PER_SEC) };
+}
+
 #endif /* CAML_INTERNALS */
 
 /* The [backtrace_slot] type represents values stored in

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -545,19 +545,19 @@ double caml_sys_time_include_children_unboxed(value include_children)
 {
 #ifdef HAS_GETRUSAGE
   struct rusage ru;
-  double acc = 0.;
+  double sec = 0.;
 
   getrusage (RUSAGE_SELF, &ru);
-  acc += ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6
-    + ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6;
+  sec += ru.ru_utime.tv_sec + (double) ru.ru_utime.tv_usec / USEC_PER_SEC
+      +  ru.ru_stime.tv_sec + (double) ru.ru_stime.tv_usec / USEC_PER_SEC;
 
   if (Bool_val(include_children)) {
     getrusage (RUSAGE_CHILDREN, &ru);
-    acc += ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6
-      + ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6;
+    sec += ru.ru_utime.tv_sec + (double) ru.ru_utime.tv_usec / USEC_PER_SEC
+        +  ru.ru_stime.tv_sec + (double) ru.ru_stime.tv_usec / USEC_PER_SEC;
   }
 
-  return acc;
+  return sec;
 #else
   #ifdef HAS_TIMES
     #ifndef CLK_TCK

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -430,14 +430,14 @@ uint64_t caml_time_counter(void)
   struct timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
   return
-    (uint64_t)t.tv_sec  * (uint64_t)1000000000 +
-    (uint64_t)t.tv_nsec;
+    (uint64_t) t.tv_sec  * NSEC_PER_SEC +
+    (uint64_t) t.tv_nsec;
 #elif defined(HAS_GETTIMEOFDAY)
   struct timeval t;
   gettimeofday(&t, 0);
   return
-    (uint64_t)t.tv_sec  * (uint64_t)1000000000 +
-    (uint64_t)t.tv_usec * (uint64_t)1000;
+    (uint64_t) t.tv_sec  * NSEC_PER_SEC +
+    (uint64_t) t.tv_usec * NSEC_PER_USEC;
 #else
 # error "No timesource available"
 #endif

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1147,7 +1147,7 @@ CAMLexport clock_t caml_win32_clock(void)
   return (clock_t)((stime.ul + utime.ul) / clocks_per_sec);
 }
 
-static double clock_period = 0;
+static double clock_period_nsec = 0;
 
 void caml_init_os_params(void)
 {
@@ -1162,7 +1162,7 @@ void caml_init_os_params(void)
 
   /* Get the number of nanoseconds for each tick in QueryPerformanceCounter */
   QueryPerformanceFrequency(&frequency);
-  clock_period = (1000000000.0 / frequency.QuadPart);
+  clock_period_nsec = (double) NSEC_PER_SEC / frequency.QuadPart;
 }
 
 uint64_t caml_time_counter(void)
@@ -1170,7 +1170,7 @@ uint64_t caml_time_counter(void)
   LARGE_INTEGER now;
 
   QueryPerformanceCounter(&now);
-  return (uint64_t)(now.QuadPart * clock_period);
+  return (uint64_t) (now.QuadPart * clock_period_nsec);
 }
 
 void *caml_plat_mem_map(uintnat size, int reserve_only)


### PR DESCRIPTION
Earlier this month I tried to fix a little mistake in dealing with time units, where a quantity of time was labelled as milliseconds but given to a function expecting microseconds. In the process of fixing it, I transiently introduced more mistakes, thankfully caught by the all-seeing shepherd @gasche. See #13539.
I discovered a pattern used in some libc implementations and in the Linux kernel to prevent these kind of mistakes, consisting of defining constants such as `NSEC_PER_SEC` or `USEC_PER_SEC`; and naming variables using the convention established by the libc: using a suffix such as `sec`, `msec`, `usec`, `nsec`, to describe what unit of time a variable holds.
This convention helps checking the homogeneity of formulas, and is even clearer than my previous proposal which introduced `POW10_X` macros. The first commit switches some code to this convention.

The second commit fixes a potential bug on Windows with the implementation of `Unix.select`. If a file descriptor list exceeds `FD_SETSIZE` (64 elements by default), or if one of the lists contains at least one fd that's not a socket, then [`select`](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-select) is emulated. In this code path, if the timeout ends up equating the sentinel value for an unbounded wait (`INFINITE` in the WinAPI, equal to $2^{32}$), then the wait becomes unbounded. I think this breaks the semantics of `Unix.select`, currently documented as:

> The fourth argument is the maximal timeout, in seconds; a negative fourth argument means no timeout (unbounded wait).

If the timeout exceeds $2^{32}$ milliseconds, and under the same code path, the timeout overflows and a smaller amount of time is used.

I've chosen to cap the timeout to $2^{32}$ milliseconds (a bit more than 49 days). As an alternative, as MSDN documents `WSAEINVAL` as a possible error value "The time-out value is not valid". An error could be raised if the timeout reaches or exceeds $2^{32}$ milliseconds.