### PR TITLE
#13598: ignore non-injective parameters when typechecking pattern

### DIFF
--- a/Changes
+++ b/Changes
@@ -806,8 +806,9 @@ ___________
   were being included in the thread descriptors.
   (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
 
-- #13579, #13583: Unsoundness involving non-injective types + gadts
-  (Jacques Garrigue, report by @v-gb,
+- #13579, #13583, #13598, #13599: Unsoundness involving non-injective types
+  and gadts.
+  (Jacques Garrigue, report by @v-gb and Tõivo Leedjärv,
    review by Richard Eisenberg and Florian Angeletti)
 
 OCaml 5.2.0 (13 May 2024)

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -44,15 +44,64 @@ type _ t = W : int M.p t
 
 let f (W: _ M.p t) = ()
 [%%expect{|
-Line 1, characters 7-8:
-1 | let f (W: _ M.p t) = ()
-           ^
-Error: This pattern matches values of type "int M.p t"
-       but a pattern was expected which matches values of type "$0 M.p t"
-       The type constructor "$0" would escape its scope
+val f : 'a M.p t -> unit = <fun>
 |}]
 
 let f (W: _ t) = ()
 [%%expect{|
 val f : int M.p t -> unit = <fun>
+|}]
+
+
+type _ t = W: int M.p t | W2: float M.p t
+[%%expect{|
+type _ t = W : int M.p t | W2 : float M.p t
+|}]
+
+let f (W: _ M.p t) = ()
+[%%expect{|
+Line 1, characters 6-18:
+1 | let f (W: _ M.p t) = ()
+          ^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+W2
+
+val f : 'a M.p t -> unit = <fun>
+|}]
+
+let f =  function W -> () | W2 -> ()
+[%%expect{|
+val f : int M.p t -> unit = <fun>
+|}]
+
+let f =  function (W: _ M.p t) -> () | W2 -> ()
+[%%expect{|
+val f : 'a M.p t -> unit = <fun>
+|}]
+
+let f: type a. a M.p t -> unit =  function W -> () | W2 -> ()
+[%%expect{|
+val f : 'a M.p t -> unit = <fun>
+|}]
+
+let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
+[%%expect{|
+val f : ('a M.p * 'a0, 'b M.p * int) Type.eq -> unit = <fun>
+|}]
+
+(** Counter-example side *)
+
+type 'a cstr = X of 'a constraint 'a = _ M.p
+type x = int M.p cstr
+type ab = A of x | B of x
+
+let test = function
+   | A a -> [a]
+   | B a -> [a]
+[%%expect {|
+type 'a cstr = X of 'a constraint 'a = 'b M.p
+type x = int M.p cstr
+type ab = A of x | B of x
+val test : ab -> x list = <fun>
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2876,11 +2876,7 @@ and unify3 uenv t1 t1' t2 t2' =
               with Not_found -> List.map (fun _ -> false) tl1
             in
             List.iter2
-              (fun i (t1, t2) ->
-                if i then unify uenv t1 t2 else begin
-                  reify uenv t1;
-                  reify uenv t2
-                end)
+              (fun i (t1, t2) -> if i then unify uenv t1 t2)
               inj (List.combine tl1 tl2)
       | (Tconstr (path,[],_),
          Tconstr (path',[],_))


### PR DESCRIPTION
This PR proposes to fix both the change in behavior in #13583 and the soundness bug discovered in #13598 by stopping to learn any equations and inequations from non-injective type parameters when typechecking patterns.

The soundness fix in #13598 was concerned about pattern typechecking recording equalities from non-injective position by a side-channel. However, this fix added type inequalities during the typechecking (by rigidifying types in non-injective positions).  Those supernumerary type inequalities are a soundness issue when checking counter-examples.

Thus, this PR goes one step further than #13598 and simply consider that non-injective type parameters are opaque when typechecking patterns.

closes  #13598