### PR TITLE
Update GitHub CI Ubuntu from 22.04 to 24.04.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 # We then upload the compiler tree as a build artifact to enable re-use in
 # subsequent jobs.
   build:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
     outputs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
@@ -81,13 +81,13 @@ jobs:
   normal:
     name: ${{ matrix.name }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
           - id: normal
             name: normal
-            dependencies: texlive-latex-extra texlive-fonts-recommended hevea sass gdb lldb python3-lldb-14
+            dependencies: texlive-latex-extra texlive-fonts-recommended hevea sass gdb lldb
           - id: debug
             name: extra (debug)
           - id: debug-s4096
@@ -105,8 +105,6 @@ jobs:
         if: matrix.dependencies != ''
         run: |
           sudo apt-get update -y && sudo apt-get install -y ${{ matrix.dependencies }}
-          # Work around lldb on Ubuntu 22.04 issue https://github.com/llvm/llvm-project/issues/55575
-          sudo  ln -s /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb/* /usr/lib/python3/dist-packages/lldb/
       - name: Run the testsuite
         if: matrix.id == 'normal'
         run: |
@@ -152,7 +150,7 @@ jobs:
       matrix:
         include:
           - name: linux-O0
-            os: ubuntu-latest
+            os: ubuntu-24.04
             config_arg: CFLAGS='-O0'
           - name: macos-x86_64
             os: macos-13
@@ -209,7 +207,7 @@ jobs:
           done
 
   i386:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: debian:12
       options: --platform linux/i386 --user root

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       matrix:
         include:
           - name: linux-O0
-            os: ubuntu-24.04
+            os: ubuntu-latest
             config_arg: CFLAGS='-O0'
           - name: macos-x86_64
             os: macos-13
@@ -207,7 +207,7 @@ jobs:
           done
 
   i386:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
       image: debian:12
       options: --platform linux/i386 --user root

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -13,10 +13,10 @@ Breakpoint created for regex camlMeander\$c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
+Process XXXX launched: 'XXXX' ($ARCH)
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
-Process XXXX launched: 'XXXX' ($ARCH)
 (lldb) backtrace
 frame 0: meander`caml_start_program
 frame 1: meander`caml_startup_common
@@ -75,7 +75,6 @@ frame 12: libc.so.6`__libc_start_call_main
 frame 13: libc.so.6`__libc_start_main_impl
 frame 14: meander`_start
 (lldb) continue
-This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 3.1
@@ -89,6 +88,7 @@ Process XXXX stopped
    7   	          "c_to_ocaml" c_to_ocaml
    8   	let omain () =
 (lldb) backtrace
+This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
 frame 0: meander`camlMeander$c_to_ocaml
 frame 1: meander`caml_start_program
 frame 2: meander`caml_callback_exn

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -13,10 +13,10 @@ Breakpoint created for regex camlMeander\$c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
+Process XXXX launched: 'XXXX' ($ARCH)
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
-Process XXXX launched: 'XXXX' ($ARCH)
 (lldb) backtrace
 frame 0: meander`caml_start_program
 frame 1: meander`caml_startup_common
@@ -75,6 +75,7 @@ frame 12: libc.so.6`__libc_start_call_main
 frame 13: libc.so.6`__libc_start_main_impl
 frame 14: meander`_start
 (lldb) continue
+
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 3.1
@@ -88,7 +89,6 @@ Process XXXX stopped
    7   	          "c_to_ocaml" c_to_ocaml
    8   	let omain () =
 (lldb) backtrace
-
 frame 0: meander`camlMeander$c_to_ocaml
 frame 1: meander`caml_start_program
 frame 2: meander`caml_callback_exn

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -13,10 +13,10 @@ Breakpoint created for regex camlMeander\$c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
-Process XXXX launched: 'XXXX' ($ARCH)
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
+Process XXXX launched: 'XXXX' ($ARCH)
 (lldb) backtrace
 frame 0: meander`caml_start_program
 frame 1: meander`caml_startup_common
@@ -88,7 +88,7 @@ Process XXXX stopped
    7   	          "c_to_ocaml" c_to_ocaml
    8   	let omain () =
 (lldb) backtrace
-This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
+
 frame 0: meander`camlMeander$c_to_ocaml
 frame 1: meander`caml_start_program
 frame 2: meander`caml_callback_exn

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -43,9 +43,8 @@
     # Work around inconsistent name mangling
     gsub(/c_to_ocaml_[0-9]+/, "c_to_ocaml")
 
-    gsub("This version of LLDB has no plugin for the language \"assembler\". Inspection of frame variables will be limited.", "")
-
     gsub("warning: This version of LLDB", "This version of LLDB")
+    gsub("This version of LLDB has no plugin for the language \"assembler\". Inspection of frame variables will be limited.", "")
     # Replace printed match results
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
     print $0

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -43,6 +43,8 @@
     # Work around inconsistent name mangling
     gsub(/c_to_ocaml_[0-9]+/, "c_to_ocaml")
 
+    gsub("This version of LLDB has no plugin for the language \"assembler\". Inspection of frame variables will be limited.", "")
+
     gsub("warning: This version of LLDB", "This version of LLDB")
     # Replace printed match results
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")


### PR DESCRIPTION
There's two parts to consider in this change. The first is that we should explicitly ask for Ubuntu 24.04 in CI, since GH is updating runners and which version of Ubuntu we get might change without warning. 

The second part is better sanitisation of the LLDB output on Linux, which needs more consideration and probably re-writing to use Python API rather than running commands as the CLI. Using the Python API should allow better control over what gets  printed out.