### PR TITLE
-dsource: \#mod is not an operator in type context

### DIFF
--- a/Changes
+++ b/Changes
@@ -813,6 +813,10 @@ ___________
   (Jacques Garrigue, report by @v-gb,
    review by Richard Eisenberg and Florian Angeletti)
 
+- #13603, #13604: fix source printing in the presence of the escaped raw
+  identifier `\#mod`.
+  (Florian Angeletti, report by Chris Casinghino, review by Gabriel Scherer)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7473,6 +7473,12 @@ module M = struct
   class \#let = object
     inherit \#val \#let as \#mutable
   end
+  let \#true = 0
+  let \#mod = 0
+  type \#mod = [ `A | `B ]
+
+  class \#mod = object end
+
 end
 
 let x = new M.\#begin
@@ -7480,6 +7486,34 @@ let x = new M.\#begin
 let f = fun x (type \#begin) (type \#end) -> 1
 
 let f: type \#if. \#if -> \#if = fun x -> x
+
+let mlet = M.\#let
+let mtrue = M.\#true
+let mmod = M.\#mod
+type tmod = M.\#mod
+type tlet = M.\#let
+type ttrue = M.\#true
+
+class \#mod = object end
+let f: #M.\#mod -> _ =  new \#mod, new M.\#mod
+
+class type \#mod = object end
+class type \#let = \#mod
+
+module type \#mod = sig type \#mod module type \#mod  end
+
+module type t =
+  \#mod with type \#mod = M.\#mod
+         and module type \#mod = M.\#mod
+
+type \#mod = [`A | `B ]
+let g = function #\#mod | #M.\#mod -> ()
+
+type \#mod = ..
+type M.\#mod += A
+
+type t = true of int
+let x = true 0
 
 (* check pretty-printing of local module open in core_type *)
 type t = String.( t )


### PR DESCRIPTION
This PR fixes #13603 by splitting the longident syntactic category in three inside the implementation of `Pparsetree`:

- Contructor-like longident for which `true` and `false` are uppercase identifiers
- Type-like longident for which `mod` is not an operator but the lowercase identifier written `\#mod` in the source.
- Regular longident for which `mod` is an operator (which should be printed `(mod)`) and `true` and `false` are lowercase identifiers introduced with the raw identifier syntax \#true and \#false.

Beyond the specific bug discovered in #13603 this PR also fixes along the way:

- the printing of `true|false|[]|()` constructors in presence of arguments
- the printing of `module type \#let`.