### PR TITLE
WIP: Update operator documentation

### DIFF
--- a/api_docgen/Ocaml_operators.mld
+++ b/api_docgen/Ocaml_operators.mld
@@ -13,28 +13,32 @@ are also listed as references.
 \hline
 Operator class                                       & Associativity \\
 \hline
-$!\ldots$ $\tilde{}\ldots$                                    &  --   \\
-$.\cdots()$ $.\cdots[]$ $.\cdots$\textbraceleft\textbraceright&  --   \\
+$!\ldots$ $\tilde{}\ldots$                                    &  -- (prefix)   \\
+$.\cdots()$ $.\cdots[]$ $.\cdots$\textbraceleft\textbraceright&  -- (link indexops)   \\
 \#\ldots                                                      & left  \\
 function application                                          & left  \\
-- -.                                                          &  --   \\
+- -.                                                          &  -- (prefix)   \\
 $**\ldots$ lsl lsr asr                                        & right \\
 $*\ldots$ /\ldots \%\ldots  mod land lor lxor                 & left  \\
 +\ldots -\ldots                                               & left  \\
-::                                                            & right \\
+::                                                            & right (note infix -) \\
 @\ldots \textasciicircum\ldots                                & right \\
 =\ldots <\ldots >\ldots |\ldots \&\ldots \$\ldots !=          & left  \\
 \& \&\&                                                       & right \\
 or ||                                                         & right \\
-,                                                             &  --   \\
+,                                                             &  -- (syntax/tuple)   \\
 <- :=                                                         & right \\
-if                                                            &  --   \\
+if                                                            &  -- (syntax)   \\
 ;                                                             & right \\
+let let\ldots match fun function try                          &  -- (syntax/link bindingops) \\
 \hline
 \end{tabular}
+
+See also \ref{ss:precedence-and-associativity}.
 %}
 
 {%html:
+TODO: Update this also
 <table align=center border=1>
 <thead><tr><th>Operator class</th><th>Associativity </th></tr></thead>
 <tr><td><code class=code>!&#X2026 ~&#X2026</code>     </td><td>&#X2013</td></tr>
@@ -61,6 +65,7 @@ if                                                            &  --   \\
 %}
 
 {%man:
+TODO: Update this also
 .IP Associativity
 Operator class
 .IP -

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -169,7 +169,7 @@ precedence come first. For infix and prefix symbols, we write
 \entree{"<-   :="}{right}
 \entree{"if"}{--}
 \entree{";"}{right}
-\entree{"let  match  fun  function  try"}{--}
+\entree{"let  let\ldots  match  fun  function  try"}{--}
 \end{tableau}
 
 It is simple to test or refresh one's understanding:


### PR DESCRIPTION
Hi,

I thought your docs on operators could do with some improvements, though I've only just made some sketches, feel free to ask for suggestions or abandon this and do it yourself. But I thought this is /slightly/ more useful than just an issue, as I can mention the files.

Suggestions:
- [ ] Link https://ocaml.org/manual/5.2/api/Ocaml_operators.html https://ocaml.org/manual/5.2/expr.html#ss:precedence-and-associativity and https://ocaml.org/manual/5.2/expr.html#ss:expr-operators
- [ ] Clarify `-` and `-.` as prefix vs as infix
- [ ] Clarify the `--` bits in the api/Ocaml_operators table, link because things like `-.` or `!...` are impossible to search for
- [ ] Add binding operator extension into operators table
- [ ] Synchronise API operators table and refman operators table (API one doesn't have let, match, fun etc)