### PR TITLE
Enable software prefetching support for ARM64, s390x, PPC64 and Riscv

### DIFF
--- a/Changes
+++ b/Changes
@@ -92,7 +92,13 @@ Working version
   Jan Midtgaard)
 
 - #13736: Fix major GC pacing bug triggered by synchronous collections.
-  (Nick Barnes, review by ?)
+  (Nick Barnes, review by Damien Doligez and Tim McGilchrist)
+
+- #13582: Enable software prefetching support for ARM64, s390x, PPC64 and RiscV.
+  Used during GC marking and sweeping to speed up both operations by
+  prefetching data.
+  (Tim McGilchrist, review by Nick Barnes, Antonin Décimo,
+   Stephen Dolan and Miod Vallat)
 
 ### Code generation and optimizations:
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -164,9 +164,7 @@ CAMLdeprecated_typedef(addr, char *);
 /* Prefetching */
 
 #ifdef CAML_INTERNALS
-#if (__has_builtin(__builtin_prefetch) || defined(__GNUC__)) && \
-    (defined(__i386__) || defined(__x86_64__) || \
-     defined(_M_IX86) || defined(_M_AMD64))
+#if (__has_builtin(__builtin_prefetch) || defined(__GNUC__))
 #define caml_prefetch(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
 #elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))


### PR DESCRIPTION
This change enables data prefetch instructions for ARM64, tested on Linux and macOS. 

An ad-hoc benchmark using [hyperfine](https://github.com/sharkdp/hyperfine)'s defaults on Stephen Dolan's [markbench](https://github.com/ocaml-bench/sandmark/blob/main/benchmarks/markbench/markbench.ml) regression test for software prefetching gives a modest speed up for Apple Silicon to a good speedup on Ampere Altra. The Ampere Altra uses the Neoverse N1 core that is common to many cloud ARM64 servers from AWS, Azure and GCP.

macOS 14.6.1  arm64 (Apple M3 Pro @ 4.0 Ghz ARMv8.6-A):
```shell
$ hyperfine --warmup 3 ./markbench-prefetch.exe ./markbench-trunk.exe --export-markdown results.md
Benchmark 1: ./markbench-prefetch.exe
  Time (mean ± σ):      7.250 s ±  0.093 s    [User: 7.160 s, System: 0.083 s]
  Range (min … max):    7.106 s …  7.455 s    10 runs
 
Benchmark 2: ./markbench-trunk.exe
  Time (mean ± σ):      8.790 s ±  0.804 s    [User: 8.686 s, System: 0.090 s]
  Range (min … max):    8.229 s … 10.435 s    10 runs
 
Summary
  ./markbench-prefetch.exe ran
    1.21 ± 0.11 times faster than ./markbench-trunk.exe
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./markbench-prefetch.exe` | 7.250 ± 0.093 | 7.106 | 7.455 | 1.00 |
| `./markbench-trunk.exe` | 8.790 ± 0.804 | 8.229 | 10.435 | 1.21 ± 0.11 |

Ubuntu 22.04.5 LTS aarch64 (Ampere Altra Mt Snow @ 3.0Ghz Armv8.2-A)
```shell
$ hyperfine --warmup 3 ./markbench-prefetch.exe ./markbench-trunk.exe --export-markdown results.md
Benchmark 1: ./markbench-prefetch.exe
  Time (mean ± σ):     15.680 s ±  0.112 s    [User: 15.359 s, System: 0.306 s]
  Range (min … max):   15.504 s … 15.772 s    10 runs
 
Benchmark 2: ./markbench-trunk.exe
  Time (mean ± σ):     53.433 s ±  0.809 s    [User: 53.076 s, System: 0.325 s]
  Range (min … max):   52.985 s … 55.588 s    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  './markbench-prefetch.exe' ran
    3.41 ± 0.06 times faster than './markbench-trunk.exe'
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./markbench-prefetch.exe` | 15.680 ± 0.112 | 15.504 | 15.772 | 1.00 |
| `./markbench-trunk.exe` | 53.433 ± 0.809 | 52.985 | 55.588 | 3.41 ± 0.06 |

## To Reproduce

To create `markbench-prefetch.exe` 
```shell
$ opam switch create 5.4+prefetch --empty 
$ opam pin add ocaml-variants git+https://github.com/tmcgilchrist/ocaml#arm64_prefetch
$ opam install ocamlfind
$ ocamlfind ocamlopt -package unix -linkpkg -o markbench-prefetch.exe markbench.ml
```
and to create `markbench-trunk.exe`
```shell
$ opam switch create 5.4.0+trunk
$ opam install ocamlfind
$ ocamlfind ocamlopt -package unix -linkpkg -o markbench-trunk.exe markbench.ml
```