### PR TITLE
remove some restrictions on function subtyping

### DIFF
--- a/Changes
+++ b/Changes
@@ -217,6 +217,11 @@ ___________
   annotations.
   (Jacques Garrigue, report and review by Gabriel Scherer and Florian Angeletti)
 
+- #13634: Allow type unification to erase optional arguments any time the first
+   non-erased argument is positional, even if there are further labeled
+   arguments.
+   (Aaron Dufour)
+
 ### Runtime system:
 
 - #13419: Fix memory bugs in runtime events system.

--- a/Changes
+++ b/Changes
@@ -1857,6 +1857,11 @@ OCaml 5.3.0 (8 January 2025)
   annotations.
   (Jacques Garrigue, report and review by Gabriel Scherer and Florian Angeletti)
 
+- #13634: Allow type unification to erase optional arguments any time the first
+   non-erased argument is positional, even if there are further labeled
+   arguments.
+   (Aaron Dufour)
+
 ### Runtime system:
 
 - #11911, #12923: Multicore statistical memory profiling.

--- a/testsuite/tests/typing-func-subtype/opt_arg_subtyping.ml
+++ b/testsuite/tests/typing-func-subtype/opt_arg_subtyping.ml
@@ -1,0 +1,48 @@
+(* TEST
+ expect;
+*)
+
+[@@@warning "-16"]
+
+let f ?x:_ _ = assert false;;
+
+(* This should be fine. There's a positional argument next, so we know that
+erasing the optional argument is okay. *)
+let _ = (f : 'a -> 'a);;
+
+[%%expect{|
+val f : ?x:'a -> 'b -> 'c = <fun>
+- : 'a -> 'a = <fun>
+|}];;
+
+let f ?x:_ ~y:_ = 1;;
+
+(* This shouldn't be allowed - we're erasing an unerasable optional argument. *)
+let _ = (f : y:'a -> int);;
+
+[%%expect {|
+val f : ?x:'a -> y:'b -> int = <fun>
+Line 4, characters 9-10:
+4 | let _ = (f : y:'a -> int);;
+             ^
+Error: The value "f" has type "?x:'b -> y:'c -> int"
+       but an expression was expected of type "y:'a -> int"
+       Labels "?x" and "y" do not match
+|}];;
+
+(* This shouldn't be allowed, either. The optional argument is erasable, but it
+could get erased without applying the positional argument if only the labeled
+argument is passed in after the typecast. *)
+let f ?x:_ ~y:_ _ = 1;;
+
+let _ = (f : y:_ -> _ -> int);;
+
+[%%expect {|
+val f : ?x:'a -> y:'b -> 'c -> int = <fun>
+Line 3, characters 9-10:
+3 | let _ = (f : y:_ -> _ -> int);;
+             ^
+Error: The value "f" has type "?x:'a -> y:'b -> 'c -> int"
+       but an expression was expected of type "y:'d -> 'e -> int"
+       Labels "?x" and "y" do not match
+|}];;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6282,27 +6282,22 @@ and type_label_exp create env loc ty_expected
 
 and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
   (* ty_expected' may be generic *)
-  let no_labels ty =
-    let ls, ~is_ret_tvar = arrow_labels env ty in
-    not is_ret_tvar && List.for_all ((=) Nolabel) ls
-  in
   let may_coerce =
     if not (is_inferred sarg) then None else
-    let work () =
-      let te = expand_head env ty_expected' in
-      match get_desc te with
-        Tarrow(Nolabel,_,ty_res0,_) ->
-          Some (no_labels ty_res0, get_level te)
-      | _ -> None
-    in
-    (* Need to be careful not to expand local constraints here *)
-    if Env.has_local_constraints env then
-      let snap = Btype.snapshot () in
-      try_finally ~always:(fun () -> Btype.backtrack snap) work
-    else work ()
+      let work () =
+        let te = expand_head env ty_expected' in
+        match get_desc te with
+          Tarrow(Nolabel,_,_,_) -> Some (get_level te)
+        | _ -> None
+      in
+      (* Need to be careful not to expand local constraints here *)
+      if Env.has_local_constraints env then
+        let snap = Btype.snapshot () in
+        try_finally ~always:(fun () -> Btype.backtrack snap) work
+      else work ()
   in
   match may_coerce with
-    Some (safe_expect, lv) ->
+    Some lv ->
       (* apply omittable arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
       let texp =
@@ -6316,17 +6311,13 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
               option_none env (instance (tpoly_get_mono ty_arg)) sarg.pexp_loc
             in
             make_args ((l, Arg ty) :: args) ty_fun
-        | Tarrow (l,_,ty_res',_) when l = Nolabel || !Clflags.classic ->
-            List.rev args, ty_fun, no_labels ty_res'
-        | Tvar _ ->  List.rev args, ty_fun, false
-        |  _ -> [], texp.exp_type, false
+        | Tarrow (l,_,_ty_res',_) when l = Nolabel || !Clflags.classic ->
+            List.rev args, ty_fun
+        | Tvar _ ->  List.rev args, ty_fun
+        |  _ -> [], texp.exp_type
       in
-      let args, ty_fun', simple_res = make_args [] texp.exp_type
+      let args, ty_fun' = make_args [] texp.exp_type
       and texp = {texp with exp_type = instance texp.exp_type} in
-      if not (simple_res || safe_expect) then begin
-        unify_exp ~sexp:sarg env texp ty_expected;
-        texp
-      end else begin
       let warn = !Clflags.principal &&
         (lv <> generic_level || get_level ty_fun' <> generic_level)
       and ty_fun = instance ty_fun' in
@@ -6391,7 +6382,6 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
                        vb_loc=Location.none; vb_rec_kind = Dynamic;
                       }],
                      func let_var) }
-      end
   | None ->
       let texp = type_expect ?recarg env sarg
         (mk_expected ?explanation ty_expected') in


### PR DESCRIPTION
Function subtyping is unnecessarily restrictive - as long as the first unerased argument is positional, erasing optional arguments via type unification is safe, even if there are future labeled arguments. This matches the usual behavior of optional arguments, and allows for functions with both optional arguments and polymorphic return types to be used more easily.  This allows for constructs like (excuse the Base-based example; off the top of my head I don't know a stdlib function with the right properties) `|> Option.value_exn` and `>>| Option.value_exn`.

This change removes the restriction that a function type must contain no labeled arguments in order for type unification to erase optional arguments, but leaves in place the requirement that the first unerased argument must be positional.

I've also added tests showing both the new behavior I'm looking to introduce (the first test) and unifications that must continue to fail (due to the first unerased argument not being positional).