### PR TITLE
Use the Windows CSPRNG to get a random seed for `Stdlib.Random`

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,6 +219,9 @@ Working version
   (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
    and Gabriel Scherer)
 
+- #13578: On Windows, use the OS CSPRNG to seed the Stdlib.Random generator.
+  (Antonin Décimo, review by Miod Vallat, Nicolás Ojeda Bär, and Xavier Leroy)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -39,11 +39,11 @@ val full_init : int array -> unit
 (** Same as {!Random.init} but takes more data as seed. *)
 
 val self_init : unit -> unit
-(** Initialize the domain-local generator with a random seed chosen
-    in a system-dependent way.  If [/dev/urandom] is available on the host
-    machine, it is used to provide a highly random initial seed.  Otherwise, a
-    less random seed is computed from system parameters (current time, process
-    IDs, domain-local state). *)
+(** Initialize the domain-local generator with a random seed chosen in a
+    system-dependent way.  If a cryptographically secure pseudorandom number
+    generator is available on the host machine, it is used to provide a highly
+    random initial seed.  Otherwise, a less random seed is computed from system
+    parameters (current time, process IDs, domain-local state). *)
 
 val bits : unit -> int
 (** Return 30 random bits in a nonnegative integer.


### PR DESCRIPTION
Windows (since Vista SP2 / Server 2008) provides a CSPRNG as the [`BCryptGenRandom`](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom) function. Use it to generate `Stdlib.Random` default seed, mimicking the use of `getentropy` or `/dev/urandom` on Unix-like systems. See the Unix counter-part `caml_unix_random_seed`: https://github.com/ocaml/ocaml/blob/9caaced74449f2886b7e35c4befe7e0a27b77407/runtime/sys.c#L604-L644