### PR TITLE
Faster caml_continuation_use_and_update_handler_noexc

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -665,7 +665,7 @@ CAMLprim value caml_continuation_use_and_update_handler_noexc
     /* The continuation has already been taken */
     return stack;
   }
-  while (Stack_parent(stk) != NULL) stk = Stack_parent(stk);
+  stk = Ptr_val(Field(cont, 1));
   Stack_handle_value(stk) = hval;
   Stack_handle_exception(stk) = hexn;
   Stack_handle_effect(stk) = heff;


### PR DESCRIPTION
The PR follows #12735. It seems that we no longer need to walk the chain of stacks when calling  caml_continuation_use_and_update_handler_noexc, we already have the other end stored inside the continuation `cont`.
See my comment https://github.com/ocaml/ocaml/pull/12735#issuecomment-2545949515