### PR TITLE
Perform a shallow clone of git submodules by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@
 
 # It is not possible to wrap lines lines in .gitattributes files
 .gitattributes typo.long-line=may typo.utf8
+.gitmodules typo.long-line=may typo.tab=may
 
 # Binary files
 /boot/ocamlc binary

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "flexdll"]
-    path = flexdll
-    url = https://github.com/ocaml/flexdll.git
+	path = flexdll
+	url = https://github.com/ocaml/flexdll.git
+	shallow = true
 [submodule "winpthreads"]
-    path = winpthreads
-    url = https://github.com/ocaml/winpthreads.git
+	path = winpthreads
+	url = https://github.com/ocaml/winpthreads.git
+	shallow = true


### PR DESCRIPTION
Users and contributors likely don't need the full history of FlexDLL and winpthreads development. The history can always be populated later, on request, or with `--no-recommend-shallow`. GitHub Actions clones are already shallow.

- https://git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-submoduleltnamegtshallow
- https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---no-recommend-shallow