### PR TITLE
Fix build of the compiler with `--disable-shared`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) $(STDLIBFLAGS) -I otherlibs/dynlink
 ARCHES=amd64 arm64 power s390x riscv
 VPATH = utils parsing typing bytecomp file_formats lambda middle_end \
   middle_end/closure middle_end/flambda middle_end/flambda/base_types \
-  asmcomp driver toplevel tools $(addprefix otherlibs/, $(ALL_OTHERLIBS))
+  asmcomp driver toplevel tools runtime \
+  $(addprefix otherlibs/, $(ALL_OTHERLIBS))
 INCLUDES = $(addprefix -I ,$(VPATH))
 
 ifeq "$(strip $(NATDYNLINKOPTS))" ""
@@ -1999,9 +2000,6 @@ ocamltest/ocamltest.opt$(EXE): ocamlopt ocamlyacc ocamllex
 # (see #9797)
 ocamltest/%: \
   VPATH := $(filter-out $(unix_directory), $(VPATH))
-
-# runtime headers are necessary to link ocamltest in custom mode
-ocamltest/%: VPATH += runtime
 
 # Ocamltest_unix and the linking of the executable itself should include the
 # Unix library, if it's being built.

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -25,6 +25,19 @@
 # have to be lazier.
 HOST_ZSTD_LIBS=ZSTD_LIBS=$(shell ocamlopt -config-var compression_c_libraries)
 
+# The build system adds various include directories which pertain to the current
+# tree, including -I runtime, which is necessary for -custom executables.
+# ocamltest is always a -custom executable, but some others (ocamldoc; the
+# debugger, etc.) are only -custom in specific circumstances. It is therefore
+# fiddly to change this in the main build system, so we perform a slightly
+# different trick by ensuring that "+" is the first entry in VPATH. This will
+# put the host compiler's standard library (and consequently its runtime
+# objects) well above the .a files found with -I runtime. For now, this seems
+# the least nefarious way of ensuring that the bytecode compiler has the C
+# headers in runtime/caml available without breaking builds with an external
+# ocamlopt.
+VPATH := + $(VPATH)
+
 CROSS_OVERRIDES=OCAMLRUN=ocamlrun NEW_OCAMLRUN=ocamlrun \
   BOOT_OCAMLLEX=ocamllex OCAMLYACC=ocamlyacc
 CROSS_COMPILER_OVERRIDES=$(CROSS_OVERRIDES) CAMLC=ocamlc CAMLOPT=ocamlopt \


### PR DESCRIPTION
This fixes a tiny regression in #13526. There is a tightrope being walked in that `ocamlc -custom` must be able to `#include <caml/mlvalues.h>` and `ocamlopt` must also find `libasmrun.a` for the correct compiler. https://github.com/ocaml/ocaml/commit/96c9d6ced14ffbf0e390291f98807e4d3d831294 fixes this by specifically altering ocamltest (which isn't built in cross-compilation mode), but unfortunately this isn't the only time when `-custom` is used within the distribution, as both the debugger and ocamldoc need it when the compiler is built with `--disable-shared`. Unfortunately, the other-configs test job doesn't quite pick this up, as `--disable-shared` is done only as part of the "minimal" test, which disables so many things that the broken tools aren't compiled!

I think adding further logic in the "main" build system to detect this is too complex. Another possible fix would be to ensure that the `runtime/caml` is located elsewhere (e.g. `include/caml`) so that `-I include` would allow `#include <caml/mlvalues.h>` _without_ also pulling in various .a files into the load path. That I think is also a bit too messy at this stage - one of the really nice things @shym has achieved with `Makefile.cross` is that both the non-cross-compiled and cross-compiled build systems work harmoniously without too many earth-shattering changes, and moving all the headers around is pretty earth-shattering!

So I propose this slightly cursed workaround in `Makefile.cross` instead - the main build normally makes `$(CAMLOPT)` be roughly `ocamlopt -nostdlib -I stdlib` (i.e. it _disables_ the configured standard library default and immediately puts the build tree's stdlib at the top of the search path). The approach here riffs on that by making `$(CAMLOPT)` be `ocamlopt -I +` when cross-compiling, which will cause the Standard Library of `ocamlopt` to be first in the load-path. That will cause libasmrun.a to be found in the right place, while not affecting any other directories.