### PR TITLE
Add Result.product and Result.Syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,6 +150,9 @@ Working version
 
 ### Standard library:
 
+- #13696: Add Result.product and Result.Syntax.
+  (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+
 - #13885: Add Dynarray.{exists2, for_all2}.
   (T. Kinsart, review by Daniel Bünzli, Gabriel Scherer, and Nicolás Ojeda Bär)
 

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -23,6 +23,11 @@ let get_error = function Error e -> e | Ok _ -> invalid_arg "result is Ok _"
 let bind r f = match r with Ok v -> f v | Error _ as e -> e
 let join = function Ok r -> r | Error _ as e -> e
 let map f = function Ok v -> Ok (f v) | Error _ as e -> e
+let product r0 r1 = match r0, r1 with
+| (Error _ as r), _
+| _, (Error _ as r) -> r
+| Ok v0, Ok v1 -> Ok (v0, v1)
+
 let map_error f = function Error e -> Error (f e) | Ok _ as v -> v
 let fold ~ok ~error = function Ok v -> ok v | Error e -> error e
 let retract = function Ok v -> v | Error v -> v

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -50,3 +50,10 @@ let compare ~ok ~error r0 r1 = match r0, r1 with
 let to_option = function Ok v -> Some v | Error _ -> None
 let to_list = function Ok v -> [v] | Error _ -> []
 let to_seq = function Ok v -> Seq.return v | Error _ -> Seq.empty
+
+module Syntax = struct
+  let ( let* ) = bind
+  let ( and* ) = product
+  let ( let+ ) r f = map f r
+  let ( and+ ) = product
+end

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -53,6 +53,12 @@ val join : (('a, 'e) result, 'e) result -> ('a, 'e) result
 val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 (** [map f r] is [Ok (f v)] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 
+val product : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+(** [product r0 r1] is [Ok (v0, v1)] if [r0] is [Ok v0] and [r1] is [Ok v2]
+    and otherwise returns the error of [r0], if any, or the error of [r1].
+
+    @since 5.4 *)
+
 val map_error : ('e -> 'f) -> ('a, 'e) result -> ('a, 'f) result
 (** [map_error f r] is [Error (f e)] if [r] is [Error e] and [r] if
     [r] is [Ok _]. *)

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -112,3 +112,23 @@ val to_list : ('a, 'e) result -> 'a list
 val to_seq : ('a, 'e) result -> 'a Seq.t
 (** [to_seq r] is [r] as a sequence. [Ok v] is the singleton sequence
     containing [v] and [Error _] is the empty sequence. *)
+
+(** {1:syntax Syntax} *)
+
+(** Binding operators.
+
+    @since 5.4 *)
+module Syntax : sig
+
+  val ( let* ) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
+  (** [( let* )] is {!Result.bind}. *)
+
+  val ( and* ) : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+  (** [( and* )] is {!Result.product}. *)
+
+  val ( let+ ) : ('a, 'e) result -> ('a -> 'b) -> ('b, 'e) result
+  (** [( let+ )] is {!Result.map}. *)
+
+  val ( and+ ) : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+  (** [( and+ )] is {!Result.product}. *)
+end

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -42,6 +42,13 @@ let test_maps () =
   assert (Result.map_error succ (Ok 2) = Ok 2);
   ()
 
+let test_product () =
+  assert (Result.product (Ok "a") (Ok 3) = Ok ("a", 3));
+  assert (Result.product (Ok "a") (Error "ha") = Error "ha");
+  assert (Result.product (Error "hi") (Error "ha") = Error "hi");
+  assert (Result.product (Error "hi") (Ok 3) = Error "hi");
+  ()
+
 let test_fold () =
   assert (Result.fold ~ok:succ ~error:succ (Ok 1) = 2);
   assert (Result.fold ~ok:succ ~error:succ (Error 1) = 2);
@@ -122,6 +129,7 @@ let tests () =
   test_bind ();
   test_join ();
   test_maps ();
+  test_product ();
   test_fold ();
   test_retract ();
   test_iters ();

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -122,6 +122,23 @@ let test_to_option_list_seq () =
   assert ((Result.to_seq (Error "ha!")) () = Seq.Nil);
   ()
 
+let test_syntax () =
+  let open Result.Syntax in
+  assert (Ok 5 =
+          let parse n = Ok n in
+          let* n0 = parse 3 in
+          let* n1 = parse 2 in
+          Ok (n0 + n1));
+  assert (Ok 3 =
+          let+ one = Ok 1
+          and+ two = Ok 2 in
+          one + two);
+  assert (Ok 1 =
+          let* three = Ok 3 in
+          let+ two = Ok 2 in
+          three - two);
+  ()
+
 let tests () =
   test_ok_error ();
   test_value ();
@@ -137,6 +154,7 @@ let tests () =
   test_equal ();
   test_compare ();
   test_to_option_list_seq ();
+  test_syntax ();
   ()
 
 let () =


### PR DESCRIPTION
This PR adds `Result.Syntax` with the binding operators for `result` values. 

Before it also added

1. `Result.{get_ok',error_to_failure}`, now living in https://github.com/ocaml/ocaml/pull/13720
2. `Result.retract`, now living in https://github.com/ocaml/ocaml/pull/13721

# Binding operators

This is a partial implementation of what has been proposed by @lpw25 in #2170 six years ago. However the `Syntax` module proposed here provides only binding operators, there is no `return`. I find it clearer to use the dedicated constructor `Ok` or `Result.ok` directly and I think it's better not to pollute our crowded scopes with unqualified identifiers. 

It is something that I use in almost all of my source files and programs.

Some people would like the named binding operator of #13325 to settle down before deciding this (see [this discussion]). However no one ever seemed to address [this question] and more than one person [points out] that they end up using at most one monad most of time in a given context (which hints at an answer to the question).

However when the latter is true named binding operators become both extremely noisy and a waste of your horizontal space. Personally I'm extremely unlikely to use them for my pervasive use of the *error* monad. Hence the proposal whose usage will, I suspect, outlive any named binding operator introduction, if it ever happens.

[this discussion]: https://github.com/ocaml/ocaml/discussions/12015
[this question]: https://github.com/ocaml/ocaml/discussions/12015#discussioncomment-5007593
[points out]: https://github.com/ocaml/ocaml/discussions/12015#discussioncomment-5051669
