### PR TITLE
Teach debugger scripts about variable number of domains

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,6 +127,10 @@ Working version
   and labels when only some modules along their path are open.
   (Gabriel Scherer, review by Florian Angeletti)
 
+- #13686: Fix Python debugger extensions (for LLDB and GDB) to restore
+  functionality broken by #13272.
+  (Nick Barnes, review by ???)
+
 ### Manual and documentation:
 
 - #13469, #13474, #13535: Document that [Hashtbl.create n] creates a hash table

--- a/tools/gdb.py
+++ b/tools/gdb.py
@@ -119,6 +119,9 @@ class GDBValue:
     def double_array(self, size):
         return self._v.cast(self._target._double_type.array(size-1)._t)
 
+    def pointer_index(self, index):
+        return GDBValue(self._v[index], self._target)
+
 class GDBTarget:
     def __init__(self):
         self._value_type = GDBType(gdb.lookup_type('value'))

--- a/tools/lldb.py
+++ b/tools/lldb.py
@@ -102,7 +102,7 @@ class LLDBValue:
         return LLDBValue(self._v.Dereference(), self._target)
 
     def struct(self):
-        t = self._v.GetType()
+        t = self._v.type
         fields = t.GetNumberOfFields()
         return {member.name:
                     LLDBValue(self._v.GetChildMemberWithName(member.name),
@@ -156,6 +156,11 @@ class LLDBValue:
 
     def double_array(self, size):
         return self._v.Cast(self._target._double_type.array(size)._t)
+
+    def pointer_index(self, index):
+        t = self._v.type.GetPointeeType()
+        address = self.unsigned() + index * t.size
+        return self._target._create_value("[]", address, LLDBType(t))
 
 class LLDBTarget:
     def __init__(self, target):


### PR DESCRIPTION
The Python scripts for GDB and LLDB to interpret OCaml values and search the OCaml heap have not kept up with recent runtime improvements, in particular #13272, so the `ocaml find` command would crash. This fixes that regression.

As part of this I added a `pointer_index` method to the value class for both LLDB and GDB (as the distinction between `a[n]` for an array `a` and `p[n]` for a pointer `p` is meaningful in LLDB internals). Both `pointer_index` and the existing `sub` method would be better as `__getitem__` methods, but that's more work than was justified here.