### PR TITLE
Use more POSIX thread-safe functions in libunix

### DIFF
--- a/Changes
+++ b/Changes
@@ -228,6 +228,10 @@ Working version
 
 ### Other libraries:
 
+- #13700: Use POSIX thread-safe getgrnam_r, getgrgid_r, getpwnam_r, getpwuid_r,
+  gmtime_r, localtime_r, getlogin_r, and fix mktime error checking.
+  (Antonin Décimo, review by David Allsopp, Stefan Muenzel, and Miod Vallat)
+
 - #14406: Better handling of address length for unix sockets, improving Haiku
   compatibility.
   (Sylvain Kerjean, review by Antonin Décimo and Nicolás Ojeda Bär)

--- a/configure
+++ b/configure
@@ -3173,6 +3173,8 @@ as_fn_append ac_func_c_list " getgrnam_r HAVE_GETGRNAM_R"
 as_fn_append ac_func_c_list " getgrgid_r HAVE_GETGRGID_R"
 as_fn_append ac_func_c_list " getpwnam_r HAVE_GETPWNAM_R"
 as_fn_append ac_func_c_list " getpwuid_r HAVE_GETPWUID_R"
+as_fn_append ac_func_c_list " gmtime_r HAVE_GMTIME_R"
+as_fn_append ac_func_c_list " localtime_r HAVE_LOCALTIME_R"
 
 # Auxiliary files required by this configure script.
 ac_aux_files="install-sh ltmain.sh config.guess config.sub"
@@ -21281,6 +21283,9 @@ then :
   printf "%s\n" "#define HAS_MKTIME 1" >>confdefs.h
 
 fi
+
+
+
 
 
 ## setsid

--- a/configure
+++ b/configure
@@ -715,6 +715,7 @@ ac_includes_default="\
 #endif"
 
 ac_header_c_list=
+ac_func_c_list=
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 DIFF
@@ -3168,6 +3169,10 @@ as_fn_append ac_header_c_list " strings.h strings_h HAVE_STRINGS_H"
 as_fn_append ac_header_c_list " sys/stat.h sys_stat_h HAVE_SYS_STAT_H"
 as_fn_append ac_header_c_list " sys/types.h sys_types_h HAVE_SYS_TYPES_H"
 as_fn_append ac_header_c_list " unistd.h unistd_h HAVE_UNISTD_H"
+as_fn_append ac_func_c_list " getgrnam_r HAVE_GETGRNAM_R"
+as_fn_append ac_func_c_list " getgrgid_r HAVE_GETGRGID_R"
+as_fn_append ac_func_c_list " getpwnam_r HAVE_GETPWNAM_R"
+as_fn_append ac_func_c_list " getpwuid_r HAVE_GETPWUID_R"
 
 # Auxiliary files required by this configure script.
 ac_aux_files="install-sh ltmain.sh config.guess config.sub"
@@ -21124,6 +21129,24 @@ then :
 
 
 fi
+
+
+ac_func=
+for ac_item in $ac_func_c_list
+do
+  if test $ac_func; then
+    ac_fn_c_check_func "$LINENO" $ac_func ac_cv_func_$ac_func
+    if eval test \"x\$ac_cv_func_$ac_func\" = xyes; then
+      echo "#define $ac_item 1" >> confdefs.h
+    fi
+    ac_func=
+  else
+    ac_func=$ac_item
+  fi
+done
+
+
+
 
 
 ## getgroups

--- a/configure
+++ b/configure
@@ -3169,6 +3169,7 @@ as_fn_append ac_header_c_list " strings.h strings_h HAVE_STRINGS_H"
 as_fn_append ac_header_c_list " sys/stat.h sys_stat_h HAVE_SYS_STAT_H"
 as_fn_append ac_header_c_list " sys/types.h sys_types_h HAVE_SYS_TYPES_H"
 as_fn_append ac_header_c_list " unistd.h unistd_h HAVE_UNISTD_H"
+as_fn_append ac_func_c_list " getlogin_r HAVE_GETLOGIN_R"
 as_fn_append ac_func_c_list " getgrnam_r HAVE_GETGRNAM_R"
 as_fn_append ac_func_c_list " getgrgid_r HAVE_GETGRGID_R"
 as_fn_append ac_func_c_list " getpwnam_r HAVE_GETPWNAM_R"
@@ -21146,6 +21147,7 @@ do
     ac_func=$ac_item
   fi
 done
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2362,6 +2362,8 @@ AC_CHECK_FUNC(
     AC_DEFINE([HAS_WAIT4], [1])
   ])
 
+AC_CHECK_FUNCS_ONCE([getgrnam_r getgrgid_r getpwnam_r getpwuid_r])
+
 ## getgroups
 AC_CHECK_FUNC([getgroups], [AC_DEFINE([HAS_GETGROUPS], [1])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2362,7 +2362,7 @@ AC_CHECK_FUNC(
     AC_DEFINE([HAS_WAIT4], [1])
   ])
 
-AC_CHECK_FUNCS_ONCE([getgrnam_r getgrgid_r getpwnam_r getpwuid_r])
+AC_CHECK_FUNCS_ONCE([getlogin_r getgrnam_r getgrgid_r getpwnam_r getpwuid_r])
 
 ## getgroups
 AC_CHECK_FUNC([getgroups], [AC_DEFINE([HAS_GETGROUPS], [1])])

--- a/configure.ac
+++ b/configure.ac
@@ -2415,6 +2415,7 @@ AC_CHECK_FUNC([gettimeofday],
 ## mktime
 
 AC_CHECK_FUNC([mktime], [AC_DEFINE([HAS_MKTIME], [1])])
+AC_CHECK_FUNCS_ONCE([gmtime_r localtime_r])
 
 ## setsid
 

--- a/otherlibs/unix/getlogin.c
+++ b/otherlibs/unix/getlogin.c
@@ -13,17 +13,51 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include "caml/unixsupport.h"
+#include <limits.h>
+#include <unistd.h>
 #include <errno.h>
 
-extern char * getlogin(void);
+#define CAML_LOGIN_NAME_MAX (256 * 4)
 
 CAMLprim value caml_unix_getlogin(value unit)
 {
+  value res;
   char * name;
+#ifdef HAVE_GETLOGIN_R
+  size_t bufsize;
+#ifdef LOGIN_NAME_MAX
+  bufsize = LOGIN_NAME_MAX;
+#else
+  long initlen = sysconf(_SC_LOGIN_NAME_MAX);
+  bufsize = initlen <= 0 ? _POSIX_LOGIN_NAME_MAX : (size_t) initlen;
+#endif
+  name = caml_stat_alloc_noexc(bufsize);
+  if (name == NULL)
+    caml_unix_error(ENOMEM, "getlogin", Nothing);
+  int e;
+  while ((e = getlogin_r(name, bufsize)) == ERANGE) {
+    bufsize *= 2;
+    char *newname;
+    if (bufsize > CAML_LOGIN_NAME_MAX ||
+        (newname = caml_stat_realloc(name)) == NULL) {
+      caml_stat_free(name);
+      caml_unix_error(ENOMEM, "getlogin", Nothing);
+    }
+    name = newname;
+  }
+  if (e != 0) {
+    caml_stat_free(name);
+#else
   name = getlogin();
-  if (name == NULL) caml_unix_error(ENOENT, "getlogin", Nothing);
-  return caml_copy_string(name);
+  if (name == NULL) {
+#endif
+    caml_unix_error(ENOENT, "getlogin", Nothing);
+  }
+  res = caml_copy_string(name);
+#ifdef HAVE_GETLOGIN_R
+  caml_stat_free(name);
+#endif
+  return res;
 }

--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -81,11 +81,11 @@ CAMLprim value caml_unix_mktime(value t)
   tm.tm_mday = Int_val(Field(t, 3));
   tm.tm_mon = Int_val(Field(t, 4));
   tm.tm_year = Int_val(Field(t, 5));
-  tm.tm_wday = Int_val(Field(t, 6));
-  tm.tm_yday = Int_val(Field(t, 7));
-  tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field(t, 8)); */
+  tm.tm_isdst = -1;
+  tm.tm_wday = -1;
   clock = mktime(&tm);
-  if (clock == (time_t) -1) caml_unix_error(ERANGE, "mktime", Nothing);
+  if (clock == (time_t) -1 && tm.tm_wday == -1)
+    caml_uerror("mktime", Nothing);
   tmval = alloc_tm(&tm);
   clkval = caml_copy_double((double) clock);
   res = caml_alloc_small(2, 0);

--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -21,7 +21,7 @@
 #include <time.h>
 #include <errno.h>
 
-static value alloc_tm(struct tm *tm)
+static value alloc_tm(const struct tm *tm)
 {
   value res;
   res = caml_alloc_small(9, 0);
@@ -39,21 +39,29 @@ static value alloc_tm(struct tm *tm)
 
 CAMLprim value caml_unix_gmtime(value t)
 {
-  time_t clock;
+  time_t clock = (time_t) Double_val(t);
   struct tm * tm;
-  clock = (time_t) Double_val(t);
+#ifdef HAVE_GMTIME_R
+  struct tm result;
+  tm = gmtime_r(&clock, &result);
+#else
   tm = gmtime(&clock);
-  if (tm == NULL) caml_unix_error(EINVAL, "gmtime", Nothing);
+#endif
+  if (tm == NULL) caml_uerror("gmtime", Nothing);
   return alloc_tm(tm);
 }
 
 CAMLprim value caml_unix_localtime(value t)
 {
-  time_t clock;
+  time_t clock = (time_t) Double_val(t);
   struct tm * tm;
-  clock = (time_t) Double_val(t);
+#ifdef HAVE_LOCALTIME_R
+  struct tm result;
+  tm = localtime_r(&clock, &result);
+#else
   tm = localtime(&clock);
-  if (tm == NULL) caml_unix_error(EINVAL, "localtime", Nothing);
+#endif
+  if (tm == NULL) caml_uerror("localtime", Nothing);
   return alloc_tm(tm);
 }
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -226,6 +226,9 @@
 
 /* Define HAS_MKTIME if you have mktime(). */
 
+#undef HAVE_GMTIME_R
+#undef HAVE_LOCALTIME_R
+
 #undef HAS_SETSID
 
 /* Define HAS_SETSID if you have setsid(). */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -324,6 +324,11 @@
 
 #undef HAVE_MAX_ALIGN_T
 
+#undef HAVE_GETGRNAM_R
+#undef HAVE_GETGRGID_R
+#undef HAVE_GETPWNAM_R
+#undef HAVE_GETPWUID_R
+
 /* 3. Language extensions. */
 
 /* Define if the C compiler supports the labels as values extension. */


### PR DESCRIPTION
- Use thread-safe functions [`getgrnam_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/getgrnam_r.html), [`getgrgid_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/getgrgid_r.html), [`getpwnam_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/getpwnam_r.html), [`getpwuid_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/getpwuid_r.html), introduced in POSIX-2008, if available.

  This sample program prints 4096 on macOS and 1024 on Arch Linux in my tests.

  ```c
  #include <unistd.h>
  #include <stdio.h>

  int main(void) {
      long int initlen = sysconf(_SC_GETGR_R_SIZE_MAX);
      printf("%ld\n", initlen);
      return 0;
  }
  ```

- Use thread-safe functions [`gmtime_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/gmtime_r.html), [`localtime_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/localtime_r.html), [`getlogin_r`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/getlogin_r.html) and if available.

- Fix `mktime` error-checking. `(time_t) -1` is a valid value. Check the error as suggested by the C23 draft and POSIX.