### PR TITLE
Clarify major GC ephemeron code

### DIFF
--- a/Changes
+++ b/Changes
@@ -1003,6 +1003,9 @@ OCaml 5.4.0 (9 October 2025)
 - #14057: Don't update memprof too early at the end of a minor GC.
   (Nick Barnes, review by Damien Doligez).
 
+- #13629: Major GC ephemeron cleanup.
+  (Nick Barnes, review by Stephen Dolan and Tim McGilchrist).
+
 ### Code generation and optimizations:
 
 - #13262, #14074: fix performance issue on Apple Silicon macOS by emitting

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -21,8 +21,16 @@
 typedef enum {
   Phase_sweep_main,
   Phase_sweep_and_mark_main,
+  /* Sweeping and marking takes place, including ephemeron marking. */
+
   Phase_mark_final,
+  /* Values with "first finalisers" (registered by Gc.finalise) are
+   * identified to be run, marking their values. This may cause
+   * further marking, and ephemeron marking. */
+
   Phase_sweep_ephe
+  /* All marking has been finished. Ephemerons are swept and "last
+   * finalisers" (Gc.finalise_last) are identified to be run. */
 } gc_phase_t;
 
 extern gc_phase_t caml_gc_phase;

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -34,29 +34,34 @@ extern value caml_ephe_none, caml_ephe_locked;
 
 struct caml_ephe_info {
   value todo;
-  /* These are ephemerons which need to be marked and swept in the current
-     cycle. If the ephemeron is alive, after marking, they go into the live
-     list after cleaning off the unreachable keys and releasing the data
-     if any of the keys are unreachable. */
+  /* Ephemerons which need to be marked and swept in the current
+     cycle. An ephemeron which is alive, after marking, goes into the
+     live list after cleaning it of keys and releasing the data if any
+     of the keys is unreachable. */
 
   value live;
-  /* These are ephemerons which are alive (marked). The keys of these ephemerons
-     may be unmarked if these ephemerons were the target of a blit operation.
-     The data field is never unmarked. */
+  /* Ephemerons which are alive (marked). The keys of these ephemerons
+     may be unmarked if these ephemerons were the target of a blit
+     operation. The data field is never unmarked. */
 
   int must_sweep_ephe;
-  /* At the beginning of [Phase_sweep_ephe] the [live] list is moved to the
-     [todo] list since the ephemerons in the [live] list may contain unmarked
-     keys if the blit operation was performed in earlier phases
-     ([Phase_mark_final] or [Phase_sweep_and_mark_main]). This move is done
-     exactly once per major cycle per domain. This field keeps track of whether
-     this move has been done for the current cycle. */
+  /* At the beginning of [Phase_sweep_ephe] the [live] list is moved
+     to the [todo] list since the ephemerons in the [live] list may
+     contain unmarked keys if the blit operation was performed in
+     earlier phases. This move is done exactly once per major cycle
+     per domain. This field keeps track of whether this move has been
+     done for the current cycle. */
 
-  uintnat cycle;
+  uintnat round;
+  /* Records the number of the round of ephemeron marking most
+   * recently completed in the current cycle. */
   struct {
     value* todop;
-    uintnat cycle;
+    uintnat round;
   } cursor;
+  /* This "cursor" structure records progress when marking ephemerons
+   * for some ephemeron round; `todop` indicates a pointer in the
+   * `todo` list above, and `round` is the round number. */
 };
 
 /** The first field 0:  weak list;


### PR DESCRIPTION
This renames "ephemeron cycles" as "ephemeron rounds", to match the "Retrofitting parallelism" paper and to avoid confusion with major GC cycles. It also adds a lot of comments, and rewrites parts of the `ephe_mark` function for increased clarity.

This helped me to reason about ephemerons when fixing a problem with orphaned ephemeron status as part of #13580.