### PR TITLE
manual: document support for latin-9 identifier.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         include:
           - id: normal
             name: normal
-            dependencies: texlive-latex-extra texlive-fonts-recommended hevea sass gdb lldb
+            dependencies: texlive-latex-extra texlive-fonts-recommended texlive-luatex hevea sass gdb lldb
           - id: debug
             name: extra (debug)
           - id: debug-s4096

--- a/Changes
+++ b/Changes
@@ -586,9 +586,9 @@ ___________
   a much more sensible behavior; also fix a typo and some formatting.
   (Frank Steffahn, review by Florian Angeletti)
 
-- #????: Document the basic support for unicode identifiers and the switch to
-   utf-8 encoded unicode text for OCaml source file
-  (Florian Angeletti, review by ???)
+- #13668: Document the basic support for unicode identifiers and the switch to
+   UTF-8 encoded Unicode text for OCaml source file
+  (Florian Angeletti, review by Daniel Bünzli)
 
 ### Compiler user-interface and warnings:
 

--- a/Changes
+++ b/Changes
@@ -588,7 +588,7 @@ ___________
 
 - #13668: Document the basic support for unicode identifiers and the switch to
    UTF-8 encoded Unicode text for OCaml source file
-  (Florian Angeletti, review by Daniel Bünzli)
+  (Florian Angeletti, review by Nicolás Ojeda Bär and Daniel Bünzli)
 
 ### Compiler user-interface and warnings:
 

--- a/Changes
+++ b/Changes
@@ -586,6 +586,10 @@ ___________
   a much more sensible behavior; also fix a typo and some formatting.
   (Frank Steffahn, review by Florian Angeletti)
 
+- #????: Document the basic support for unicode identifiers and the switch to
+   utf-8 encoded unicode text for OCaml source file
+  (Florian Angeletti, review by ???)
+
 ### Compiler user-interface and warnings:
 
 * #12084, #13669, #13673: Check link order when creating archive and when using

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -56,7 +56,7 @@ $(DIRS):
 
 pdf: files latex_files | texstuff
 	cd texstuff \
-	  && TEXINPUTS=$(TEXINPUTS) pdflatex manual.tex
+	  && TEXINPUTS=$(TEXINPUTS) lualatex manual.tex
 
 index: | texstuff
 	cd texstuff \

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -1,13 +1,8 @@
 \documentclass[11pt]{book}
-\usepackage{lmodern}% for T1 encoding and support of bold ttfamily
 
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
+% HEVEA\usepackage[utf8]{inputenc}
 \usepackage{microtype}
-% HEVEA\@def@charset{UTF-8}%
-% Unicode character declarations
-\DeclareUnicodeCharacter{207A}{{}^{+}}
-\DeclareUnicodeCharacter{2014}{---}
+\usepackage{fontspec}
 
 \usepackage{fullpage}
 \usepackage{syntaxdef}

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -41,18 +41,21 @@ lowercase-ident:
    (lowercase-letter || "_") { letter || "0"\ldots"9" || "_" || "'" } ;
 letter: uppercase-letter || lowercase-letter ;
 lowercase-letter:
-"a"\ldots"z" || "š" || "ž" || "œ" || "ß" \ldots "ö" || "ø" \dots "ÿ" ;
+"a"\ldots"z"  || 'U+00DF' \ldots 'U+00F6' || 'U+00F8' \dots 'U+00FF' || 'U+0153' || 'U+0161' || 'U+017E'  ;
 uppercase-letter:
-  "A"\ldots"Z" || "Š" || "Ž" || "Œ" || "Ÿ" || "À" \ldots "Ö" || "Ø" \ldots "Þ" || "ẞ"
+  "A"\ldots"Z" || 'U+00C0' \ldots 'U+00D6' || 'U+00D8' \ldots 'U+00DE' \\
+  || 'U+0152' || 'U+0160' || 'U+017D' || 'U+0178' || 'U+1E9E'
  ;
 \end{syntax}
 
 Identifiers are sequences of letters, digits, "_" (the underscore
 character), and "'" (the single quote), starting with a
 letter or an underscore.
-Letters contain at least the 52 lowercase and uppercase
-letters from the ASCII set, and the 70 lowercase and uppercase letters
-from the ISO 8859-15 character set extended with uppercase ẞ.
+Letters contain the 52 lowercase and uppercase letters from the ASCII set,
+letters from the Latin-1 Supplement block ("U+0080" to "U+00FF"), letters
+"ŠšŽžŒœŸ" from the Latin Extended-A block ("U+0100" to "U+017F") and upper case
+ẞ ("U+189E"). Any byte sequence which is equivalent to a supported Unicode
+character under NFC (Normalization Form C) is supported too.
 
 All characters in an identifier are
 meaningful. The current implementation accepts identifiers up to

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -54,10 +54,11 @@ Identifiers are sequences of letters, digits, "_" (the underscore
 character), and "'" (the single quote), starting with a
 letter or an underscore.
 Letters contain the 52 lowercase and uppercase letters from the ASCII set,
-letters from the Latin-1 Supplement block ("U+0080" to "U+00FF"), letters
-"ŠšŽžŒœŸ" from the Latin Extended-A block ("U+0100" to "U+017F") and upper case
-ẞ ("U+189E"). Any byte sequence which is equivalent to a supported Unicode
-character under NFC (Normalization Form C) is supported too.
+letters "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ" from
+the Latin-1 Supplement block, letters "ŠšŽžŒœŸ" from the Latin Extended-A block
+and upper case ẞ ("U+189E"). Any byte sequence which is equivalent to one of
+these Unicode characters under NFC\footnote{Normalization Form C} is supported
+too.
 
 All characters in an identifier are
 meaningful. The current implementation accepts identifiers up to

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -1,5 +1,10 @@
 \section{s:lexical-conventions}{Lexical conventions}
 %HEVEA\cutname{lex.html}
+
+\subsubsection*{sss:lex:text-encoding}{Source file encoding}
+
+OCaml source files are expected to be valid UTF-8 encoded unicode text.
+
 \subsubsection*{sss:lex:blanks}{Blanks}
 
 The following characters are considered as blanks: space,
@@ -31,21 +36,23 @@ let f = function
 
 \begin{syntax}
 ident: (letter || "_") { letter || "0"\ldots"9" || "_" || "'" } ;
-capitalized-ident: ("A"\ldots"Z") { letter || "0"\ldots"9" || "_" || "'" } ;
+capitalized-ident: uppercase-letter { letter || "0"\ldots"9" || "_" || "'" } ;
 lowercase-ident:
-   ("a"\ldots"z" || "_") { letter || "0"\ldots"9" || "_" || "'" } ;
-letter: "A"\ldots"Z" || "a"\ldots"z"
+   (lowercase-letter || "_") { letter || "0"\ldots"9" || "_" || "'" } ;
+letter: uppercase-letter || lowercase-letter ;
+lowercase-letter:
+"a"\ldots"z" || "š" || "ž" || "œ" || "ß" \ldots "ö" || "ø" \dots "ÿ" ;
+uppercase-letter:
+  "A"\ldots"Z" || "Š" || "Ž" || "Œ" || "Ÿ" || "À" \ldots "Ö" || "Ø" \ldots "Þ" || "ẞ"
+ ;
 \end{syntax}
 
 Identifiers are sequences of letters, digits, "_" (the underscore
 character), and "'" (the single quote), starting with a
 letter or an underscore.
 Letters contain at least the 52 lowercase and uppercase
-letters from the ASCII set. The current implementation
-also recognizes as letters some characters from the ISO
-8859-1 set (characters 192--214 and 216--222 as uppercase letters;
-characters 223--246 and 248--255 as lowercase letters). This
-feature is deprecated and should be avoided for future compatibility.
+letters from the ASCII set, and the 70 lowercase and uppercase letters
+from the ISO 8859-15 character set extended with uppercase ẞ.
 
 All characters in an identifier are
 meaningful. The current implementation accepts identifiers up to
@@ -186,7 +193,7 @@ string-literal:
        |  '{' quoted-string-id '|' { newline | any-char } '|' quoted-string-id '}'
 ;
 quoted-string-id:
-     { 'a'...'z' || '_' }
+     { lowercase-letter || '_' }
 ;
 string-character:
           regular-string-char

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -3,7 +3,7 @@
 
 \subsubsection*{sss:lex:text-encoding}{Source file encoding}
 
-OCaml source files are expected to be valid UTF-8 encoded unicode text.
+OCaml source files are expected to be valid UTF-8 encoded Unicode text.
 
 \subsubsection*{sss:lex:blanks}{Blanks}
 

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -4,6 +4,8 @@
 \subsubsection*{sss:lex:text-encoding}{Source file encoding}
 
 OCaml source files are expected to be valid UTF-8 encoded Unicode text.
+The interpretation of source files which are not UTF-8 encoded is unspecified.
+Such source files may be rejected in the future.
 
 \subsubsection*{sss:lex:blanks}{Blanks}
 

--- a/manual/tools/transf.mll
+++ b/manual/tools/transf.mll
@@ -6,7 +6,7 @@
   match c with
   | '\'' -> printf "{\\textquotesingle}"
   | '`' -> printf "{\\textasciigrave}"
-  | _ -> printf "\\char%d" (int_of_char c);
+  | _ -> printf "{\\char%d}" (int_of_char c);
   ;;
 }
 

--- a/manual/tools/transf.mll
+++ b/manual/tools/transf.mll
@@ -83,6 +83,10 @@ and inquote = parse
   | '\'' {
       print_string "}";
       syntax lexbuf }
+  | ['\128' - '\255'] {
+      print_char (lexeme_char lexbuf 0);
+      inquote lexbuf
+    }
   | _ {
       print_char_repr (lexeme_char lexbuf 0);
       inquote lexbuf }
@@ -94,6 +98,10 @@ and indoublequote = parse
   | '"' {
       print_string "}";
       syntax lexbuf }
+  | ['\128' - '\255'] {
+      print_char (lexeme_char lexbuf 0);
+      indoublequote lexbuf
+    }
   | _ {
       print_char_repr (lexeme_char lexbuf 0);
       indoublequote lexbuf }


### PR DESCRIPTION
This PR document the new lexical convention for identifiers with the addition of support for the latin-9 character subset of unicode. It also adds a brief comment that OCaml source files are now expected to be valid UTF-8 encoded unicode text.

The first two commit of this PR implements a few prerequisite:
- The first commit switches the latex driver to lualatex for better support of unicode characters (and better font support in general).
- The second commit improve the support of unicode character in the grammar definition pseudo-environment by not escaping unicode characters beyond the ascii range.