### PR TITLE
runtime: distinguish two kind of mutexes

### DIFF
--- a/Changes
+++ b/Changes
@@ -79,6 +79,10 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #13716: distinguish two kinds of mutex in the runtime system
+  (Gabriel Scherer, review by Antonin Décimo, Guillaume Munch-Maccagnoni
+   and Miod Vallat)
+
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in
   terms of a single construct.
   (Nicolás Ojeda Bär, review by Gabriel Scherer, Samuel Vivien, Ulysse Gérard

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -507,7 +507,7 @@ static void caml_thread_reinitialize(void)
   for (struct channel *chan = caml_all_opened_channels;
        chan != NULL;
        chan = chan->next) {
-    caml_plat_mutex_reinit(&chan->mutex);
+    caml_mutex_reinit(&chan->mutex);
   }
 }
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -392,7 +392,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_mutex_lock_non_blocking(&named_value_lock);
+  caml_mutex_lock_while_yielding_the_runtime_system(&named_value_lock);
   name = NULL; /* block may have moved while we waited for the lock. */
   for (struct named_value *nv = named_value_table[h];
        nv != NULL;
@@ -419,7 +419,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
 
 CAMLexport const value* caml_named_value(char const *name)
 {
-  caml_mutex_lock_non_blocking(&named_value_lock);
+  caml_mutex_lock_while_yielding_the_runtime_system(&named_value_lock);
   for (struct named_value *nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
@@ -434,7 +434,7 @@ CAMLexport const value* caml_named_value(char const *name)
 
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
-  caml_mutex_lock_non_blocking(&named_value_lock);
+  caml_mutex_lock_while_yielding_the_runtime_system(&named_value_lock);
   for (int i = 0; i < Named_value_size; i++){
     for (struct named_value *nv = named_value_table[i];
          nv != NULL;

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -26,6 +26,7 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
+#include "caml/sync.h"
 
 /* A note about callbacks and GC.  For best performance, a callback such as
      [caml_callback_exn(value closure, value arg)]
@@ -391,7 +392,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_plat_lock_non_blocking(&named_value_lock);
+  caml_mutex_lock_non_blocking(&named_value_lock);
   name = NULL; /* block may have moved while we waited for the lock. */
   for (struct named_value *nv = named_value_table[h];
        nv != NULL;
@@ -412,28 +413,28 @@ CAMLprim value caml_register_named_value(value vname, value val)
     named_value_table[h] = nv;
     caml_register_generational_global_root(&nv->val);
   }
-  caml_plat_unlock(&named_value_lock);
+  caml_mutex_unlock(&named_value_lock);
   CAMLreturn(Val_unit);
 }
 
 CAMLexport const value* caml_named_value(char const *name)
 {
-  caml_plat_lock_non_blocking(&named_value_lock);
+  caml_mutex_lock_non_blocking(&named_value_lock);
   for (struct named_value *nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
     if (strcmp(name, nv->name) == 0){
-      caml_plat_unlock(&named_value_lock);
+      caml_mutex_unlock(&named_value_lock);
       return &nv->val;
     }
   }
-  caml_plat_unlock(&named_value_lock);
+  caml_mutex_unlock(&named_value_lock);
   return NULL;
 }
 
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
-  caml_plat_lock_non_blocking(&named_value_lock);
+  caml_mutex_lock_non_blocking(&named_value_lock);
   for (int i = 0; i < Named_value_size; i++){
     for (struct named_value *nv = named_value_table[i];
          nv != NULL;
@@ -441,5 +442,5 @@ CAMLexport void caml_iterate_named_values(caml_named_action f)
       f( Op_val(nv->val), nv->name );
     }
   }
-  caml_plat_unlock(&named_value_lock);
+  caml_mutex_unlock(&named_value_lock);
 }

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -25,15 +25,17 @@
 #include "mlvalues.h"
 
 #ifndef _MSC_VER
-#include "platform.h"
+#include "sync.h"
 #else
-/* We avoid including platform.h (which is really only necessary here to declare
-   caml_plat_mutex) because that would end up pulling in pthread.h but we want
-   to hide it on the MSVC port as it is not the native way to handle threads.
-   So we inline here just the implementation of caml_plat_mutex on that port,
-   this should be kept in sync */
+/* We avoid including sync.h (which is really only necessary here to
+   declare sync_mutex) because that would end up pulling in pthread.h
+   but we want to hide it on the MSVC port as it is not the native way
+   to handle threads. So we inline here just the implementation of
+   caml_plat_mutex and sync_mutex on that port, this should be kept in
+   sync */
 #include <stdint.h>
 typedef intptr_t caml_plat_mutex;
+typedef caml_plat_mutex * sync_mutex;
 #endif
 
 #if defined(_WIN32)
@@ -49,7 +51,7 @@ struct channel {
   char * end;                   /* Physical end of the buffer */
   char * curr;                  /* Current position in the buffer */
   char * max;                   /* Logical end of the buffer (for input) */
-  caml_plat_mutex mutex;        /* Mutex protecting buffer */
+  sync_mutex mutex;             /* Mutex protecting the buffer */
   struct channel * next, * prev;/* Double chaining of channels (flush_all) */
   uintnat refcount;             /* Number of custom blocks owning the channel */
   int flags;                    /* Bitfield */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -66,46 +66,31 @@ Caml_inline void cpu_relax(void) {
 }
 
 
-/* Warning: blocking functions.
+/* Runtime mutexes and conditional variables.
 
-   Blocking functions are for use in the runtime outside of the
-   mutator, or when the domain lock is not held.
+   The functions below are for use within the runtime system, outside
+   of mutator code. Within critical sections for
+   [caml_plat_lock_blocking], it is incorrect to use the runtime
+   (allocating, releasing the domain lock, running a STW section,
+   raising an exception, etc.).
 
-   In order to use them inside the mutator and while holding the
-   domain lock, one must make sure that the wait is very short, and
-   that no deadlock can arise from the interaction with the domain
-   locks and the stop-the-world sections.
+   In particular, those mutex are higher-ranked than the domain lock,
+   it is invalid to take the domain lock while they are held.
 
-   In particular one must not call [caml_plat_lock_blocking] on a
-   mutex while the domain lock is held:
-    - if any critical section of the mutex crosses an allocation, a
-      blocking section releasing the domain lock, or any other
-      potential STW section, nor
-    - if the same lock is acquired at any point using [Mutex.lock] or
-      [caml_plat_lock_non_blocking] on the same domain (circular
-      deadlock with the domain lock).
+   Threads blocked on a mutex will not react to STW interruptions, so
+   this should only be used for very short critical sections.
 
-   Hence, as a general rule, prefer [caml_plat_lock_non_blocking] to
-   lock a mutex when inside the mutator and holding the domain lock.
-   The domain lock must be held in order to call
-   [caml_plat_lock_non_blocking].
+   Mutator code that needs to take a lock and use the runtime within
+   its critical section should use the lower-ranked, non-blocking
+   mutator mutexes from caml/sync.h.
 
-   It is possible to combine calls to [caml_plat_lock_non_blocking] on
-   a mutex from the mutator holding the domain lock with calls to
-   [caml_plat_lock_blocking] on another mutator that has released
-   their domain lock, but not with calls to [caml_plat_lock_blocking]
-   from a STW section or a custom block finaliser.
-
-   These functions never raise exceptions; errors are fatal. Thus, for
-   usages where bugs are susceptible to be introduced by users, the
-   functions from caml/sync.h should be used instead.
+   These functions never raise exceptions; errors are fatal.
 */
 
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 CAMLextern void caml_plat_mutex_init(caml_plat_mutex*);
 Caml_inline void caml_plat_lock_blocking(caml_plat_mutex*);
-Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex*);
 Caml_inline int caml_plat_try_lock(caml_plat_mutex*);
 void caml_plat_assert_locked(caml_plat_mutex*);
 void caml_plat_assert_all_locks_unlocked(void);
@@ -119,6 +104,7 @@ void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*); /* blocking */
 void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);
+
 
 /* Futexes
 
@@ -470,20 +456,12 @@ Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
   }
 }
 
-CAMLextern void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m);
-
-Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex* m)
-{
-  if (!caml_plat_try_lock(m)) {
-    caml_plat_lock_non_blocking_actual(m);
-  }
-}
-
 Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 {
   DEBUG_UNLOCK(m);
   check_err("unlock", pthread_mutex_unlock(m));
 }
+
 
 extern intnat caml_plat_pagesize;
 extern intnat caml_plat_mmap_alignment;

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -52,7 +52,8 @@ CAMLextern void caml_mutex_init(sync_mutex *mut);
 CAMLextern void caml_mutex_reinit(sync_mutex *mut);
 CAMLextern void caml_mutex_free(sync_mutex *mut);
 
-CAMLextern void caml_mutex_lock_non_blocking(sync_mutex mut);
+CAMLextern void caml_mutex_lock_while_yielding_the_runtime_system(
+  sync_mutex mut);
 CAMLextern void caml_mutex_unlock(sync_mutex mut);
 
 value caml_ml_mutex_lock(value wrapper);

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -23,10 +23,24 @@
 #include "mlvalues.h"
 #include "platform.h"
 
-/* OCaml mutexes and condition variables can also be manipulated from
-   C code with non-raising primitives from caml/platform.h. In this
-   case, pairs of lock/unlock for a critical section must come from
-   the same header (sync.h or platform.h). */
+/* Mutator mutexes and condition variables.
+
+   The mutexes defined in this file are intended for use by mutators
+   that own the OCaml runtime -- [caml_mutex_*] can be used from
+   C mutator code, and [caml_ml_*] from OCaml mutator code.
+
+   They are lower-ranked than the domain mutex: if the [mutex_lock*]
+   functions needs to block, they will release the domain lock to do
+   so (if it is held). In this sense they are "non-blocking", they
+   yield control to the backup thread or other OCaml threads.
+
+   Conversely, it is safe to release the domain lock and perform
+   other runtime effects within their critical section.
+
+   When there is a failure, the [caml_mutex_*] functions abort with
+   a fatal error while the [caml_ml_mutex_*] functions raise an
+   OCaml exception.
+ */
 
 typedef caml_plat_mutex * sync_mutex;
 typedef caml_plat_cond * sync_condvar;
@@ -34,8 +48,12 @@ typedef caml_plat_cond * sync_condvar;
 #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
 #define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
-CAMLextern int caml_mutex_lock(sync_mutex mut);
-CAMLextern int caml_mutex_unlock(sync_mutex mut);
+CAMLextern void caml_mutex_init(sync_mutex *mut);
+CAMLextern void caml_mutex_reinit(sync_mutex *mut);
+CAMLextern void caml_mutex_free(sync_mutex *mut);
+
+CAMLextern void caml_mutex_lock_non_blocking(sync_mutex mut);
+CAMLextern void caml_mutex_unlock(sync_mutex mut);
 
 value caml_ml_mutex_lock(value wrapper);
 value caml_ml_mutex_unlock(value wrapper);

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -87,7 +87,7 @@ static CAMLthread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {
-  caml_mutex_lock_non_blocking(chan->mutex);
+  caml_mutex_lock_while_yielding_the_runtime_system(chan->mutex);
   last_channel_locked = chan;
 }
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -40,6 +40,7 @@
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
 #include "caml/platform.h"
+#include "caml/sync.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/bigarray.h"
@@ -86,13 +87,13 @@ static CAMLthread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {
-  caml_plat_lock_non_blocking(&chan->mutex);
+  caml_mutex_lock_non_blocking(chan->mutex);
   last_channel_locked = chan;
 }
 
 CAMLexport void caml_channel_unlock(struct channel *chan)
 {
-  caml_plat_unlock(&chan->mutex);
+  caml_mutex_unlock(chan->mutex);
   last_channel_locked = NULL;
 }
 
@@ -182,7 +183,7 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
   caml_leave_blocking_section();
   channel->curr = channel->max = channel->buff;
   channel->end = channel->buff + IO_BUFFER_SIZE;
-  caml_plat_mutex_init(&channel->mutex);
+  caml_mutex_init(&channel->mutex);
   channel->refcount = 0;
   channel->prev = NULL;
   channel->next = NULL;
@@ -204,7 +205,7 @@ CAMLexport void caml_close_channel(struct channel *channel)
 {
   CAMLassert((channel->flags & CHANNEL_FLAG_MANAGED_BY_GC) == 0);
   close(channel->fd);
-  caml_plat_mutex_free(&channel->mutex);
+  caml_mutex_free(&channel->mutex);
   caml_stat_free(channel->name);
   caml_stat_free(channel->buff);
   caml_stat_free(channel);
@@ -570,7 +571,7 @@ void caml_finalize_channel(value vchan)
   }
   unlink_channel(chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
-  caml_plat_mutex_free(&chan->mutex);
+  caml_mutex_free(&chan->mutex);
   caml_stat_free(chan->name);
   if (chan->fd != -1) caml_stat_free(chan->buff);
   caml_stat_free(chan);

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -90,16 +90,6 @@ void caml_plat_assert_all_locks_unlocked(void)
 #endif
 }
 
-CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
-{
-  /* Avoid exceptions */
-  caml_enter_blocking_section_no_pending();
-  int rc = pthread_mutex_lock(m);
-  caml_leave_blocking_section();
-  check_err("lock_non_blocking", rc);
-  DEBUG_LOCK(m);
-}
-
 void caml_plat_mutex_free(caml_plat_mutex* m)
 {
   check_err("mutex_free", pthread_mutex_destroy(m));

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -704,7 +704,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     act = 2;
     break;
   }
-  caml_mutex_lock_non_blocking(&signal_install_mutex);
+  caml_mutex_lock_while_yielding_the_runtime_system(&signal_install_mutex);
   /* Note: no safepoint for calling signals in this critical section */
   oldact = caml_set_signal_action(sig, act);
   switch (oldact) {

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -31,6 +31,7 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
+#include "caml/sync.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
@@ -703,7 +704,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     act = 2;
     break;
   }
-  caml_plat_lock_non_blocking(&signal_install_mutex);
+  caml_mutex_lock_non_blocking(&signal_install_mutex);
   /* Note: no safepoint for calling signals in this critical section */
   oldact = caml_set_signal_action(sig, act);
   switch (oldact) {
@@ -727,10 +728,10 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     }
     caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
   }
-  caml_plat_unlock(&signal_install_mutex);
+  caml_mutex_unlock(&signal_install_mutex);
   caml_get_value_or_raise(caml_process_pending_signals_res());
   CAMLreturn (res);
  err:
-  caml_plat_unlock(&signal_install_mutex);
+  caml_mutex_unlock(&signal_install_mutex);
   caml_sys_error(NO_ARG);
 }

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -80,14 +80,41 @@ static const struct custom_operations caml_mutex_ops = {
   custom_fixed_length_default
 };
 
-CAMLexport int caml_mutex_lock(sync_mutex mut)
-{
-  return sync_mutex_lock(mut);
+CAMLexport void caml_mutex_init(sync_mutex *mut) {
+    check_err("caml_mutex_init", sync_mutex_create(mut));
 }
 
-CAMLexport int caml_mutex_unlock(sync_mutex mut)
+CAMLexport void caml_mutex_reinit(sync_mutex *mut) {
+    caml_plat_mutex_reinit(*mut);
+}
+
+CAMLexport void caml_mutex_free(sync_mutex *mut) {
+    check_err("caml_mutex_free", sync_mutex_destroy(*mut));
+    *mut = NULL;
+}
+
+CAMLexport void caml_mutex_lock_non_blocking(sync_mutex mut)
 {
-  return sync_mutex_unlock(mut);
+  if (Caml_state_opt == NULL) {
+    /* If we do not own the domain lock,
+       we can lock the mutex directly. */
+    check_err("caml_mutex_lock", sync_mutex_lock(mut));
+  }
+  else if (sync_mutex_trylock(mut) != MUTEX_PREVIOUSLY_UNLOCKED) {
+    /* If we own the domain lock and would block on the mutex,
+       release the domain lock before taking the lock. */
+    caml_enter_blocking_section();
+    int retcode = sync_mutex_lock(mut);
+    caml_leave_blocking_section();
+    check_err("caml_mutex_lock", retcode);
+  }
+  DEBUG_LOCK(mut);
+}
+
+CAMLexport void caml_mutex_unlock(sync_mutex mut)
+{
+  DEBUG_UNLOCK(mut);
+  check_err("caml_mutex_unlock", sync_mutex_unlock(mut));
 }
 
 CAMLprim value caml_ml_mutex_new(value unit)

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -104,7 +104,8 @@ CAMLexport void caml_mutex_lock_while_yielding_the_runtime_system(
   else if (sync_mutex_trylock(mut) != MUTEX_PREVIOUSLY_UNLOCKED) {
     /* If we own the domain lock and would block on the mutex,
        release the domain lock before taking the lock. */
-    caml_enter_blocking_section();
+    caml_enter_blocking_section_no_pending();
+    /* Note: we use [..._no_pending] to ensure that no exceptions are raised. */
     int retcode = sync_mutex_lock(mut);
     caml_leave_blocking_section();
     check_err("caml_mutex_lock", retcode);

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -93,7 +93,8 @@ CAMLexport void caml_mutex_free(sync_mutex *mut) {
     *mut = NULL;
 }
 
-CAMLexport void caml_mutex_lock_non_blocking(sync_mutex mut)
+CAMLexport void caml_mutex_lock_while_yielding_the_runtime_system(
+  sync_mutex mut)
 {
   if (Caml_state_opt == NULL) {
     /* If we do not own the domain lock,


### PR DESCRIPTION
## Summary

This PR distinguishes two kind of mutexes:

- 'runtime' mutexes are for blocking critical sections which do not access the runtime.

- 'mutator' mutexes are for non-blocking critical sections (blocking on a mutex releases the runtime lock) which may access the runtime system.

This refactoring comes from the discussions in #13227, it tries to avoid a class of bug where the same mutex is used in both blocking and non-blocking fashion, resulting in subtle deadlock situations.

## More details

The runtime has a `caml_plat_lock_blocking` function that takes a mutex in the obvious way. This function should be used very carefully, because it in blocks a domain without transferring control to its backup thread or otherwise listening to STW interruptions, and it can easily cause deadlocks if the critical section itself contains an STW poll point. In #13063, @gadmm introduced a different mutex-taking function, `caml_plat_lock_non_blocking` that releases the domain lock when it needs to block, and should be used in any critical section that could be long or needs to use the runtime system.

We are still learning about what's a correct usage discipline for these two functions (on Monday I temporarily introduced a bug in trunk, detected reported on Tuesday morning by @jmid in #13713 and fixed on Tuesday evening by @gadmm in #13714 ). In #13714 we realized that it is incorrect to mix uses of `lock_blocking` and `lock_non_blocking` on the same mutex -- except in very specific use-cases that are not currently used in the runtime. The current PR proposes to separate the two APIs so that there is no risk to make this mistake again in the future. The goal is to have a system that is simpler to reason about and to use correctly for non-experts such as myself.