### PR TITLE
Optimize caml_sys_file_mode

### DIFF
--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -279,9 +279,11 @@ static int caml_sys_file_mode(value name)
   struct stat st;
 #endif
   int ret;
-
+  char_os *p;
+  
   if (! caml_string_is_c_safe(name)) { errno = ENOENT; return -1; }
-  ret = stat_os(String_val(name), &st);
+  p = caml_stat_strdup_to_os(String_val(name));
+  ret = stat_os(p, &st);
   if (ret == -1) return -1; else return st.st_mode;
 }
 

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -278,15 +278,10 @@ static int caml_sys_file_mode(value name)
 #else
   struct stat st;
 #endif
-  char_os * p;
   int ret;
 
   if (! caml_string_is_c_safe(name)) { errno = ENOENT; return -1; }
-  p = caml_stat_strdup_to_os(String_val(name));
-  caml_enter_blocking_section();
-  ret = stat_os(p, &st);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
+  ret = stat_os(String_val(name), &st);
   if (ret == -1) return -1; else return st.st_mode;
 }
 


### PR DESCRIPTION
I think that entering and leaving a blocking section (and copying a string) to call stat which can not block is overkill, and makes a lot of call in Sys module slower than necessary. The only case it could be useful is with network file system ? 