### PR TITLE
Fix side-effect of removal of equation_generation

### DIFF
--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -52,7 +52,6 @@ let f (W: _ t) = ()
 val f : int M.p t -> unit = <fun>
 |}]
 
-
 type _ t = W: int M.p t | W2: float M.p t
 [%%expect{|
 type _ t = W : int M.p t | W2 : float M.p t

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -59,12 +59,13 @@ type _ t = W : int M.p t | W2 : float M.p t
 
 let f (W: _ M.p t) = ()
 [%%expect{|
-Line 1, characters 7-8:
+Line 1, characters 6-18:
 1 | let f (W: _ M.p t) = ()
-           ^
-Error: This pattern matches values of type "int M.p t"
-       but a pattern was expected which matches values of type "$0 M.p t"
-       The type constructor "$0" would escape its scope
+          ^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "W2"
+
+val f : int M.p t -> unit = <fun>
 |}]
 
 let f =  function W -> () | W2 -> ()
@@ -74,12 +75,7 @@ val f : int M.p t -> unit = <fun>
 
 let f =  function (W: _ M.p t) -> () | W2 -> ()
 [%%expect{|
-Line 1, characters 19-20:
-1 | let f =  function (W: _ M.p t) -> () | W2 -> ()
-                       ^
-Error: This pattern matches values of type "int M.p t"
-       but a pattern was expected which matches values of type "$0 M.p t"
-       The type constructor "$0" would escape its scope
+val f : int M.p t -> unit = <fun>
 |}]
 
 let f: type a. a M.p t -> unit =  function W -> () | W2 -> ()

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -44,12 +44,7 @@ type _ t = W : int M.p t
 
 let f (W: _ M.p t) = ()
 [%%expect{|
-Line 1, characters 7-8:
-1 | let f (W: _ M.p t) = ()
-           ^
-Error: This pattern matches values of type "int M.p t"
-       but a pattern was expected which matches values of type "$0 M.p t"
-       The type constructor "$0" would escape its scope
+val f : int M.p t -> unit = <fun>
 |}]
 
 let f (W: _ t) = ()

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3289,8 +3289,8 @@ let unify_gadt (penv : Pattern_env.t) ty1 ty2 =
     unify uenv ty1 ty2;
     equated_types
   in
-  let closed = closed_type_expr ty1 && closed_type_expr ty2 in
-  if closed then with_univar_pairs [] do_unify_gadt else
+  let no_leak = penv.allow_recursive_equations || closed_type_expr ty2 in
+  if no_leak then with_univar_pairs [] do_unify_gadt else
   let snap = Btype.snapshot () in
   try
     (* If there are free variables, first try normal unification *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3279,15 +3279,28 @@ let unify uenv ty1 ty2 =
 
 let unify_gadt (penv : Pattern_env.t) ty1 ty2 =
   let equated_types = TypePairs.create 0 in
-  let uenv = Pattern
-      { penv;
-        equated_types;
-        assume_injective = true;
-        unify_eq_set = TypePairs.create 11; }
-  in
-  with_univar_pairs [] (fun () ->
+  let do_unify_gadt () =
+    let uenv = Pattern
+        { penv;
+          equated_types;
+          assume_injective = true;
+          unify_eq_set = TypePairs.create 11; }
+    in
     unify uenv ty1 ty2;
-    equated_types)
+    equated_types
+  in
+  let closed = closed_type_expr ty1 && closed_type_expr ty2 in
+  if closed then with_univar_pairs [] do_unify_gadt else
+  let snap = Btype.snapshot () in
+  try
+    (* If there are free variables, first try normal unification *)
+    let uenv = Expression {env = penv.env; in_subst = false} in
+    with_univar_pairs [] (fun () -> unify uenv ty1 ty2);
+    equated_types
+  with Unify _ ->
+    (* If it fails, retry in pattern mode *)
+    Btype.backtrack snap;
+    with_univar_pairs [] do_unify_gadt
 
 let unify_var uenv t1 t2 =
   if eq_type t1 t2 then () else

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -275,7 +275,11 @@ val unify_gadt:
         Pattern_env.t -> type_expr -> type_expr -> Btype.TypePairs.t
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible.
-           Returns the pairs of types that have been equated.  *)
+           Returns the pairs of types that have been equated.
+           Type variables in the first [type_expr] are assumed
+           to be non-leaking (safely reifiable), moreover if
+           [allow_recursive_equations = true] the same assumption
+           is made for the second [type_expr]. *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -273,13 +273,13 @@ val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
         Pattern_env.t -> type_expr -> type_expr -> Btype.TypePairs.t
-        (* Unify the two types given and update the environment with the
-           local constraints. Raise [Unify] if not possible.
+        (* [unify_gadt penv ty1 ty2] unifies [ty1] and [ty2] in
+           [Pattern] mode, possible adding local constraints to the
+           environment in [penv]. Raises [Unify] if not possible.
            Returns the pairs of types that have been equated.
-           Type variables in the first [type_expr] are assumed
-           to be non-leaking (safely reifiable), moreover if
-           [allow_recursive_equations = true] the same assumption
-           is made for the second [type_expr]. *)
+           Type variables in [ty1] are assumed to be non-leaking (safely
+           reifiable), moreover if [penv.allow_recursive_equations = true]
+           the same assumption is made for [ty2]. *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -456,6 +456,8 @@ let unify_pat_types_return_equated_pairs ~refine loc penv ty ty' =
       raise(Typetexp.Error(loc, !!penv, Typetexp.Variant_tags (l1, l2)))
 
 let unify_pat_types_refine ~refine loc penv ty ty' =
+  (* [refine=true] only in calls originating from [check_counter_example_pat],
+     which in turn may contain only non-leaking type variables *)
   ignore (unify_pat_types_return_equated_pairs ~refine loc penv ty ty')
 
 (** [sdesc_for_hint] is used by error messages to report literals in their

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -923,6 +923,8 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
   let unify_res ty_res expected_ty =
     let refine =
       refine || constr.cstr_generalized && no_existentials = None in
+    (* Here [ty_res] contains only fresh (non-leaking) type variables,
+       so the requirement of [unify_gadt] is fulfilled. *)
     unify_pat_types_return_equated_pairs ~refine loc penv ty_res expected_ty
   in
 


### PR DESCRIPTION
In #13583, we removed the `equation_generation` logic, at it was unsound.
However, it means that `unify_gadt` can now fail because of non-injective type constructors.
This PR fixes that by first attempting to do normal unification in `unify_gadt` when there are type variables involved.