### PR TITLE
Allow (ty :> int) for immediate types

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
   (Nicolás Ojeda Bär, review by Richard Eisenberg, Jeremy Yallop, Jacques
   Garrigue, and Gabriel Scherer)
 
+- #13644: Allow to use (ty :> int) for any immediate type ty.
+  (Christophe Raffalli, review by ...)
+
 ### Runtime system:
 
 - #13352: Concurrency refactors and cleanups.

--- a/Changes
+++ b/Changes
@@ -12,7 +12,7 @@ Working version
   (Nicolás Ojeda Bär, review by Richard Eisenberg, Jeremy Yallop, Jacques
   Garrigue, and Gabriel Scherer)
 
-- #13644: Allow to use (ty :> int) for any immediate type ty.
+- #13645: Allow to use (ty :> int) for any immediate type ty.
   (Christophe Raffalli, review by ...)
 
 ### Runtime system:

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -736,6 +736,14 @@ fun x -> (x :> < m : 'a -> 'a > as 'a);;
 <fun>
 |}];;
 
+fun x -> (x : int -> bool :> int -> int);;
+[%%expect{|
+- : (int -> bool) -> int -> int = <fun>
+|}];;
+fun x -> (x : int -> int :> bool -> int);;
+[%%expect{|
+- : (int -> int) -> bool -> int = <fun>
+|}];;
 fun x -> (x : int -> bool :> 'a -> 'a);;
 [%%expect{|
 Line 1, characters 9-38:
@@ -744,13 +752,13 @@ Line 1, characters 9-38:
 Error: Type "int -> bool" is not a subtype of "int -> int"
        Type "bool" is not a subtype of "int"
 |}];;
-fun x -> (x : int -> bool :> int -> int);;
+fun x -> (x : int -> string :> int -> int);;
 [%%expect{|
-Line 1, characters 9-40:
-1 | fun x -> (x : int -> bool :> int -> int);;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "int -> bool" is not a subtype of "int -> int"
-       Type "bool" is not a subtype of "int"
+Line 1, characters 9-42:
+1 | fun x -> (x : int -> string :> int -> int);;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "int -> string" is not a subtype of "int -> int"
+       Type "string" is not a subtype of "int"
 |}];;
 fun x -> (x : < > :> < .. >);;
 [%%expect{|

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4886,6 +4886,10 @@ let subtype_error ~env ~trace ~unification_trace =
                     ~trace:(expand_subtype_trace env (List.rev trace))
                     ~unification_trace))
 
+let is_immediate env p1 =
+  let decl = Env.find_type p1 env in
+  decl.type_immediate = Type_immediacy.Always
+
 let rec subtype_rec env trace t1 t2 cstrs =
   if eq_type t1 t2 then cstrs else
 
@@ -4955,6 +4959,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
         subtype_rec env trace (expand_abbrev_opt env t1) t2 cstrs
 (*  | (_, Tconstr(p2, _, _)) when generic_private_abbrev false env p2 ->
         subtype_rec env trace t1 (expand_abbrev_opt env t2) cstrs *)
+    | (Tconstr(p1,_,_), _) when is_immediate env p1 ->
+       subtype_rec env trace Predef.type_int t2 cstrs
     | (Tobject (f1, _), Tobject (f2, _))
       when is_Tvar (object_row f1) && is_Tvar (object_row f2) ->
         (* Same row variable implies same object. *)


### PR DESCRIPTION
The main use is to index an array by an ADT. example:

```
type weekDay = Mon | Tue | Wen | Thu | Fri | Sat | Sun
let set a (x:weekDay) str = a.(x :> int) <- str 
```

This way we can both use such a type as an index and benefit from pattern matching on constructor without
guard clause.