### PR TITLE
Various fixes to set thread name

### DIFF
--- a/Changes
+++ b/Changes
@@ -93,7 +93,7 @@ Working version
   default environment (where `TEMP` is set), there is no discernible change.
   (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
 
-- #13504: Add `Thread.set_current_thread_name`.
+- #13504, #13625: Add `Thread.set_current_thread_name`.
   (Romain Beauxis, review by Gabriel Scherer and Antonin Décimo)
 
 ### Tools:

--- a/configure
+++ b/configure
@@ -20253,13 +20253,18 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
 ## prctl
-ac_fn_check_decl "$LINENO" "prctl" "ac_cv_have_decl_prctl" "#include <sys/prctl.h>
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_prctl" = xyes
+
+  for ac_func in prctl
+do :
+  ac_fn_c_check_func "$LINENO" "prctl" "ac_cv_func_prctl"
+if test "x$ac_cv_func_prctl" = xyes
 then :
-  printf "%s\n" "#define HAS_DECL_PRCTL  1" >>confdefs.h
+  printf "%s\n" "#define HAVE_PRCTL 1" >>confdefs.h
+ printf "%s\n" "#define HAS_PRCTL 1" >>confdefs.h
 
 fi
+
+done
 
 ## pthread_setname_np
 
@@ -20299,19 +20304,18 @@ then :
   printf "%s\n" "#define HAVE_SETTHREADDESCRIPTION 1" >>confdefs.h
  printf "%s\n" "#define HAS_SETTHREADDESCRIPTION 1" >>confdefs.h
 
-fi
-
-done
-
-ac_fn_check_decl "$LINENO" "SetThreadDescription" "ac_cv_have_decl_SetThreadDescription" "#define WIN32_LEAN_AND_MEAN
-    #include <windows.h>
-    #include <processthreadsapi.h>
+  ac_fn_check_decl "$LINENO" "SetThreadDescription" "ac_cv_have_decl_SetThreadDescription" "#define WIN32_LEAN_AND_MEAN
+      #include <windows.h>
+      #include <processthreadsapi.h>
 " "$ac_c_undeclared_builtin_options" "CFLAGS"
 if test "x$ac_cv_have_decl_SetThreadDescription" = xyes
 then :
   printf "%s\n" "#define HAS_DECL_SETTHREADDESCRIPTION 1" >>confdefs.h
 
 fi
+fi
+
+done
 
 ## Activate the systhread library
 

--- a/configure.ac
+++ b/configure.ac
@@ -2420,11 +2420,9 @@ AC_LINK_IFELSE(
     [AC_MSG_RESULT([pthread_getaffinity_np not found])])])
 
 ## prctl
-AC_CHECK_DECL(
+AC_CHECK_FUNCS(
   [prctl],
-  [AC_DEFINE([HAS_DECL_PRCTL] , [1])],
-  [],
-  [#include <sys/prctl.h>])
+  [AC_DEFINE([HAS_PRCTL], [1])])
 
 ## pthread_setname_np
 AC_CHECK_FUNCS(
@@ -2439,15 +2437,14 @@ AC_CHECK_FUNCS(
 ## SetThreadDescription
 AC_CHECK_FUNCS(
   [SetThreadDescription],
-  [AC_DEFINE([HAS_SETTHREADDESCRIPTION], [1])])
-
-AC_CHECK_DECL(
-  [SetThreadDescription],
-  [AC_DEFINE([HAS_DECL_SETTHREADDESCRIPTION], [1])],
-  [],
-  [[#define WIN32_LEAN_AND_MEAN
-    #include <windows.h>
-    #include <processthreadsapi.h>]])
+  [AC_DEFINE([HAS_SETTHREADDESCRIPTION], [1])
+  AC_CHECK_DECL(
+    [SetThreadDescription],
+    [AC_DEFINE([HAS_DECL_SETTHREADDESCRIPTION], [1])],
+    [],
+    [[#define WIN32_LEAN_AND_MEAN
+      #include <windows.h>
+      #include <processthreadsapi.h>]])])
 
 ## Activate the systhread library
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -21,14 +21,15 @@
 #if defined(_WIN32)
 #  include <windows.h>
 #  include <processthreadsapi.h>
-#  include <caml/osdeps.h>
+#  include "caml/osdeps.h"
 
 #  if defined(HAS_SETTHREADDESCRIPTION) && \
       !defined(HAS_DECL_SETTHREADDESCRIPTION)
-HRESULT SetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription);
+WINBASEAPI HRESULT WINAPI
+SetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription);
 #  endif
 
-#elif defined(HAS_DECL_PRCTL)
+#elif defined(HAS_PRCTL)
 #  include <sys/prctl.h>
 #elif defined(HAS_PTHREAD_SETNAME_NP) || defined(HAS_PTHREAD_SET_NAME_NP)
 #  include <pthread.h>
@@ -994,7 +995,7 @@ CAMLprim value caml_set_current_thread_name(value name)
   pthread_setname_np(pthread_self(), String_val(name));
 #  endif
 
-#elif defined(HAS_DECL_PRCTL)
+#elif defined(HAS_PRCTL)
   prctl(PR_SET_NAME, String_val(name));
 #elif defined(HAS_PTHREAD_SETNAME_NP)
 #  if defined(__APPLE__)

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -108,7 +108,7 @@
 
 #undef HAS_PTHREAD_NP_H
 
-#undef HAS_DECL_PRCTL
+#undef HAS_PRCTL
 
 #undef HAS_PTHREAD_SETNAME_NP
 


### PR DESCRIPTION
- a Debian code search shows that projects check at configure-time for the `prctl` symbol, not the declaration.
  https://codesearch.debian.net/search?q=HAVE_PRCTL
  https://codesearch.debian.net/search?q=HAVE_DECL_PRCTL
- only check for `SetThreadDescription` declaration if the symbol has been found;
- fix `SetThreadDescription` missing declaration to include `__declspec(import)` and `__cdecl` (for x86). The declaration should have been copied from the header rather than from the documentation, which is missing these bits;
- fix `caml/osdeps.h` include style.

cc @toots, @gasche who (resp.) authored and reviewed #13504.