### PR TITLE
Make ocamlmklib fail on unknown parameter

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,10 @@ Working version
 
 ### Tools:
 
+* #13638: ocamlmklib exits with code 4 if passed an unrecognised option, as it
+  does with an unrecognised file.
+  (David Allsopp, review by Antonin Décimo and Sébastien Hinderer)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -165,7 +165,7 @@ let parse_arguments argv =
     else if s = "-framework" then
       (let a = next_arg s in c_opts := a :: s :: !c_opts)
     else if starts_with s "-" then
-      prerr_endline ("Unknown option " ^ s)
+      raise (Bad_argument("Unknown option " ^ s))
     else
       raise (Bad_argument("Don't know what to do with " ^ s))
   done;


### PR DESCRIPTION
In the spirit of #12613. The original `ocamlmklib` shell script used to ignore command line options it didn't recognise (I'm going to guess for build system simplicity). The present OCaml rewrite of it was introduced in OCaml 3.04 and temporarily did return an error status, but this got "corrected" in 31cbd26c16f81c8a273ad3ba988c49db6b0dbe38.

I can see why this might have been acceptable 20+ years ago, but I don't think it's good or consistent (and I just got bitten by it while trying to write some sanity-checking tests...). The rest of the distribution returns a non-zero status when passed on invalid argument - so should ocamlmklib!


(cc @garrigue, but only because the original commit is yours!)