### PR TITLE
Fix a few typos

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -191,11 +191,11 @@ has excellent documentation.
   VERSION::               version string. Run `tools/autogen` after changing.
   asmcomp/::              native-code compiler and linker
   boot/::                 bootstrap compiler
-  build-aux/:             autotools support scripts
+  build-aux/::            autotools support scripts
   bytecomp/::             bytecode compiler and linker
   compilerlibs/::         the OCaml compiler as a library
   configure::             configure script
-  configure.ac:           autoconf input file
+  configure.ac::          autoconf input file
   debugger/::             source-level replay debugger
   driver/::               driver code for the compilers
   flexdll/::              git submodule -- see link:README.win32.adoc[]

--- a/configure
+++ b/configure
@@ -14596,7 +14596,7 @@ case $ocaml_cc_vendor,$host in #(
     oc_ldflags='-Wl,-no_compact_unwind';
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  *,aarch64-*-darwin*|arm64-*-darwin*) :
+  *,aarch64-*-darwin*|*,arm64-*-darwin*) :
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   *,*-*-cygwin*) :

--- a/configure.ac
+++ b/configure.ac
@@ -1066,7 +1066,7 @@ AS_CASE([$ocaml_cc_vendor,$host],
   [*,x86_64-*-darwin*],
     [oc_ldflags='-Wl,-no_compact_unwind';
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
-  [*,aarch64-*-darwin*|arm64-*-darwin*],
+  [*,aarch64-*-darwin*|*,arm64-*-darwin*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"


### PR DESCRIPTION
This PR fixes:
- a typo in `configure`: I don’t really know if that branch is just dead code, though,
- two syntax typos in `HACKING.adoc`.