### PR TITLE
Support unicode identifiers in comments

### DIFF
--- a/Changes
+++ b/Changes
@@ -241,6 +241,9 @@ Working version
   (Gabriel Scherer, review by Jan Midtgaard and Miod Vallat,
    report by Jan Midtgaard)
 
+- #13710: Support unicode identifiers in comments.
+  (Pieter Goetschalckx, review by Florian Angeletti and Gabriel Scherer)
+
 OCaml 5.3.0
 ___________
 

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -470,7 +470,6 @@ let symbolchar_or_hash =
 let kwdopchar =
   ['$' '&' '*' '+' '-' '/' '<' '=' '>' '@' '^' '|']
 
-let ident = (lowercase | uppercase) identchar*
 let ident_ext = identstart_ext  identchar_ext*
 let extattrident = ident_ext ('.' ident_ext)*
 
@@ -826,7 +825,7 @@ and comment = parse
         store_normalized_newline nl;
         comment lexbuf
       }
-  | ident
+  | ident_ext
       { store_lexeme lexbuf; comment lexbuf }
   | _
       { store_lexeme lexbuf; comment lexbuf }

--- a/testsuite/tests/parsing/comments.compilers.reference
+++ b/testsuite/tests/parsing/comments.compilers.reference
@@ -23,5 +23,6 @@ val two : int = 2
 val three : int = 3
 val four : int = 4
 val set : int = 5
+val unit : unit = ()
 val meta : int = 6
 

--- a/testsuite/tests/parsing/comments.ml
+++ b/testsuite/tests/parsing/comments.ml
@@ -25,6 +25,8 @@ let four = (* We are inserting quoted litteral here {p|*)|p}, {œ|(*|œ} *) 4;;
 
 let set = (** [x < min({x'|x'∊l})] *) 5;;
 
+let unit = let é' = ignore in é' '"';;
+
 
 let meta = (* (* Reminder: quoted strings *)
 {é|Some text|é};;
@@ -46,4 +48,6 @@ let three =
 
 let four = (* We are inserting quoted litteral here {p|*)|p}, {œ|(*|œ} *) 4;;
 
-let set = (** [x < min({x'|x'∊l})] *) 5;; *) 6;;
+let set = (** [x < min({x'|x'∊l})] *) 5;;
+
+let unit = let é' = ignore in é' '"';; *) 6;;


### PR DESCRIPTION
The comment lexer was not updated to support unicode identifiers in #12664.

If you try to comment out this block of code, the comment is not valid:
```ocaml
(* let é' = ignore in é' '"' *)
```

This can be fixed by using `ident_ext` instead of `ident` in the comment lexer.

I don't think we need to validate with `Utf8_lexeme.validate_identifier`. This means that the same comment with an invalid identifier will be accepted too:
```ocaml
(* let 🐫' = ignore in 🐫' '"' *)
```
Avoiding that will be complicated, but accepting invalid code in comments is less problematic than not accepting valid code.