### PR TITLE
AppVeyor: only call Cygwin setup once when upgrading is forced

### DIFF
--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -61,11 +61,12 @@ if %ERRORLEVEL% equ 1 (
 goto :EOF
 
 :UpgradeCygwin
+set CYGWIN_FLAGS=
 if %CYGWIN_UPGRADE_REQUIRED% equ 1 (
-  set CYGWIN_FLAGS=--upgrade-also
-  set CYGWIN_UPGRADE_REQUIRED=0
-) else (
-  set CYGWIN_FLAGS=
+  if "%CYGWIN_INSTALL_PACKAGES%" neq "" (
+    set CYGWIN_FLAGS=--upgrade-also
+    set CYGWIN_UPGRADE_REQUIRED=0
+  )
 )
 if "%CYGWIN_INSTALL_PACKAGES%" neq "" "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" %CYGWIN_FLAGS% --packages %CYGWIN_INSTALL_PACKAGES:~1%
 for %%P in (%CYGWIN_COMMANDS%) do "%CYG_ROOT%\bin\%%P.exe" --version 2> nul > nul || set CYGWIN_UPGRADE_REQUIRED=1


### PR DESCRIPTION
The Cygwin installation in AppVeyor isn't very frequently updated. Most of the that doesn't matter, but we have this setting in appveyor.yml which can be changed to `1` to allow it to be forced when necessary:
https://github.com/ocaml/ocaml/blob/e2b1636f59fd57c0378d551715f9d377477346fc/appveyor.yml#L37

Earlier in the year while debugging a Cygwin problem, I needed to use this setting while also changing the packages which get installed - the logic in the batch file causes Cygwin's setup to be run twice: the first time to install requested packages, and then second time to upgrade the installation.

There's no need to run it twice - it's possible to pass `--upgrade-also` to the first invocation, which is what this tweak does.