### PR TITLE
Use correct CFA register on ARM64

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,6 +190,10 @@ Working version
 - #13541, #13591: Fix headers for C++ inclusion.
   (Antonin Décimo, review by Nick Barnes, report by Kate Deplaix)
 
+- #13595: Use x19 as Canonical Frame Address (CFA) register. This would cause
+  backtraces to be truncated when calling no alloc C code.
+  (Tim McGilchrist, report by Nick Barnes, review by Nick Barnes)
+
 OCaml 5.3.0
 ___________
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -765,7 +765,7 @@ let emit_instr env i =
           (* Store OCaml stack in x19 register and restore later. *)
           `	mov	x19, sp\n`;
           cfi_remember_state ();
-          cfi_def_cfa_register ~reg:29;
+          cfi_def_cfa_register ~reg:19;
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
           `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`;
           `	mov	sp, {emit_reg reg_tmp1}\n`;

--- a/testsuite/tests/unwind/check-linker-version.sh
+++ b/testsuite/tests/unwind/check-linker-version.sh
@@ -1,13 +1,14 @@
-#!/bin/sh
-exec > ${ocamltest_response} 2>&1
-LDFULL="`ld -v 2>&1`"
-LD="`echo $LDFULL | grep -o \"ld64-[0-9]*\"`"
-LDVER="`echo $LD | sed \"s/ld64-//\"`"
-if [[ -z "$LD" ]]; then
-  echo "unknown linker: pattern ld64-[0-9]* not found in 'ld -v' output";
-  test_result=${TEST_SKIP};
-elif [[ $LDVER -lt 224 ]]; then
-  echo "ld version is $LDVER, only 224 or above are supported";
+#!/usr/bin/env bash
+
+LDVER=$(ld -v 2>&1 | egrep -o "PROJECT:ld(64)?-[0-9]*" | sed -E "s/PROJECT:ld(64)?-//")
+
+# Extract the first 3 parts of an LD version number
+version () {
+    echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'
+}
+
+if [ $(version "$LDVER") -lt $(version "224.0.0.0") ]; then
+  echo "ld version is $LDVER, only 224 or above are supported.";
   test_result=${TEST_SKIP};
 else
   test_result=${TEST_PASS};


### PR DESCRIPTION
I noticed that `testsuite/tests/unwind/driver.ml` was failing on my Mac. @tmcgilchrist identified and fixed the problem (wrong CFA register), which was related to my use of an old version of XCode, not exercised by the CI. This solution is his but with a tweak from me for the `check-linker-version.sh` script.