### PR TITLE
Add eager bool functions: Bool.(logand, logor, logxor).

### DIFF
--- a/Changes
+++ b/Changes
@@ -76,6 +76,9 @@ Working version
 
 ### Standard library:
 
+- ?: Add eager boolean operations logand, logor, logxor
+  (Jeremy Yallop, review by ?)
+
 - #13463, #13572: Avoid Queue.empty to be raised by Format when used
   concurrently. prefer undefined behavior to uncaught exception.
   (Chritophe Raffalli, review by Gabriel Scherer and Daniel Bünzli)

--- a/Changes
+++ b/Changes
@@ -76,8 +76,8 @@ Working version
 
 ### Standard library:
 
-- ?: Add eager boolean operations logand, logor, logxor
-  (Jeremy Yallop, review by ?)
+- #13662: Add eager boolean operations Bool.logand, Bool.logor, Bool.logxor
+  (Jeremy Yallop, review by Nicolás Ojeda Bär)
 
 - #13463, #13572: Avoid Queue.empty to be raised by Format when used
   concurrently. prefer undefined behavior to uncaught exception.

--- a/stdlib/bool.ml
+++ b/stdlib/bool.ml
@@ -18,6 +18,9 @@ type t = bool = false | true
 external not : bool -> bool = "%boolnot"
 external ( && ) : bool -> bool -> bool = "%sequand"
 external ( || ) : bool -> bool -> bool = "%sequor"
+external logand : bool -> bool -> bool = "%andint"
+external logor : bool -> bool -> bool = "%orint"
+external logxor : bool -> bool -> bool = "%xorint"
 let equal : bool -> bool -> bool = ( = )
 let compare : bool -> bool -> int = Stdlib.compare
 external to_int : bool -> int = "%identity"

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -39,6 +39,18 @@ external ( || ) : bool -> bool -> bool = "%sequor"
     If [e0] evaluates to [true], [e1] is not evaluated. Right-associative
     operator at precedence level 2/11. *)
 
+val logand : bool -> bool -> bool
+(** [logand e1 e2] is the eager boolean conjunction of expressions [e1] and
+    [e2]. *)
+
+val logor : bool -> bool -> bool
+(** [logor e1 e2] is the eager boolean disjunction of expressions [e1] and
+    [e2]. *)
+
+val logxor : bool -> bool -> bool
+(** [logxor e1 e2] is the eager boolean exclusive disjunction of
+    expressions [e1] and [e2]. *)
+
 (** {1:preds Predicates and comparisons} *)
 
 val equal : bool -> bool -> bool

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -40,16 +40,13 @@ external ( || ) : bool -> bool -> bool = "%sequor"
     operator at precedence level 2/11. *)
 
 val logand : bool -> bool -> bool
-(** [logand e1 e2] is the eager boolean conjunction of expressions [e1] and
-    [e2]. *)
+(** [logand b1 b2] is [true] if and only if [b1] and [b2] are both [true]. *)
 
 val logor : bool -> bool -> bool
-(** [logor e1 e2] is the eager boolean disjunction of expressions [e1] and
-    [e2]. *)
+(** [logor b1 b2] is [true] if and only if either [b1] or [b2] is [true]. *)
 
 val logxor : bool -> bool -> bool
-(** [logxor e1 e2] is the eager boolean exclusive disjunction of
-    expressions [e1] and [e2]. *)
+(** [logxor b1 b2] is [true] if exactly one of [b1] and [b2] is [true]. *)
 
 (** {1:preds Predicates and comparisons} *)
 

--- a/testsuite/tests/lib-bool/test.ml
+++ b/testsuite/tests/lib-bool/test.ml
@@ -17,6 +17,18 @@ let test_and () =
   assert (!wit = 2); wit := 0;
   ()
 
+let test_eager_and () =
+  let wit = ref 0 in
+  assert (Bool.logand (incr wit; false) (incr wit; false) = false);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logand (incr wit; false) (incr wit; true) = false);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logand (incr wit; true) (incr wit; false) = false);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logand (incr wit; true) (incr wit; true) = true);
+  assert (!wit = 2); wit := 0;
+  ()
+
 let test_or () =
   let wit = ref 0 in
   assert (Bool.( || ) (incr wit; false) (incr wit; false) = false);
@@ -27,6 +39,30 @@ let test_or () =
   assert (!wit = 1); wit := 0;
   assert (Bool.( || ) (incr wit; true) (incr wit; true) = true);
   assert (!wit = 1); wit := 0;
+  ()
+
+let test_eager_or () =
+  let wit = ref 0 in
+  assert (Bool.logor (incr wit; false) (incr wit; false) = false);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logor (incr wit; false) (incr wit; true) = true);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logor (incr wit; true) (incr wit; false) = true);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logor (incr wit; true) (incr wit; true) = true);
+  assert (!wit = 2); wit := 0;
+  ()
+
+let test_eager_xor () =
+  let wit = ref 0 in
+  assert (Bool.logxor (incr wit; false) (incr wit; false) = false);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logxor (incr wit; false) (incr wit; true) = true);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logxor (incr wit; true) (incr wit; false) = true);
+  assert (!wit = 2); wit := 0;
+  assert (Bool.logxor (incr wit; true) (incr wit; true) = false);
+  assert (!wit = 2); wit := 0;
   ()
 
 let test_equal () =
@@ -79,7 +115,10 @@ let test_hash () =
 let tests () =
   test_not ();
   test_and ();
+  test_eager_and ();
   test_or ();
+  test_eager_or ();
+  test_eager_xor ();
   test_equal ();
   test_compare ();
   test_to_int ();


### PR DESCRIPTION
### Motivation

This PR is based on a request from Oleg Kiselyov, who mentioned recently that it would be useful to have eager logical boolean operations as well as the short-circuiting (lazy) versions.  The lazy versions generate code with conditional jumps that might sometimes be slower than a sequence of bitwise operations.

### Implementation

Branchless implementations of the operators are easy, since we can just reuse the existing primitives for int:

```ocaml
external logand : bool -> bool -> bool = "%andint"
external logor : bool -> bool -> bool = "%orint"
external logxor : bool -> bool -> bool = "%xorint"
```

### Benchmarking

The eager operators are sometimes faster than the lazy operators.  [Here's](https://gist.github.com/yallop/ee2c75a54204ba6670598b33d15ba310) a benchmark that tests eager and lazy versions of [`Uchar.is_valid`](https://github.com/ocaml/ocaml/blob/d90601c59028f8045bb26d37f546070f5a212549/stdlib/uchar.ml#L43) on an array of integers, half of which are valid.  On my system, with OCaml 5.2.0, the results are as follows:

| Name       | Time/run | Percentage |
|------------|----------|------------|
| loop_lazy  | 67.46us  | 100.00%    |
| loop_eager | 41.88us  | 62.08%     |

### Other implementations

There's an implementation in Base ([here](https://github.com/janestreet/base/blob/de1f1123/src/bool.ml#L75-L81)) and an unoptimized implementation in Batteries with funny names (`logand` is called [`mul`](https://github.com/ocaml-batteries-team/batteries-included/blob/00c591ea/src/batBool.ml#L45) and `logor` is called [`add`](https://github.com/ocaml-batteries-team/batteries-included/blob/00c591ea/src/batBool.ml#L44)).

