### PR TITLE
Fix Numbers.Int_base.compare

### DIFF
--- a/Changes
+++ b/Changes
@@ -136,6 +136,9 @@ Working version
 - #13539: Use nanosleep instead of usleep, if available.
   (Antonin Décimo, review by Miod Vallat and Gabriel Scherer)
 
+- #13606: Fix Numbers.Int_base.compare
+  (Mark Shinwell, review by Vincent Laviron)
+
 ### Build system:
 
 ### Bug fixes:

--- a/utils/numbers.ml
+++ b/utils/numbers.ml
@@ -17,7 +17,7 @@
 module Int_base = Identifiable.Make (struct
   type t = int
 
-  let compare x y = x - y
+  let compare = Int.compare
   let output oc x = Printf.fprintf oc "%i" x
   let hash i = i
   let equal (i : int) j = i = j


### PR DESCRIPTION
The `compare` function used for integers in (parts of) the compiler is wrong (i.e. not suitable for use as argument of `Map.Make`). This eventually caused bugs in the flambda-backend compiler, which was building maps with potentially negative numbers as keys (see https://github.com/ocaml-flambda/flambda-backend/pull/3268 for the same fix there).