### PR TITLE
#12628 Express full path of unsafe value when compiling recursive modules

### DIFF
--- a/.depend
+++ b/.depend
@@ -4794,6 +4794,7 @@ lambda/translmod.cmx : \
 lambda/translmod.cmi : \
     typing/typedtree.cmi \
     typing/primitive.cmi \
+    typing/path.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi

--- a/Changes
+++ b/Changes
@@ -51,6 +51,11 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #12628: Improved error message for unsafe values: print out the full path for
+  the value that is unsafe when they are detected during the compilation of
+  recursive modules.
+  (Shivam Acharya, review by Gabriel Scherer and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -49,7 +49,11 @@ type unsafe_component =
   | Unsafe_typext
 
 type unsafe_info =
-  | Unsafe of { reason:unsafe_component; loc:Location.t; subid:Ident.t }
+  | Unsafe of {
+      reason:unsafe_component;
+      loc:Location.t;
+      path:Path.t
+    }
   | Unnamed
 
 type error =


### PR DESCRIPTION
This PR partly addresses #12628. When determining the shape of the modules, we keep track of the full path traversed, such that upon raising an unsafe value exception we can reconstruct the full path allowing the user to identify where they must make changes.

PS: This is my first contribution to this project, so I welcome all potential suggestions on improvements, thank you!