### PR TITLE
Add application let-operator `( let@ )`

### DIFF
--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -47,6 +47,7 @@ exception Undefined_recursive_module = Undefined_recursive_module
 
 external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
 external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+external ( let@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
 
 (* Debugging *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -308,6 +308,18 @@ external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
  @since 4.01
 *)
 
+external ( let@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+(** Application let-operator, exactly equal to [( @@ )]. This is useful in its
+    own right because it makes callback-style APIs usable with a more 'direct'
+    style, eg:
+
+    {[
+    let copyfile srcfile dstfile =
+      let@ in_channel = In_channel.with_open_bin srcfile in
+      let@ out_channel = Out_channel.with_open_bin dstfile in
+      Out_channel.output_string out_channel (In_channel.input_all in_channel)
+    ]} *)
+
 (** {1 Integer arithmetic} *)
 
 (** Integers are [Sys.int_size] bits wide.

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -147,6 +147,7 @@ Line 3, characters 4-8:
 3 |     let+ x = 1 in
         ^^^^
 Error: Unbound value "(let+)"
+Hint: Did you mean "let@"?
 |}];;
 
 module And_unbound = struct

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -92,6 +92,7 @@ Line 1, characters 8-13:
 1 | let x = \#let;;
             ^^^^^
 Error: Unbound value "\#let"
+Hint: Did you mean "let@"?
 |}]
 
 let f ~\#let ?\#and () = 1


### PR DESCRIPTION
This allows using any callback-style function like `val foo : a -> (b ->
c) -> d` in a more 'direct' style.

The reasoning behind this addition is that, there was an earlier attempt to add a more full-fledged set of let-operators to the standard library, but it stalled because of, among other reasons, discussions about introducing new named let-operators like `Option/let*` or similar for readability reasons.

However, the `let@` operator approach is different. It's not tied to a named function like `Option.bind`, so it wouldn't be impacted by any such new syntax. And it can work with _any_ function that has the above callback-style signature, so eg `let@ num = Option.bind optional_num in ...`, `let@ env = Eio_main.run in ...`.

The only thing the reader would have to learn would be this callback inversion pattern, instead of multiple specific let-operator symbols and their mappings to different behaviours like `let*`, `let+`, `and+`.