### PR TITLE
Improve `regular_nested` example for “Polymorphism” chapter of the manual

### DIFF
--- a/Changes
+++ b/Changes
@@ -124,6 +124,12 @@ Working version
    review by Florian Angeletti, Anil Madhavapeddy, Gabriel Scherer,
    and Miod Vallat)
 
+- #13666: Rewrite parts of the example code around nested lists in Chapter 6
+  (Polymorphism and its limitations -> Polymorphic recursion) giving the
+  "depth" function [in the non-polymorphically-recursive part of the example]
+  a much more sensible behavior; also fix a typo and some formatting.
+  (Frank Steffahn, review by Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #13428: support dump=[source | parsetree | lambda | ... | cmm | ...]

--- a/manual/src/tutorials/polymorphism.etex
+++ b/manual/src/tutorials/polymorphism.etex
@@ -280,18 +280,17 @@ With a regular polymorphic algebraic data type, the type parameters of
 the type constructor are constant within the definition of the type. For
 instance, we can look at arbitrarily nested list defined as:
 \begin{caml_example}{toplevel}
-  type 'a regular_nested = List of 'a list | Nested of 'a regular_nested list
-  let l = Nested[ List [1]; Nested [List[2;3]]; Nested[Nested[]] ];;
+type 'a regular_nested = List of 'a list | Nested of 'a regular_nested list;;
+let l = Nested[ List [1]; Nested [List[2;3]]; Nested[Nested[]] ];;
 \end{caml_example}
 Note that the type constructor "regular_nested" always appears as
 "'a regular_nested" in the definition above, with the same parameter
-"'a". Equipped with this type, one can compute a maximal depth with
+"'a". Equipped with this type, one can compute a depth with
 a classic recursive function
 \begin{caml_example}{toplevel}
-  let rec maximal_depth = function
+let rec regular_depth = function
   | List _ -> 1
-  | Nested [] -> 0
-  | Nested (a::q) -> 1 + max (maximal_depth a) (maximal_depth (Nested q));;
+  | Nested n -> 1 + List.fold_left max 1 (List.map regular_depth n);;
 \end{caml_example}
 
 Non-regular recursive algebraic data types correspond to polymorphic algebraic
@@ -299,11 +298,11 @@ data types whose parameter types vary between the left and right side of
 the type definition. For instance, it might be interesting to define a datatype
 that ensures that all lists are nested at the same depth:
 \begin{caml_example}{toplevel}
-  type 'a nested = List of 'a list | Nested of 'a list nested;;
+type 'a nested = List of 'a list | Nested of 'a list nested;;
 \end{caml_example}
 Intuitively, a value of type "'a nested" is a list of list \dots of list of
-elements "a" with "k" nested list. We can then adapt the "maximal_depth"
-function defined on "regular_depth" into a "depth" function that computes this
+elements "a" with "k" nested list. We can then adapt the "regular_depth"
+function defined on "regular_nested" into a "depth" function that computes this
 "k". As a first try, we may define
 \begin{caml_example}{toplevel}[error]
 let rec depth = function
@@ -350,13 +349,13 @@ Second, it also notifies the type checker that the type of the function should
 be polymorphic. Indeed, without explicit polymorphic type annotation, the
 following type annotation is perfectly valid
 \begin{caml_example}{toplevel}
-  let sum: 'a -> 'b -> 'c = fun x y -> x + y;;
+let sum: 'a -> 'b -> 'c = fun x y -> x + y;;
 \end{caml_example}
 since "'a","'b" and "'c" denote type variables that may or may not be
 polymorphic. Whereas, it is an error to unify an explicitly polymorphic type
 with a non-polymorphic type:
 \begin{caml_example}{toplevel}[error]
-  let sum: 'a 'b 'c. 'a -> 'b -> 'c = fun x y -> x + y;;
+let sum: 'a 'b 'c. 'a -> 'b -> 'c = fun x y -> x + y;;
 \end{caml_example}
 
 An important remark here is that it is not needed to explicit fully


### PR DESCRIPTION
Previously, the example dept function for `regular_nested` was clearly buggy. In particular the expression
```
1 + max (maximal_depth a) (maximal_depth (Nested q))
```
was adding `1` to the `maximal_depth (Nested q)` side, too, resulting in unbalanced depth calculation (later list elements get increasingly larger “depth”)

The minimal fix would have been
```
max (1 + maximal_depth a) (maximal_depth (Nested q))
```
but then I still find the `Nested [] -> 0` case confusing. Adding a `List []` element to produce `Nested [List []]` makes the depth jump by `2`!?

I could just re-define this as `Nested [] -> 1`, but I believe that a mutually recursive definition is even easier to understand.

In particular, now the new
```
let rec regular_depth = function
  | List _ -> 1
  | Nested n -> 1 + max_regular_depth n
and …;;
```
is structurally (at least superficially) very similar to
```
let rec depth = function
  | List _ -> 1
  | Nested n -> 1 + depth n;;
```
which helps readers focus less on wondering if the latter really is just the result of directly “adapting” the former.

The naming is also changed to keep more consistent: now it is `regular_nested` with `regular_depth
and then `nested` with `depth`

Finally, there also was a clear type; the original text had one instance where it misspelled “`regular_nested`” as “`regular_depth`” in line 306 (now 308).

(This PR also includes a few instances of bad-looking extra indentation removed, and the definition of `type 'a regular_nested` is not separated via `;;` from the example `let l = ...` which should help improve readability)