### PR TITLE
Rewrite mutable globals for GC control to be atomic

### DIFF
--- a/Changes
+++ b/Changes
@@ -226,6 +226,10 @@ Working version
 
 ### Bug fixes:
 
+- #13691: Make four globals underlying Gc.control atomic to avoid C data
+  races against them
+  (Jan Midtgaard, review by Miod Vallat and Sadiq Jaffer)
+
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)
 

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -51,7 +51,7 @@ struct custom_operations {
 extern "C" {
 #endif
 
-CAMLextern uintnat caml_custom_major_ratio;
+CAMLextern _Atomic uintnat caml_custom_major_ratio;
 
 CAMLextern value caml_alloc_custom(const struct custom_operations * ops,
                                    uintnat size, /*size in bytes*/

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -28,9 +28,9 @@
 #include "caml/signals.h"
 #include "caml/memprof.h"
 
-uintnat caml_custom_major_ratio = Custom_major_ratio_def;
-uintnat caml_custom_minor_ratio = Custom_minor_ratio_def;
-uintnat caml_custom_minor_max_bsz = Custom_minor_max_bsz_def;
+_Atomic uintnat caml_custom_major_ratio = Custom_major_ratio_def;
+_Atomic uintnat caml_custom_minor_ratio = Custom_minor_ratio_def;
+_Atomic uintnat caml_custom_minor_max_bsz = Custom_minor_max_bsz_def;
 
 mlsize_t caml_custom_get_max_major (void)
 {
@@ -45,7 +45,7 @@ mlsize_t caml_custom_get_max_major (void)
      allocated during the previous cycle.  [heap_size / 150] is really
      [heap_size * (2/3) / 100] (but faster). */
   return caml_heap_size(Caml_state->shared_heap) / 150
-         * caml_custom_major_ratio;
+         * atomic_load_relaxed(&caml_custom_major_ratio);
 }
 
 /* [mem] is an amount of out-of-heap resources, in the same units as
@@ -70,7 +70,8 @@ static value alloc_custom_gen (const struct custom_operations * ops,
   CAMLlocal1(result);
 
   wosize = 1 + (bsz + sizeof(value) - 1) / sizeof(value);
-  if (wosize <= Max_young_wosize && mem <= caml_custom_minor_max_bsz) {
+  if (wosize <= Max_young_wosize
+      && mem <= atomic_load_relaxed(&caml_custom_minor_max_bsz)) {
     result = caml_alloc_small(wosize, Custom_tag);
     Custom_ops_val(result) = ops;
     if (ops->finalize != NULL || mem != 0) {
@@ -95,7 +96,8 @@ static value alloc_custom_gen (const struct custom_operations * ops,
 Caml_inline mlsize_t get_max_minor (void)
 {
   return
-    Bsize_wsize (Caml_state->minor_heap_wsz) / 100 * caml_custom_minor_ratio;
+    Bsize_wsize (Caml_state->minor_heap_wsz) / 100
+                * atomic_load_relaxed(&caml_custom_minor_ratio);
 }
 
 CAMLexport value caml_alloc_custom(const struct custom_operations * ops,


### PR DESCRIPTION
Four globals underlying `Gc.control` are racy. Consider, e.g., this program:
```ocaml
(* file race.ml *)
let default_control = Gc.{
    minor_heap_size = 262_144;      (* Default: 256k. *)
    major_heap_increment = 0;       (* Default: https://github.com/ocaml/ocaml/pull/13440 *)
    space_overhead = 120;           (* Default: 120. *)
    verbose = 0;                    (* Default: 0. *)
    max_overhead = 0;               (* Default: https://github.com/ocaml/ocaml/pull/13440 *)
    stack_limit = 134_217_728;      (* Default: 128M. https://github.com/ocaml/ocaml/pull/13440 *)
    allocation_policy = 0;          (* "This option is ignored in OCaml 5.x." *)
    window_size = 0;                (* Default: https://github.com/ocaml/ocaml/pull/13440 *)
    custom_major_ratio = 44;        (* Default: 44. *)
    custom_minor_ratio = 100;       (* Default: 100. *)
    custom_minor_max_size = 70_000; (* Default: 70000 bytes. *)
  }

let () =
  let t1 = Domain.spawn (fun () -> Gc.set { default_control with custom_major_ratio = 22 }; Unix.sleep 1) in
  let t2 = Domain.spawn (fun () -> Gc.set { default_control with custom_major_ratio = 33 }; Unix.sleep 1) in
  Domain.join t1;
  Domain.join t2;
  Printf.printf "All OK\n"
```

Compile and run it under a TSan-enabled switch:
```
./race.exe 
==================
WARNING: ThreadSanitizer: data race (pid=49476)
  Read of size 8 at 0x55eb876a01b0 by thread T4 (mutexes: write M91):
    #0 caml_gc_set runtime/gc_ctrl.c:180 (race.exe+0x10dc2d)
    #1 caml_c_call <null> (race.exe+0x141e8b)
    #2 camlRace$fun_618 <null> (race.exe+0x6a325)
    #3 camlStdlib__Domain$body_742 <null> (race.exe+0xab37f)
    #4 caml_start_program <null> (race.exe+0x141faf)
    #5 caml_callback_exn runtime/callback.c:206 (race.exe+0xfa5d3)
    #6 caml_callback_res runtime/callback.c:321 (race.exe+0xfb262)
    #7 domain_thread_func runtime/domain.c:1267 (race.exe+0x100ecd)

  Previous write of size 8 at 0x55eb876a01b0 by thread T1 (mutexes: write M85):
    #0 caml_gc_set runtime/gc_ctrl.c:181 (race.exe+0x10dd67)
    #1 caml_c_call <null> (race.exe+0x141e8b)
    #2 camlRace$fun_614 <null> (race.exe+0x6a2d5)
    #3 camlStdlib__Domain$body_742 <null> (race.exe+0xab37f)
    #4 caml_start_program <null> (race.exe+0x141faf)
    #5 caml_callback_exn runtime/callback.c:206 (race.exe+0xfa5d3)
    #6 caml_callback_res runtime/callback.c:321 (race.exe+0xfb262)
    #7 domain_thread_func runtime/domain.c:1267 (race.exe+0x100ecd)

  Location is global 'caml_custom_major_ratio' of size 8 at 0x55eb876a01b0 (race.exe+0x0000001c21b0)

  [...]
```

This is a problem for four globals, which I've confirmed with variations of the above and which this PR rewrites to be atomic:
- `caml_percent_free`
- `caml_custom_major_ratio`
- `caml_custom_minor_ratio`
- `caml_custom_minor_max_bsz`

thus bringing them in line with `caml_verb_gc` which is already atomic.

Like the code for `caml_verb_gc`, the PR uses `atomic_load_relaxed` and `atomic_store_relaxed` to make it clear that these are atomic operations, even though this is not strictly required. It however keeps `caml_runtime_parameters`
and `CAML_GC_MESSAGE` as is (for readability) - like for `caml_verb_gc`.
