### PR TITLE
Fix #13579 by removing equations_generation

### DIFF
--- a/Changes
+++ b/Changes
@@ -783,6 +783,9 @@ ___________
   were being included in the thread descriptors.
   (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
 
+- #13579: Unsoundness involving non-injective types + gadts
+  (Jacques Garrigue, report by @v-gb)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/Changes
+++ b/Changes
@@ -784,7 +784,8 @@ ___________
   (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
 
 - #13579, #13583: Unsoundness involving non-injective types + gadts
-  (Jacques Garrigue, report by @v-gb)
+  (Jacques Garrigue, report by @v-gb,
+   review by Richard Eisenberg and Florian Angeletti)
 
 OCaml 5.2.0 (13 May 2024)
 -------------------------

--- a/Changes
+++ b/Changes
@@ -783,7 +783,7 @@ ___________
   were being included in the thread descriptors.
   (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
 
-- #13579: Unsoundness involving non-injective types + gadts
+- #13579, #13583: Unsoundness involving non-injective types + gadts
   (Jacques Garrigue, report by @v-gb)
 
 OCaml 5.2.0 (13 May 2024)

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -2,7 +2,7 @@
  expect;
 *)
 
-(* #13679 *)
+(* #13579 *)
 
 module F(X : sig type 'a t end) = struct
   type (_, _) gadt = T : ('a X.t, 'a) gadt

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -1,0 +1,34 @@
+(* TEST
+ expect;
+*)
+
+(* #13679 *)
+
+module F(X : sig type 'a t end) = struct
+  type (_, _) gadt = T : ('a X.t, 'a) gadt
+  
+  let equate_param2_based_on_param1 (type tt m1 m2)
+        (T : (tt, m1) gadt) (T : (tt, m2) gadt) : (m1, m2) Type.eq =
+     Equal
+  ;;
+end
+[%%expect{|
+Line 6, characters 5-10:
+6 |      Equal
+         ^^^^^
+Error: The constructor "Equal" has type "(m1, m1) Type.eq"
+       but an expression was expected of type "(m1, m2) Type.eq"
+       Type "m1" is not compatible with type "m2"
+|}]
+
+(* could cause unsoundness
+module Z = F(struct type 'a t = unit end)
+
+let () =
+  let t1 = (Z.T : (unit, int) Z.gadt) in
+  let t2 = (Z.T : (unit, string) Z.gadt) in
+  let eq : (int, string) Type.eq = Z.equate_param2_based_on_param1 t1 t2 in
+  let cast (type a b) (Equal : (a, b) Type.eq) (a : a) : b = a in
+  print_string (cast eq 1)
+;;
+*)

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -32,3 +32,27 @@ let () =
   print_string (cast eq 1)
 ;;
 *)
+
+(* Side-effect of the fix *)
+
+module M = struct type 'a p end
+type _ t = W: int M.p t
+[%%expect{|
+module M : sig type 'a p end
+type _ t = W : int M.p t
+|}]
+
+let f (W: _ M.p t) = ()
+[%%expect{|
+Line 1, characters 7-8:
+1 | let f (W: _ M.p t) = ()
+           ^
+Error: This pattern matches values of type "int M.p t"
+       but a pattern was expected which matches values of type "$0 M.p t"
+       The type constructor "$0" would escape its scope
+|}]
+
+let f (W: _ t) = ()
+[%%expect{|
+val f : int M.p t -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -6,7 +6,7 @@
 
 module F(X : sig type 'a t end) = struct
   type (_, _) gadt = T : ('a X.t, 'a) gadt
-  
+
   let equate_param2_based_on_param1 (type tt m1 m2)
         (T : (tt, m1) gadt) (T : (tt, m2) gadt) : (m1, m2) Type.eq =
      Equal

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -403,10 +403,6 @@ let in_subst_mode = function
   | Expression {in_subst} -> in_subst
   | Pattern _ -> false
 
-let can_generate_equations = function
-  | Expression _ -> false
-  | Pattern _  -> true
-
 (* Can only be called when generate_equations is true *)
 let record_equation uenv t1 t2 =
   match uenv with
@@ -2685,10 +2681,8 @@ let unify3_var uenv t1' t2 t2' =
   | exception Unify_trace _ when in_pattern_mode uenv ->
       reify uenv t1';
       reify uenv t2';
-      if can_generate_equations uenv then begin
-        occur_univar ~inj_only:true (get_env uenv) t2';
-        record_equation uenv t1' t2';
-      end
+      occur_univar ~inj_only:true (get_env uenv) t2';
+      record_equation uenv t1' t2'
 
 (*
    1. When unifying two non-abbreviated types, one type is made a link
@@ -2847,7 +2841,7 @@ and unify3 uenv t1 t1' t2 t2' =
       | (Ttuple tl1, Ttuple tl2) ->
           unify_list uenv tl1 tl2
       | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _)) when Path.same p1 p2 ->
-          if not (can_generate_equations uenv) then
+          if not (in_pattern_mode uenv) then
             unify_list uenv tl1 tl2
           else if can_assume_injective uenv then
             without_assume_injective uenv (fun uenv -> unify_list uenv tl1 tl2)
@@ -2870,9 +2864,9 @@ and unify3 uenv t1 t1' t2 t2' =
               inj (List.combine tl1 tl2)
       | (Tconstr (path,[],_),
          Tconstr (path',[],_))
-        when let env = get_env uenv in
-        is_instantiable env path && is_instantiable env path'
-        && can_generate_equations uenv ->
+        when in_pattern_mode uenv &&
+        let env = get_env uenv in
+        is_instantiable env path && is_instantiable env path' ->
           let source, destination =
             if Path.scope path > Path.scope path'
             then  path , t2'
@@ -2881,24 +2875,20 @@ and unify3 uenv t1 t1' t2 t2' =
           record_equation uenv t1' t2';
           add_gadt_equation uenv source destination
       | (Tconstr (path,[],_), _)
-        when is_instantiable (get_env uenv) path
-        && can_generate_equations uenv ->
+        when in_pattern_mode uenv && is_instantiable (get_env uenv) path ->
           reify uenv t2';
           record_equation uenv t1' t2';
           add_gadt_equation uenv path t2'
       | (_, Tconstr (path,[],_))
-        when is_instantiable (get_env uenv) path
-        && can_generate_equations uenv ->
+        when in_pattern_mode uenv && is_instantiable (get_env uenv) path ->
           reify uenv t1';
           record_equation uenv t1' t2';
           add_gadt_equation uenv path t1'
       | (Tconstr (_,_,_), _) | (_, Tconstr (_,_,_)) when in_pattern_mode uenv ->
           reify uenv t1';
           reify uenv t2';
-          if can_generate_equations uenv then (
-            mcomp_for Unify (get_env uenv) t1' t2';
-            record_equation uenv t1' t2'
-          )
+          mcomp_for Unify (get_env uenv) t1' t2';
+          record_equation uenv t1' t2'
       | (Tobject (fi1, nm1), Tobject (fi2, _)) ->
           unify_fields uenv fi1 fi2;
           (* Type [t2'] may have been instantiated by [unify_fields] *)
@@ -2920,10 +2910,8 @@ and unify3 uenv t1 t1' t2 t2' =
               backtrack snap;
               reify uenv t1';
               reify uenv t2';
-              if can_generate_equations uenv then (
-                mcomp_for Unify (get_env uenv) t1' t2';
-                record_equation uenv t1' t2'
-              )
+              mcomp_for Unify (get_env uenv) t1' t2';
+              record_equation uenv t1' t2'
           end
       | (Tfield(f,kind,_,rem), Tnil) | (Tnil, Tfield(f,kind,_,rem)) ->
           begin match field_kind_repr kind with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -349,10 +349,6 @@ end
 
 (**** unification mode ****)
 
-type equations_generation =
-  | Forbidden
-  | Allowed of { equated_types : TypePairs.t }
-
 type unification_environment =
   | Expression of
       { env : Env.t;
@@ -360,7 +356,7 @@ type unification_environment =
     (* normal unification mode *)
   | Pattern of
       { penv : Pattern_env.t;
-        equations_generation : equations_generation;
+        equated_types : TypePairs.t;
         assume_injective : bool;
         unify_eq_set : TypePairs.t; }
     (* GADT constraint unification mode:
@@ -408,15 +404,15 @@ let in_subst_mode = function
   | Pattern _ -> false
 
 let can_generate_equations = function
-  | Expression _ | Pattern { equations_generation = Forbidden } -> false
-  | Pattern { equations_generation = Allowed _ } -> true
+  | Expression _ -> false
+  | Pattern _  -> true
 
 (* Can only be called when generate_equations is true *)
 let record_equation uenv t1 t2 =
   match uenv with
-  | Expression _ | Pattern { equations_generation = Forbidden } ->
+  | Expression _ ->
       invalid_arg "Ctype.record_equation"
-  | Pattern { equations_generation = Allowed { equated_types } } ->
+  | Pattern { equated_types } ->
       TypePairs.add equated_types (t1, t2)
 
 let can_assume_injective = function
@@ -437,11 +433,6 @@ let without_assume_injective uenv f =
   match uenv with
   | Expression _ as uenv -> f uenv
   | Pattern r -> f (Pattern { r with assume_injective = false })
-
-let without_generating_equations uenv f =
-  match uenv with
-  | Expression _ as uenv -> f uenv
-  | Pattern r -> f (Pattern { r with equations_generation = Forbidden })
 
 (*** Checks for type definitions ***)
 
@@ -2872,15 +2863,10 @@ and unify3 uenv t1 t1' t2 t2' =
             in
             List.iter2
               (fun i (t1, t2) ->
-                if i then unify uenv t1 t2 else
-                without_generating_equations uenv
-                  begin fun uenv ->
-                    let snap = snapshot () in
-                    try unify uenv t1 t2 with Unify_trace _ ->
-                      backtrack snap;
-                      reify uenv t1;
-                      reify uenv t2
-                  end)
+                if i then unify uenv t1 t2 else begin
+                  reify uenv t1;
+                  reify uenv t2
+                end)
               inj (List.combine tl1 tl2)
       | (Tconstr (path,[],_),
          Tconstr (path',[],_))
@@ -3285,10 +3271,9 @@ let unify uenv ty1 ty2 =
 
 let unify_gadt (penv : Pattern_env.t) ty1 ty2 =
   let equated_types = TypePairs.create 0 in
-  let equations_generation = Allowed { equated_types } in
   let uenv = Pattern
       { penv;
-        equations_generation;
+        equated_types;
         assume_injective = true;
         unify_eq_set = TypePairs.create 11; }
   in


### PR DESCRIPTION
Issue #13579 discovered a soundness issue in unification.
This is a side-effect of using the `equations_generation = Forbidden` mode in `unify3`.
Namely, this mode was used when unifying non-injective types parameters in `Pattern` mode.
The assumption was that, since those unifications were not allowed to instantiate abstract types, non-injective types could not cause the introduction of equations.
#13759 shows that this assumption was wrong: if we allow instantiations in non-injective type parameters, those instantiations can later on cause the introduction of equations while unifying injective one.

The reasonable thing to do is just to scrape the `equations_generation = Forbidden` mode (it was only used in a single place), and only reify in that case, like we do everywhere else.

There is no failure in the testsuite. I wonder whether this unsoundness was unwittingly used in the wild.