### PR TITLE
Change free list representation in shared heap

### DIFF
--- a/Changes
+++ b/Changes
@@ -384,6 +384,9 @@ OCaml 5.4.0
   between Unix/Windows).
   (David Allsopp, review by Nick Barnes, Antonin Décimo and Miod Vallat)
 
+- #13616: Change free list representation in shared heap
+  (Sadiq Jaffer, review by Damien Doligez)
+
 - #13352: Concurrency refactors and cleanups.
   (Antonin Décimo, review by Gabriel Scherer, David Allsopp, and Miod Vallat)
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -189,8 +189,7 @@ Caml_inline void pb_fill_mode(prefetch_buffer_t *pb)
 
 Caml_inline void pb_push(prefetch_buffer_t* pb, value v)
 {
-  CAMLassert(Is_block(v));
-  CAMLassert(!Is_young(v));
+  CAMLassert(Is_block(v) && !Is_young(v));
   CAMLassert(v != Debug_free_major);
   CAMLassert(pb->enqueued < pb->dequeued + PREFETCH_BUFFER_SIZE);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -189,7 +189,8 @@ Caml_inline void pb_fill_mode(prefetch_buffer_t *pb)
 
 Caml_inline void pb_push(prefetch_buffer_t* pb, value v)
 {
-  CAMLassert(Is_block(v) && !Is_young(v));
+  CAMLassert(Is_block(v));
+  CAMLassert(!Is_young(v));
   CAMLassert(v != Debug_free_major);
   CAMLassert(pb->enqueued < pb->dequeued + PREFETCH_BUFFER_SIZE);
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -63,8 +63,7 @@ static_assert(sizeof(pool) == Bsize_wsize(POOL_HEADER_WSIZE), "");
 #define POOL_BLOCK_FREE_HD(hd) \
   (Tag_hd(hd) == No_scan_tag && (Color_hd(hd) == NOT_MARKABLE))
 #define POOL_BLOCK_FREE_HP(p) (POOL_BLOCK_FREE_HD(Hd_hp(p)))
-#define POOL_FREE_HEADER(wosize) \
-  ((header_t)(((wosize) << HEADER_WOSIZE_SHIFT) | NOT_MARKABLE | No_scan_tag))
+#define POOL_FREE_HEADER(wosize) Make_header(wosize, No_scan_tag, NOT_MARKABLE)
 
 typedef struct large_alloc {
   caml_domain_state* owner;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -451,7 +451,7 @@ static void* pool_allocate(struct caml_heap_state* local, sizeclass sz) {
 
   p = r->next_obj;
   /* assert that p is inside the pool */
-  CAMLassert(p >= (value*)r + POOL_HEADER_WSIZE);
+  CAMLassert(p >= (value*)POOL_FIRST_BLOCK(r, sz));
   CAMLassert(p < (value*)r + POOL_WSIZE);
   CAMLassert(POOL_BLOCK_FREE_HP(p));
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -561,7 +561,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
 
     work = end - p;
     do {
-      header_t hd = (header_t)*p;
+      header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
 
       if( (char*)p + caml_plat_pagesize < (char*)end ) {
         caml_prefetch((char*)p + caml_plat_pagesize);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -600,7 +600,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
         /* update stats */
         s->pool_live_blocks--;
         s->pool_live_words -= Whsize_hd(hd);
-        local->owner->swept_words += wh;
+        local->owner->swept_words += Whsize_hd(hd);
         s->pool_frag_words -= (wh - Whsize_hd(hd));
 
         /* reload hd */

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -559,8 +559,8 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
     do {
       header_t hd = (header_t)*p;
 
-      if( p + 4096 < end ) {
-        caml_prefetch(p + 4096);
+      if( (char*)p + caml_plat_pagesize < (char*)end ) {
+        caml_prefetch((char*)p + caml_plat_pagesize);
       }
 
       /* The pools mark a block as being free by setting the tag to No_scan_tag

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -448,7 +448,8 @@ static void* pool_allocate(struct caml_heap_state* local, sizeclass sz) {
 
   p = r->next_obj;
   /* assert that p is inside the pool */
-  CAMLassert(p >= (value*)r + POOL_HEADER_WSIZE && p < (value*)r + POOL_WSIZE);
+  CAMLassert(p >= (value*)r + POOL_HEADER_WSIZE);
+  CAMLassert(p < (value*)r + POOL_WSIZE);
   CAMLassert(POOL_BLOCK_FREE_HP(p));
 
   /* in this case there are more free blocks immediately after */

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -325,6 +325,10 @@ Caml_inline void pool_initialize(pool* r,
   p[0] = POOL_FREE_HEADER(pool_blocks-1);
   p[1] = 0;
 
+#ifdef DEBUG
+  for (p += 2; p < end; p++) *p = Debug_free_major;
+#endif
+
   CAMLassert((uintptr_t)end % Cache_line_bsize == 0);
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -559,6 +559,8 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
 
     a->next_obj = 0;
 
+    /* note that the below will have to be changed for the new GC pacing
+      logic */
     work = end - p;
     do {
       header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1110,9 +1110,13 @@ static void compact_update_pools(pool *cur_pool)
     mlsize_t wh = wsize_sizeclass[cur_pool->sz];
 
     while (p + wh <= end) {
-      if (*p &&
-          Has_status_val(Val_hp(p), caml_global_heap_state.UNMARKED)) {
-        compact_update_block(p);
+      if (!POOL_BLOCK_FREE_HP(p)) {
+        if (Has_status_val(Val_hp(p), caml_global_heap_state.UNMARKED)) {
+          compact_update_block(p);
+        }
+      } else {
+        /* Skip over free blocks */
+        p += wh * Wosize_hp(p);
       }
       p += wh;
     }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -559,6 +559,10 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
     do {
       header_t hd = (header_t)*p;
 
+      if( p + 4096 < end ) {
+        caml_prefetch(p + 4096);
+      }
+
       /* The pools mark a block as being free by setting the tag to No_scan_tag
         and the color to NOT_MARKABLE. The wosize is used to indicate the
         number of contiguous free blocks that follow. The first field is a

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -784,6 +784,8 @@ static void pool_finalise(struct caml_heap_state* local, pool** plist,
         }
         atomic_store_relaxed((atomic_uintnat*)p, 0);
         p[1] = (value)0;
+      } else {
+        p += wh * Wosize_hd(hd);
       }
       p += wh;
     }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1384,7 +1384,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
 
               CAMLassert((header_t*)next <= POOL_END(to_pool));
 
-              *next = POOL_FREE_HEADER(Wosize_hp(new_p) - 1);
+              *next = POOL_FREE_HEADER(wosize - 1);
               next[1] = new_p[1];
               to_pool->next_obj = next;
             } else {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -627,10 +627,8 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
                                                   + Wosize_hd(hd) + 1);
           } else {
             /* in this case there's a non-free block between us so update
-                the next pointer if necessary */
-            if( last_free_block[1] != (value)p ) {
-              last_free_block[1] = (value)p;
-            }
+                the next pointer */
+            last_free_block[1] = (value)p;
 
             last_free_block = p;
           }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -613,7 +613,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
       to point to this one */
       if (POOL_BLOCK_FREE_HD(hd)) {
         /* if any block is free then this is no longer a full pool */
-        CAMLassert (all_used == 0);
+        all_used = 0;
 
         /* if there was a free block before us, check first if we can
            merge with it */

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1573,7 +1573,9 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
         s->overhead += wh - Whsize_hd(hd);
         s->live_blocks++;
       } else {
-        s->free += wh * (Wosize_hd(hd)+1);
+        /* count the free block and any that follow it (stored in the
+           size bits in the header)*/
+        s->free += wh * (1 + Wosize_hd(hd));
         p += Wosize_hd(hd) * wh;
       }
       p += wh;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -652,7 +652,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
     CAMLassert(p == end);
 
     if( !all_used ) {
-      /* the last free block should have 0 as it's next pointer */
+      /* the last free block should have 0 as its next pointer */
       last_free_block[1] = 0;
     }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -611,7 +611,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
       to point to this one */
       if (POOL_BLOCK_FREE_HD(hd)) {
         /* if any block is free then this is no longer a full pool */
-        all_used = 0;
+        CAMLassert (all_used == 0);
 
         /* if there was a free block before us, check first if we can
            merge with it */


### PR DESCRIPTION
**TL;DR** This PR essentially run-length encodes the free blocks in the shared heap, so sweeping takes time proportional to the non-free proportion of the heap rather than the total size.

![image](https://github.com/user-attachments/assets/5172005a-a9f3-458c-b0e8-deefca66bccd)

## Changes

Trunk currently uses a zeroed header to indicate a free block in the shared heap. We instead use the colour NOT_MARKABLE and the tag No_scan_tag because this combination can never be found in the shared heap. This allows us to use the size bits in the header to store the number of free blocks that follow. This impacts the runtime in several ways.

### Sweeping

At sweep time we can jump over large runs of free blocks, which can give a speedup for very sparse heaps as well as lower cache pollution.

### Allocation

There is an extra cost when allocating in to the shared heap. When taking a block from the free list, if the size is non-zero it must be decremented and written to the header over the next block. This incurs an extra write which for small block sizes will likely be in the same cache line.

### Pool initialisation

When initialising a pool (fresh or re-allocating from the free list) we need only initialise the first block to indicate that the entirety is free.

## Benchmarks

### Synthetic

These [benchmarks](https://gist.github.com/sadiqj/bec7fe5c8d9a06a8040e49cfd5daaac6) create a number of different shared heaps after which we do many full cycles of the heap. These kinds of workloads would (hopefuly!) never be encountered by users but are included to demonstrate the tradeoffs from this PR:

1) `test_sparse.ml` creates a very sparse heap where only a small percentage of each shared pool is used and there are long contiguous free regions.
2) `test_dense.ml` creates a dense heap that should have the vast majority of it's pools full.
3) `test.ml` creates a heap where every other element in the shared pools should be empty (so live/free/live/free) which should be a worst-case for this PR, as we do more work for no gain.
4) `test_rand.ml` creates a heap with similar occupancy to `test.ml` (50%) but where the choice is made randomly. This leads to much higher chances of contiguous free blocks.

#### Results:

```
  'build/test_sparse.sweep.opt' ran
    3.85 ± 0.02 times faster than 'build/test_sparse.trunk.opt'

  'build/test_dense.trunk.opt' ran
    1.03 ± 0.00 times faster than 'build/test_dense.sweep.opt'

  'build/test.trunk.opt' ran
    1.23 ± 0.00 times faster than 'build/test.sweep.opt'

  'build/test_rand.sweep.opt' ran
    1.14 ± 0.00 times faster than 'build/test_rand.trunk.opt'
```
    
#### Summary

Heaps with runs of free blocks get much faster. Completely dense heaps and heaps with only single free blocks are slower because of the additional work done.

### Sandmark

Below is a sandmark macro benchmark run:

![image](https://github.com/user-attachments/assets/10779d28-8301-4538-9884-f1798f0d2ff4)

https://gist.github.com/sadiqj/63392e2c8323e2dc794ed740115067b0 has the raw sandmark results and the analysis notebook output.

Some of the benchmarks show substantial speedups and there's one `thread_ring_lwt_stream` that shows a ~5% performance impact. The relatively short-running nature of the sandmark benchmarks means there is probably only a small chance of ending up with a large sparsely populated heap.

## Pacing

One big thing to note is that this PR maintains the existing work calculation. That is, the GC did work proportional to the size of the swept pool. This is no longer true but changing it here would probably not lead to a fair comparison against trunk.

cc @NickBarnes @stedolan @damiendoligez 