### PR TITLE
Hold lock around ephemeron debugging code.

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -378,15 +378,16 @@ Caml_inline value ephe_list_tail(value e)
 #ifdef DEBUG
 static void orph_ephe_list_verify_status (int status)
 {
-  value v;
+  caml_plat_lock_blocking(&orphaned_lock);
 
-  v = orph_structs.ephe_list_live;
+  value v = orph_structs.ephe_list_live;
 
   while (v) {
     CAMLassert (Tag_val(v) == Abstract_tag);
     CAMLassert (Has_status_val(v, status));
     v = Ephe_link(v);
   }
+  caml_plat_unlock(&orphaned_lock);
 }
 #endif
 


### PR DESCRIPTION
In the major GC, we have a structure `orph_structs` shared between domains, for managing orphaning and adopting ephemeron and finaliser data from terminating domains. There is a lock `orphaned_lock` to manage access to this structure. Here in `orph_ephe_list_verify_status()` we look at the structure (specifically, we step along the ephemerons list in it) without taking the lock.