### PR TITLE
Avoid register stall on conversion instructions on amd64

### DIFF
--- a/Changes
+++ b/Changes
@@ -74,6 +74,10 @@ Working version
   (Gabriel Scherer and Clément Allain, review by Vincent Laviron,
    report by Vesa Karvonen)
 
+- #13672 Avoid register stall on conversion instructions on amd64.
+  (Pierre Chambart, review by Gabriel Scherer and Xavier Leroy,
+   report by Patrick Nicodemus)
+
 ### Standard library:
 
 - #13463, #13572: Avoid Queue.empty to be raised by Format when used

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -583,6 +583,7 @@ let emit_instr env fallthrough i =
       | Thirtytwo_signed ->
           I.movsxd (addressing addressing_mode DWORD i 0) dest
       | Single ->
+          I.xorpd dest dest; (* avoid partial register stall *)
           I.cvtss2sd (addressing addressing_mode REAL4 i 0) dest
       | Double ->
           I.movsd (addressing addressing_mode REAL8 i 0) dest
@@ -703,6 +704,7 @@ let emit_instr env fallthrough i =
   | Lop(Iaddf | Isubf | Imulf | Idivf as floatop) ->
       instr_for_floatop floatop (arg i 1) (res i 0)
   | Lop(Ifloatofint) ->
+      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
       I.cvtsi2sd  (arg i 0)  (res i 0)
   | Lop(Iintoffloat) ->
       I.cvttsd2si (arg i 0) (res i 0)


### PR DESCRIPTION
The conversion instructions only set the low bits of the xmm registers and that can create partial register stall. 

This was actually noticed on flambda2, but it applies exactly the same way on upstream OCaml: https://github.com/ocaml-flambda/flambda-backend/issues/3293
In a small loop where conversion from int and division occur, this led to a x7 speedup. Note that recent AMD processors seems to be less affected than Intel ones.

```OCaml
let loop n =
  let acc = ref 0. in
  let k = ref n in
  while !k != 0 do
    let a = float_of_int !k in
    let b = !acc +. 1./. (a *. a) in
    acc := 0. +. b;
    k := !k - 1
  done;
  !acc

let () =
  for i = 0 to 10000 do
    let _ = (loop[@inlined never]) 100_000 in
    ()
  done
```

```asm
.L101:
	cmpq	$1, %rax
	je	.L100
	movq	%rax, %rbx
	sarq	$1, %rbx
	xorpd	%xmm1, %xmm1 ;; The new xor instruction
	cvtsi2sdq	%rbx, %xmm1 ;; The result is xmm1
	mulsd	%xmm1, %xmm1
	movsd	.L103(%rip), %xmm2
	divsd	%xmm1, %xmm2
	movapd	%xmm0, %xmm1
	addsd	%xmm2, %xmm1 ;; xmm1 is set here
	xorpd	%xmm0, %xmm0
	addsd	%xmm1, %xmm0
	addq	$-2, %rax
	cmpq	(%r14), %r15
	ja	.L101
	jmp	.L104
```

There are a few random operations in the source program to ensure that the register for the conversion gets assigned to something that depends on the result of the division. This example is very fragile.

There was another similar PR for the sqrt instruction https://github.com/ocaml/ocaml/pull/9041. Sadly sqrt was not the only instruction that we use that get affected by this problem. But right now I don't know of any other.