### PR TITLE
Do not raise exceptions from inside skiplist.c and lk_skiplist.c

### DIFF
--- a/Changes
+++ b/Changes
@@ -58,6 +58,10 @@ Working version
   (Stephen Dolan, report by Timothy Bourke, review by Mark Shinwell and Damien
   Doligez)
 
+- #13613: Functions from caml/skiplist.h and caml/lf_skiplist.h no longer raise
+  Out_of_memory exceptions that the runtime could not handle.
+  (Guillaume Munch-Maccagnoni, review by Stephen Dolan)
+
 ### Code generation and optimizations:
 
 - #13565: less tagging in switches compiled to affine transformations

--- a/runtime/caml/lf_skiplist.h
+++ b/runtime/caml/lf_skiplist.h
@@ -100,7 +100,7 @@ extern void caml_lf_skiplist_free_garbage(struct lf_skiplist *sk);
    [var] designates the current element.
    [action] can refer to [var->key] and [var->data].
    [action] can safely remove the current element, i.e. call
-   [caml_skiplist_remove] on [var->key].  The traversal will
+   [caml_lf_skiplist_remove] on [var->key].  The traversal will
    continue with the skiplist element following the removed element.
    Other operations performed over the skiplist during its traversal have
    unspecified effects on the traversal. */

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -356,10 +356,7 @@ int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key, uintnat data) {
        * [top_level] and goes to 0. Each entry will point to the successors in
          the [succ] array for that level. */
       int top_level = random_level();
-      /* attentive readers will have noticed that we assume memory is aligned to
-       * atleast even addresses. This is certainly the case on glibc amd64 and
-       * Visual C++ on Windows though I can find no guarantees for other
-         platforms. */
+      /* sufficiently aligned for LF_SK_MARK/UNMARK */
       struct lf_skipcell *new_cell = caml_stat_alloc_noexc(
           SIZEOF_LF_SKIPCELL + (top_level + 1) * sizeof(struct lf_skipcell *));
       if (new_cell == NULL)

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -96,15 +96,19 @@ void caml_lf_skiplist_init(struct lf_skiplist *sk) {
   /* This concurrent skip list has two sentinel nodes, the first [head] is
   less than any possible key in the data structure and the second [tail] is
   greater than any key. */
-  sk->head = caml_stat_alloc(SIZEOF_LF_SKIPCELL +
-                             NUM_LEVELS * sizeof(struct lf_skipcell *));
+  sk->head = caml_stat_alloc_noexc(SIZEOF_LF_SKIPCELL +
+                                   NUM_LEVELS * sizeof(struct lf_skipcell *));
+  if (sk->head == NULL)
+    caml_fatal_error("caml_lf_skiplist_init: out of memory");
   sk->head->key = 0;
   sk->head->data = 0;
   sk->head->garbage_next = NULL;
   sk->head->top_level = NUM_LEVELS - 1;
 
-  sk->tail = caml_stat_alloc(SIZEOF_LF_SKIPCELL +
-                             NUM_LEVELS * sizeof(struct lf_skipcell *));
+  sk->tail = caml_stat_alloc_noexc(SIZEOF_LF_SKIPCELL +
+                                   NUM_LEVELS * sizeof(struct lf_skipcell *));
+  if (sk->tail == NULL)
+    caml_fatal_error("caml_lf_skiplist_init: out of memory");
   sk->tail->key = CAML_UINTNAT_MAX;
   sk->tail->data = 0;
   sk->tail->garbage_next = NULL;
@@ -356,8 +360,10 @@ int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key, uintnat data) {
        * atleast even addresses. This is certainly the case on glibc amd64 and
        * Visual C++ on Windows though I can find no guarantees for other
          platforms. */
-      struct lf_skipcell *new_cell = caml_stat_alloc(
+      struct lf_skipcell *new_cell = caml_stat_alloc_noexc(
           SIZEOF_LF_SKIPCELL + (top_level + 1) * sizeof(struct lf_skipcell *));
+      if (new_cell == NULL)
+        caml_fatal_error("caml_lf_skiplist_insert: out of memory");
       new_cell->top_level = top_level;
       new_cell->key = key;
       new_cell->data = data;

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -147,8 +147,10 @@ int caml_skiplist_insert(struct skiplist * sk,
       update[i] = &sk->forward[i];
     sk->level = new_level;
   }
-  f = caml_stat_alloc(SIZEOF_SKIPCELL +
-                      (new_level + 1) * sizeof(struct skipcell *));
+  f = caml_stat_alloc_noexc(SIZEOF_SKIPCELL +
+                            (new_level + 1) * sizeof(struct skipcell *));
+  if (f == NULL)
+    caml_fatal_error("caml_skiplist_insert: out of memory");
   f->key = key;
   f->data = data;
   for (int i = 0; i <= new_level; i++) {


### PR DESCRIPTION
Functions in `skiplist.c` and `lk_skiplist.c` can raise `Out_of_memory` exceptions. Callers mostly do not know how to handle them. They would require `_noexc` or `_res` variants of the skiplist functions to do anything about it.

To get the discussion rolling, here is a PR that makes these allocation failures fatal errors.