### PR TITLE
adds data_types to dune configuration

### DIFF
--- a/dune
+++ b/dune
@@ -64,7 +64,7 @@
    typetexp patterns printpat parmatch stypes typeopt typedecl value_rec_check
    typecore
    typeclass typemod typedecl_variance typedecl_properties typedecl_immediacy
-   typedecl_unboxed typedecl_separability cmt2annot out_type
+   typedecl_unboxed typedecl_separability cmt2annot out_type data_types
    ; manual update: mli only files
    annot outcometree value_rec_types
 


### PR DESCRIPTION
Dune configuration was missing a module definition which caused builds to fail. This commit adds the module definition.