### PR TITLE
add Char.is_digit

### DIFF
--- a/Changes
+++ b/Changes
@@ -84,6 +84,9 @@ Working version
   (Christophe Raffalli, review by Nicolás Ojeda Bär and Gabriel Scherer and
    Hugo Heuzard)
 
+- #136567: Add `Char.is_digit`.
+  (Léo Andrès, review by ?)
+
 ### Other libraries:
 
 - #13429: add `Unix.sigwait`, a binding to the `sigwait` system call;

--- a/stdlib/char.ml
+++ b/stdlib/char.ml
@@ -59,6 +59,10 @@ type t = char
 let compare c1 c2 = code c1 - code c2
 let equal (c1: t) (c2: t) = compare c1 c2 = 0
 
+let is_digit = function
+  | '0' .. '9' -> true
+  | _c -> false
+
 external seeded_hash_param :
   int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -67,6 +67,11 @@ val hash : t -> int
 
     @since 5.1 *)
 
+val is_digit: t -> bool
+  (** Check if a character belongs to the set [{'0'..'9'}].
+
+      @since 5.4 *)
+
 (**/**)
 
 (* The following is for system use only. Do not call directly. *)

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -24,6 +24,7 @@ module C' :
     val compare : t -> t -> int
     val equal : t -> t -> bool
     val seeded_hash : int -> t -> int
+    val is_digit : t -> bool
     val hash : t -> int
     external unsafe_chr : int -> char = "%identity"
   end
@@ -39,6 +40,7 @@ module C3 :
     val compare : t -> t -> int
     val equal : t -> t -> bool
     val seeded_hash : int -> t -> int
+    val is_digit : t -> bool
     val hash : t -> int
     external unsafe_chr : int -> char = "%identity"
   end
@@ -69,6 +71,7 @@ module F :
       val equal : t -> t -> bool
       val seeded_hash : int -> t -> int
       val hash : t -> int
+      val is_digit : t -> bool
       external unsafe_chr : int -> char = "%identity"
     end
 module C4 :
@@ -83,6 +86,7 @@ module C4 :
     val equal : t -> t -> bool
     val seeded_hash : int -> t -> int
     val hash : t -> int
+    val is_digit : t -> bool
     external unsafe_chr : int -> char = "%identity"
   end
 - : char = 'B'


### PR DESCRIPTION
It is easy to define but it's convenient to be able to use it directly. Plus it is [quite often](https://sherlocode.com/?q=let+is_digit) redefined.