### PR TITLE
Fix #13598 by protecting partial_pred

### DIFF
--- a/Changes
+++ b/Changes
@@ -845,6 +845,10 @@ ___________
   (Jacques Garrigue, report by @v-gb,
    review by Richard Eisenberg and Florian Angeletti)
 
+- #13598: Falsely triggered warning 56 [unreachable-case]
+  This was caused by unproper protection of the retyping function.
+  (Jacques Garrigue, report by Tõivo Leedjärv, review by ???)
+
 - #13603, #13604: fix source printing in the presence of the escaped raw
   identifier `\#mod`.
   (Florian Angeletti, report by Chris Casinghino, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -847,7 +847,7 @@ ___________
 
 - #13598: Falsely triggered warning 56 [unreachable-case]
   This was caused by unproper protection of the retyping function.
-  (Jacques Garrigue, report by Tõivo Leedjärv, review by ???)
+  (Jacques Garrigue, report by Tõivo Leedjärv, review by Florian Angeletti)
 
 - #13603, #13604: fix source printing in the presence of the escaped raw
   identifier `\#mod`.

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -56,3 +56,66 @@ let f (W: _ t) = ()
 [%%expect{|
 val f : int M.p t -> unit = <fun>
 |}]
+
+
+type _ t = W: int M.p t | W2: float M.p t
+[%%expect{|
+type _ t = W : int M.p t | W2 : float M.p t
+|}]
+
+let f (W: _ M.p t) = ()
+[%%expect{|
+Line 1, characters 7-8:
+1 | let f (W: _ M.p t) = ()
+           ^
+Error: This pattern matches values of type "int M.p t"
+       but a pattern was expected which matches values of type "$0 M.p t"
+       The type constructor "$0" would escape its scope
+|}]
+
+let f =  function W -> () | W2 -> ()
+[%%expect{|
+val f : int M.p t -> unit = <fun>
+|}]
+
+let f =  function (W: _ M.p t) -> () | W2 -> ()
+[%%expect{|
+Line 1, characters 19-20:
+1 | let f =  function (W: _ M.p t) -> () | W2 -> ()
+                       ^
+Error: This pattern matches values of type "int M.p t"
+       but a pattern was expected which matches values of type "$0 M.p t"
+       The type constructor "$0" would escape its scope
+|}]
+
+let f: type a. a M.p t -> unit =  function W -> () | W2 -> ()
+[%%expect{|
+val f : 'a M.p t -> unit = <fun>
+|}]
+
+let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
+[%%expect{|
+Line 1, characters 16-21:
+1 | let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
+                    ^^^^^
+Error: This pattern matches values of type "($'a M.p * a, $'a M.p * a) Type.eq"
+       but a pattern was expected which matches values of type
+         "($'a M.p * a, 'b M.p * int) Type.eq"
+       The type constructor "$'a" would escape its scope
+|}]
+
+(** Counter-example side *)
+
+type 'a cstr = X of 'a constraint 'a = _ M.p
+type x = int M.p cstr
+type ab = A of x | B of x
+
+let test = function
+   | A a -> [a]
+   | B a -> [a]
+[%%expect {|
+type 'a cstr = X of 'a constraint 'a = 'b M.p
+type x = int M.p cstr
+type ab = A of x | B of x
+val test : ab -> x list = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -143,15 +143,15 @@ exception Incompatible
 (**** Control tracing of GADT instances *)
 
 let trace_gadt_instances = ref false
-let check_trace_gadt_instances env =
-  not !trace_gadt_instances && Env.has_local_constraints env &&
+let check_trace_gadt_instances ?(force=false) env =
+  not !trace_gadt_instances && (force || Env.has_local_constraints env) &&
   (trace_gadt_instances := true; cleanup_abbrev (); true)
 
 let reset_trace_gadt_instances b =
   if b then trace_gadt_instances := false
 
-let wrap_trace_gadt_instances env f x =
-  let b = check_trace_gadt_instances env in
+let wrap_trace_gadt_instances ?force env f x =
+  let b = check_trace_gadt_instances ?force env in
   let y = f x in
   reset_trace_gadt_instances b;
   y
@@ -1578,6 +1578,7 @@ let check_abbrev_env env =
   if not (Env.same_type_declarations env !previous_env) then begin
     (* prerr_endline "cleanup expansion cache"; *)
     cleanup_abbrev ();
+    simple_abbrevs := Mnil;
     previous_env := env
   end
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -152,9 +152,8 @@ let reset_trace_gadt_instances b =
 
 let wrap_trace_gadt_instances ?force env f x =
   let b = check_trace_gadt_instances ?force env in
-  let y = f x in
-  reset_trace_gadt_instances b;
-  y
+  Misc.try_finally (fun () -> f x)
+    ~always:(fun () -> reset_trace_gadt_instances b)
 
 (**** Abbreviations without parameters ****)
 (* Shall reset after generalizing *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -468,7 +468,7 @@ val collapse_conj_params: Env.t -> type_expr list -> unit
         (* Collapse conjunctive types in class parameters *)
 
 val get_current_level: unit -> int
-val wrap_trace_gadt_instances: Env.t -> ('a -> 'b) -> 'a -> 'b
+val wrap_trace_gadt_instances: ?force:bool -> Env.t -> ('a -> 'b) -> 'a -> 'b
 
 val immediacy : Env.t -> type_expr -> Type_immediacy.t
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2517,8 +2517,10 @@ let check_counter_example_pat ~counter_example_args penv tp expected_ty =
      way -- one of the functions it calls writes an entry into
      [tps_pattern_forces] -- so we can just ignore module patterns. *)
   let type_pat_state = create_type_pat_state Modules_ignored in
-  check_counter_example_pat
-    ~info:counter_example_args ~penv type_pat_state tp expected_ty (fun x -> x)
+  wrap_trace_gadt_instances ~force:true !!penv
+    (check_counter_example_pat ~info:counter_example_args ~penv
+       type_pat_state tp expected_ty)
+    (fun x -> x)
 
 (* this function is passed to Partial.parmatch
    to type check gadt nonexhaustiveness *)
@@ -2533,8 +2535,7 @@ let partial_pred ~lev ~splitting_mode ?(explode=0) env expected_ty p =
       } in
   try
     let typed_p =
-      wrap_trace_gadt_instances ~force:true !!penv
-        (check_counter_example_pat ~counter_example_args penv p) expected_ty
+      check_counter_example_pat ~counter_example_args penv p expected_ty
     in
     set_state state penv;
     (* types are invalidated but we don't need them here *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2533,7 +2533,8 @@ let partial_pred ~lev ~splitting_mode ?(explode=0) env expected_ty p =
       } in
   try
     let typed_p =
-      check_counter_example_pat ~counter_example_args penv p expected_ty
+      wrap_trace_gadt_instances ~force:true !!penv
+        (check_counter_example_pat ~counter_example_args penv p) expected_ty
     in
     set_state state penv;
     (* types are invalidated but we don't need them here *)


### PR DESCRIPTION
This is an alternative fix to #13598, this time protecting `partial_pred` with `trace_gadt_instances ~force:true`, to ensure that we do not look up old abbreviations. (That was a trick one.)

It is required, since the behaviour of the exhaustivity check was potentially buggy, but does not preclude merging #13599 too.