### PR TITLE
Fix a bad optimisation in ephemeron marking and cleaning

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -359,11 +359,10 @@ static intnat ephe_mark (intnat budget, uintnat for_cycle,
             }
           }
         }
-        else {
-          if (Tag_val (key) == Infix_tag) key -= Infix_offset_val (key);
-          if (is_unmarked (key))
-            alive_data = 0;
-        }
+
+        if (Tag_val (key) == Infix_tag) key -= Infix_offset_val (key);
+        if (is_unmarked (key))
+          alive_data = 0;
       }
     }
     budget -= Whsize_wosize(i);


### PR DESCRIPTION
When reviewing some ephemeron code with @NickBarnes, he and I noticed that the optimisation to short-circuit lazy values used as ephemeron keys is

  - (a) wrong, because it fails to set `alive_data = 0`, so ephemerons whose key is a forced lazy float will never be cleaned
  - (b) almost useless, because the physical identity of lazy values changes as they are forced so they're not really meaningful as ephemeron keys

This patch just deletes the optimisation, so that no future reader will have to contemplate the interactions between ephemerons, lazy floats, and the flat-float-array optimisation.

(Gc.finalise actually fails with an exception if you try to apply it to a lazy float. We should perhaps have done that with ephemerons too, but I don't think it's worth a breaking change now)

**Update**: I'm now convinced that this change makes things worse, so I've changed this patch to one that fixes the weird optimisation instead of just deleting it. I'm still on the fence about whether lazy values should be allowed in ephemerons at all.