### PR TITLE
Use C99 `stdint.h` fixed-width integers and `inttypes.h` format macros

### DIFF
--- a/Changes
+++ b/Changes
@@ -191,6 +191,10 @@ Working version
 - #14094: toplevel, simplify check on installed printer types
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13656: Use C99 stdint.h/inttypes.h fixed-width integer types and
+  macros to define OCaml integers.
+  (Antonin Décimo, review by Nick Barnes)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/otherlibs/unix/mmap_win32.c
+++ b/otherlibs/unix/mmap_win32.c
@@ -42,7 +42,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   int flags, major_dim, mode, perm;
   intnat num_dims;
   intnat dim[CAML_BA_MAX_NUM_DIMS];
-  __int64 startpos, data_size;
+  int64_t startpos, data_size;
   LARGE_INTEGER file_size;
   uintnat array_size, delta;
   void * addr;

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -75,7 +75,7 @@ static const int file_kind_table[] = {
 static double stat_timestamp(__time64_t tm)
 {
   /* Split the timestamp into seconds and remaining 100ns units */
-  __int64 sec = tm / (NSEC_PER_SEC / 100);  /* 10^7 */
+  int64_t sec = tm / (NSEC_PER_SEC / 100);  /* 10^7 */
   int n100sec = tm % (NSEC_PER_SEC / 100);
   /* The conversion of sec to FP is exact for the foreseeable future.
      (It starts rounding when sec > 2^53, i.e. in 285 million years.) */
@@ -91,7 +91,7 @@ static double stat_timestamp(__time64_t tm)
   return t;
 }
 
-static value stat_aux(int use_64, __int64 st_ino, struct _stat64 *buf)
+static value stat_aux(int use_64, int64_t st_ino, struct _stat64 *buf)
 {
   CAMLparam0 ();
   CAMLlocal1 (v);
@@ -162,7 +162,7 @@ Caml_inline ULONGLONG convert_time(FILETIME time)
 }
 
 /* path allocated outside the OCaml heap */
-static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, __int64* st_ino, struct _stat64* res)
+static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, int64_t* st_ino, struct _stat64* res)
 {
   BY_HANDLE_FILE_INFORMATION info;
   wchar_t* ptr;
@@ -269,8 +269,8 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
         res->st_size = 0;
       }
       else {
-        res->st_size = ((__int64)(info.nFileSizeHigh)) << 32 |
-                       ((__int64)info.nFileSizeLow);
+        res->st_size = ((int64_t)(info.nFileSizeHigh)) << 32 |
+                       ((int64_t)info.nFileSizeLow);
       }
     }
 
@@ -296,7 +296,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
      */
     res->st_nlink = info.nNumberOfLinks;
     res->st_dev = info.dwVolumeSerialNumber;
-    *st_ino = ((__int64)(info.nFileIndexHigh)) << 32 | ((__int64)info.nFileIndexLow);
+    *st_ino = ((int64_t)(info.nFileIndexHigh)) << 32 | ((int64_t)info.nFileIndexLow);
   }
 
   if (do_lstat && is_symlink) {
@@ -326,7 +326,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
   return 1;
 }
 
-static int do_stat(int do_lstat, int use_64, const char* opath, HANDLE fstat, __int64* st_ino, struct _stat64* res)
+static int do_stat(int do_lstat, int use_64, const char* opath, HANDLE fstat, int64_t* st_ino, struct _stat64* res)
 {
   wchar_t* wpath;
   int ret;
@@ -340,7 +340,7 @@ CAMLprim value caml_unix_stat(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "stat");
   if (!do_stat(0, 0, String_val(path), NULL, &st_ino, &buf)) {
@@ -353,7 +353,7 @@ CAMLprim value caml_unix_stat_64(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "stat");
   if (!do_stat(0, 1, String_val(path), NULL, &st_ino, &buf)) {
@@ -366,7 +366,7 @@ CAMLprim value caml_unix_lstat(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "lstat");
   if (!do_stat(1, 0, String_val(path), NULL, &st_ino, &buf)) {
@@ -379,7 +379,7 @@ CAMLprim value caml_unix_lstat_64(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "lstat");
   if (!do_stat(1, 1, String_val(path), NULL, &st_ino, &buf)) {
@@ -391,7 +391,7 @@ CAMLprim value caml_unix_lstat_64(value path)
 static value do_fstat(value handle, int use_64)
 {
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
   HANDLE h;
   DWORD ft;
 

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -72,7 +72,7 @@ static const int file_kind_table[] = {
    when the same file is accessed either from Windows or from Linux.
  */
 
-static double stat_timestamp(__time64_t tm)
+static double stat_timestamp(time_t tm)
 {
   /* Split the timestamp into seconds and remaining 100ns units */
   int64_t sec = tm / (NSEC_PER_SEC / 100);  /* 10^7 */
@@ -170,7 +170,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, i
   unsigned short mode;
   int is_symlink = 0;
   ULONGLONG stamp;
-  __time64_t mtime = 0;
+  time_t mtime = 0;
 
   if (!path) {
     h = fstat;

--- a/otherlibs/unix/truncate_win32.c
+++ b/otherlibs/unix/truncate_win32.c
@@ -26,7 +26,7 @@
 #include "caml/unixsupport.h"
 #include <windows.h>
 
-static int truncate_handle(HANDLE fh, __int64 len)
+static int truncate_handle(HANDLE fh, int64_t len)
 {
   LARGE_INTEGER fp;
   fp.QuadPart = len;
@@ -38,7 +38,7 @@ static int truncate_handle(HANDLE fh, __int64 len)
   return 0;
 }
 
-static int ftruncate(HANDLE fh, __int64 len)
+static int ftruncate(HANDLE fh, int64_t len)
 {
   HANDLE dupfh, currproc;
   int ret;
@@ -54,7 +54,7 @@ static int ftruncate(HANDLE fh, __int64 len)
   return ret;
 }
 
-static int truncate(WCHAR * path, __int64 len)
+static int truncate(WCHAR * path, int64_t len)
 {
   HANDLE fh;
   int ret;
@@ -91,7 +91,7 @@ CAMLprim value caml_unix_truncate_64(value path, value vlen)
   CAMLparam2(path, vlen);
   WCHAR * p;
   int ret;
-  __int64 len = Int64_val(vlen);
+  int64_t len = Int64_val(vlen);
   caml_unix_check_path(path, "truncate");
   p = caml_stat_strdup_to_utf16(String_val(path));
   caml_enter_blocking_section();
@@ -119,7 +119,7 @@ CAMLprim value caml_unix_ftruncate_64(value fd, value vlen)
 {
   int ret;
   HANDLE h = Handle_val(fd);
-  __int64 len = Int64_val(vlen);
+  int64_t len = Int64_val(vlen);
   caml_enter_blocking_section();
   ret = ftruncate(h, len);
   caml_leave_blocking_section();

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -20,8 +20,8 @@
 #include "mlvalues.h"
 #include "camlatomic.h"
 
-typedef signed char caml_ba_int8;
-typedef unsigned char caml_ba_uint8;
+typedef int8_t caml_ba_int8;
+typedef uint8_t caml_ba_uint8;
 typedef int16_t caml_ba_int16;
 typedef uint16_t caml_ba_uint16;
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -98,8 +98,8 @@
   #define ARCH_UINT64_TYPE unsigned long long
   #define ARCH_INT64_PRINTF_FORMAT "I64"
 #elif defined(_MSC_VER)
-  #define ARCH_INT64_TYPE __int64
-  #define ARCH_UINT64_TYPE unsigned __int64
+  #define ARCH_INT64_TYPE int64_t
+  #define ARCH_UINT64_TYPE uint64_t
   #define ARCH_INT64_PRINTF_FORMAT "I64"
 #else
   #if SIZEOF_LONG == 8

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -98,23 +98,18 @@
 #define ARCH_INT64_PRINTF_FORMAT "l"
 #endif
 
+typedef intptr_t intnat;
+typedef uintptr_t uintnat;
+
 #if SIZEOF_PTR == SIZEOF_LONG
 /* Standard models: ILP32 or I32LP64 */
-typedef long intnat;
-typedef unsigned long uintnat;
 #define ARCH_INTNAT_PRINTF_FORMAT "l"
 #elif SIZEOF_PTR == SIZEOF_INT
 /* Hypothetical IP32L64 model */
-typedef int intnat;
-typedef unsigned int uintnat;
 #define ARCH_INTNAT_PRINTF_FORMAT ""
 #elif SIZEOF_PTR == 8
 /* Win64 model: IL32P64 */
-typedef int64_t intnat;
-typedef uint64_t uintnat;
 #define ARCH_INTNAT_PRINTF_FORMAT ARCH_INT64_PRINTF_FORMAT
-#else
-#error "No integer type available to represent pointers"
 #endif
 
 #define CAML_INTNAT_MIN INTPTR_MIN

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -46,12 +46,11 @@
 
 #include <stddef.h>
 #include <limits.h>
+#include <stdint.h>
 
 #if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
 #define HAS_LOCALE
 #endif
-
-#include <stdint.h>
 
 /* Disable the mingw-w64 *printf shims */
 #if defined(CAML_INTERNALS) && defined(__MINGW32__)
@@ -75,44 +74,28 @@
 /* Types for 32-bit integers, 64-bit integers, and
    native integers (as wide as a pointer type) */
 
-#ifndef ARCH_INT32_TYPE
+#define ARCH_INT32_TYPE int32_t
+#define ARCH_UINT32_TYPE uint32_t
+
 #if SIZEOF_INT == 4
-#define ARCH_INT32_TYPE int
-#define ARCH_UINT32_TYPE unsigned int
 #define ARCH_INT32_PRINTF_FORMAT ""
 #elif SIZEOF_LONG == 4
-#define ARCH_INT32_TYPE long
-#define ARCH_UINT32_TYPE unsigned long
 #define ARCH_INT32_PRINTF_FORMAT "l"
 #elif SIZEOF_SHORT == 4
-#define ARCH_INT32_TYPE short
-#define ARCH_UINT32_TYPE unsigned short
 #define ARCH_INT32_PRINTF_FORMAT ""
-#else
-#error "No 32-bit integer type available"
-#endif
 #endif
 
+#define ARCH_INT64_TYPE int64_t
+#define ARCH_UINT64_TYPE uint64_t
+
 #if defined(__MINGW32__) && !__USE_MINGW_ANSI_STDIO && !defined(_UCRT)
-  #define ARCH_INT64_TYPE long long
-  #define ARCH_UINT64_TYPE unsigned long long
-  #define ARCH_INT64_PRINTF_FORMAT "I64"
+#define ARCH_INT64_PRINTF_FORMAT "I64"
 #elif defined(_MSC_VER)
-  #define ARCH_INT64_TYPE int64_t
-  #define ARCH_UINT64_TYPE uint64_t
-  #define ARCH_INT64_PRINTF_FORMAT "I64"
-#else
-  #if SIZEOF_LONG == 8
-    #define ARCH_INT64_TYPE long
-    #define ARCH_UINT64_TYPE unsigned long
-    #define ARCH_INT64_PRINTF_FORMAT "l"
-  #elif SIZEOF_LONGLONG == 8
-    #define ARCH_INT64_TYPE long long
-    #define ARCH_UINT64_TYPE unsigned long long
-    #define ARCH_INT64_PRINTF_FORMAT "ll"
-  #else
-    #error "No 64-bit integer type available"
-  #endif
+#define ARCH_INT64_PRINTF_FORMAT "I64"
+#elif SIZEOF_LONGLONG == 8
+#define ARCH_INT64_PRINTF_FORMAT "ll"
+#elif SIZEOF_LONG == 8
+#define ARCH_INT64_PRINTF_FORMAT "l"
 #endif
 
 #if SIZEOF_PTR == SIZEOF_LONG

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -46,7 +46,7 @@
 
 #include <stddef.h>
 #include <limits.h>
-#include <stdint.h>
+#include <inttypes.h>
 
 #if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
 #define HAS_LOCALE

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -65,11 +65,18 @@
   #define __USE_MINGW_ANSI_STDIO 0
 #endif
 
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !__USE_MINGW_ANSI_STDIO && !defined(_UCRT)
 #define ARCH_SIZET_PRINTF_FORMAT "I"
 #else
 #define ARCH_SIZET_PRINTF_FORMAT "z"
 #endif
+
+#define CAML_PRIdSZT ARCH_SIZET_PRINTF_FORMAT "d"
+#define CAML_PRIiSZT ARCH_SIZET_PRINTF_FORMAT "i"
+#define CAML_PRIoSZT ARCH_SIZET_PRINTF_FORMAT "o"
+#define CAML_PRIuSZT ARCH_SIZET_PRINTF_FORMAT "u"
+#define CAML_PRIxSZT ARCH_SIZET_PRINTF_FORMAT "x"
+#define CAML_PRIXSZT ARCH_SIZET_PRINTF_FORMAT "X"
 
 /* Types for 32-bit integers, 64-bit integers, and
    native integers (as wide as a pointer type) */
@@ -111,6 +118,13 @@ typedef uintptr_t uintnat;
 /* Win64 model: IL32P64 */
 #define ARCH_INTNAT_PRINTF_FORMAT ARCH_INT64_PRINTF_FORMAT
 #endif
+
+#define CAML_PRIdNAT PRIdPTR
+#define CAML_PRIiNAT PRIiPTR
+#define CAML_PRIoNAT PRIoPTR
+#define CAML_PRIuNAT PRIuPTR
+#define CAML_PRIxNAT PRIxPTR
+#define CAML_PRIXNAT PRIXPTR
 
 #define CAML_INTNAT_MIN INTPTR_MIN
 #define CAML_INTNAT_MAX INTPTR_MAX

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -37,7 +37,7 @@ typedef intptr_t caml_plat_mutex;
 #endif
 
 #if defined(_WIN32)
-typedef __int64 file_offset;
+typedef int64_t file_offset;
 #else
 #include <sys/types.h>
 typedef off_t file_offset;

--- a/runtime/clambda_checks.c
+++ b/runtime/clambda_checks.c
@@ -58,15 +58,14 @@ value caml_check_field_access(value v, value pos, value v_descr)
   value orig_v = v;
   if (v == (value) 0) {
     fprintf(stderr,
-      "Access to field %" ARCH_INT64_PRINTF_FORMAT
-      "u of NULL: %s\n", (ARCH_UINT64_TYPE) Long_val(pos), descr);
+      "Access to field %" PRIu64 " of NULL: %s\n",
+      (uint64_t) Long_val(pos), descr);
     abort();
   }
   if (!Is_block(v)) {
     fprintf(stderr,
-      "Access to field %" ARCH_INT64_PRINTF_FORMAT
-      "u of non-boxed value %p is illegal: %s\n",
-      (ARCH_UINT64_TYPE) Long_val(pos), (void*) v, descr);
+      "Access to field %" PRIu64 " of non-boxed value %p is illegal: %s\n",
+      (uint64_t) Long_val(pos), (void*) v, descr);
     abort();
   }
   if (Tag_val(v) == Infix_tag) {
@@ -77,11 +76,9 @@ value caml_check_field_access(value v, value pos, value v_descr)
   CAMLassert(Long_val(pos) >= 0);
   if (Long_val(pos) >= Wosize_val(v)) {
     fprintf(stderr,
-      "Access to field %" ARCH_INT64_PRINTF_FORMAT
-      "u of value %p of size %" ARCH_INT64_PRINTF_FORMAT "u is illegal: %s\n",
-      (ARCH_UINT64_TYPE) Long_val(pos), (void*) v,
-      (ARCH_UINT64_TYPE) Wosize_val(v),
-      descr);
+      "Access to field %" PRIu64 " of value %p of size "
+      "%" PRIu64 " is illegal: %s\n",
+      (uint64_t) Long_val(pos), (void*) v, (uint64_t) Wosize_val(v), descr);
     abort();
   }
   return orig_v;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -443,8 +443,7 @@ Caml_inline void check_minor_heap(void) {
   CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
   caml_gc_log("young_start: %p, young_end: %p, minor_heap_area_start: %p,"
-      " minor_heap_area_end: %p, minor_heap_wsz: %"
-      ARCH_SIZET_PRINTF_FORMAT "u words",
+      " minor_heap_area_end: %p, minor_heap_wsz: %" CAML_PRIuSZT " words",
       domain_state->young_start,
       domain_state->young_end,
       (value*)domain_self->minor_heap_area_start,
@@ -463,9 +462,8 @@ Caml_inline void check_minor_heap(void) {
 static void free_minor_heap(void) {
   caml_domain_state* domain_state = Caml_state;
 
-  caml_gc_log ("trying to free old minor heap: %"
-        ARCH_SIZET_PRINTF_FORMAT "uk words",
-        domain_state->minor_heap_wsz / 1024);
+  caml_gc_log("trying to free old minor heap: %" CAML_PRIuSZT "k words",
+              domain_state->minor_heap_wsz / 1024);
 
   check_minor_heap();
 
@@ -494,8 +492,8 @@ static int allocate_minor_heap(asize_t wsize) {
 
   CAMLassert (wsize <= caml_minor_heap_max_wsz);
 
-  caml_gc_log ("trying to allocate minor heap: %"
-               ARCH_SIZET_PRINTF_FORMAT "uk words", wsize / 1024);
+  caml_gc_log("trying to allocate minor heap: %" CAML_PRIuSZT "k words",
+              wsize / 1024);
 
   if (!caml_mem_commit(
           (void*)domain_self->minor_heap_area_start, Bsize_wsize(wsize))) {
@@ -894,8 +892,7 @@ static
 void domain_resize_heap_reservation_from_stw_single(uintnat new_minor_wsz)
 {
   CAML_EV_BEGIN(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
-  caml_gc_log("stw_resize_minor_heap_reservation: "
-              "unreserve_minor_heaps");
+  caml_gc_log("stw_resize_minor_heap_reservation: unreserve_minor_heaps");
 
   unreserve_minor_heaps_from_stw_single();
   /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
@@ -934,8 +931,7 @@ stw_resize_minor_heap_reservation(caml_domain_state* domain,
     domain_resize_heap_reservation_from_stw_single(new_minor_wsz);
   }
 
-  caml_gc_log("stw_resize_minor_heap_reservation: "
-              "allocate_minor_heap");
+  caml_gc_log("stw_resize_minor_heap_reservation: allocate_minor_heap");
   /* Note: each domain allocates its own minor heap. This seems
      important to get good NUMA behavior. We don't want a single
      domain to allocate all minor heaps, which could create locality
@@ -946,8 +942,8 @@ stw_resize_minor_heap_reservation(caml_domain_state* domain,
 }
 
 void caml_update_minor_heap_max(uintnat requested_wsz) {
-  caml_gc_log("Changing heap_max_wsz from %" ARCH_INTNAT_PRINTF_FORMAT
-              "u to %" ARCH_INTNAT_PRINTF_FORMAT "u.",
+  caml_gc_log("Changing heap_max_wsz from %" CAML_PRIuNAT
+              " to %" CAML_PRIuNAT ".",
               caml_minor_heap_max_wsz, requested_wsz);
   while (requested_wsz > caml_minor_heap_max_wsz) {
     caml_try_run_on_all_domains(
@@ -1259,7 +1255,7 @@ static void* domain_thread_func(void* v)
   if (domain_self) {
     install_backup_thread(domain_self);
 
-    caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
+    caml_gc_log("Domain starting (unique_id = %" CAML_PRIuNAT ")",
                 domain_self->interruptor.unique_id);
     CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
     /* FIXME: ignoring errors during domain initialization is unsafe

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -75,9 +75,8 @@ void caml_change_max_stack_size (uintnat new_max_wsize)
 
   if (new_max_wsize < wsize) new_max_wsize = wsize;
   if (new_max_wsize != caml_max_stack_wsize){
-    caml_gc_log ("Changing stack limit to %"
-                 ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
-                     new_max_wsize * sizeof (value) / 1024);
+    caml_gc_log ("Changing stack limit to %" CAML_PRIuNAT "k bytes",
+                 new_max_wsize * sizeof (value) / 1024);
   }
   caml_max_stack_wsize = new_max_wsize;
 }
@@ -228,8 +227,8 @@ value caml_alloc_stack (value hval, value hexn, value heff) {
 
   if (!stack) caml_raise_out_of_memory();
 
-  fiber_debug_log ("Allocate stack=%p of %" ARCH_INTNAT_PRINTF_FORMAT
-                     "u words", stack, caml_fiber_wsz);
+  fiber_debug_log ("Allocate stack=%p of %" CAML_PRIuNAT "words",
+                   stack, caml_fiber_wsz);
 
   return Val_ptr(stack);
 }
@@ -474,12 +473,10 @@ int caml_try_realloc_stack(asize_t required_space)
   } while (wsize < stack_used + required_space);
 
   if (wsize > 4096 / sizeof(value)) {
-    caml_gc_log ("Growing stack to %"
-                 ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
+    caml_gc_log ("Growing stack to %" CAML_PRIuNAT "k bytes",
                  (uintnat) wsize * sizeof(value) / 1024);
   } else {
-    caml_gc_log ("Growing stack to %"
-                 ARCH_INTNAT_PRINTF_FORMAT "u bytes",
+    caml_gc_log ("Growing stack to %" CAML_PRIuNAT " bytes",
                  (uintnat) wsize * sizeof(value));
   }
 

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -118,7 +118,7 @@ void caml_disasm_instr(code_t pc)
 void
 caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
 {
-  fprintf (f, "%#" ARCH_INTNAT_PRINTF_FORMAT "x", v);
+  fprintf (f, "%#" CAML_PRIxNAT, v);
   if (!v)
     return;
   if (prog && v % sizeof (int) == 0
@@ -126,7 +126,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
            && (code_t) v < (code_t) ((char *) prog + proglen))
     fprintf (f, "=code@%ld", (long) ((code_t) v - prog));
   else if (Is_long (v))
-    fprintf (f, "=long%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val (v));
+    fprintf (f, "=long%" CAML_PRIdNAT, Long_val (v));
   else if (Stack_base(Caml_state->current_stack) <= (value*)v &&
            (value*)v < Stack_high(Caml_state->current_stack))
     fprintf (f, "=stack_%ld",
@@ -177,7 +177,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
         };
         if (i > 0)
           putc (' ', f);
-        fprintf (f, "%#" ARCH_INTNAT_PRINTF_FORMAT "x", Field (v, i));
+        fprintf (f, "%#" CAML_PRIxNAT, Field (v, i));
       };
       if (s > 0)
         putc (')', f);
@@ -193,7 +193,7 @@ caml_trace_accu_sp_file (value accu, value * sp, code_t prog, asize_t proglen,
   value *p;
   fprintf (f, "accu=");
   caml_trace_value_file (accu, prog, proglen, f);
-  fprintf (f, "\n sp=%#" ARCH_INTNAT_PRINTF_FORMAT "x @%ld:",
+  fprintf (f, "\n sp=%#" CAML_PRIxNAT " @%ld:",
            (intnat) sp, (long) (Stack_high(Caml_state->current_stack) - sp));
   for (p = sp, i = 0;
        i < 12 + (1 << caml_params->trace_level) &&

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -363,7 +363,7 @@ value caml_bytecode_interpreter(code_t prog, asize_t prog_size,
     caml_bcodcount++;
     if (caml_icount-- == 0) caml_stop_here ();
     if (caml_params->trace_level>1)
-      printf("\n##%" ARCH_INTNAT_PRINTF_FORMAT "d\n", caml_bcodcount);
+      printf("\n##%" CAML_PRIdNAT "\n", caml_bcodcount);
     if (caml_params->trace_level>0) caml_disasm_instr(pc);
     if (caml_params->event_trace>0) caml_event_trace(pc);
     if (caml_params->trace_level>1) {
@@ -1417,9 +1417,7 @@ do_resume: {
 #ifdef _MSC_VER
       CAMLunreachable();
 #else
-      caml_fatal_error("bad opcode (%"
-                           ARCH_INTNAT_PRINTF_FORMAT "x)",
-                           (intnat) *(pc-1));
+      caml_fatal_error("bad opcode (%" CAML_PRIxNAT ")", (intnat) *(pc-1));
 #endif
     }
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -396,14 +396,12 @@ static intnat ephe_mark (intnat budget, uintnat for_cycle,
     marked++;
   }
 
-  caml_gc_log
-  ("Mark Ephemeron: %s. Ephemeron cycle=%"ARCH_INTNAT_PRINTF_FORMAT"d "
-   "examined=%"ARCH_INTNAT_PRINTF_FORMAT"d "
-   "trivial_data=%"ARCH_INTNAT_PRINTF_FORMAT"d "
-   "marked=%"ARCH_INTNAT_PRINTF_FORMAT"d",
-   domain_state->ephe_info->cursor.cycle == for_cycle ?
-     "Continued from cursor" : "Discarded cursor",
-   for_cycle, marked, trivial_data, made_live);
+  caml_gc_log ("Mark Ephemeron: %s. Ephemeron cycle=%" CAML_PRIdNAT " "
+               "examined=%" CAML_PRIdNAT " trivial_data=%" CAML_PRIdNAT " "
+               "marked=%" CAML_PRIdNAT,
+               domain_state->ephe_info->cursor.cycle == for_cycle ?
+                 "Continued from cursor" : "Discarded cursor",
+               for_cycle, marked, trivial_data, made_live);
 
   domain_state->ephe_info->cursor.cycle = for_cycle;
   domain_state->ephe_info->cursor.todop = prev_linkp;
@@ -814,36 +812,25 @@ update_major_slice_work(intnat howmuch,
 
   extra_work = (intnat) (my_extra_count * (double) total_cycle_work);
 
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "heap_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
-                  (uintnat)heap_words);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "allocated_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE, "heap_words = %" CAML_PRIuNAT "\n",
+                  heap_words);
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words = %" CAML_PRIuNAT "\n",
                    my_alloc_count);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "allocated_words_direct = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_direct = %" CAML_PRIuNAT "\n",
                    my_alloc_direct_count);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "allocated_words_suspended = "
-                  "%" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_suspended = %" CAML_PRIuNAT "\n",
                    my_alloc_suspended_count);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "allocated_words_resumed = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_resumed = %" CAML_PRIuNAT "\n",
                    my_alloc_resumed_count);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "alloc work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+  CAML_GC_MESSAGE(SLICESIZE, "alloc work-to-do = %" CAML_PRIdNAT "\n",
                    alloc_work);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "dependent_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE, "dependent_words = %" CAML_PRIuNAT "\n",
                    my_dependent_count);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "dependent work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+  CAML_GC_MESSAGE(SLICESIZE, "dependent work-to-do = %" CAML_PRIdNAT "\n",
                   dependent_work);
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "extra_heap_resources = %" ARCH_INTNAT_PRINTF_FORMAT "uu\n",
+  CAML_GC_MESSAGE(SLICESIZE, "extra_heap_resources = %" CAML_PRIuNAT "u\n",
                   (uintnat) (my_extra_count * 1000000));
-  CAML_GC_MESSAGE(SLICESIZE,
-                  "extra work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+  CAML_GC_MESSAGE(SLICESIZE, "extra work-to-do = %" CAML_PRIdNAT "\n",
                   extra_work);
 
   new_work = max3 (alloc_work, dependent_work, extra_work);
@@ -861,22 +848,21 @@ update_major_slice_work(intnat howmuch,
   }
 
   caml_gc_log("Updated major work: [%c] "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u heap_words, "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u allocated, "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u allocated (direct), "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u allocated (suspended), "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u allocated (resumed), "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "d alloc_work, "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "d dependent_work, "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "d extra_work,  "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u work counter %s,  "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u alloc counter,  "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u slice target,  "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "d slice budget"
+              " %" CAML_PRIuNAT " heap_words, "
+              " %" CAML_PRIuNAT " allocated, "
+              " %" CAML_PRIuNAT " allocated (direct), "
+              " %" CAML_PRIuNAT " allocated (suspended), "
+              " %" CAML_PRIuNAT " allocated (resumed), "
+              " %" CAML_PRIdNAT " alloc_work, "
+              " %" CAML_PRIdNAT " dependent_work, "
+              " %" CAML_PRIdNAT " extra_work, "
+              " %" CAML_PRIuNAT " work counter %s, "
+              " %" CAML_PRIuNAT " alloc counter, "
+              " %" CAML_PRIuNAT " slice target, "
+              " %" CAML_PRIdNAT " slice budget"
               ,
               caml_gc_phase_char(may_access_gc_phase),
-              (uintnat)heap_words,
-              my_alloc_count, my_alloc_direct_count,
+              heap_words, my_alloc_count, my_alloc_direct_count,
               my_alloc_suspended_count, my_alloc_resumed_count,
               alloc_work, dependent_work, extra_work,
               atomic_load (&work_counter),
@@ -927,8 +913,7 @@ static intnat get_major_slice_work(collection_slice_mode mode){
 static void commit_major_slice_work(intnat words_done) {
   caml_domain_state *dom_st = Caml_state;
 
-  caml_gc_log ("Commit major slice work: "
-               " %"ARCH_INTNAT_PRINTF_FORMAT"d words_done, ",
+  caml_gc_log ("Commit major slice work:  %" CAML_PRIdNAT " words_done, ",
                words_done);
 
   dom_st->slice_budget -= words_done;
@@ -1040,7 +1025,7 @@ static void mark_stack_prune(struct mark_stack* stk)
     ++old_compressed_entries;
   }
   if (old_compressed_entries > 0) {
-    caml_gc_log("Preserved %"ARCH_INTNAT_PRINTF_FORMAT "d compressed entries",
+    caml_gc_log("Preserved %" CAML_PRIdNAT " compressed entries",
                 old_compressed_entries);
   }
   caml_addrmap_clear(&stk->compressed_stack);
@@ -1063,9 +1048,9 @@ static void mark_stack_prune(struct mark_stack* stk)
     }
   }
 
-  caml_gc_log("Compressed %"ARCH_INTNAT_PRINTF_FORMAT "d mark stack words into "
-              "%"ARCH_INTNAT_PRINTF_FORMAT "d mark stack entries and "
-              "%"ARCH_INTNAT_PRINTF_FORMAT "d compressed entries",
+  caml_gc_log("Compressed %" CAML_PRIdNAT " mark stack words into "
+              "%" CAML_PRIdNAT " mark stack entries and "
+              "%" CAML_PRIdNAT " compressed entries",
               total_words, new_stk_count,
               compressed_entries+old_compressed_entries);
 
@@ -1098,8 +1083,8 @@ static void realloc_mark_stack (struct mark_stack* stk)
   if (mark_stack_bsize - mark_stack_large_bsize < local_heap_bsize / 32) {
     uintnat target_bsize = (mark_stack_bsize - mark_stack_large_bsize) * 2
                               + mark_stack_large_bsize;
-    caml_gc_log ("Growing mark stack to %"ARCH_INTNAT_PRINTF_FORMAT"uk bytes"
-                 "(large block %"ARCH_INTNAT_PRINTF_FORMAT"uk bytes)\n",
+    caml_gc_log ("Growing mark stack to %" CAML_PRIuNAT "k bytes"
+                 "(large block %" CAML_PRIuNAT "k bytes)\n",
                  target_bsize / 1024, mark_stack_large_bsize / 1024);
 
     new = (mark_entry*) caml_stat_resize_noexc ((char*) stk->stack,
@@ -1112,9 +1097,8 @@ static void realloc_mark_stack (struct mark_stack* stk)
     caml_gc_log ("No room for growing mark stack. Compressing..\n");
   }
 
-  caml_gc_log ("Mark stack size is %"ARCH_INTNAT_PRINTF_FORMAT"u "
-               "bytes (> major heap size of this domain %"
-               ARCH_INTNAT_PRINTF_FORMAT"u bytes / 32). Compressing..\n",
+  caml_gc_log ("Mark stack size is %" CAML_PRIuNAT " bytes (> major heap size "
+               "of this domain %" CAML_PRIuNAT " bytes / 32). Compressing...\n",
                mark_stack_bsize,
                local_heap_bsize);
   mark_stack_prune(stk);
@@ -1201,9 +1185,8 @@ void caml_shrink_mark_stack (void)
   intnat init_stack_bsize = MARK_STACK_INIT_SIZE * sizeof(mark_entry);
   mark_entry* shrunk_stack;
 
-  caml_gc_log ("Shrinking mark stack to %"
-                  ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
-                  init_stack_bsize / 1024);
+  caml_gc_log ("Shrinking mark stack to %" CAML_PRIuNAT "k bytes\n",
+               init_stack_bsize / 1024);
 
   shrunk_stack = (mark_entry*) caml_stat_resize_noexc ((char*) stk->stack,
                                               init_stack_bsize);
@@ -1499,8 +1482,8 @@ static void cycle_major_heap_from_stw_single(
   /* FIXME: delete caml_cycle_heap_from_stw_single
      and have per-domain copies of the data? */
   caml_cycle_heap_from_stw_single();
-  caml_gc_log("GC cycle %lu completed (heap cycled)",
-              (long unsigned int)caml_major_cycles_completed);
+  caml_gc_log("GC cycle %" CAML_PRIuNAT " completed (heap cycled)",
+              caml_major_cycles_completed);
 
   caml_major_cycles_completed++;
   CAML_GC_MESSAGE(SLICESIZE, "Starting major GC cycle\n");
@@ -1514,9 +1497,9 @@ static void cycle_major_heap_from_stw_single(
     not_garbage_words = s.heap_stats.pool_live_words
       + s.heap_stats.large_words;
     swept_words = domain->swept_words;
-    caml_gc_log ("heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d "
-                 "not_garbage_words %"ARCH_INTNAT_PRINTF_FORMAT"d "
-                 "swept_words %"ARCH_INTNAT_PRINTF_FORMAT"d",
+    caml_gc_log ("heap_words: %" CAML_PRIdNAT " "
+                 "not_garbage_words %" CAML_PRIdNAT " "
+                 "swept_words %" CAML_PRIdNAT,
                  heap_words, not_garbage_words, swept_words);
 
     static struct {
@@ -2017,14 +2000,13 @@ mark_again:
   call_timing_hook(&caml_major_slice_end_hook);
   if (log_events) CAML_EV_END(EV_MAJOR_SLICE);
 
-  caml_gc_log
-    ("Major slice [%c%c%c]: %ld sweep, %ld mark (%lu blocks)",
+  caml_gc_log("Major slice [%c%c%c]: %" CAML_PRIdNAT " sweep, "
+              "% " CAML_PRIdNAT " mark (%" CAML_PRIuNAT " blocks)",
               collection_slice_mode_char(mode),
               !caml_incoming_interrupts_queued() ? '.' : '*',
               caml_gc_phase_char(may_access_gc_phase),
-              (long)sweep_work, (long)mark_work,
-              (unsigned long)(domain_state->stat_blocks_marked
-                                                      - blocks_marked_before));
+              sweep_work, mark_work,
+              domain_state->stat_blocks_marked - blocks_marked_before);
 
   if (mode != Slice_opportunistic && is_complete_phase_sweep_ephe()) {
     /* To handle the case where multiple domains try to finish the major cycle
@@ -2146,8 +2128,8 @@ void caml_empty_mark_stack (void)
   }
 
   if (Caml_state->stat_blocks_marked)
-    caml_gc_log("Finished marking major heap. Marked %u blocks",
-                (unsigned)Caml_state->stat_blocks_marked);
+    caml_gc_log("Finished marking major heap. Marked %" CAML_PRIuNAT " blocks",
+                Caml_state->stat_blocks_marked);
   Caml_state->stat_blocks_marked = 0;
 }
 

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -139,9 +139,9 @@ CAMLprim value caml_realloc_global(value size)
   actual_size = Wosize_val(old_global_data);
   if (requested_size >= actual_size) {
     requested_size = (requested_size + 0x100) & 0xFFFFFF00;
-    CAML_GC_MESSAGE(STACKSIZE, "Growing global data to %"
-                     ARCH_INTNAT_PRINTF_FORMAT "u entries\n",
-                     requested_size);
+    CAML_GC_MESSAGE(STACKSIZE,
+                    "Growing global data to %" CAML_PRIuNAT " entries\n",
+                    requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);
     for (mlsize_t i = 0; i < actual_size; i++)
       caml_initialize(&Field(new_global_data, i), Field(old_global_data, i));

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -579,10 +579,9 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
         ref_end = foreign_major_ref->ptr;
       }
 
-      caml_gc_log("idx: %d, foreign_domain: %d, ref_size: %"
-        ARCH_INTNAT_PRINTF_FORMAT"d, refs_per_domain: %"
-        ARCH_INTNAT_PRINTF_FORMAT"d, ref_base: %p, ref_ptr: %p, ref_start: %p"
-        ", ref_end: %p",
+      caml_gc_log("idx: %d, foreign_domain: %d, ref_size: %" CAML_PRIdNAT ", "
+        "refs_per_domain: %" CAML_PRIdNAT ", ref_base: %p, ref_ptr: %p, "
+        "ref_start: %p, ref_end: %p",
         participating_idx, foreign_domain->id, major_ref_size, refs_per_domain,
         foreign_major_ref->base, foreign_major_ref->ptr, ref_start, ref_end);
 
@@ -637,7 +636,7 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
   promote_result result = oldify_mopup (&st, 1); /* ephemerons promoted here */
   CAML_EV_END(EV_MINOR_REMEMBERED_SET_PROMOTE);
   CAML_EV_END(EV_MINOR_REMEMBERED_SET);
-  caml_gc_log("promoted %d roots, %" ARCH_INTNAT_PRINTF_FORMAT "u bytes",
+  caml_gc_log("promoted %d roots, %" CAML_PRIuNAT " bytes",
               remembered_roots, st.live_bytes);
 
 #ifdef DEBUG
@@ -1078,7 +1077,7 @@ void caml_realloc_ref_table (struct caml_ref_table *tbl)
     ((struct generic_table *) tbl, sizeof (value *),
      EV_C_REQUEST_MINOR_REALLOC_REF_TABLE,
      "ref_table threshold crossed\n",
-     "Growing ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
+     "Growing ref_table to %" CAML_PRIdNAT "k bytes\n",
      "ref_table overflow");
 }
 
@@ -1088,7 +1087,7 @@ void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *tbl)
     ((struct generic_table *) tbl, sizeof (struct caml_ephe_ref_elt),
      EV_C_REQUEST_MINOR_REALLOC_EPHE_REF_TABLE,
      "ephe_ref_table threshold crossed\n",
-     "Growing ephe_ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
+     "Growing ephe_ref_table to %" CAML_PRIdNAT "k bytes\n",
      "ephe_ref_table overflow");
 }
 
@@ -1098,6 +1097,6 @@ void caml_realloc_custom_table (struct caml_custom_table *tbl)
     ((struct generic_table *) tbl, sizeof (struct caml_custom_elt),
      EV_C_REQUEST_MINOR_REALLOC_CUSTOM_TABLE,
      "custom_table threshold crossed\n",
-     "Growing custom_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
+     "Growing custom_table to %" CAML_PRIdNAT "k bytes\n",
      "custom_table overflow");
 }

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -125,7 +125,7 @@ static void print_token(const struct parser_tables *tables, int state,
             state, token_name(tables->names_block, Tag_val(tok)));
     v = Field(tok, 0);
     if (Is_long(v))
-      fprintf(stderr, "%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val(v));
+      fprintf(stderr, "%" CAML_PRIdNAT, Long_val(v));
     else if (Tag_val(v) == String_tag)
       fprintf(stderr, "%s", String_val(v));
     else if (Tag_val(v) == Double_tag)

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -417,15 +417,12 @@ void* caml_mem_map(uintnat size, int reserve_only)
   void* mem = caml_plat_mem_map(size, reserve_only);
 
   if (mem == 0) {
-    CAML_GC_MESSAGE(ADDRSPACE,
-                    "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
-                    size);
+    CAML_GC_MESSAGE(ADDRSPACE, "mmap %" CAML_PRIdNAT " bytes failed", size);
     return 0;
   }
 
-  CAML_GC_MESSAGE(ADDRSPACE,
-                  "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                  " bytes at %p for heaps\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE, "mmap %" CAML_PRIdNAT " bytes at %p for heaps\n",
+                  size, mem);
 
 #ifdef DEBUG
   caml_lf_skiplist_insert(&mmap_blocks, (uintnat)mem, size);
@@ -437,9 +434,8 @@ void* caml_mem_map(uintnat size, int reserve_only)
 void* caml_mem_commit(void* mem, uintnat size)
 {
   CAMLassert(Is_page_aligned(size));
-  CAML_GC_MESSAGE(ADDRSPACE,
-                  "commit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                  " bytes at %p for heaps\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE, "commit %" CAML_PRIdNAT " bytes at %p for heaps\n",
+                  size, mem);
   return caml_plat_mem_commit(mem, size);
 }
 
@@ -447,8 +443,8 @@ void caml_mem_decommit(void* mem, uintnat size)
 {
   if (size) {
     CAML_GC_MESSAGE(ADDRSPACE,
-                    "decommit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                    " bytes at %p for heaps\n", size, mem);
+                    "decommit %" CAML_PRIdNAT " bytes at %p for heaps\n",
+                    size, mem);
     caml_plat_mem_decommit(mem, size);
   }
 }
@@ -460,9 +456,8 @@ void caml_mem_unmap(void* mem, uintnat size)
   CAMLassert(caml_lf_skiplist_find(&mmap_blocks, (uintnat)mem, &data) != 0);
   CAMLassert(data == size);
 #endif
-  CAML_GC_MESSAGE(ADDRSPACE,
-                  "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                  " bytes at %p for heaps\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE, "munmap %" CAML_PRIdNAT " bytes at %p for heaps\n",
+                  size, mem);
   caml_plat_mem_unmap(mem, size);
 #ifdef DEBUG
   caml_lf_skiplist_remove(&mmap_blocks, (uintnat)mem);

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -79,8 +79,7 @@ CAMLexport char * caml_format_exception(value exn)
       if (i > start) add_string(&buf, ", ");
       v = Field(bucket, i);
       if (Is_long(v)) {
-        snprintf(intbuf, sizeof(intbuf),
-                 "%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val(v));
+        snprintf(intbuf, sizeof(intbuf), "%" CAML_PRIdNAT, Long_val(v));
         add_string(&buf, intbuf);
       } else if (Tag_val(v) == String_tag) {
         add_char(&buf, '"');

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1434,7 +1434,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
 
 struct mem_stats {
   /* unit is words */
-  uintnat alloced;
+  uintnat allocated;
   uintnat live;
   uintnat free;
   uintnat overhead;
@@ -1470,7 +1470,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
       p += wh;
     }
     CAMLassert(end == p);
-    s->alloced += POOL_WSIZE;
+    s->allocated += POOL_WSIZE;
   }
 }
 
@@ -1478,7 +1478,7 @@ static void verify_large(large_alloc* a, struct mem_stats* s) {
   for (; a; a = a->next) {
     header_t hd = *(header_t*)((char*)a + LARGE_ALLOC_HEADER_SZ);
     CAMLassert (!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
-    s->alloced += Wsize_bsize(LARGE_ALLOC_HEADER_SZ) + Whsize_hd(hd);
+    s->allocated += Wsize_bsize(LARGE_ALLOC_HEADER_SZ) + Whsize_hd(hd);
     s->overhead += Wsize_bsize(LARGE_ALLOC_HEADER_SZ);
     s->live_blocks++;
   }
@@ -1499,25 +1499,25 @@ static void verify_swept (struct caml_heap_state* local) {
       verify_pool(p, i, &pool_stats);
     }
   }
-  caml_gc_log("Pooled memory: %" CAML_PRIuNAT " alloced, "
+  caml_gc_log("Pooled memory: %" CAML_PRIuNAT " allocated, "
               "%" CAML_PRIuNAT " free, %" CAML_PRIuNAT " fragmentation",
-              pool_stats.alloced, pool_stats.free, pool_stats.overhead);
+              pool_stats.allocated, pool_stats.free, pool_stats.overhead);
 
   verify_large(local->swept_large, &large_stats);
   CAMLassert(local->unswept_large == NULL);
-  caml_gc_log("Large memory: %" CAML_PRIuNAT " alloced, "
+  caml_gc_log("Large memory: %" CAML_PRIuNAT " allocated, "
               "%" CAML_PRIuNAT " free, %" CAML_PRIuNAT " fragmentation",
-              large_stats.alloced, large_stats.free, large_stats.overhead);
+              large_stats.allocated, large_stats.free, large_stats.overhead);
 
   /* Check stats are being computed correctly */
-  CAMLassert(local->stats.pool_words == pool_stats.alloced);
+  CAMLassert(local->stats.pool_words == pool_stats.allocated);
   CAMLassert(local->stats.pool_live_words == pool_stats.live);
   CAMLassert(local->stats.pool_live_blocks == pool_stats.live_blocks);
   CAMLassert(local->stats.pool_frag_words == pool_stats.overhead);
   CAMLassert(local->stats.pool_words -
          (local->stats.pool_live_words + local->stats.pool_frag_words)
          == pool_stats.free);
-  CAMLassert(local->stats.large_words == large_stats.alloced);
+  CAMLassert(local->stats.large_words == large_stats.allocated);
   CAMLassert(local->stats.large_blocks == large_stats.live_blocks);
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1499,18 +1499,14 @@ static void verify_swept (struct caml_heap_state* local) {
       verify_pool(p, i, &pool_stats);
     }
   }
-  caml_gc_log("Pooled memory: %" ARCH_INTNAT_PRINTF_FORMAT
-                "u alloced, %" ARCH_INTNAT_PRINTF_FORMAT
-                "u free, %" ARCH_INTNAT_PRINTF_FORMAT
-                "u fragmentation",
+  caml_gc_log("Pooled memory: %" CAML_PRIuNAT " alloced, "
+              "%" CAML_PRIuNAT " free, %" CAML_PRIuNAT " fragmentation",
               pool_stats.alloced, pool_stats.free, pool_stats.overhead);
 
   verify_large(local->swept_large, &large_stats);
   CAMLassert(local->unswept_large == NULL);
-  caml_gc_log("Large memory: %" ARCH_INTNAT_PRINTF_FORMAT
-                "u alloced, %" ARCH_INTNAT_PRINTF_FORMAT
-                "u free, %" ARCH_INTNAT_PRINTF_FORMAT
-                "u fragmentation",
+  caml_gc_log("Large memory: %" CAML_PRIuNAT " alloced, "
+              "%" CAML_PRIuNAT " free, %" CAML_PRIuNAT " fragmentation",
               large_stats.alloced, large_stats.free, large_stats.overhead);
 
   /* Check stats are being computed correctly */

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -160,33 +160,23 @@ CAMLexport void caml_do_exit(int retcode)
         top_heap_words = caml_top_heap_words(Caml_state->shared_heap);
       }
 
-      CAML_GC_MESSAGE(STATS,
-          "allocated_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat)allocated_words);
-      CAML_GC_MESSAGE(STATS,
-          "minor_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat) minwords);
-      CAML_GC_MESSAGE(STATS,
-          "promoted_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat) s.alloc_stats.promoted_words);
-      CAML_GC_MESSAGE(STATS,
-          "major_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat) majwords);
-      CAML_GC_MESSAGE(STATS,
-          "minor_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat) atomic_load(&caml_minor_collections_count));
-      CAML_GC_MESSAGE(STATS,
-          "major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          caml_major_cycles_completed);
-      CAML_GC_MESSAGE(STATS,
-          "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat)s.alloc_stats.forced_major_collections);
-      CAML_GC_MESSAGE(STATS,
-          "heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          heap_words);
-      CAML_GC_MESSAGE(STATS,
-          "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          top_heap_words);
+      CAML_GC_MESSAGE(STATS, "allocated_words: %" CAML_PRIdNAT "\n",
+                      (intnat) allocated_words);
+      CAML_GC_MESSAGE(STATS, "minor_words: %" CAML_PRIdNAT "\n",
+                      (intnat) minwords);
+      CAML_GC_MESSAGE(STATS, "promoted_words: %" CAML_PRIdNAT "\n",
+                      (intnat) s.alloc_stats.promoted_words);
+      CAML_GC_MESSAGE(STATS, "major_words: %" CAML_PRIdNAT "\n",
+                      (intnat) majwords);
+      CAML_GC_MESSAGE(STATS, "minor_collections: %" CAML_PRIdNAT "\n",
+                      (intnat) atomic_load(&caml_minor_collections_count));
+      CAML_GC_MESSAGE(STATS, "major_collections: %" CAML_PRIdNAT "\n",
+                      caml_major_cycles_completed);
+      CAML_GC_MESSAGE(STATS, "forced_major_collections: %" CAML_PRIdNAT "\n",
+                      (intnat) s.alloc_stats.forced_major_collections);
+      CAML_GC_MESSAGE(STATS, "heap_words: %" CAML_PRIdNAT "\n", heap_words);
+      CAML_GC_MESSAGE(STATS, "top_heap_words: %" CAML_PRIdNAT "\n",
+                      top_heap_words);
     }
   }
 

--- a/testsuite/tests/asmgen/mainarith.c
+++ b/testsuite/tests/asmgen/mainarith.c
@@ -20,7 +20,6 @@
 #include <string.h>
 
 #include <caml/config.h>
-#define FMT ARCH_INTNAT_PRINTF_FORMAT
 
 void caml_call_poll(void)
 {
@@ -41,15 +40,16 @@ volatile double H;
 #define INTTEST(arg,res) \
   { intnat result = (res); \
     if (arg != result) \
-      printf("Failed test \"%s == %s\" for X=%"FMT"d and Y=%"FMT"d: " \
-             "result %"FMT"d, expected %"FMT"d\n",                    \
+      printf("Failed test \"%s == %s\" for X=%" CAML_PRIdNAT " and " \
+             "Y=%" CAML_PRIdNAT ": result %" CAML_PRIdNAT ", "       \
+             "expected %" CAML_PRIdNAT "\n",                         \
              #arg, #res, X, Y, arg, result); \
   }
 #define INTFLOATTEST(arg,res) \
   { intnat result = (res); \
     if (arg != result) \
       printf("Failed test \"%s == %s\" for F=%.15g and G=%.15g: "\
-             "result %"FMT"d, expected %"FMT"d\n",               \
+             "result %" CAML_PRIdNAT ", expected %" CAML_PRIdNAT "\n", \
              #arg, #res, F, G, arg, result); \
   }
 #define FLOATTEST(arg,res) \
@@ -64,8 +64,8 @@ volatile double H;
 #define FLOATINTTEST(arg,res) \
   { double result = (res); \
     if (arg < result || arg > result) \
-      printf("Failed test \"%s == %s\" for X=%"FMT"d and Y=%"FMT"d: "\
-             "result %.15g, expected %.15g\n",                       \
+      printf("Failed test \"%s == %s\" for X=%" CAML_PRIdNAT " and " \
+             "Y=%" CAML_PRIdNAT ": result %.15g, expected %.15g\n",  \
              #arg, #res, X, Y, arg, result); \
   }
 

--- a/testsuite/tests/asmgen/mainimmed.c
+++ b/testsuite/tests/asmgen/mainimmed.c
@@ -17,12 +17,11 @@ void caml_ml_array_bound_error(void)
 
 /* One round of testing */
 
-#define FMT ARCH_INTNAT_PRINTF_FORMAT
-
 static void check(int i, intnat x, intnat result, intnat expected)
 {
   if (result != expected) {
-    printf("Test %d, argument %"FMT"d: got %"FMT"d, expected %"FMT"d\n",
+    printf("Test %d, argument %" CAML_PRIdNAT ": got %" CAML_PRIdNAT ", "
+           "expected %" CAML_PRIdNAT "\n",
            i, x, result, expected);
   }
 }

--- a/testsuite/tests/lf_skiplist/stubs.c
+++ b/testsuite/tests/lf_skiplist/stubs.c
@@ -3,7 +3,6 @@
 #include <caml/lf_skiplist.h>
 #include <caml/memory.h>
 #include <assert.h>
-#define FMT ARCH_INTNAT_PRINTF_FORMAT
 
 CAMLprim value test_skiplist_serial(value val) {
   CAMLparam0();
@@ -85,8 +84,9 @@ CAMLprim value clean_skiplist(value val) {
     int len = get_len(atomic_load(&the_list.garbage_head),the_list.head) ;
     if (v >= 0) {
       if (len != v) {
-        fprintf(stderr,"len=%d, and v=%" FMT "d differ, space leak detected\n",
-                        len,v);
+        fprintf(stderr,
+                "len=%d, and v=%" CAML_PRIdNAT " differ, space leak detected\n",
+                len,v);
       }
     }
   }
@@ -137,7 +137,7 @@ CAMLprim value insert_skiplist(value turn_val,value ndoms_val,value domain_id_va
   uintnat turn = Long_val(turn_val);
   uintnat k = calc_key(domain_id,turn) ;
   uintnat v =  calc_value(domain_id) ;
-  //  fprintf(stderr,"I: %" FMT "u -> %" FMT "u\n",k,v);
+  //  fprintf(stderr,"I: %" CAML_PRIuNAT " -> %" FMT "u\n",k,v);
   int r = caml_lf_skiplist_insert(&the_list, k, v) ;
   assert(r);
   CAMLreturn(Val_unit);

--- a/testsuite/tests/lib-unix/win-stat/fakeclock.c
+++ b/testsuite/tests/lib-unix/win-stat/fakeclock.c
@@ -13,16 +13,17 @@
 /**************************************************************************/
 
 #include <windows.h>
+#include <stdint.h>
 
 typedef union ufiletime_int64
 {
-  unsigned __int64 scalar;
+  uint64_t scalar;
   FILETIME ft;
 } filetime_int64;
 
 static filetime_int64 clk;
 static DWORD wall = 0;
-static unsigned __int64 bias = 0LL;
+static uint64_t bias = 0ULL;
 
 BOOL WINAPI FakeConvert(const FILETIME* lpFileTime, LPFILETIME lpLocalFileTime)
 {


### PR DESCRIPTION
This PR attempts to modernize a small part of the code base by switching to C99 fixed-width integer types for defining OCaml integers. They are defined in the [`stdint.h`](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/stdint.h.html) header. Then, the PR switches to using format macros from [`inttypes.h`](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/inttypes.h.html).

A notable change is that `intnat`/`uintnat` are now defined in terms of `intptr_t`/`uintptr_t`.

The original `ARCH_INTNAT_PRINTF_FORMAT` macro only included a length modifier without a conversion specifier, contrary to C99 macros which includes both. For consistency with the standard, I've introduced the `CAML_PRI.NAT` and `CAML_PRI.SZT` family of macros, aiming to replace the `ARCH_.*_PRINTF_FORMAT` macros.

```diff
-printf("%" ARCH_INTNAT_PRINTF_FORMAT "d", an_intnat_value);
+printf("%" CAML_PRIdNAT, an_intnat_value);
```