### PR TITLE
Set `FLEXDIR` when bootstrapping flexlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,9 +645,10 @@ flexlink.byte$(EXE): $(FLEXDLL_SOURCES)
 	  OCAMLOPT='$(value BOOT_OCAMLC) $(USE_RUNTIME_PRIMS) $(USE_STDLIB)' \
 	  flexlink.exe support
 	cp $(FLEXDLL_SOURCE_DIR)/flexlink.exe $@
+	cp $(addprefix $(FLEXDLL_SOURCE_DIR)/, $(FLEXDLL_OBJECTS)) $(ROOTDIR)
 
 partialclean::
-	rm -f flexlink.byte flexlink.byte.exe
+	rm -f flexlink.byte flexlink.byte.exe flexdll_*.o flexdll_*.obj
 
 $(BYTE_BINDIR)/flexlink$(EXE): \
     boot/ocamlrun$(EXE) flexlink.byte$(EXE) | $(BYTE_BINDIR)
@@ -655,7 +656,6 @@ $(BYTE_BINDIR)/flexlink$(EXE): \
 # Start with a copy to ensure that the result is always executable
 	cp boot/ocamlrun$(EXE) $@
 	cat flexlink.byte$(EXE) >> $@
-	cp $(addprefix $(FLEXDLL_SOURCE_DIR)/, $(FLEXDLL_OBJECTS)) $(BYTE_BINDIR)
 
 partialclean::
 	rm -f $(BYTE_BINDIR)/flexlink $(BYTE_BINDIR)/flexlink.exe
@@ -886,7 +886,6 @@ flexlink.opt$(EXE): \
 	cp $(FLEXDLL_SOURCE_DIR)/flexlink.exe $@
 	rm -f $(OPT_BINDIR)/flexlink$(EXE)
 	cd $(OPT_BINDIR); $(LN) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
-	cp $(addprefix $(BYTE_BINDIR)/, $(FLEXDLL_OBJECTS)) $(OPT_BINDIR)
 
 else
 
@@ -2803,8 +2802,7 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	  flexlink.byte$(EXE) "$(INSTALL_BINDIR)"
 endif # ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	$(MKDIR) "$(INSTALL_FLEXDLLDIR)"
-	$(INSTALL_DATA) $(addprefix $(BYTE_BINDIR)/, $(FLEXDLL_OBJECTS)) \
-    "$(INSTALL_FLEXDLLDIR)"
+	$(INSTALL_DATA) $(FLEXDLL_OBJECTS) "$(INSTALL_FLEXDLLDIR)"
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 	$(INSTALL_DATA) Makefile.config "$(INSTALL_LIBDIR)"
 	$(INSTALL_DATA) $(DOC_FILES) "$(INSTALL_DOCDIR)"

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -177,6 +177,8 @@ OC_NATIVE_COMPFLAGS = @oc_native_compflags@
 
 OC_NATIVE_LINKFLAGS = -g
 
+BUILD_TRIPLET = @build@
+
 # Platform-dependent command to create symbolic links
 LN = @ln@
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -141,9 +141,29 @@ ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 ifeq "$(filter $(REAL_ROOT_DIR)/$(BYTE_BINDIR), $(subst :, ,$(PATH)))" ""
   export PATH := \
     $(REAL_ROOT_DIR)/$(OPT_BINDIR):$(REAL_ROOT_DIR)/$(BYTE_BINDIR):$(PATH)
+  # $(BUILD_COMPANY_SYSTEM) is the last two parts of $(BUILD_TRIPLET)
+  BUILD_TRIPLET_FIELDS := $(subst -,$(SPACE),$(BUILD_TRIPLET))
+  BUILD_COMPANY_SYSTEM := $(subst $(SPACE),-,$\
+    $(wordlist 2, $(words $(BUILD_TRIPLET_FIELDS)), $(BUILD_TRIPLET_FIELDS)))
+  # Use the FLEXDIR environment variable to tell flexlink where the support
+  # objects are located. Passing this location using -I would defeat the whole
+  # purpose of the PATH-trick (bootstrapped flexlink is indistinguishable from
+  # an installed flexlink). flexlink also looks for the objects in the same
+  # directory as the executable, but this is slightly irritating as it requires
+  # copying them to both byte/bin/ and opt/bin/ but also doesn't work if
+  # opt/bin/flexlink.exe is a symlink to flexlink.opt.exe, as flexlink can end
+  # up looking in the directory for the target of the symlink, rather than the
+  # symlink itself.
+ifeq "" "$(filter pc-msys pc-cygwin%, $(BUILD_COMPANY_SYSTEM))"
+  export FLEXDIR := $(REAL_ROOT_DIR)
+else
+  export FLEXDIR := $(shell cygpath -w "$(REAL_ROOT_DIR)")
+endif
+  undefine BUILD_TRIPLET_FIELDS
+  undefine BUILD_COMPANY_SYSTEM
 endif
   undefine REAL_ROOT_DIR
-endif
+endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 
 # List of other libraries
 ALL_OTHERLIBS = dynlink str systhreads unix runtime_events

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -96,10 +96,9 @@ cross-flexdll: | $(BYTE_BINDIR) $(OPT_BINDIR)
 	$(LN) flexlink.opt.exe flexlink.byte.exe
 	cp flexlink.byte.exe $(BYTE_BINDIR)/flexlink
 	cd $(BYTE_BINDIR) && $(LN) flexlink flexlink.exe
-	cp $(addprefix $(FLEXDLL_SOURCE_DIR)/, $(FLEXDLL_OBJECTS)) $(BYTE_BINDIR)
+	cp $(addprefix $(FLEXDLL_SOURCE_DIR)/, $(FLEXDLL_OBJECTS)) $(ROOTDIR)
 	cp flexlink.opt.exe $(OPT_BINDIR)/flexlink
 	cd $(OPT_BINDIR) && $(LN) flexlink flexlink.exe
-	cp $(addprefix $(FLEXDLL_SOURCE_DIR)/, $(FLEXDLL_OBJECTS)) $(OPT_BINDIR)
 
 INSTALL_OVERRIDES=build_ocamldoc=false WITH_DEBUGGER= OCAMLRUN=ocamlrun
 


### PR DESCRIPTION
Follow-up to #13494. When linking, `flexlink` needs one of its system-specific support objects (e.g. `flexdll_mingw64.o`). When `flexlink.exe` is bootstrapped with OCaml, these objects are installed in `%PREFIX%\lib\ocaml\flexdll` and the compiler automatically adds `-I +flexdll`. _During the build_, however, we currently rely on `flexlink`'s historical default, which is to look for these objects in `Filename.dirname Sys.executable_name`. In the build, this just means the objects get copied to both `byte/bin/` and `opt/bin/` and it Just Works™ (full mechanism described in #12278). However, `opt/bin/flexlink.exe` is now capable of being a symlink to `../../flexlink.opt.exe`, and the root directory doesn't contain the objects.

This PR simplifies things by instead setting the `FLEXDIR` environment variable (which, if set, is used by `flexlink` _instead_ of `Filename.dirname Sys.executable_name`). That change is fairly simple - it's made slightly more complicated by cross-compilation, since the root directory path has to be run via `cygpath`, but only if we're building on MSYS2 / Cygwin.