### PR TITLE
runtime: help gcc static analyzer by widening a test

### DIFF
--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -214,7 +214,7 @@ static char * read_section(int fd, struct exec_trailer *trail,
   char * data;
 
   len = caml_seek_optional_section(fd, trail, name);
-  if (len == -1) return NULL;
+  if (len < 0) return NULL; // (len == -1) widened to (len < 0) to help gcc
   data = caml_stat_alloc(len + 1);
   if (read(fd, data, len) != len)
     caml_fatal_error("error reading section %s", name);


### PR DESCRIPTION
This is a follow-up of https://github.com/ocaml/ocaml/pull/13537 which proposes to help GCC analyse by widening a test for a error condition rather than trying to keep track which versions of gcc can correctly analyze the runtime code. 

In particular, this restores the compiler build on the ubuntu 24.10 version of gcc 14.2 . 


cc @MisterDA 