### PR TITLE
Add Result.{get_ok',error_to_failure}

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,6 +150,10 @@ Working version
 
 ### Standard library:
 
+- #13720: Add Result.{get_ok',error_to_failure}
+ (Daniel Bünzli, review by wikku, Gabriel Scherer, Nicolás Ojeda Bär,
+  Vincent Laviron and hirrolot)
+
 - #13696: Add Result.product and Result.Syntax.
   (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
 

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -19,6 +19,7 @@ let ok v = Ok v
 let error e = Error e
 let value r ~default = match r with Ok v -> v | Error _ -> default
 let get_ok = function Ok v -> v | Error _ -> invalid_arg "result is Error _"
+let get_ok' = function Ok v -> v | Error e -> invalid_arg e
 let get_error = function Error e -> e | Ok _ -> invalid_arg "result is Ok _"
 let bind r f = match r with Ok v -> f v | Error _ as e -> e
 let join = function Ok r -> r | Error _ as e -> e

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -21,6 +21,7 @@ let value r ~default = match r with Ok v -> v | Error _ -> default
 let get_ok = function Ok v -> v | Error _ -> invalid_arg "result is Error _"
 let get_ok' = function Ok v -> v | Error e -> invalid_arg e
 let get_error = function Error e -> e | Ok _ -> invalid_arg "result is Ok _"
+let error_to_failure = function Ok v -> v | Error e -> failwith e
 let bind r f = match r with Ok v -> f v | Error _ as e -> e
 let join = function Ok r -> r | Error _ as e -> e
 let map f = function Ok v -> Ok (f v) | Error _ as e -> e

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -50,6 +50,12 @@ val get_error : ('a, 'e) result -> 'e
 
     @raise Invalid_argument if [r] is [Ok _]. *)
 
+val error_to_failure : ('a, string) result -> 'a
+(** [error_to_failure r] is [v] if [r] is [Ok v] and raises [Failure e]
+    if [r] is [Error e].
+
+    @since 5.4 *)
+
 val bind : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
 (** [bind r f] is [f v] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -39,6 +39,12 @@ val get_ok : ('a, 'e) result -> 'a
 
     @raise Invalid_argument if [r] is [Error _]. *)
 
+val get_ok' : ('a, string) result -> 'a
+(** [get_ok'] is like {!get_ok} but in case of error uses the
+    error message for raising [Invalid_argument].
+
+    @since 5.4 *)
+
 val get_error : ('a, 'e) result -> 'e
 (** [get_error r] is [e] if [r] is [Error e] and raise otherwise.
 

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -26,6 +26,13 @@ let test_get_ok_error () =
   assert_raise_invalid_argument Result.get_error (Ok 2);
   ()
 
+let test_error_to_failure () =
+  assert (Result.error_to_failure (Ok 3) = 3);
+  (match Result.error_to_failure (Error "ha") with
+   exception Failure "ha" [@warning "-52"] -> ();
+   | _ -> assert false);
+  ()
+
 let test_bind () =
   assert (Result.bind (Ok 3) (fun x -> Ok (succ x)) = Ok 4);
   assert (Result.bind (Ok 3) (fun x -> Error (strf "hu%d!" x)) = Error "hu3!");
@@ -147,6 +154,7 @@ let tests () =
   test_ok_error ();
   test_value ();
   test_get_ok_error ();
+  test_error_to_failure ();
   test_bind ();
   test_join ();
   test_maps ();

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -17,7 +17,11 @@ let test_value () =
 
 let test_get_ok_error () =
   assert (Result.get_ok (Ok 3) = 3);
+  assert (Result.get_ok' (Ok 3) = 3);
   assert_raise_invalid_argument Result.get_ok (Error "ha!");
+  (match Result.get_ok' (Error "ha!") with
+   exception Invalid_argument "ha!" [@warning "-52"] -> ();
+   | _ -> assert false);
   assert (Result.get_error (Error "ha!") = "ha!");
   assert_raise_invalid_argument Result.get_error (Ok 2);
   ()


### PR DESCRIPTION
Split from https://github.com/ocaml/ocaml/pull/13696 please read the discussion there before commenting on the names.

# Interaction with exceptions

1. `Result.get_ok'` this is like `Result.get_ok` but takes the opportunity of having a `string` error case to directly transfer the message to the `Invalid_argument` exception. If we have nice error messages at hand it's silly not to use them for programming errors.
   
2. `Result.error_to_failure`, transforms `string` error cases to `Failure _` exceptions. This is something I often use internally in the implementation of functions. It allows to avoid the error monad in the implementation and just resurface it at the API boundary by simply wrapping the body of the function with a top level `| Failure e -> Error e` exception handler.