### PR TITLE
gprinttyp: pretty printing for levels

### DIFF
--- a/.depend
+++ b/.depend
@@ -867,6 +867,7 @@ typing/gprinttyp.cmo : \
     typing/types.cmi \
     typing/path.cmi \
     parsing/longident.cmi \
+    typing/ident.cmi \
     utils/format_doc.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
@@ -876,6 +877,7 @@ typing/gprinttyp.cmx : \
     typing/types.cmx \
     typing/path.cmx \
     parsing/longident.cmx \
+    typing/ident.cmx \
     utils/format_doc.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmx \

--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -553,7 +553,8 @@ module Digraph = struct
     | 6 -> "⁶"
     | 7 -> "⁷"
     | 8 -> "⁸"
-    | _ -> "⁹"
+    | 9 -> "⁹"
+    | _ -> assert false
     in
     Format.pp_print_string ppf s
 

--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -568,7 +568,7 @@ module Digraph = struct
 
   let superscript_level ppf lvl =
     (* avoid a dependency on Btype *)
-    if lvl = Ident.highest_scope then Format.pp_print_string ppf "ʷ"
+    if lvl = Ident.highest_scope then Format.pp_print_string ppf "᪲"
     else superscript ppf lvl
 
   let add_node explicit_d color id ?lvl tynode dg =

--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -139,16 +139,29 @@ module Index: sig
     | Main of int
     | Synthetic of int
     | Named_subnode of { id:int; synth:bool; name:string }
+  type level_and_scope = { level:int; scope: int }
+  type 'a desc = {
+    id: 'a;
+    color: Decoration.color option;
+    desc: Types.type_desc;
+    lvl:level_and_scope;
+  }
   val subnode: name:string -> t -> t
   val either_ext: Types.row_field_cell ->  t
-  val split:
-    params -> Types.type_expr -> t * Decoration.color option * Types.type_desc
+  val split: params -> Types.type_expr -> t desc
   val colorize: params -> t -> Decoration.color option
 end = struct
   type t =
     | Main of int
     | Synthetic of int
     | Named_subnode of { id:int; synth:bool; name:string }
+  type level_and_scope = { level:int; scope: int }
+  type 'a desc = {
+    id: 'a;
+    color: Decoration.color option;
+    desc: Types.type_desc;
+    lvl:level_and_scope;
+  }
 
   type name_map = {
     (* We keep the main and synthetic and index space separate to avoid index
@@ -221,7 +234,13 @@ end = struct
   let split params x =
     let x = repr params x in
     let color = colorize_id params x.id in
-    pretty_id params x.id, color, x.desc
+    let scope = Types.Transient_expr.get_scope x in
+    let level = x.level in
+    { id = pretty_id params x.id;
+      color;
+      desc = x.desc;
+      lvl = {level;scope}
+    }
 
   let subnode ~name x = match x with
     | Main id -> Named_subnode {id;name;synth=false}
@@ -521,8 +540,48 @@ module Digraph = struct
   let labelf fmt = labelk Fun.id fmt
   let labelr fmt = labelk Decoration.make fmt
 
-  let add_node explicit_d color id tynode dg =
-    let d = labelf "<SUB>%a</SUB>" Pp.prettier_index id in
+  (* Use unicode superscript digit to circumvent graphviz limited support for
+     superscript. *)
+  let superscript_digit ppf n =
+    let s = match n with
+    | 1 -> "¹"
+    | 2 -> "²"
+    | 3 -> "³"
+    | 0 -> "⁰"
+    | 4 -> "⁴"
+    | 5 -> "⁵"
+    | 6 -> "⁶"
+    | 7 -> "⁷"
+    | 8 -> "⁸"
+    | _ -> "⁹"
+    in
+    Format.pp_print_string ppf s
+
+  let rec superscript ppf n =
+    if n < 10 then
+      superscript_digit ppf n
+    else begin
+      superscript ppf (n/10);
+      superscript_digit ppf (n mod 10)
+    end
+
+  let superscript_level ppf lvl =
+    (* avoid a dependency on Btype *)
+    if lvl = Ident.highest_scope then Format.pp_print_string ppf "ʷ"
+    else superscript ppf lvl
+
+  let add_node explicit_d color id ?lvl tynode dg =
+    let d = match lvl with
+      | None -> labelf "<SUB>%a</SUB>" Pp.prettier_index id
+      | Some {Index.level; scope=0} ->
+          labelf "<SUB>%a %a</SUB>"
+            Pp.prettier_index id superscript_level level
+      | Some {Index.level; scope} ->
+          labelf "<SUB>%a %a⁺%a</SUB>"
+            Pp.prettier_index id
+            superscript_level level
+            superscript scope
+    in
     let d = match color with
     | None -> Decoration.make d
     | Some x -> Decoration.(make (filled x :: d))
@@ -564,9 +623,10 @@ module Digraph = struct
       dg |> add std (Edge(id0,id))
 
   let split_fresh_typ params ty0 g =
-    let (id, color, desc) = Index.split params ty0 in
+    let {Index.id; _ } as desc = Index.split params ty0 in
     let tynode = Node id in
-    if Elt_map.mem tynode g then id, None else id, Some (tynode,color,desc)
+    if Elt_map.mem tynode g then id, None
+    else id, Some { desc with id = tynode }
 
   let pp_path = Format_doc.compat Path.print
 
@@ -574,8 +634,8 @@ module Digraph = struct
     let id, next = split_fresh_typ params ty0 dg.elts in
     match next with
     | None -> id, dg
-    | Some (tynode,color,desc) ->
-        id, node params color id tynode desc dg
+    | Some Index.{id=tynode; color; desc; lvl} ->
+        id, node params color ~lvl id tynode desc dg
   and edge params id0 lbl ty gh =
     let id, gh = inject_typ params ty gh in
     add lbl (Edge(id0,id)) gh
@@ -594,8 +654,8 @@ module Digraph = struct
     snd @@ List.fold_left
       (numbered_edge params id0)
       (0,gh) l
-  and node params color id tynode desc dg =
-    let add_tynode l = add_node l color id tynode dg in
+  and node params color ~lvl id tynode desc dg =
+    let add_tynode l = add_node l color ~lvl id tynode dg in
     let mk fmt = labelk (fun l -> add_tynode (Decoration.make l)) fmt in
     let numbered = numbered_edges params id in
     let edge = edge params id in
@@ -630,13 +690,13 @@ module Digraph = struct
         in
         begin match split_fresh_typ params t dg.elts with
         | _, None -> dg
-        | next_id, Some (_, color, desc) ->
-            group_fields ~params ~prev_id:id
+        | next_id, Some {Index.color; desc; lvl; _ } ->
+            group_fields ~params ~prev_id:id ~lvl
               dg.elts dg.graph empty_subgraph
               ~id:next_id ~color ~desc
         end
     | Types.Tfield _ ->
-        group_fields ~params ~prev_id:id
+        group_fields ~params ~prev_id:id ~lvl
           dg.elts dg.graph empty_subgraph
           ~color ~id ~desc
     | Types.Tnil -> mk "[Nil]"
@@ -713,7 +773,7 @@ module Digraph = struct
         )
       rf
   and group_fields ~params ~prev_id elts main fields
-      ~color ~id ~desc =
+      ~color ~lvl ~id ~desc =
     let add_tynode dg l = add_node l color id (Node id) dg in
     let mk dg fmt = labelk (fun l -> add_tynode dg (Decoration.make l)) fmt in
     let merge elts ~main ~fields =
@@ -731,8 +791,8 @@ module Digraph = struct
         let id_next, next = split_fresh_typ params next elts in
         begin match next with
         | None -> {elts; graph=main}
-        | Some (_,color,desc) ->
-            group_fields ~params ~prev_id:id
+        | Some {Index.color; desc; lvl; _} ->
+            group_fields ~params ~prev_id:id ~lvl
               elts main fields
               ~id:id_next ~desc ~color
         end
@@ -745,7 +805,7 @@ module Digraph = struct
     | Types.Tnil -> merge elts ~main ~fields
     | _ ->
         let dg = merge elts ~main ~fields in
-        node params color id (Node id) desc dg
+        node params color ~lvl id (Node id) desc dg
 end
 
 let params

--- a/typing/gprinttyp.mli
+++ b/typing/gprinttyp.mli
@@ -20,10 +20,10 @@
 (**
 A type node is printed as
 {[
-    .------------.
-    | <desc>  id |---->
-    |            |--->
-    .------------.
+    .-------------.
+    | <desc>  idˡᵛˡ |---->
+    |             |--->
+    .-------------.
 ]}
 where the description part might be:
 - a path: [list/8!]

--- a/typing/gprinttyp.mli
+++ b/typing/gprinttyp.mli
@@ -20,10 +20,11 @@
 (**
 A type node is printed as
 {[
-    .-------------.
-    | <desc>  idˡᵛˡ |---->
-    |             |--->
-    .-------------.
+    .---------------.
+    |           lvl |
+    | <desc>  ID    |---->
+    |               |--->
+    .---------------.
 ]}
 where the description part might be:
 - a path: [list/8!]


### PR DESCRIPTION
This small PR a pretty-printer for type node level in the `Gprinttyp` debugging module. To make those as lightweight as possible and to circumvent the limited support of nested subscript and superscript in graphiz , the pretty printer uses unicode superscript to render levels as superscript the right corner of the node indices (eg `1531 ⁸`), for instance the problematic counter-example check in #13600 can be rendered as


![0045-Unify2_expand--](https://github.com/user-attachments/assets/f98c3668-f673-4a83-985b-a30467473df2)
