### PR TITLE
Allow more minor custom blocks

### DIFF
--- a/Changes
+++ b/Changes
@@ -67,6 +67,9 @@ Working version
   (Stephen Dolan and David Allsopp, report by Thomas Leonard, review by Tim
    McGilchrist and Fabrice Buoro)
 
+- #??: Allow more minor custom blocks
+  (Stephen Dolan, review by ??)
+
 ### Code generation and optimizations:
 
 - #13565: less tagging in switches compiled to affine transformations

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -234,12 +234,12 @@ typedef uint64_t uintnat;
 
 /* Default setting for the ratio of custom garbage to minor heap size.
    Documented in gc.mli */
-#define Custom_minor_ratio_def 100
+#define Custom_minor_ratio_def 400
 
 /* Default setting for maximum size of custom objects counted as garbage
    in the minor heap.
    Documented in gc.mli */
-#define Custom_minor_max_bsz_def 70000
+#define Custom_minor_max_bsz_def 10
 
 /* Minimum amount of work to do in a major GC slice. */
 #define Major_slice_work_min 512

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -63,14 +63,15 @@ static value alloc_custom_gen (const struct custom_operations * ops,
                                uintnat bsz,
                                mlsize_t mem,
                                mlsize_t max_major,
-                               mlsize_t max_minor)
+                               mlsize_t max_minor,
+                               int minor_ok)
 {
   mlsize_t wosize;
   CAMLparam0();
   CAMLlocal1(result);
 
   wosize = 1 + (bsz + sizeof(value) - 1) / sizeof(value);
-  if (wosize <= Max_young_wosize && mem <= caml_custom_minor_max_bsz) {
+  if (wosize <= Max_young_wosize && minor_ok) {
     result = caml_alloc_small(wosize, Custom_tag);
     Custom_ops_val(result) = ops;
     if (ops->finalize != NULL || mem != 0) {
@@ -105,14 +106,22 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
 {
   mlsize_t max_major = max;
   mlsize_t max_minor = max == 0 ? get_max_minor() : max;
-  return alloc_custom_gen (ops, bsz, mem, max_major, max_minor);
+  return alloc_custom_gen (ops, bsz, mem, max_major, max_minor, 1);
 }
 
 CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
                                        uintnat bsz,
                                        mlsize_t mem)
 {
-  value v = alloc_custom_gen (ops, bsz, mem, 0, get_max_minor());
+  mlsize_t max_minor = get_max_minor (); /* total allocs before minor GC */
+  mlsize_t max_minor_single;      /* largest allowed alloc on minor heap */
+  if (caml_custom_minor_max_bsz > 100) {
+    max_minor_single = caml_custom_minor_max_bsz;
+  } else {
+    max_minor_single = max_minor * caml_custom_minor_max_bsz / 100;
+  }
+  value v = alloc_custom_gen (ops, bsz, mem, 0,
+                              max_minor, (mem < max_minor_single));
   size_t mem_words = (mem + sizeof(value) - 1) / sizeof(value);
   caml_memprof_sample_block(v, mem_words, mem_words, CAML_MEMPROF_SRC_CUSTOM);
   return v;

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -215,7 +215,15 @@ type control =
         heap. Expressed as a percentage of minor heap size.
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
-        Default: 100.
+
+        The main reason to limit the size of memory held in the minor
+        heap is to avoid long minor GC pauses. Since custom values are
+        typically faster to GC than normal values (they cannot hold
+        pointers so need no scanning), an large amount of data can be
+        held by the minor heap in custom blocks without significantly
+        affecting GC time. So, by default, this value is above 100%.
+
+        Default: 400.
         @since 4.08 *)
 
     custom_minor_max_size : int;
@@ -224,7 +232,11 @@ type control =
         than this many bytes are allocated on the major heap.
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
-        Default: 70000 bytes.
+        Numbers <=100 are interpreted as percentages of the size
+        that would immediately trigger minor GC (minor heap size
+        times custom_minor_ratio).
+        Default: 10 %.
+
         @since 4.08 *)
   }
 (** The GC parameters are given as a [control] record.  Note that


### PR DESCRIPTION
OCaml 5.2+ has a different policy than previous versions for when to place a Bigarray (or other `caml_alloc_custom_mem` block) on the minor heap. I think the new policy is good, but the default parameter settings are not.

For instance, compared to OCaml 4, a program which e.g. creates and throws away a lot of 256k Bigarrays runs slower and uses more memory in 5.2. This is because beyond a threshold of 70k (by default, adjustable as `custom_minor_max_size`), Bigarrays go directly to the major heap. Furthermore, if a total amount of 2MB (by default, adjustable as `custom_minor_ratio` times minor heap size) of Bigarrays are allocated, a minor GC is forced.

This patch adjusts the defaults in two ways:

  -  **Larger default custom_minor_ratio**: The main reason to limit the minor GC size is latency: at a minor GC, all live minor values are promoted in a stop-the-world fashion, and if there are lots of these that can take a long time. Bigarrays are very cheap to promote (since they are mostly off-heap), and do not cause more GC scanning (since they cannot contain pointers), so we can safely have more of them than we have normal OCaml objects without risking long GC pauses. So, `custom_minor_ratio` is set by default to 400, allowing Bigarrays on the minor heap to hold memory up to 4x larger than the minor heap.

  - **Larger, and proportional, custom_minor_max_size**: The value of `custom_minor_max_size` now follows the convention of `major_heap_increment`, being treated as a proportion if it is less than 100. The default value is `10`, meaning that to be forced directly onto the major heap, a Bigarray needs to be 10% of the size that would trigger an immediate minor GC (that is, 10% of minor heap size times custom_minor_ratio). Making this relative to minor GC size is less surprising for users: it means that increasing the size of the minor heap will reduce the amount of data promoted to the major heap, which is not currently true for Bigarrays - you must increase another parameter as well. Making this proportional scales both automatically.

The combined effect is that the largest Bigarray that can be managed by the minor heap is about 10x larger than before.

(There's also some minor code rearrangement in custom.c: previously, the variable `custom_minor_max_size` whose units are bytes was also used to compare values coming from `caml_alloc_custom`, whose units are abstract. Now it is only used by `caml_alloc_custom_mem`, whose units are bytes)