### PR TITLE
Better errors for illegal recursive modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -152,9 +152,9 @@ Working version
   checked.
   (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
 
-- #13646: Improve the error message when a recursive module type
+- #13646: Improve the error messages when a recursive module type
   references another recursive module type.
-  (Stefan Muenzel, review by ???)
+  (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -152,6 +152,10 @@ Working version
   checked.
   (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
 
+- #13646: Improve the error message when a recursive module type
+  references another recursive module type.
+  (Stefan Muenzel, review by ???)
+
 ### Internal/compiler-libs changes:
 
 - #13624: Added location to exception definitions and type extensions

--- a/testsuite/tests/typing-recmod/gpr1626.ml
+++ b/testsuite/tests/typing-recmod/gpr1626.ml
@@ -12,7 +12,19 @@ module rec M : S with module M := M = M;;
 Line 1, characters 34-35:
 1 | module rec M : S with module M := M = M;;
                                       ^
-Error: The module type of the recursive module "M"
-       cannot be accessed from the definition of the module type of "M".
-       Recursive module types are not allowed.
+Error: This module type is recursive. This use of the recursive module "M"
+       within the definition of the module "M"
+       makes the module type of "M" depend on itself.
+       Such recursive definitions of module types are not allowed.
+|}];;
+
+module rec M : S = M and P : S with module M := M = P;;
+[%%expect{|
+Line 1, characters 48-49:
+1 | module rec M : S = M and P : S with module M := M = P;;
+                                                    ^
+Error: This module type is recursive. This use of the recursive module "M"
+       within the definition of the module "P"
+       makes the module type of "P" depend on the module type of "M".
+       Such recursive definitions of module types are not allowed.
 |}];;

--- a/testsuite/tests/typing-recmod/gpr1626.ml
+++ b/testsuite/tests/typing-recmod/gpr1626.ml
@@ -12,5 +12,7 @@ module rec M : S with module M := M = M;;
 Line 1, characters 34-35:
 1 | module rec M : S with module M := M = M;;
                                       ^
-Error: Illegal recursive module reference
+Error: The module type of the recursive module "M"
+       cannot be accessed from the definition of the module type of "M".
+       Recursive module types are not allowed.
 |}];;

--- a/testsuite/tests/typing-recmod/gpr1626.ml
+++ b/testsuite/tests/typing-recmod/gpr1626.ml
@@ -13,8 +13,7 @@ Line 1, characters 34-35:
 1 | module rec M : S with module M := M = M;;
                                       ^
 Error: This module type is recursive. This use of the recursive module "M"
-       within the definition of the module "M"
-       makes the module type of "M" depend on itself.
+       within its own definition makes the module type of "M" depend on itself.
        Such recursive definitions of module types are not allowed.
 |}];;
 

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -9,9 +9,23 @@ and Baz : sig class type c = object inherit Bar.c end end = Baz;;
 Line 2, characters 44-49:
 2 | and Bar : sig class type c = object inherit Foo.c end end = Bar
                                                 ^^^^^
-Error: The class type "Foo.c" in the module type of the recursive module "Foo"
-       cannot be accessed from the definition of the module type of "Bar".
-       Recursive class types are not allowed.
+Error: This class type is recursive. This use of the class type "Foo.c"
+       from the recursive module "Foo" within the definition of
+       the class type "c" in the recursive module "Bar"
+       makes the module type of "Bar" depend on the module type of "Foo".
+       Such definitions of class types within recursive modules are not allowed.
+|}]
+
+module rec Foo : sig class type c = object inherit Foo.c end end = Foo;;
+[%%expect {|
+Line 1, characters 51-56:
+1 | module rec Foo : sig class type c = object inherit Foo.c end end = Foo;;
+                                                       ^^^^^
+Error: This class type is recursive. This use of the class type "Foo.c"
+       from the recursive module "Foo" within the definition of
+       the class type "c" in the recursive module "Foo"
+       makes the module type of "Foo" depend on itself.
+       Such definitions of class types within recursive modules are not allowed.
 |}]
 
 module rec Foo : sig class type c = object method x : int end end = Foo
@@ -25,9 +39,11 @@ let baz (x : Baz.c) = x#x;;
 Line 2, characters 29-34:
 2 | and Bar : sig class type c = Foo.c end = Bar
                                  ^^^^^
-Error: The class type "Foo.c" in the module type of the recursive module "Foo"
-       cannot be accessed from the definition of the module type of "Bar".
-       Recursive class types are not allowed.
+Error: This class type is recursive. This use of the class type "Foo.c"
+       from the recursive module "Foo" within the definition of
+       the class type "c" in the recursive module "Bar"
+       makes the module type of "Bar" depend on the module type of "Foo".
+       Such definitions of class types within recursive modules are not allowed.
 |}]
 
 (* #12480 *)

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -13,7 +13,8 @@ Error: This class type is recursive. This use of the class type "Foo.c"
        from the recursive module "Foo" within the definition of
        the class type "c" in the recursive module "Bar"
        makes the module type of "Bar" depend on the module type of "Foo".
-       Such definitions of class types within recursive modules are not allowed.
+       Such recursive definitions of class types within recursive modules
+       are not allowed.
 |}]
 
 module rec Foo : sig class type c = object inherit Foo.c end end = Foo;;
@@ -25,7 +26,8 @@ Error: This class type is recursive. This use of the class type "Foo.c"
        from the recursive module "Foo" within the definition of
        the class type "c" in the recursive module "Foo"
        makes the module type of "Foo" depend on itself.
-       Such definitions of class types within recursive modules are not allowed.
+       Such recursive definitions of class types within recursive modules
+       are not allowed.
 |}]
 
 module rec Foo : sig class type c = object method x : int end end = Foo
@@ -43,7 +45,8 @@ Error: This class type is recursive. This use of the class type "Foo.c"
        from the recursive module "Foo" within the definition of
        the class type "c" in the recursive module "Bar"
        makes the module type of "Bar" depend on the module type of "Foo".
-       Such definitions of class types within recursive modules are not allowed.
+       Such recursive definitions of class types within recursive modules
+       are not allowed.
 |}]
 
 (* #12480 *)

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -9,7 +9,9 @@ and Baz : sig class type c = object inherit Bar.c end end = Baz;;
 Line 2, characters 44-49:
 2 | and Bar : sig class type c = object inherit Foo.c end end = Bar
                                                 ^^^^^
-Error: Illegal recursive module reference
+Error: The module type of the recursive module "Foo"
+       cannot be accessed from the definition of the module type of "Bar".
+       Recursive module types are not allowed.
 |}]
 
 module rec Foo : sig class type c = object method x : int end end = Foo
@@ -23,7 +25,9 @@ let baz (x : Baz.c) = x#x;;
 Line 2, characters 29-34:
 2 | and Bar : sig class type c = Foo.c end = Bar
                                  ^^^^^
-Error: Illegal recursive module reference
+Error: The module type of the recursive module "Foo"
+       cannot be accessed from the definition of the module type of "Bar".
+       Recursive module types are not allowed.
 |}]
 
 (* #12480 *)

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -9,9 +9,9 @@ and Baz : sig class type c = object inherit Bar.c end end = Baz;;
 Line 2, characters 44-49:
 2 | and Bar : sig class type c = object inherit Foo.c end end = Bar
                                                 ^^^^^
-Error: The module type of the recursive module "Foo"
+Error: The class type "Foo.c" in the module type of the recursive module "Foo"
        cannot be accessed from the definition of the module type of "Bar".
-       Recursive module types are not allowed.
+       Recursive class types are not allowed.
 |}]
 
 module rec Foo : sig class type c = object method x : int end end = Foo
@@ -25,9 +25,9 @@ let baz (x : Baz.c) = x#x;;
 Line 2, characters 29-34:
 2 | and Bar : sig class type c = Foo.c end = Bar
                                  ^^^^^
-Error: The module type of the recursive module "Foo"
+Error: The class type "Foo.c" in the module type of the recursive module "Foo"
        cannot be accessed from the definition of the module type of "Bar".
-       Recursive module types are not allowed.
+       Recursive class types are not allowed.
 |}]
 
 (* #12480 *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3666,43 +3666,42 @@ let report_lookup_error_doc _loc env ppf = function
        quoted_longident lid
   | Illegal_reference_to_recursive_module { container; unbound } ->
       let container = Option.value ~default:"_" container in
+      let self_or_unbound =
+        if String.equal container unbound
+        then dprintf "itself"
+        else dprintf "the module type of %a" Style.inline_code unbound
+      in
       fprintf ppf
         "@[<hov>This module type is recursive.@ \
          This use of the recursive module %a@ \
          within the definition of the module %a@ \
-         makes the module type of %a depend on "
+         makes the module type of %a depend on@ %t.@ \
+         Such recursive definitions of module types are not allowed.@]"
         Style.inline_code unbound
         Style.inline_code container
-        Style.inline_code container;
-      if String.equal container unbound
-      then fprintf ppf "itself"
-      else fprintf ppf "the module type of %a" Style.inline_code unbound;
-      fprintf ppf
-        ".@ \
-         Such recursive definitions of module types are not allowed.@]"
+        Style.inline_code container
+        self_or_unbound
   | Illegal_reference_to_recursive_class_type
       { container; unbound; unbound_class_type; container_class_type } ->
       let container = Option.value ~default:"_" container in
+      let self_or_unbound =
+        if String.equal container unbound
+        then dprintf "itself"
+        else dprintf "the module type of %a" Style.inline_code unbound
+      in
       fprintf ppf
-        "@[<hov>This class type is recursive.@ \
-         This use of the class type %a@ \
-         from the recursive module %a@ \
-         within the definition of@ the class type %a@ \
-         in the recursive module %a@ \
-         makes the module type of %a@ \
-         depend on "
+        "@[<hov>This class type is recursive.@ This use of the class type %a@ \
+         from the recursive module %a@ within the definition of@ \
+         the class type %a@ in the recursive module %a@ \
+         makes the module type of %a@ depend on %t.@ \
+         Such recursive definitions of@ class types within recursive modules@ \
+         are not allowed.@]"
         quoted_longident unbound_class_type
         Style.inline_code unbound
         Style.inline_code container_class_type
         Style.inline_code container
-        Style.inline_code container;
-      if String.equal container unbound
-      then fprintf ppf "itself"
-      else fprintf ppf "the module type of %a" Style.inline_code unbound;
-      fprintf ppf
-        ".@ \
-         Such definitions of class types within recursive modules are not \
-         allowed.@]"
+        Style.inline_code container
+        self_or_unbound
   | Structure_used_as_functor lid ->
       fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
         quoted_longident lid

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -656,6 +656,11 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module of
       { container: string option; unbound : string }
+  | Illegal_reference_to_recursive_class_type of
+      { container : string option;
+        unbound : string;
+        class_type : Longident.t;
+      }
   | Cannot_scrape_alias of Longident.t * Path.t
 
 type error =
@@ -3665,6 +3670,15 @@ let report_lookup_error_doc _loc env ppf = function
          Recursive module types are not allowed.@]"
        Style.inline_code unbound
        Style.inline_code (Option.value ~default:"_" container)
+  | Illegal_reference_to_recursive_class_type
+      { container; unbound; class_type } ->
+      fprintf ppf
+        "@[The class type %a in the module type of the recursive module %a@ \
+         cannot be accessed from the definition of the module type of %a.@ \
+         Recursive class types are not allowed.@]"
+        quoted_longident class_type
+        Style.inline_code unbound
+        Style.inline_code (Option.value ~default:"_" container)
   | Structure_used_as_functor lid ->
       fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
         quoted_longident lid

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3666,19 +3666,21 @@ let report_lookup_error_doc _loc env ppf = function
        quoted_longident lid
   | Illegal_reference_to_recursive_module { container; unbound } ->
       let container = Option.value ~default:"_" container in
-      let self_or_unbound =
+      let self_or_definition, self_or_unbound =
         if String.equal container unbound
-        then dprintf "itself"
-        else dprintf "the module type of %a" Style.inline_code unbound
+        then dprintf "its own definition", dprintf "itself"
+        else
+          dprintf "the definition of the module %a" Style.inline_code container,
+          dprintf "the module type of %a" Style.inline_code unbound
       in
       fprintf ppf
         "@[<hov>This module type is recursive.@ \
          This use of the recursive module %a@ \
-         within the definition of the module %a@ \
+         within %t@ \
          makes the module type of %a depend on@ %t.@ \
          Such recursive definitions of module types are not allowed.@]"
         Style.inline_code unbound
-        Style.inline_code container
+        self_or_definition
         Style.inline_code container
         self_or_unbound
   | Illegal_reference_to_recursive_class_type

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -138,7 +138,8 @@ type value_unbound_reason =
   | Val_unbound_ghost_recursive of Location.t
 
 type module_unbound_reason =
-  | Mod_unbound_illegal_recursion
+  | Mod_unbound_illegal_recursion of
+      { container : string option; unbound : string }
 
 type summary =
     Env_empty
@@ -653,7 +654,8 @@ type lookup_error =
   | Functor_used_as_structure of Longident.t
   | Abstract_used_as_structure of Longident.t
   | Generative_used_as_applicative of Longident.t
-  | Illegal_reference_to_recursive_module
+  | Illegal_reference_to_recursive_module of
+      { container: string option; unbound : string }
   | Cannot_scrape_alias of Longident.t * Path.t
 
 type error =
@@ -2669,9 +2671,10 @@ let may_lookup_error report_errors loc env err =
 
 let report_module_unbound ~errors ~loc env reason =
   match reason with
-  | Mod_unbound_illegal_recursion ->
+  | Mod_unbound_illegal_recursion { container; unbound } ->
       (* see #5965 *)
-    may_lookup_error errors loc env Illegal_reference_to_recursive_module
+      may_lookup_error errors loc env
+        (Illegal_reference_to_recursive_module { container; unbound })
 
 let report_value_unbound ~errors ~loc env reason lid =
   match reason with
@@ -3655,8 +3658,13 @@ let report_lookup_error_doc _loc env ppf = function
         "The ancestor variable %a@ \
          cannot be accessed from the definition of an instance variable"
        quoted_longident lid
-  | Illegal_reference_to_recursive_module ->
-     fprintf ppf "Illegal recursive module reference"
+  | Illegal_reference_to_recursive_module { container; unbound } ->
+      fprintf ppf
+        "@[The module type of the recursive module %a@ \
+         cannot be accessed from the definition of the module type of %a.@ \
+         Recursive module types are not allowed.@]"
+       Style.inline_code unbound
+       Style.inline_code (Option.value ~default:"_" container)
   | Structure_used_as_functor lid ->
       fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
         quoted_longident lid

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -659,7 +659,8 @@ type lookup_error =
   | Illegal_reference_to_recursive_class_type of
       { container : string option;
         unbound : string;
-        class_type : Longident.t;
+        unbound_class_type : Longident.t;
+        container_class_type : string;
       }
   | Cannot_scrape_alias of Longident.t * Path.t
 
@@ -3664,21 +3665,44 @@ let report_lookup_error_doc _loc env ppf = function
          cannot be accessed from the definition of an instance variable"
        quoted_longident lid
   | Illegal_reference_to_recursive_module { container; unbound } ->
+      let container = Option.value ~default:"_" container in
       fprintf ppf
-        "@[The module type of the recursive module %a@ \
-         cannot be accessed from the definition of the module type of %a.@ \
-         Recursive module types are not allowed.@]"
-       Style.inline_code unbound
-       Style.inline_code (Option.value ~default:"_" container)
-  | Illegal_reference_to_recursive_class_type
-      { container; unbound; class_type } ->
-      fprintf ppf
-        "@[The class type %a in the module type of the recursive module %a@ \
-         cannot be accessed from the definition of the module type of %a.@ \
-         Recursive class types are not allowed.@]"
-        quoted_longident class_type
+        "@[<hov>This module type is recursive.@ \
+         This use of the recursive module %a@ \
+         within the definition of the module %a@ \
+         makes the module type of %a depend on "
         Style.inline_code unbound
-        Style.inline_code (Option.value ~default:"_" container)
+        Style.inline_code container
+        Style.inline_code container;
+      if String.equal container unbound
+      then fprintf ppf "itself"
+      else fprintf ppf "the module type of %a" Style.inline_code unbound;
+      fprintf ppf
+        ".@ \
+         Such recursive definitions of module types are not allowed.@]"
+  | Illegal_reference_to_recursive_class_type
+      { container; unbound; unbound_class_type; container_class_type } ->
+      let container = Option.value ~default:"_" container in
+      fprintf ppf
+        "@[<hov>This class type is recursive.@ \
+         This use of the class type %a@ \
+         from the recursive module %a@ \
+         within the definition of@ the class type %a@ \
+         in the recursive module %a@ \
+         makes the module type of %a@ \
+         depend on "
+        quoted_longident unbound_class_type
+        Style.inline_code unbound
+        Style.inline_code container_class_type
+        Style.inline_code container
+        Style.inline_code container;
+      if String.equal container unbound
+      then fprintf ppf "itself"
+      else fprintf ppf "the module type of %a" Style.inline_code unbound;
+      fprintf ppf
+        ".@ \
+         Such definitions of class types within recursive modules are not \
+         allowed.@]"
   | Structure_used_as_functor lid ->
       fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
         quoted_longident lid

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -26,7 +26,8 @@ type value_unbound_reason =
   | Val_unbound_ghost_recursive of Location.t
 
 type module_unbound_reason =
-  | Mod_unbound_illegal_recursion
+  | Mod_unbound_illegal_recursion of
+      { container : string option; unbound: string }
 
 type summary =
     Env_empty
@@ -182,7 +183,8 @@ type lookup_error =
   | Functor_used_as_structure of Longident.t
   | Abstract_used_as_structure of Longident.t
   | Generative_used_as_applicative of Longident.t
-  | Illegal_reference_to_recursive_module
+  | Illegal_reference_to_recursive_module of
+      { container : string option; unbound : string }
   | Cannot_scrape_alias of Longident.t * Path.t
 
 val lookup_error: Location.t -> t -> lookup_error -> 'a

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -188,7 +188,8 @@ type lookup_error =
   | Illegal_reference_to_recursive_class_type of
       { container : string option;
         unbound : string;
-        class_type : Longident.t;
+        unbound_class_type : Longident.t;
+        container_class_type : string
       }
   | Cannot_scrape_alias of Longident.t * Path.t
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -185,6 +185,11 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module of
       { container : string option; unbound : string }
+  | Illegal_reference_to_recursive_class_type of
+      { container : string option;
+        unbound : string;
+        class_type : Longident.t;
+      }
   | Cannot_scrape_alias of Longident.t * Path.t
 
 val lookup_error: Location.t -> t -> lookup_error -> 'a

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1931,7 +1931,20 @@ let () =
 let rec check_recmod_class_type env cty =
   match cty.pcty_desc with
   | Pcty_constr(lid, _) ->
-      ignore (Env.lookup_cltype ~use:false ~loc:lid.loc lid.txt env)
+      begin try
+        ignore (Env.lookup_cltype ~use:false ~loc:lid.loc lid.txt env)
+      with
+      | Env.Error
+          (Lookup_error
+             (location, env,
+              Illegal_reference_to_recursive_module { container; unbound; })) ->
+          raise (Env.Error
+                   (Lookup_error (location, env,
+                                  Illegal_reference_to_recursive_class_type
+                                    { container;
+                                      unbound;
+                                      class_type = lid.txt })))
+      end
   | Pcty_extension _ -> ()
   | Pcty_arrow(_, _, cty) ->
       check_recmod_class_type env cty
@@ -1964,6 +1977,8 @@ let approx_class_declarations env sdecls =
   let decls, env = class_type_declarations env (List.map approx_class sdecls) in
   List.iter (check_recmod_decl env) sdecls;
   decls, env
+
+
 
 (*******************************)
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1928,7 +1928,7 @@ let () =
 (*******************************)
 
 (* Check that there is no references through recursive modules (GPR#6491) *)
-let rec check_recmod_class_type env cty =
+let rec check_recmod_class_type env name cty =
   match cty.pcty_desc with
   | Pcty_constr(lid, _) ->
       begin try
@@ -1943,28 +1943,30 @@ let rec check_recmod_class_type env cty =
             (Illegal_reference_to_recursive_class_type
                { container;
                  unbound;
-                 class_type = lid.txt })
+                 unbound_class_type = lid.txt;
+                 container_class_type = name.txt;
+               })
       end
   | Pcty_extension _ -> ()
   | Pcty_arrow(_, _, cty) ->
-      check_recmod_class_type env cty
+      check_recmod_class_type env name cty
   | Pcty_open(od, cty) ->
       let _, env = !type_open_descr env od in
-      check_recmod_class_type env cty
+      check_recmod_class_type env name cty
   | Pcty_signature csig ->
-      check_recmod_class_sig env csig
+      check_recmod_class_sig env name csig
 
-and check_recmod_class_sig env csig =
+and check_recmod_class_sig env name csig =
   List.iter
     (fun ctf ->
        match ctf.pctf_desc with
-       | Pctf_inherit cty -> check_recmod_class_type env cty
+       | Pctf_inherit cty -> check_recmod_class_type env name cty
        | Pctf_val _ | Pctf_method _
        | Pctf_constraint _ | Pctf_attribute _ | Pctf_extension _ -> ())
     csig.pcsig_fields
 
 let check_recmod_decl env sdecl =
-  check_recmod_class_type env sdecl.pci_expr
+  check_recmod_class_type env sdecl.pci_name sdecl.pci_expr
 
 (* Approximate the class declaration as class ['params] id = object end *)
 let approx_class sdecl =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1938,12 +1938,12 @@ let rec check_recmod_class_type env cty =
           (Lookup_error
              (location, env,
               Illegal_reference_to_recursive_module { container; unbound; })) ->
-          raise (Env.Error
-                   (Lookup_error (location, env,
-                                  Illegal_reference_to_recursive_class_type
-                                    { container;
-                                      unbound;
-                                      class_type = lid.txt })))
+          Env.lookup_error
+            location env
+            (Illegal_reference_to_recursive_class_type
+               { container;
+                 unbound;
+                 class_type = lid.txt })
       end
   | Pcty_extension _ -> ()
   | Pcty_arrow(_, _, cty) ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1742,7 +1742,9 @@ and transl_recmodule_modtypes env sdecls =
       (fun env ->
          Option.fold ~none:env ~some:(fun id -> (* cf #5965 *)
            Env.enter_unbound_module (Ident.name id)
-             (Mod_unbound_illegal_recursion { container; unbound = Ident.name id }) env
+             (Mod_unbound_illegal_recursion
+                { container; unbound = Ident.name id })
+             env
          ))
       env ids
   in
@@ -1751,7 +1753,8 @@ and transl_recmodule_modtypes env sdecls =
       (fun id pmd ->
          let md_uid = Uid.mk ~current_unit:(Env.get_current_unit ()) in
          let md =
-           { md_type = approx_modtype (approx_env pmd.pmd_name.txt) pmd.pmd_type;
+           { md_type =
+               approx_modtype (approx_env pmd.pmd_name.txt) pmd.pmd_type;
              md_loc = pmd.pmd_loc;
              md_attributes = pmd.pmd_attributes;
              md_uid }

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1737,12 +1737,12 @@ and transl_recmodule_modtypes env sdecls =
     List.map (fun x -> Option.map (Ident.create_scoped ~scope) x.pmd_name.txt)
       sdecls
   in
-  let approx_env =
+  let approx_env container =
     List.fold_left
       (fun env ->
          Option.fold ~none:env ~some:(fun id -> (* cf #5965 *)
            Env.enter_unbound_module (Ident.name id)
-             Mod_unbound_illegal_recursion env
+             (Mod_unbound_illegal_recursion { container; unbound = Ident.name id }) env
          ))
       env ids
   in
@@ -1751,7 +1751,7 @@ and transl_recmodule_modtypes env sdecls =
       (fun id pmd ->
          let md_uid = Uid.mk ~current_unit:(Env.get_current_unit ()) in
          let md =
-           { md_type = approx_modtype approx_env pmd.pmd_type;
+           { md_type = approx_modtype (approx_env pmd.pmd_name.txt) pmd.pmd_type;
              md_loc = pmd.pmd_loc;
              md_attributes = pmd.pmd_attributes;
              md_uid }


### PR DESCRIPTION
Attempt to replace the not very helpful `Error: Illegal recursive module reference` with something more descriptive:
```
Error: The module type of the recursive module "Foo"
       cannot be accessed from the definition of the module type of "Bar".
       Recursive module types are not allowed.
```
I assume the statement of what is not allowed is accurate?