### PR TITLE
Added an error detection when generating typing constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -373,7 +373,9 @@ Working version
   (Tim McGilchrist, report by Nick Barnes, review by Nick Barnes)
 
 * #13605: Fix ungenerated constraints when they where impossible due to polyvars
-  issues (Samuel Vivien, review by Florian Angeletti and Jacques Garrigue)
+  issues
+  (Samuel Vivien, review by Florian Angeletti, Richard Eisenberg
+   and Jacques Garrigue)
 
 - #13677, #13679: domain.c: remove backup_thread_running to simplify
   concurrent state updates to the backup thread status.

--- a/Changes
+++ b/Changes
@@ -372,6 +372,9 @@ Working version
   backtraces to be truncated when calling no alloc C code.
   (Tim McGilchrist, report by Nick Barnes, review by Nick Barnes)
 
+* #13605: Fix ungenerated constraints when they where impossible due to polyvars
+  issues (Samuel Vivien, review by Florian Angeletti and Jacques Garrigue)
+
 - #13677, #13679: domain.c: remove backup_thread_running to simplify
   concurrent state updates to the backup thread status.
   (Gabriel Scherer, review by Jan Midtgaard and Miod Vallat,

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -462,3 +462,25 @@ type 'a x = [ `X of 'e ] constraint 'a = 'e list
 type p = private [> a x ]
 and a = int list
 |}]
+
+(* PR #13605 *)
+
+type 'a t3 = < m : 'b. (int -> 'b) as 'a >
+
+[%%expect{|
+Line 1, characters 23-40:
+1 | type 'a t3 = < m : 'b. (int -> 'b) as 'a >
+                           ^^^^^^^^^^^^^^^^^
+Error: This type "'a" should be an instance of type "int -> 'b"
+       The universal variable "'b" would escape its scope
+|}]
+
+type 'a t4 = < m : 'b. int -> ('b as 'a) > * 'a
+
+[%%expect{|
+Line 1, characters 31-39:
+1 | type 'a t4 = < m : 'b. int -> ('b as 'a) > * 'a
+                                   ^^^^^^^^
+Error: This type "'a" should be an instance of type "'b"
+       The universal variable "'b" would escape its scope
+|}]

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -484,3 +484,15 @@ Line 1, characters 31-39:
 Error: This type "'a" should be an instance of type "'b"
        The universal variable "'b" would escape its scope
 |}]
+
+class type ['a] c = object
+  method m : 'b. (int -> 'b) as 'a
+end
+
+[%%expect{|
+Line 2, characters 17-34:
+2 |   method m : 'b. (int -> 'b) as 'a
+                     ^^^^^^^^^^^^^^^^^
+Error: This type "'a" should be an instance of type "int -> 'b"
+       The universal variable "'b" would escape its scope
+|}]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -313,7 +313,11 @@ end = struct
         if flavor = Unification || is_in_scope name then
           let v = new_global_var () in
           let snap = Btype.snapshot () in
-          if try unify env v ty; true with _ -> Btype.backtrack snap; false
+          if try unify env v ty; true
+            with
+                Unify err when is_in_scope name ->
+                  raise (Error(loc, env, Type_mismatch err))
+              | _ -> Btype.backtrack snap; false
           then try
             r := (loc, v, lookup_global_type_variable name) :: !r
           with Not_found ->


### PR DESCRIPTION
This is an attempt to fix #13559.

The problem comes from the fact that constraints are dropped when they pose scoping issues. This is needed because recursive types work this way but should not be used in types definition when the type is defined before.

Thus this PR adds a small check that fails in that case.