### PR TITLE
Refactor `Typecore.type_application`

### DIFF
--- a/Changes
+++ b/Changes
@@ -140,7 +140,8 @@ Working version
   (Mark Shinwell, review by Vincent Laviron)
 
 - #13612: Refactor `type_application`
-  (Ulysse Gérard, Leo White, review by Antonin Décimo, ...)
+  (Ulysse Gérard, Leo White, review by Antonin Décimo, Gabriel Scherer,
+   Samuel Vivien, Florian Angeletti and Jacques Garrigue)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -139,6 +139,9 @@ Working version
 - #13606: Fix Numbers.Int_base.compare
   (Mark Shinwell, review by Vincent Laviron)
 
+- #13612: Refactor `type_application`
+  (Ulysse Gérard, Leo White, review by Antonin Décimo, ...)
+
 ### Build system:
 
 ### Bug fixes:

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -220,7 +220,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
     && List.for_all (fun (_, arg) -> not (is_omitted arg)) oargs ->
       let argl, extra_args = cut p.prim_arity oargs in
       let arg_exps =
-         List.map (function _, Arg x -> x | _ -> assert false) argl
+         List.map (function _, Arg x -> x | _, Omitted () -> assert false) argl
       in
       let args = transl_list ~scopes arg_exps in
       let prim_exp = if extra_args = [] then Some e else None in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -719,10 +719,7 @@ and transl_apply ~scopes
            if we already passed here this is a no-op. *)
         let l =
           List.map
-            (fun (arg, opt) ->
-               match arg with
-               | Omitted () -> arg, opt
-               | Arg arg -> Arg (protect "arg" arg), opt)
+            (fun (arg, opt) -> Typedtree.map_apply_arg (protect "arg") arg, opt)
             l
         in
         let id_arg = Ident.create_local "param" in
@@ -748,11 +745,7 @@ and transl_apply ~scopes
     | [] ->
         lapply lam (List.rev_map fst args)
   in
-  let transl_arg arg =
-    match arg with
-    | Omitted () as arg -> arg
-    | Arg exp -> Arg (transl_exp ~scopes exp)
-  in
+  let transl_arg arg = Typedtree.map_apply_arg (transl_exp ~scopes) arg in
   (build_apply lam [] (List.map (fun (l, arg) ->
                                    transl_arg arg,
                                    Btype.is_optional l)

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -28,7 +28,7 @@ val transl_apply: scopes:scopes
                   -> ?tailcall:tailcall_attribute
                   -> ?inlined:inline_attribute
                   -> ?specialised:specialise_attribute
-                  -> lambda -> (arg_label * expression option) list
+                  -> lambda -> (arg_label * apply_arg) list
                   -> scoped_location -> lambda
 val transl_let: scopes:scopes -> ?in_structure:bool -> rec_flag
                 -> value_binding list -> lambda -> lambda

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -709,7 +709,7 @@ module Analyser =
             in
            (parameter :: params, k)
 
-      | (Parsetree.Pcl_apply (p_class_expr2, _), Tcl_apply (tt_class_expr2, exp_opt_optional_list)) ->
+      | (Parsetree.Pcl_apply (p_class_expr2, _), Tcl_apply (tt_class_expr2, arg_list)) ->
           let applied_name =
             (* we want an ident, or else the class applied will appear in the form object ... end,
                because if the class applied has no name, the code is kinda ugly, isn't it ? *)
@@ -725,12 +725,12 @@ module Analyser =
                     Odoc_messages.object_end
           in
           let param_exps = List.fold_left
-              (fun acc -> fun (_, exp_opt) ->
-                match exp_opt with
-                  None -> acc
-                | Some e -> acc @ [e])
+              (fun acc -> fun (_, arg) ->
+                match arg with
+                | Omitted () -> acc
+                | Arg e -> acc @ [e])
               []
-              exp_opt_optional_list
+              arg_list
           in
           let param_types = List.map (fun e -> e.Typedtree.exp_type) param_exps in
           let params_code =

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -724,13 +724,10 @@ module Analyser =
                 |  _ ->
                     Odoc_messages.object_end
           in
-          let param_exps = List.fold_left
-              (fun acc -> fun (_, arg) ->
-                match arg with
-                | Omitted () -> acc
-                | Arg e -> acc @ [e])
-              []
-              arg_list
+          let param_exps = List.filter_map (function
+              | _, Omitted () -> None
+              | _, Arg e -> Some e)
+            arg_list
           in
           let param_types = List.map (fun e -> e.Typedtree.exp_type) param_exps in
           let params_code =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -350,7 +350,7 @@ and expression i ppf x =
   | Texp_apply (e, l) ->
       line i ppf "Texp_apply\n";
       expression i ppf e;
-      list i label_x_expression ppf l;
+      list i label_x_apply_arg ppf l;
   | Texp_match (e, l1, l2, partial) ->
       line i ppf "Texp_match%a\n" fmt_partiality partial;
       expression i ppf e;
@@ -646,7 +646,7 @@ and class_expr i ppf x =
   | Tcl_apply (ce, l) ->
       line i ppf "Tcl_apply\n";
       class_expr i ppf ce;
-      list i label_x_expression ppf l;
+      list i label_x_apply_arg ppf l;
   | Tcl_let (rf, l1, l2, ce) ->
       line i ppf "Tcl_let %a\n" fmt_rec_flag rf;
       list i (value_binding rf) ppf l1;
@@ -976,10 +976,10 @@ and record_field i ppf = function
   | _, Kept _ ->
       line i ppf "<kept>"
 
-and label_x_expression i ppf (l, e) =
+and label_x_apply_arg i ppf (l, e) =
   line i ppf "<arg>\n";
   arg_label (i+1) ppf l;
-  (match e with None -> () | Some e -> expression (i+1) ppf e)
+  (match e with Omitted () -> () | Arg e -> expression (i+1) ppf e)
 
 and ident_x_expression_def i ppf (l, e) =
   line i ppf "<def> \"%a\"\n" fmt_ident l;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -308,7 +308,10 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       function_body sub body
   | Texp_apply (exp, list) ->
       sub.expr sub exp;
-      List.iter (fun (_, o) -> Option.iter (sub.expr sub) o) list
+      List.iter (function
+        | (_, Arg exp) -> sub.expr sub exp
+        | (_, Omitted ()) -> ())
+        list
   | Texp_match (exp, cases, effs, _) ->
       sub.expr sub exp;
       List.iter (sub.case sub) cases;
@@ -522,7 +525,10 @@ let class_expr sub {cl_loc; cl_desc; cl_env; cl_attributes; _} =
       sub.class_expr sub cl
   | Tcl_apply (cl, args) ->
       sub.class_expr sub cl;
-      List.iter (fun (_, e) -> Option.iter (sub.expr sub) e) args
+      List.iter (function
+        | (_, Arg exp) -> sub.expr sub exp
+        | (_, Omitted ()) -> ())
+        args
   | Tcl_let (rec_flag, value_bindings, ivars, cl) ->
       sub.value_bindings sub (rec_flag, value_bindings);
       List.iter (fun (_, e) -> sub.expr sub e) ivars;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -360,7 +360,10 @@ let expr sub x =
     | Texp_apply (exp, list) ->
         Texp_apply (
           sub.expr sub exp,
-          List.map (tuple2 id (Option.map (sub.expr sub))) list
+          List.map (function
+            | (lbl, Arg exp) -> (lbl, Arg (sub.expr sub exp))
+            | (lbl, Omitted ()) -> (lbl, Omitted ()))
+            list
         )
     | Texp_match (exp, cases, eff_cases, p) ->
         Texp_match (
@@ -687,7 +690,10 @@ let class_expr sub x =
     | Tcl_apply (cl, args) ->
         Tcl_apply (
           sub.class_expr sub cl,
-          List.map (tuple2 id (Option.map (sub.expr sub))) args
+          List.map (function
+            | (lbl, Arg exp) -> (lbl, Arg (sub.expr sub exp))
+            | (lbl, Omitted ()) -> (lbl, Omitted ()))
+            args
         )
     | Tcl_let (rec_flag, value_bindings, ivars, cl) ->
         let (rec_flag, value_bindings) =

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -360,10 +360,7 @@ let expr sub x =
     | Texp_apply (exp, list) ->
         Texp_apply (
           sub.expr sub exp,
-          List.map (function
-            | (lbl, Arg exp) -> (lbl, Arg (sub.expr sub exp))
-            | (lbl, Omitted ()) -> (lbl, Omitted ()))
-            list
+          List.map (tuple2 id (Typedtree.map_apply_arg (sub.expr sub))) list
         )
     | Texp_match (exp, cases, eff_cases, p) ->
         Texp_match (
@@ -690,10 +687,7 @@ let class_expr sub x =
     | Tcl_apply (cl, args) ->
         Tcl_apply (
           sub.class_expr sub cl,
-          List.map (function
-            | (lbl, Arg exp) -> (lbl, Arg (sub.expr sub exp))
-            | (lbl, Omitted ()) -> (lbl, Omitted ()))
-            args
+          List.map (tuple2 id (Typedtree.map_apply_arg (sub.expr sub))) args
         )
     | Tcl_let (rec_flag, value_bindings, ivars, cl) ->
         let (rec_flag, value_bindings) =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1226,7 +1226,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
             let name = Btype.label_name l
             and optional = Btype.is_optional l in
             let use_arg sarg l' =
-              Some (
+              Arg (
                 if not optional || Btype.is_optional l' then
                   type_argument val_env sarg ty ty0
                 else
@@ -1237,7 +1237,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
               )
             in
             let eliminate_optional_arg () =
-              Some (option_none val_env ty0 Location.none)
+              Arg (option_none val_env ty0 Location.none)
             in
             let remaining_sargs, arg =
               if ignore_labels then begin
@@ -1269,9 +1269,13 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                     if Btype.is_optional l && List.mem_assoc Nolabel sargs then
                       eliminate_optional_arg ()
                     else
-                      None
+                      Omitted ()
             in
-            let omitted = if arg = None then (l,ty0) :: omitted else omitted in
+            let omitted =
+              match arg with
+              | Omitted () -> (l,ty0) :: omitted
+              | Arg _ -> omitted
+            in
             type_args ((l,arg)::args) omitted ty_fun ty_fun0 remaining_sargs
         | _ ->
             match sargs with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2750,10 +2750,10 @@ let collect_unknown_apply_args env funct ty_fun rev_args sargs =
 let collect_apply_args env funct ignore_labels ty_fun ty_fun0 sargs =
   let warned = ref false in
   let rec loop ty_fun ty_fun0 rev_args sargs =
-    let ty_fun' = expand_head env ty_fun in
     if sargs = [] then
       collect_unknown_apply_args env funct ty_fun0 rev_args sargs
     else
+    let ty_fun' = expand_head env ty_fun in
     match get_desc ty_fun', get_desc (expand_head env ty_fun0) with
     | Tarrow (l, ty_arg, ty_ret, com), Tarrow (_, ty_arg0, ty_ret0, _)
       when is_commu_ok com ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2832,7 +2832,7 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 sargs =
   in
   loop ty_fun ty_fun0 [] sargs
 
-let type_omitted_parameters ty_ret args =
+let type_omitted_parameters_and_build_result_type ty_ret args =
   let ty_ret, args =
     List.fold_left
       (fun (ty_ret, args) (lbl, arg) ->
@@ -5627,7 +5627,7 @@ and type_application env funct sargs =
                          (Optional "opt", Arg None);
                          (Nolabel, Arg n)] *)
       let ty_ret, args =
-        type_omitted_parameters ty_ret args in
+        type_omitted_parameters_and_build_result_type ty_ret args in
       (* example:
          [ty_ret] becomes [a:bar -> unit]
          [args] becomes [(Label "a", Omitted ());

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5635,7 +5635,7 @@ and type_application env funct sargs =
                          (Optional "opt", Arg None);
                          (Nolabel, Arg n)]
       *)
-      args, ty_ret
+      args, instance ty_ret
 
 and type_construct env ~sexp lid sarg ty_expected_explained =
   let { ty = ty_expected; explanation } = ty_expected_explained in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2685,7 +2685,7 @@ let remaining_function_type ty_ret rev_args =
             ty_ret)
     ty_ret rev_args
 
-let collect_unknown_apply_args env funct ty_fun rev_args sargs =
+let collect_unknown_apply_args env funct ty_fun0 rev_args sargs =
   let labels_match ~param ~arg =
     param = arg
     || !Clflags.classic && arg = Nolabel && not (is_optional param)
@@ -2746,7 +2746,7 @@ let collect_unknown_apply_args env funct ty_fun rev_args sargs =
       let arg = Unknown_arg { sarg; ty_arg } in
       loop ty_res ((lbl, Arg arg) :: rev_args) rest
   in
-  loop ty_fun rev_args sargs
+  loop ty_fun0 rev_args sargs
 
 let collect_apply_args env funct ignore_labels ty_fun ty_fun0 sargs =
   let warned = ref false in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2622,7 +2622,7 @@ let list_labels env ty =
   result
 
 
-(* Collecting arguments for function applications *)
+(* Collecting arguments for function applications. *)
 
 type untyped_apply_arg =
   | Known_arg of
@@ -2632,16 +2632,38 @@ type untyped_apply_arg =
         ty_arg0 : type_expr;
         wrapped_in_some : bool;
       }
+    (* - [f arg] when is known to be a function (f : _ -> _)
+       - [f ~lab:arg] when (f : lab:_ -> _)
+       - [f ?lab:arg] when (f : ?lab:_ -> _)
+       In these cases we have [wrapped_in_some = false].
+
+       - [f ~lab:arg] when (f : ?lab:_ -> _)
+         In this case [wrapped_in_some = true].
+
+       [ty_arg] is the (possibly generic) expected type of the argument,
+       and [ty_arg0] is an instance of [ty_arg].
+    *)
   | Unknown_arg of
       {
         sarg : Parsetree.expression;
         ty_arg : type_expr;
       }
+    (* [f arg] when [f] is not known (either a type variable,
+       or the weird [commu_ok] case where a function type is known
+       but not principally).
+
+       [ty_arg] is the expected type of the argument, usually just
+       a fresh type variable. *)
   | Eliminated_optional_arg of
       {
         ty_arg : type_expr;
         level: int;
       }
+    (* [~foo] in [f x] with [f : ?foo:ty -> _ -> _]
+       ([foo] is an optional argument that was not passed,
+        but a following argument was passed).
+
+       [level] is the level of the function arrow. *)
 
 type untyped_omitted_param =
   {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2730,7 +2730,8 @@ let collect_unknown_apply_args env funct ty_fun rev_args sargs =
                     attached (eg. an optional argument that is not passed). *)
                   rev_args
                   |> List.find_map (function
-                      | _, Arg (Known_arg { sarg = {pexp_loc = loc; _ }}) ->
+                      | _, Arg (Known_arg { sarg = {pexp_loc = loc; _ }}
+                               | Unknown_arg { sarg = {pexp_loc = loc; _}}) ->
                           Some loc
                       | _ -> None)
                   |> Option.value ~default:funct.exp_loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5594,7 +5594,7 @@ and type_application env funct sargs =
       let ignore_labels =
         !Clflags.classic ||
         begin
-          let ls, tvar = list_labels env funct.exp_type in
+          let ls, tvar = list_labels env ty in
           not tvar &&
           let labels = List.filter (fun l -> not (is_optional l)) ls in
           List.length labels = List.length sargs &&

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2825,8 +2825,7 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 sargs =
         in
         loop ty_ret ty_ret0 ((l, arg) :: rev_args) remaining_sargs
     | _ ->
-      (* We're not looking at a *known* function type anymore, or there are no
-        arguments left. *)
+      (* We're not looking at a *known* function type anymore. *)
       collect_unknown_apply_args env funct ty_fun0 rev_args sargs
   in
   loop ty_fun ty_fun0 [] sargs

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2632,7 +2632,8 @@ type untyped_apply_arg =
         ty_arg0 : type_expr;
         wrapped_in_some : bool;
       }
-    (* - [f arg] when is known to be a function (f : _ -> _)
+    (* [arg] is a [Known_arg] in:
+       - [f arg] when is known to be a function (f : _ -> _)
        - [f ~lab:arg] when (f : lab:_ -> _)
        - [f ?lab:arg] when (f : ?lab:_ -> _)
        In these cases we have [wrapped_in_some = false].
@@ -2641,15 +2642,15 @@ type untyped_apply_arg =
          In this case [wrapped_in_some = true].
 
        [ty_arg] is the (possibly generic) expected type of the argument,
-       and [ty_arg0] is an instance of [ty_arg].
-    *)
+       and [ty_arg0] is an instance of [ty_arg]. *)
   | Unknown_arg of
       {
         sarg : Parsetree.expression;
         ty_arg : type_expr;
       }
-    (* [f arg] when [f] is not known (either a type variable,
-       or the weird [commu_ok] case where a function type is known
+    (* [arg] is an [Unknown_arg] in:
+       [f arg] when [f] is not known (either a type variable,
+       or the [commu_ok] case where a function type is known
        but not principally).
 
        [ty_arg] is the expected type of the argument, usually just
@@ -2659,9 +2660,9 @@ type untyped_apply_arg =
         ty_arg : type_expr;
         level: int;
       }
-    (* [~foo] in [f x] with [f : ?foo:ty -> _ -> _]
-       ([foo] is an optional argument that was not passed,
-        but a following argument was passed).
+    (* When [f : ?foo:ty -> _ -> _], [~foo] is an [Eliminated_optional_arg]
+       in [f x] ([foo] is an optional argument that was not passed,  but a
+       following positional argument was passed).
 
        [level] is the level of the function arrow. *)
 
@@ -5611,8 +5612,7 @@ and type_application env funct sargs =
       (* Consider for example the application
            [f n]
          with
-           [f : a:bar -> ?opt:baz -> int -> unit]
-      *)
+           [f : a:bar -> ?opt:baz -> int -> unit] *)
       let ty_ret, args =
         collect_apply_args env funct ignore_labels ty (instance ty) sargs
       in
@@ -5625,16 +5625,14 @@ and type_application env funct sargs =
       (* example: type-check [n] and generate [None] for [?opt].
          [args] becomes [(Label "a", Omitted bar);
                          (Optional "opt", Arg None);
-                         (Nolabel, Arg n)]
-       *)
+                         (Nolabel, Arg n)] *)
       let ty_ret, args =
         type_omitted_parameters ty_ret args in
       (* example:
          [ty_ret] becomes [a:bar -> unit]
          [args] becomes [(Label "a", Omitted ());
                          (Optional "opt", Arg None);
-                         (Nolabel, Arg n)]
-      *)
+                         (Nolabel, Arg n)] *)
       args, instance ty_ret
 
 and type_construct env ~sexp lid sarg ty_expected_explained =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -104,7 +104,7 @@ and expression_desc =
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
   | Texp_function of function_param list * function_body
-  | Texp_apply of expression * (arg_label * expression option) list
+  | Texp_apply of expression * (arg_label * apply_arg) list
   | Texp_match of expression * computation case list * value case list * partial
   | Texp_try of expression * value case list * value case list
   | Texp_tuple of expression list
@@ -202,6 +202,12 @@ and binding_op =
     bop_loc : Location.t;
   }
 
+and ('a, 'b) arg_or_omitted =
+  | Arg of 'a
+  | Omitted of 'b
+
+and apply_arg = (expression, unit) arg_or_omitted
+
 (* Value expressions for the class language *)
 
 and class_expr =
@@ -219,7 +225,7 @@ and class_expr_desc =
   | Tcl_fun of
       arg_label * pattern * (Ident.t * expression) list
       * class_expr * partial
-  | Tcl_apply of class_expr * (arg_label * expression option) list
+  | Tcl_apply of class_expr * (arg_label * apply_arg) list
   | Tcl_let of rec_flag * value_binding list *
                   (Ident.t * expression) list * class_expr
   | Tcl_constraint of

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -900,3 +900,7 @@ let split_pattern pat =
         combine_opts (into cpat) exns1 exns2
   in
   split_pattern pat
+
+let map_apply_arg f = function
+  | Arg arg -> Arg (f arg)
+  | Omitted _ as arg -> arg

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -198,10 +198,10 @@ and expression_desc =
         Parameters' effects are run left-to-right when an n-ary function is
         saturated with n arguments.
     *)
-  | Texp_apply of expression * (arg_label * expression option) list
+  | Texp_apply of expression * (arg_label * apply_arg) list
         (** E0 ~l1:E1 ... ~ln:En
 
-            The expression can be None if the expression is abstracted over
+            The expression can be Omitted if the expression is abstracted over
             this argument. It currently appears when a label is applied.
 
             For example:
@@ -210,7 +210,7 @@ and expression_desc =
 
             The resulting typedtree for the application is:
             Texp_apply (Texp_ident "f/1037",
-                        [(Nolabel, None);
+                        [(Nolabel, Omitted ());
                          (Labelled "y", Some (Texp_constant Const_int 3))
                         ])
          *)
@@ -367,6 +367,12 @@ and binding_op =
     bop_loc : Location.t;
   }
 
+and ('a, 'b) arg_or_omitted =
+  | Arg of 'a
+  | Omitted of 'b
+
+and apply_arg = (expression, unit) arg_or_omitted
+
 (* Value expressions for the class language *)
 
 and class_expr =
@@ -384,7 +390,7 @@ and class_expr_desc =
   | Tcl_fun of
       arg_label * pattern * (Ident.t * expression) list
       * class_expr * partial
-  | Tcl_apply of class_expr * (arg_label * expression option) list
+  | Tcl_apply of class_expr * (arg_label * apply_arg) list
   | Tcl_let of rec_flag * value_binding list *
                   (Ident.t * expression) list * class_expr
   | Tcl_constraint of

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -928,3 +928,6 @@ val pat_bound_idents_full:
 (** Splits an or pattern into its value (left) and exception (right) parts. *)
 val split_pattern:
   computation general_pattern -> pattern option * pattern option
+
+val map_apply_arg:
+  ('a -> ' b) -> ('a, 'omitted) arg_or_omitted ->  ('b, 'omitted) arg_or_omitted

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -211,7 +211,7 @@ and expression_desc =
             The resulting typedtree for the application is:
             Texp_apply (Texp_ident "f/1037",
                         [(Nolabel, Omitted ());
-                         (Labelled "y", Some (Texp_constant Const_int 3))
+                         (Labelled "y", Arg (Texp_constant Const_int 3))
                         ])
          *)
   | Texp_match of expression * computation case list * value case list * partial

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -441,10 +441,10 @@ let expression sub exp =
         Pexp_function (params, constraint_, body)
     | Texp_apply (exp, list) ->
         Pexp_apply (sub.expr sub exp,
-          List.fold_right (fun (label, expo) list ->
-              match expo with
-                None -> list
-              | Some exp -> (label, sub.expr sub exp) :: list
+          List.fold_right (fun (label, arg) list ->
+              match arg with
+              | Omitted () -> list
+              | Arg exp -> (label, sub.expr sub exp) :: list
           ) list [])
     | Texp_match (exp, cases, eff_cases, _) ->
       let merged_cases = List.map (sub.case sub) cases
@@ -738,8 +738,8 @@ let class_expr sub cexpr =
         Pcl_apply (sub.class_expr sub cl,
           List.fold_right (fun (label, expo) list ->
               match expo with
-                None -> list
-              | Some exp -> (label, sub.expr sub exp) :: list
+              | Omitted () -> list
+              | Arg exp -> (label, sub.expr sub exp) :: list
           ) args [])
 
     | Tcl_let (rec_flat, bindings, _ivars, cl) ->

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -119,9 +119,9 @@ let is_ref : Types.value_description -> bool = function
 
 (* See the note on abstracted arguments in the documentation for
     Typedtree.Texp_apply *)
-let is_abstracted_arg : arg_label * expression option -> bool = function
-  | (_, None) -> true
-  | (_, Some _) -> false
+let is_abstracted_arg : arg_label * apply_arg -> bool = function
+  | (_, Omitted ()) -> true
+  | (_, Arg _) -> false
 
 let classify_expression : Typedtree.expression -> sd =
   (* We need to keep track of the size of expressions
@@ -632,7 +632,7 @@ let rec expression : Typedtree.expression -> term_judg =
       path pth << Dereference
     | Texp_instvar (self_path, pth, _inst_var) ->
         join [path self_path << Dereference; path pth]
-    | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, [_, Some arg])
+    | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, [_, Arg arg])
       when is_ref vd ->
       (*
         G |- e: m[Guard]
@@ -652,8 +652,8 @@ let rec expression : Typedtree.expression -> term_judg =
            function is stored in the closure without being called. *)
         let rec split_args ~has_omitted_arg = function
           | [] -> [], []
-          | (_, None) :: rest -> split_args ~has_omitted_arg:true rest
-          | (_, Some arg) :: rest ->
+          | (_, Omitted ()) :: rest -> split_args ~has_omitted_arg:true rest
+          | (_, Arg arg) :: rest ->
             let applied, delayed = split_args ~has_omitted_arg rest in
             if has_omitted_arg
             then applied, arg :: delayed
@@ -1189,7 +1189,11 @@ and class_expr : Typedtree.class_expr -> term_judg =
         let ids = List.map fst args in
         remove_ids ids (class_expr ce << Delay)
     | Tcl_apply (ce, args) ->
-        let arg (_label, eo) = option expression eo in
+        let arg (_, arg) =
+          match arg with
+          | Omitted () -> empty
+          | Arg e -> expression e
+        in
         join [
           class_expr ce << Dereference;
           list arg args << Dereference;


### PR DESCRIPTION
This PR proposes a refactor of `Typecore.type_application`.
This work was originally done by @lpw25 in Jane Street's fork of the compiler with extensions. Jane Street has asked for help from Tarides to upstream these changes.

This PR introduces a more descriptive type for arguments of a function application:

```ocaml
type expression_desc =
  | ...
  | Texp_apply of expression * (arg_label * apply_arg) list

and apply_arg = (expression, unit) arg_or_omitted

and ('a, 'b) arg_or_omitted =
  | Arg of 'a
  | Omitted of 'b
```

These were formerly represented with the type `expression option`.

The typing of applications is now clearly split in two phases: first `collect_apply_args` maps over the arguments, classify them and collect additional information. Then `type_apply_arg` and `type_omitted_parameters` perform the actual typing.

The classification was previously done by imperatively filling lists such as `eliminated_optional_arguments` and `omitted_parameters`. Now it uses the type parameters of `arg_or_omitted` to store additional information and specific type constructors are introduced for these cases:

```ocaml
type untyped_apply_arg =
  | Known_arg of
      { sarg : Parsetree.expression;
        ty_arg : type_expr;
        ty_arg0 : type_expr;
        mode_arg : Alloc_mode.t;
        wrapped_in_some : bool; }
  | Unknown_arg of
      { sarg : Parsetree.expression;
        ty_arg : type_expr;
        mode_arg : Alloc_mode.t; }
  | Eliminated_optional_arg of
      { mode_fun: Alloc_mode.t;
        ty_arg : type_expr;
        mode_arg : Alloc_mode.t;
        level: int;}

type untyped_omitted_param =
  { mode_fun: Alloc_mode.t;
    ty_arg : type_expr;
    mode_arg : Alloc_mode.t;
    level: int; }

(untyped_apply_arg, untyped_omitted_param) arg_or_omitted
```

Thus, the flow for typing an application can now be summarized with these three functions:

```ocaml
collect_apply_args :
  ... (arg_label * expression) list ->
  ... * (untyped_apply_arg, untyped_omitted_param) arg_or_omitted list

type_apply_arg :
  ... (untyped_apply_arg, untyped_omitted_param) arg_or_omitted ->
  ... * (Typedtree.expression, untyped_omitted_param) arg_or_omitted

type_omitted_parameters :
  ... (Typedtree.expression, untyped_omitted_param) arg_or_omitted list ->
  ... * (Typedtree.expression, unit) arg_or_omitted list
```

I was not familiar with the typing process of function application before doing this work but my impression is that these changes do make the code clearer and more robust.

cc @OlivierNicole @goldfirere 
