### PR TITLE
Fix #13713 and re-fix the runtime events deadlock

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,9 +64,11 @@ Working version
 - #13701: optimize `caml_continuation_use` based on #12735
   (Hugo Heuzard, review by KC Sivaramakrishnan)
 
-- #13227: Review of locking in the multicore runtime. Fix deadlocks in
-  runtime events and potential deadlocks with named values.
-  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+- #13227, #13714: Review of locking in the multicore runtime. Fix
+  deadlocks in runtime events and potential deadlocks with named
+  values.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, tests by
+  Jan Midtgaard)
 
 ### Code generation and optimizations:
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -91,8 +91,10 @@ Caml_inline void cpu_relax(void) {
    [caml_plat_lock_non_blocking].
 
    It is possible to combine calls to [caml_plat_lock_non_blocking] on
-   a mutex from the mutator with calls to [caml_plat_lock_blocking] on
-   the same mutex from a STW section.
+   a mutex from the mutator holding the domain lock with calls to
+   [caml_plat_lock_blocking] on another mutator that has released
+   their domain lock, but not with calls to [caml_plat_lock_blocking]
+   from a STW section or a custom block finaliser.
 
    These functions never raise exceptions; errors are fatal. Thus, for
    usages where bugs are susceptible to be introduced by users, the

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -559,7 +559,7 @@ void caml_finalize_channel(value vchan)
   }
   /* Don't run concurrently with caml_ml_out_channels_list that may resurrect
      a dead channel . */
-  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   chan->refcount --;
   if (chan->refcount > 0 || notflushed) {
     /* We need to keep the channel around, either because it is being
@@ -612,7 +612,7 @@ CAMLprim value caml_ml_open_descriptor_in_with_flags(int fd, int flags)
   struct channel * chan = caml_open_descriptor_in(fd);
   chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
-  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
@@ -627,7 +627,7 @@ CAMLprim value caml_ml_open_descriptor_out_with_flags(int fd, int flags)
   struct channel * chan = caml_open_descriptor_out(fd);
   chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
-  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
@@ -663,7 +663,7 @@ CAMLprim value caml_ml_out_channels_list (value unit)
   struct channel_list *channel_list = NULL, *cl_tmp;
   mlsize_t num_channels = 0;
 
-  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   for (struct channel *channel = caml_all_opened_channels;
        channel != NULL;
        channel = channel->next) {

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -663,6 +663,12 @@ CAMLprim value caml_ml_out_channels_list (value unit)
   struct channel_list *channel_list = NULL, *cl_tmp;
   mlsize_t num_channels = 0;
 
+  /* We cannot use [caml_plat_lock_non_blocking] inside
+     [caml_finalize_channel], so instead we must be careful here not
+     to trigger a STW while holding [caml_all_opened_channels_mutex].
+     This is why we allocate a temporary list with malloc. This is
+     unsatisfactory because the critical section inside
+     caml_ml_out_channels_list is not guaranteed to be short.*/
   caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   for (struct channel *channel = caml_all_opened_channels;
        channel != NULL;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -717,7 +717,13 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   Field(event, 3) = event_tag;
 
 
-  caml_plat_lock_non_blocking(&user_events_lock);
+  /* Pre-allocate to avoid STW while holding [user_events_lock]. */
+  list_item = caml_alloc_small(2, 0);
+
+  /* [user_events_lock] can be acquired during STW, so we must use
+     caml_plat_lock_blocking and be careful to avoid triggering any
+     STW while holding it */
+  caml_plat_lock_blocking(&user_events_lock);
   // critical section: when we update the user_events list we need to make sure
   // it is not updated while we construct the pointer to the next element
 
@@ -727,7 +733,6 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   }
 
   // event is added to the list of known events
-  list_item = caml_alloc_small(2, 0);
   Field(list_item, 0) = event;
   Field(list_item, 1) = user_events;
   caml_modify_generational_global_root(&user_events, list_item);
@@ -833,7 +838,7 @@ CAMLexport value caml_runtime_events_user_resolve(
   CAMLlocal3(event, cur_event_name, ml_event_name);
 
   // TODO: it might be possible to atomic load instead
-  caml_plat_lock_non_blocking(&user_events_lock);
+  caml_plat_lock_blocking(&user_events_lock);
   value current_user_event = user_events;
   caml_plat_unlock(&user_events_lock);
 


### PR DESCRIPTION
As noticed by @gasche, after @jmid's report of a deadlock at #13713, the channel finalizer cannot call `caml_plat_lock_non_blocking`. This reverts the parts of the change that caused the bug at #13713 and better documents what happens here.

Better reasoning about the interaction between `caml_plat_lock_non_blocking` and `caml_plat_lock_blocking` leads to tighter constraints about how they should be mixed. This shows that the previous patch did not fix the deadlock inside runtime events as thought, so I fix it differently here.