### PR TITLE
Fix #13688 by moving before_generalize call inside with_new_pool

### DIFF
--- a/testsuite/tests/typing-misc/automatic_generalize.ml
+++ b/testsuite/tests/typing-misc/automatic_generalize.ml
@@ -1,0 +1,13 @@
+(* TEST
+ expect;
+*)
+
+(* #13688 *)
+type 'e opt = 'e option constraint 'e = [> `A ]
+let f: unit -> [> `A] opt = fun () -> None
+let x = f ()
+[%%expect{|
+type 'a opt = 'a option constraint 'a = [> `A ]
+val f : unit -> [> `A ] opt = <fun>
+val x : [> `A ] opt = None
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -207,9 +207,9 @@ let with_local_level_gen ~begin_def ~structure ?before_generalize f =
     end
   in
   simple_abbrevs := Mnil;
-  (* Nodes in [pool] were either created by the above call to [f],
-     or they were created before, generalized, and then added to
-     the pool by [update_level].
+  (* Nodes in [pool] were either created by the above calls to [f]
+     and [before_generalize], or they were created before, generalized,
+     and then added to the pool by [update_level].
      In the latter case, their level was already kept for backtracking
      by a call to [set_level] inside [update_level].
      Since backtracking can only go back to a snapshot taken before [f] was

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -193,16 +193,19 @@ let create_scope () =
   level
 
 let wrap_end_def f = Misc.try_finally f ~always:end_def
-let wrap_end_def_new_pool f =
-  wrap_end_def (fun _ -> with_new_pool ~level:!current_level f)
 
 (* [with_local_level_gen] handles both the scoping structure of levels
    and automatic generalization through pools (cf. btype.ml) *)
 let with_local_level_gen ~begin_def ~structure ?before_generalize f =
   begin_def ();
   let level = !current_level in
-  let result, pool = wrap_end_def_new_pool f in
-  Option.iter (fun g -> g result) before_generalize;
+  let result, pool =
+    with_new_pool ~level:!current_level begin fun () ->
+      let result = wrap_end_def f in
+      Option.iter (fun g -> g result) before_generalize;
+      result
+    end
+  in
   simple_abbrevs := Mnil;
   (* Nodes in [pool] were either created by the above call to [f],
      or they were created before, generalized, and then added to


### PR DESCRIPTION
In #13688, @Octachron found a strange behavior with generalization  related to automatic generalization.
The cause is indeed a subtle bug in `Ctype.with_local_level_gen`, where `before_generalize` allocates fresh nodes in the wrong pool.
This PR fixes the problem by moving the call inside `Btype.with_new_pool`.

Closes #13688.