### PR TITLE
Generational stack scanning

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Working version
 
 ### Runtime system:
 
+- #13574, #13594: Generational scanning of stack frames for ARM 64 bits, POWER,
+  and RISC-V.  This reduces minor GC work in the presence of deep call stacks.
+  (Xavier Leroy, review by Miod Vallat, Gabriel Scherer and Olivier Nicole)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -22,6 +22,8 @@ open Format
 
 let macosx = (Config.system = "macosx")
 
+let top_bits_ignore = (Config.system = "linux")
+
 (* Machine-specific command-line options *)
 
 let command_line_options = []

--- a/asmcomp/arm64/arch.mli
+++ b/asmcomp/arm64/arch.mli
@@ -20,6 +20,8 @@
 
 val macosx : bool
 
+val top_bits_ignore : bool
+
 (* Machine-specific command-line options *)
 
 val command_line_options : (string * Arg.spec * string) list

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -530,7 +530,7 @@ module Size = struct
     | Lop (Idls_get) -> 1
     | Lop (Ireturn_addr) -> 1
     | Lreloadretaddr -> 0
-    | Lreturn -> epilogue_size f
+    | Lreturn -> epilogue_size f + (if top_bits_ignore then 0 else 1)
     | Llabel _ -> 0
     | Lbranch _ -> 1
     | Lcondbranch (tst, _) ->
@@ -983,7 +983,13 @@ let emit_instr env i =
     | Lreloadretaddr ->
         ()
     | Lreturn ->
-        output_epilogue env (fun () -> `	ret\n`)
+        output_epilogue env begin fun () ->
+          if not top_bits_ignore then begin
+            (* mask the top 8 bits ourselves *)
+            `	and	x30, x30, #0x00FFFFFFFFFFFFFF\n`;
+          end;
+          `	ret\n`
+        end
     | Llabel lbl ->
         `{emit_label lbl}:\n`
     | Lbranch lbl ->

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -169,6 +169,12 @@ G(name):
         CFI_ADJUST(-16)
 .endm
 
+.macro NORMALIZE_RETURN_ADDRESS
+#ifndef SYS_linux
+        and     x30, x30, #0x00FFFFFFFFFFFFFF /* ignore top bits */
+#endif
+.endm
+
 /* Stack switching operations */
 
 /* struct stack_info */
@@ -507,6 +513,7 @@ L(caml_call_gc):
         RESTORE_ALL_REGS
     /* Free stack space and return to caller */
         LEAVE_FUNCTION
+        NORMALIZE_RETURN_ADDRESS
         ret
         CFI_ENDPROC
 END_FUNCTION(caml_call_gc)
@@ -599,6 +606,7 @@ FUNCTION(caml_c_call)
 #endif
     /* Return */
         LEAVE_FUNCTION
+        NORMALIZE_RETURN_ADDRESS
         RET_FROM_C_CALL
         CFI_ENDPROC
 END_FUNCTION(caml_c_call)
@@ -626,6 +634,7 @@ FUNCTION(caml_c_call_stack_args)
         SWITCH_C_TO_OCAML
     /* Return */
         LEAVE_FUNCTION
+        NORMALIZE_RETURN_ADDRESS
         RET_FROM_C_CALL
         CFI_ENDPROC
 END_FUNCTION(caml_c_call_stack_args)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -52,6 +52,9 @@ frame_descr * caml_next_frame_descriptor
       /* Regular frame, update sp/pc and return the frame descriptor */
       *sp += frame_size(d);
       *pc = Saved_return_address(*sp);
+#ifdef Mask_already_scanned
+      *pc = Mask_already_scanned(*pc);
+#endif
       return d;
     } else {
       /* This marks the top of an ML stack chunk. Move sp to the previous stack
@@ -65,6 +68,9 @@ frame_descr * caml_next_frame_descriptor
       }
       *sp = First_frame(*sp);
       *pc = Saved_return_address(*sp);
+#ifdef Mask_already_scanned
+      *pc = Mask_already_scanned(*pc);
+#endif
     }
   }
 }

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -52,9 +52,6 @@ frame_descr * caml_next_frame_descriptor
       /* Regular frame, update sp/pc and return the frame descriptor */
       *sp += frame_size(d);
       *pc = Saved_return_address(*sp);
-#ifdef Mask_already_scanned
-      *pc = Mask_already_scanned(*pc);
-#endif
       return d;
     } else {
       /* This marks the top of an ML stack chunk. Move sp to the previous stack
@@ -68,9 +65,6 @@ frame_descr * caml_next_frame_descriptor
       }
       *sp = First_frame(*sp);
       *pc = Saved_return_address(*sp);
-#ifdef Mask_already_scanned
-      *pc = Mask_already_scanned(*pc);
-#endif
     }
   }
 }

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -23,6 +23,7 @@
 
 typedef enum {
   SCANNING_ONLY_YOUNG_VALUES = 1, // action is a no-op outside the minor heap
+  SCANNING_ONLY_RECENT_FRAMES = 2, // generational scanning of stack frames
 } scanning_action_flags;
 
 typedef void (*scanning_action) (void*, value, volatile value *);

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -50,6 +50,7 @@
 #define First_frame(sp) (sp)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 32 + 16 + 8))
 #define Stack_header_size (32 + 16 + 16)
+#define CODE_POINTER_MARK_BIT 0
 #endif
 
 #ifdef TARGET_s390x
@@ -82,6 +83,9 @@
 #define First_frame(sp) ((sp) + 16)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
 #define Stack_header_size 32
+#if defined(SYS_linux)
+#define CODE_POINTER_MARK_BIT 60
+#endif
 #endif
 
 #ifdef TARGET_riscv
@@ -92,6 +96,15 @@
 #define First_frame(sp) ((sp) + 16)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
 #define Stack_header_size 32
+#define CODE_POINTER_MARK_BIT 0
+#endif
+
+#ifdef CODE_POINTER_MARK_BIT
+#define CODE_POINTER_MARK_MASK ((uintnat) 1 << CODE_POINTER_MARK_BIT)
+#define Already_scanned(sp, retaddr) ((retaddr) & CODE_POINTER_MARK_MASK)
+#define Mask_already_scanned(retaddr) ((retaddr) & ~CODE_POINTER_MARK_MASK)
+#define Mark_scanned(sp, retaddr) \
+  Saved_return_address(sp) = (retaddr) | CODE_POINTER_MARK_MASK
 #endif
 
 /* Declaration of variables used in the asm code */

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -46,7 +46,7 @@
 /* Size of the gc_regs structure, in words.
    See power.S and power/proc.ml for the indices */
 #define Wosize_gc_regs (23 /* int regs */ + 14 /* caller-save float regs */)
-#define Saved_return_address(sp) *((intnat *)((sp) + 16))
+#define Saved_return_address_raw(sp) *((intnat *)((sp) + 16))
 #define First_frame(sp) (sp)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 32 + 16 + 8))
 #define Stack_header_size (32 + 16 + 16)
@@ -55,7 +55,7 @@
 
 #ifdef TARGET_s390x
 #define Wosize_gc_regs (2 + 9 /* int regs */ + 16 /* float regs */)
-#define Saved_return_address(sp) *((intnat *)((sp) - 8))
+#define Saved_return_address_raw(sp) *((intnat *)((sp) - 8))
 #define First_frame(sp) ((sp) + 8)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
 #define Stack_header_size 32
@@ -65,7 +65,7 @@
 /* Size of the gc_regs structure, in words.
    See amd64.S and amd64/proc.ml for the indices */
 #define Wosize_gc_regs (13 /* int regs */ + 16 /* float regs */)
-#define Saved_return_address(sp) *((intnat *)((sp) - 8))
+#define Saved_return_address_raw(sp) *((intnat *)((sp) - 8))
 #ifdef WITH_FRAME_POINTERS
 #define First_frame(sp) ((sp) + 16)
 #else
@@ -79,7 +79,7 @@
 /* Size of the gc_regs structure, in words.
    See arm64.S and arm64/proc.ml for the indices */
 #define Wosize_gc_regs (2 + 24 /* int regs */ + 24 /* float regs */)
-#define Saved_return_address(sp) *((intnat *)((sp) - 8))
+#define Saved_return_address_raw(sp) *((intnat *)((sp) - 8))
 #define First_frame(sp) ((sp) + 16)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
 #define Stack_header_size 32
@@ -90,7 +90,7 @@
 /* Size of the gc_regs structure, in words.
    See riscv.S and riscv/proc.ml for the indices */
 #define Wosize_gc_regs (2 + 22 /* int regs */ + 20 /* float regs */)
-#define Saved_return_address(sp) *((intnat *)((sp) - 8))
+#define Saved_return_address_raw(sp) *((intnat *)((sp) - 8))
 #define First_frame(sp) ((sp) + 16)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
 #define Stack_header_size 32
@@ -101,8 +101,12 @@
 #define CODE_POINTER_MARK_MASK ((uintnat) 1 << CODE_POINTER_MARK_BIT)
 #define Already_scanned(sp, retaddr) ((retaddr) & CODE_POINTER_MARK_MASK)
 #define Mask_already_scanned(retaddr) ((retaddr) & ~CODE_POINTER_MARK_MASK)
+#define Saved_return_address(sp) \
+  Mask_already_scanned(Saved_return_address_raw(sp))
 #define Mark_scanned(sp, retaddr) \
-  Saved_return_address(sp) = (retaddr) | CODE_POINTER_MARK_MASK
+  Saved_return_address_raw(sp) = (retaddr) | CODE_POINTER_MARK_MASK
+#else
+#define Saved_return_address Saved_return_address_raw
 #endif
 
 /* Declaration of variables used in the asm code */

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -83,9 +83,7 @@
 #define First_frame(sp) ((sp) + 16)
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
 #define Stack_header_size 32
-#if defined(SYS_linux)
 #define CODE_POINTER_MARK_BIT 60
-#endif
 #endif
 
 #ifdef TARGET_riscv

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -241,9 +241,6 @@ void caml_get_stack_sp_pc (struct stack_info* stack,
   char* p = (char*)stack->sp;
   p = First_frame(p);
   *pc = Saved_return_address(p); /* ret addr */
-#ifdef Mask_already_scanned
-  *pc = Mask_already_scanned(*pc);
-#endif
   *sp = p;                       /* pointer to first frame */
 }
 
@@ -266,7 +263,7 @@ Caml_inline void scan_stack_frames(
 next_chunk:
   if (sp == (char*)Stack_high(stack)) return;
   sp = First_frame(sp);
-  retaddr = Saved_return_address(sp);
+  retaddr = Saved_return_address_raw(sp);
 
   while(1) {
 #ifdef Already_scanned
@@ -295,7 +292,7 @@ next_chunk:
       }
       /* Move to next frame */
       sp += frame_size(d);
-      retaddr = Saved_return_address(sp);
+      retaddr = Saved_return_address_raw(sp);
     } else {
       /* This marks the top of an ML stack chunk. Move sp to the previous
        * stack chunk.  */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -233,7 +233,7 @@ static int try_update_object_header(value v, volatile value *p, value result,
 
 /* oldify_one is a no-op outside the minor heap. */
 static scanning_action_flags oldify_scanning_flags =
-  SCANNING_ONLY_YOUNG_VALUES;
+  SCANNING_ONLY_YOUNG_VALUES | SCANNING_ONLY_RECENT_FRAMES;
 
 /* Note that the tests on the tag depend on the fact that Infix_tag,
    Forward_tag, and No_scan_tag are contiguous. */

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -201,7 +201,7 @@ Caml_inline void caml_tsan_debug_log_pc(const char* msg, uintnat pc)
 #endif
 }
 
-/* This function is called by `caml_raise_exn` or `caml_tsan_raise_notrace_exn`
+/* This function is called by `caml_raise_exn` or `caml_tsan_exit_on_raise_asm`
  from an OCaml stack.
  - [pc] is the program counter where `caml_raise_exn` would return, i.e. the
  next instruction after `caml_raise_exn` in the function that raised the
@@ -210,6 +210,10 @@ Caml_inline void caml_tsan_debug_log_pc(const char* msg, uintnat pc)
   [pc].
  - [trapsp] is the address of the next exception handler.
 
+ It can also be called by `caml_raise_exception` which is called from C.
+ In that case it discards the C stack and works on the OCaml stack underneath,
+ as if `caml_raise_exn` was raised directly from there.
+
  This function iterates over every function stack frame between [sp] and
  [trapsp], calling `__tsan_func_exit` for each function. */
 void caml_tsan_exit_on_raise(uintnat pc, char* sp, char* trapsp)
@@ -217,6 +221,12 @@ void caml_tsan_exit_on_raise(uintnat pc, char* sp, char* trapsp)
   caml_domain_state* domain_state = Caml_state;
   caml_frame_descrs* fds = caml_get_frame_descrs();
   uintnat next_pc = pc;
+
+#ifdef Mask_already_scanned
+  // If we come from [caml_raise_exception], the [pc] comes from an
+  // OCaml stack that may have been scanned by the GC.
+  next_pc = Mask_already_scanned(next_pc);
+#endif
 
   /* iterate on each frame  */
   while (1) {
@@ -302,6 +312,12 @@ void caml_tsan_exit_on_perform(uintnat pc, char* sp)
   caml_frame_descrs* fds = caml_get_frame_descrs();
   uintnat next_pc = pc;
 
+#ifdef Mask_already_scanned
+  // [caml_perform] may be a tail-call, in which case [pc] was the
+  // return address of the caller, which may have been scanned.
+  next_pc = Mask_already_scanned(next_pc);
+#endif
+
   /* iterate on each frame  */
   while (1) {
     frame_descr* descr = caml_next_frame_descriptor(fds, &next_pc, &sp, stack);
@@ -332,7 +348,10 @@ CAMLno_tsan void caml_tsan_entry_on_resume(uintnat pc, char* sp,
 {
   caml_frame_descrs* fds = caml_get_frame_descrs();
   uintnat next_pc = pc;
+
 #ifdef Mask_already_scanned
+  // the stack to resume may have been scanned by the GC after
+  // [caml_perform] suspended it, so it may be marked.
   next_pc = Mask_already_scanned(next_pc);
 #endif
 

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -332,6 +332,9 @@ CAMLno_tsan void caml_tsan_entry_on_resume(uintnat pc, char* sp,
 {
   caml_frame_descrs* fds = caml_get_frame_descrs();
   uintnat next_pc = pc;
+#ifdef Mask_already_scanned
+  next_pc = Mask_already_scanned(next_pc);
+#endif
 
   caml_next_frame_descriptor(fds, &next_pc, &sp, (struct stack_info*)stack);
   if (next_pc == 0) {


### PR DESCRIPTION
Following discussions at #11923 and the request at #13574, this PR PR is a first step towards generational scanning of stack frames during minor GCs: scanning can stop when it reaches a frame that has not changed since the previous minor GC.

The first commit 97ac9a5012 simply ports the OCaml 4 approach to OCaml 5.  Already-scanned frames are identified by an otherwise-ignored bit in the corresponding return addresses stored in the stack.  This is supported for POWER, RISC-V, and ARM 64-bit in top-bits-ignore mode, that is, currently, ARM64/Linux but not ARM64/macOS.  The nice thing about this approach is that it incurs zero performance overhead on the mutators, and requires no extra stack space.

Commit  e8f7ea1b46 refactors the OCaml 4 code a bit to make it more applicable to other marking scheme later.  It also opens the possibility to detect ignored bits in the configure script rather than hard-wiring their existence in `caml/stack.h`.

Commit d9145d98c6 is a failed experiment to implement top-bits-ignore for x86-64 by catching SIGSEGV arising out of RET instructions and fixing them in the signal handler.  It is prohibitively slow, so 62a9b88ab0 reverts this commit.  I left the code temporarily in this PR as a warning sign for those of you who would be tempted to do things with signals here.

Commit c960af4753 implements a form of top-bits-ignore for ARM64/macOS, just by masking the top 8 bits of the return address before every `ret` instruction.  Unlike hardware TBI, it does not come for free: code size increases by 2% (for the OCaml stdlib) and execution time by 0.5% on an average of small benchmarks.  The +0.5% does not include the potential reduction in GC time offered by generational stack scanning.  Maybe Sandmark can give better performance estimates.

~~I trieds a similar "mask bits off before returning" approach for x86-64 but the performance figures were all over the place, so I probably did something wrong.~~

Marking this PR as a draft because there are other approaches to explore, this is just to get the ball rolling.

Closes: #13574.



