### PR TITLE
Add Result.retract

### DIFF
--- a/Changes
+++ b/Changes
@@ -93,6 +93,9 @@ Working version
 
 ### Standard library:
 
+- #13721: Add Result.retract
+  (Daniel Bünzli, review by Gabriel Scherer)
+
 - #13695: Add Stdlib.Char.Ascii
   (Daniel Bünzli, review by by Nicolás Ojeda Bär and Jeremy Yallop)
 

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -25,6 +25,7 @@ let join = function Ok r -> r | Error _ as e -> e
 let map f = function Ok v -> Ok (f v) | Error _ as e -> e
 let map_error f = function Error e -> Error (f e) | Ok _ as v -> v
 let fold ~ok ~error = function Ok v -> ok v | Error e -> error e
+let retract = function Ok v -> v | Error v -> v
 let iter f = function Ok v -> f v | Error _ -> ()
 let iter_error f = function Error e -> f e | Ok _ -> ()
 let is_ok = function Ok _ -> true | Error _ -> false

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -61,6 +61,11 @@ val fold : ok:('a -> 'c) -> error:('e -> 'c) -> ('a, 'e) result -> 'c
 (** [fold ~ok ~error r] is [ok v] if [r] is [Ok v] and [error e] if [r]
     is [Error e]. *)
 
+val retract : ('a, 'a) result -> 'a
+(** [retract r] is [v] if [r] is [Ok v] or [Error v].
+
+    @since 5.4 *)
+
 val iter : ('a -> unit) -> ('a, 'e) result -> unit
 (** [iter f r] is [f v] if [r] is [Ok v] and [()] otherwise. *)
 

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -49,6 +49,11 @@ let test_fold () =
   assert (Result.(fold ~ok ~error) (Error "ha!") = (Error "ha!"));
   ()
 
+let test_retract () =
+  assert (Result.retract (Ok 3) = 3);
+  assert (Result.retract (Error 2) = 2);
+  ()
+
 let test_iters () =
   let count = ref 0 in
   let set_count x = count := x in
@@ -118,6 +123,7 @@ let tests () =
   test_join ();
   test_maps ();
   test_fold ();
+  test_retract ();
   test_iters ();
   test_is_ok_error ();
   test_equal ();

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -32,16 +32,16 @@ let example_1 () =
   | { a = true; b = Either.Left y } -> Result.Ok y;;
 (let
   (example_1/311 =
-     (function param/335[int]
+     (function param/336[int]
        (let (input/313 = (makemutable 0 (int,*) 1 [0: 1]))
          (if (field_int 0 input/313)
-           (let (*match*/338 =o (field_mut 1 input/313))
-             (switch* *match*/338
+           (let (*match*/339 =o (field_mut 1 input/313))
+             (switch* *match*/339
               case tag 0:
                (if (seq (setfield_ptr 1 input/313 [1: 3]) 0) [1: 3]
-                 (let (*match*/340 =o (field_mut 1 input/313))
-                   (switch* *match*/340
-                    case tag 0: (makeblock 0 (int) (field_imm 0 *match*/340))
+                 (let (*match*/341 =o (field_mut 1 input/313))
+                   (switch* *match*/341
+                    case tag 0: (makeblock 0 (int) (field_imm 0 *match*/341))
                     case tag 1:
                      (raise
                        (makeblock 0 (global Match_failure/20!)
@@ -77,25 +77,25 @@ let example_2 () =
       Result.Error 3
   | { a = true; b = { mut = Either.Left y } } -> Result.Ok y;;
 (let
-  (example_2/347 =
-     (function param/351[int]
-       (let (input/349 = (makeblock 0 (int,*) 1 (makemutable 0 [0: 1])))
-         (if (field_int 0 input/349)
-           (let (*match*/355 =o (field_mut 0 (field_imm 1 input/349)))
-             (switch* *match*/355
+  (example_2/348 =
+     (function param/352[int]
+       (let (input/350 = (makeblock 0 (int,*) 1 (makemutable 0 [0: 1])))
+         (if (field_int 0 input/350)
+           (let (*match*/356 =o (field_mut 0 (field_imm 1 input/350)))
+             (switch* *match*/356
               case tag 0:
-               (if (seq (setfield_ptr 0 (field_imm 1 input/349) [1: 3]) 0)
+               (if (seq (setfield_ptr 0 (field_imm 1 input/350) [1: 3]) 0)
                  [1: 3]
-                 (let (*match*/358 =o (field_mut 0 (field_imm 1 input/349)))
-                   (switch* *match*/358
-                    case tag 0: (makeblock 0 (int) (field_imm 0 *match*/358))
+                 (let (*match*/359 =o (field_mut 0 (field_imm 1 input/350)))
+                   (switch* *match*/359
+                    case tag 0: (makeblock 0 (int) (field_imm 0 *match*/359))
                     case tag 1:
                      (raise
                        (makeblock 0 (global Match_failure/20!)
                          [0: "contexts_2.ml" 11 2])))))
               case tag 1: [1: 2]))
            [1: 1]))))
-  (apply (field_mut 1 (global Toploop!)) "example_2" example_2/347))
+  (apply (field_mut 1 (global Toploop!)) "example_2" example_2/348))
 val example_2 : unit -> (bool, int) Result.t = <fun>
 |}]
 
@@ -122,16 +122,16 @@ let example_3 () =
       Result.Error 3
   | { mut = (true, Either.Left y) } -> Result.Ok y;;
 (let
-  (example_3/364 =
-     (function param/368[int]
-       (let (input/366 =mut [0: 1 [0: 1]] *match*/369 =o *input/366)
-         (if (field_imm 0 *match*/369)
-           (switch* (field_imm 1 *match*/369)
+  (example_3/365 =
+     (function param/369[int]
+       (let (input/367 =mut [0: 1 [0: 1]] *match*/370 =o *input/367)
+         (if (field_imm 0 *match*/370)
+           (switch* (field_imm 1 *match*/370)
             case tag 0:
-             (if (seq (assign input/366 [0: 1 [1: 3]]) 0) [1: 3]
-               (makeblock 0 (int) (field_imm 0 (field_imm 1 *match*/369))))
+             (if (seq (assign input/367 [0: 1 [1: 3]]) 0) [1: 3]
+               (makeblock 0 (int) (field_imm 0 (field_imm 1 *match*/370))))
             case tag 1: [1: 2])
            [1: 1]))))
-  (apply (field_mut 1 (global Toploop!)) "example_3" example_3/364))
+  (apply (field_mut 1 (global Toploop!)) "example_3" example_3/365))
 val example_3 : unit -> (bool, int) Result.t = <fun>
 |}]


### PR DESCRIPTION
Split from https://github.com/ocaml/ocaml/pull/13696 please read the discussion there before commenting on the name.

# Retracting the result type for equal success and error type

The `Result.retract : ('a, 'a) result -> 'a` function is useful when your success and error types eventually end up being the same and it's time to operate on either case uniformly. Formally this is just `Result.fold ~ok:Fun.id ~error:Fun.id` but I would like to have it as a combinator.

One example of this is when both case end up being an HTTP response and it's time to send it. For now I have it as other names in libraries like for example [`Http.Response.result`] and used [here]. But I'd prefer to have it simply as `Result.retract` as the pattern can be used in other contexts.

[`Http.Response.result`]: https://erratique.ch/software/webs/doc/Webs/Http/Response/index.html#val-result
[here]: https://github.com/dbuenzli/webs/blob/0edac44b35befee12d9bd96b7a4b048f60fdb309/examples/unix_send_file.ml#L20-L23