### PR TITLE
[refactoring] typemod.ml readability tweaks

### DIFF
--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2142,11 +2142,11 @@ let check_package_closed ~loc ~env ~typ fl =
 
 let not_principal msg = Warnings.Not_principal (Format_doc.Doc.msg msg)
 
-let rec type_module ?(alias=false) ~strengthen funct_body anchor env smod =
+let rec type_module ?(alias=false) ~strengthen ~funct_body anchor env smod =
   Builtin_attributes.warning_scope smod.pmod_attributes
-    (fun () -> type_module_aux ~alias ~strengthen funct_body anchor env smod)
+    (fun () -> type_module_aux ~alias ~strengthen ~funct_body anchor env smod)
 
-and type_module_aux ~alias ~strengthen funct_body anchor env smod =
+and type_module_aux ~alias ~strengthen ~funct_body anchor env smod =
   match smod.pmod_desc with
     Pmod_ident lid ->
       let path =
@@ -2189,7 +2189,7 @@ and type_module_aux ~alias ~strengthen funct_body anchor env smod =
       md, shape
   | Pmod_structure sstr ->
       let (str, sg, names, shape, _finalenv) =
-        type_structure funct_body anchor env sstr in
+        type_structure ~funct_body anchor env sstr in
       let md =
         { mod_desc = Tmod_structure str;
           mod_type = Mty_signature sg;
@@ -2232,7 +2232,7 @@ and type_module_aux ~alias ~strengthen funct_body anchor env smod =
           var, true
       in
       let body, body_shape =
-        type_module ~strengthen:true funct_body None newenv sbody
+        type_module ~strengthen:true ~funct_body None newenv sbody
       in
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type);
@@ -2241,10 +2241,10 @@ and type_module_aux ~alias ~strengthen funct_body anchor env smod =
         mod_loc = smod.pmod_loc },
       Shape.abs funct_shape_param body_shape
   | Pmod_apply _ | Pmod_apply_unit _ ->
-      type_application smod.pmod_loc ~strengthen funct_body env smod
+      type_application smod.pmod_loc ~strengthen ~funct_body env smod
   | Pmod_constraint(sarg, smty) ->
       let arg, arg_shape =
-        type_module ~alias ~strengthen:true funct_body anchor env sarg
+        type_module ~alias ~strengthen:true ~funct_body anchor env sarg
       in
       let mty = transl_modtype env smty in
       let md, final_shape =
@@ -2288,12 +2288,12 @@ and type_module_aux ~alias ~strengthen funct_body anchor env smod =
   | Pmod_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-and type_application loc ~strengthen funct_body env smod =
-  let rec extract_application funct_body env sargs smod =
+and type_application loc ~strengthen ~funct_body env smod =
+  let rec extract_application ~funct_body env sargs smod =
     match smod.pmod_desc with
     | Pmod_apply (f, sarg) ->
         let arg, shape =
-          type_module ~strengthen:true funct_body None env sarg
+          type_module ~strengthen:true ~funct_body None env sarg
         in
         let summary = {
           loc = smod.pmod_loc;
@@ -2306,7 +2306,7 @@ and type_application loc ~strengthen funct_body env smod =
             shape;
           }
         } in
-        extract_application funct_body env (summary::sargs) f
+        extract_application ~funct_body env (summary::sargs) f
     | Pmod_apply_unit f ->
         let summary = {
           loc = smod.pmod_loc;
@@ -2314,17 +2314,17 @@ and type_application loc ~strengthen funct_body env smod =
           f_loc = f.pmod_loc;
           arg = None
         } in
-        extract_application funct_body env (summary::sargs) f
+        extract_application ~funct_body env (summary::sargs) f
     | _ -> smod, sargs
   in
-  let sfunct, args = extract_application funct_body env [] smod in
+  let sfunct, args = extract_application ~funct_body env [] smod in
   let funct, funct_shape =
     let has_path { arg } = match arg with
       | None | Some { path = None } -> false
       | Some { path = Some _ } -> true
     in
     let strengthen = strengthen && List.for_all has_path args in
-    type_module ~strengthen funct_body None env sfunct
+    type_module ~strengthen ~funct_body None env sfunct
   in
   List.fold_left
     (type_one_application ~ctx:(loc, sfunct, funct, args) funct_body env)
@@ -2435,13 +2435,13 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       in
       raise(Includemod.Apply_error {loc=apply_loc;env;app_name;mty_f;args})
 
-and type_open_decl ?used_slot ?toplevel funct_body names env sod =
+and type_open_decl ?used_slot ?toplevel ~funct_body names env sod =
   Builtin_attributes.warning_scope sod.popen_attributes
     (fun () ->
-       type_open_decl_aux ?used_slot ?toplevel funct_body names env sod
+       type_open_decl_aux ?used_slot ?toplevel ~funct_body names env sod
     )
 
-and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
+and type_open_decl_aux ?used_slot ?toplevel ~funct_body names env od =
   let loc = od.popen_loc in
   match od.popen_expr.pmod_desc with
   | Pmod_ident lid ->
@@ -2465,7 +2465,7 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
     open_descr, [], newenv
   | _ ->
     let md, mod_shape =
-      type_module ~strengthen:true funct_body None env od.popen_expr
+      type_module ~strengthen:true ~funct_body None env od.popen_expr
     in
     let scope = Ctype.create_scope () in
     let sg, newenv =
@@ -2501,7 +2501,7 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
     } in
     open_descr, sg, newenv
 
-and type_structure ?(toplevel = false) funct_body anchor env sstr =
+and type_structure ?(toplevel = false) ~funct_body anchor env sstr =
   let names = Signature_names.create () in
 
   let type_str_item env shape_map {pstr_loc = loc; pstr_desc = desc} =
@@ -2603,7 +2603,7 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
         let modl, md_shape =
           Builtin_attributes.warning_scope attrs
             (fun () ->
-               type_module ~alias:true ~strengthen:true funct_body
+               type_module ~alias:true ~strengthen:true ~funct_body
                  (anchor_submodule name.txt anchor) env smodl
             )
         in
@@ -2682,7 +2682,7 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
                let modl, shape =
                  Builtin_attributes.warning_scope attrs
                    (fun () ->
-                      type_module ~strengthen:true funct_body
+                      type_module ~strengthen:true ~funct_body
                         (anchor_recmodule id) newenv smodl
                    )
                in
@@ -2744,7 +2744,7 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
         Tstr_modtype mtd, [Sig_modtype (id, decl, Exported)], map, newenv
     | Pstr_open sod ->
         let (od, sg, newenv) =
-          type_open_decl ~toplevel funct_body names env sod
+          type_open_decl ~toplevel ~funct_body names env sod
         in
         Tstr_open od, sg, shape_map, newenv
     | Pstr_class cl ->
@@ -2810,7 +2810,7 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
         let smodl = sincl.pincl_mod in
         let modl, modl_shape =
           Builtin_attributes.warning_scope sincl.pincl_attributes
-            (fun () -> type_module ~strengthen:true funct_body None env smodl)
+            (fun () -> type_module ~strengthen:true ~funct_body None env smodl)
         in
         let scope = Ctype.create_scope () in
         (* Rename all identifiers bound by this signature to avoid clashes *)
@@ -2862,14 +2862,14 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
 
 let type_toplevel_phrase env s =
   Env.reset_required_globals ();
-  type_structure ~toplevel:true false None env s
+  type_structure ~toplevel:true ~funct_body:false None env s
 
 let type_module_alias =
-  type_module ~alias:true ~strengthen:true false None
+  type_module ~alias:true ~strengthen:true ~funct_body:false None
 let type_module =
-  type_module ~strengthen:true false None
+  type_module ~strengthen:true ~funct_body:false None
 let type_structure =
-  type_structure false None
+  type_structure ~funct_body:false None
 
 (* Normalize types in a signature *)
 
@@ -3014,8 +3014,8 @@ let type_package env m p fl =
 (* Fill in the forward declarations *)
 
 let type_open_decl ?used_slot env od =
-  type_open_decl ?used_slot ?toplevel:None false (Signature_names.create ()) env
-    od
+  type_open_decl ?used_slot ?toplevel:None ~funct_body:false
+    (Signature_names.create ()) env od
 
 let type_open_descr ?used_slot env od =
   type_open_descr ?used_slot ?toplevel:None env od


### PR DESCRIPTION
I tried to read the type-checking code for `Tstr_open` in typemod.ml, and encountered the following line:

```ocaml
let type_module_alias = type_module ~alias:true true false None
```

I dislike unlabeled boolean arguments with a passion: at the callsite they are completely unreadable. This PR contains two minor refactoring commits that merely add a label to those boolean arguments, now the same declaration reads as follows:

```ocaml
let type_module_alias =
  type_module ~alias:true ~strengthen:true ~funct_body:false None
```

This is a refactoring-only PR that should be easy to review, as there are zero changes in behavior.