### PR TITLE
Some minor UTF-8 spring-cleaning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -56,23 +56,20 @@ META.in                  typo.missing-header
 
 # Hyperlinks and other markup features cause long lines
 *.adoc                   typo.long-line=may typo.very-long-line=may typo.utf8=may
-*.md                     typo.long-line=may typo.very-long-line=may
+*.md                     typo.long-line=may typo.very-long-line=may typo.utf8=may
 
 # Github templates and scripts lack headers, have long lines
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may
-/.github/workflows/build-cross.yml typo.non-ascii
-/.github/workflows/build-msvc.yml typo.utf8
+/.github/workflows/*.yml typo.utf8=may
 
-/.mailmap                typo.long-line typo.missing-header typo.non-ascii
-/CONTRIBUTING.md         typo.non-ascii=may
-/README.adoc             typo.non-ascii=may
-/README.win32.adoc       typo.non-ascii=may
+/.mailmap                typo.long-line typo.missing-header typo.utf8
+/CONTRIBUTING.md         typo.utf8
 /Changes                 typo.utf8 typo.missing-header
 /release-info/News       typo.utf8 typo.missing-header
 /LICENSE                 typo.very-long-line typo.missing-header
 # tools/ci/appveyor/appveyor_build.cmd only has missing-header because
 # dra27 too lazy to update check-typo to interpret Cmd-style comments!
-/tools/ci/appveyor/appveyor_build.cmd       typo.very-long-line typo.missing-header typo.non-ascii
+/tools/ci/appveyor/appveyor_build.cmd       typo.very-long-line typo.missing-header typo.utf8
 /tools/ci/inria/bootstrap/remove-sinh-primitive.patch typo.prune
 /release-info/howto.md                    typo.missing-header typo.long-line
 /release-info/templates/*.md              typo.missing-header typo.very-long-line=may
@@ -111,7 +108,7 @@ otherlibs/unix/symlink_win32.c     typo.long-line
 
 # Some Unicode characters here and there
 utils/misc.ml            typo.utf8
-runtime/sak.c            typo.non-ascii
+runtime/sak.c            typo.utf8
 
 testsuite/tests/**                                      typo.missing-header typo.long-line=may
 testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab linguist-language=Fortran

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,7 @@
 * text=auto
 
 # It is not possible to wrap lines lines in .gitattributes files
-.gitattributes typo.long-line=may typo.utf8
+.gitattributes typo.long-line=may typo.non-ascii
 .gitmodules typo.long-line=may typo.tab=may
 
 .editorconfig typo.missing-header=may
@@ -55,21 +55,21 @@ tools/mantis2gh_stripped.csv typo.missing-header
 META.in                  typo.missing-header
 
 # Hyperlinks and other markup features cause long lines
-*.adoc                   typo.long-line=may typo.very-long-line=may typo.utf8=may
-*.md                     typo.long-line=may typo.very-long-line=may typo.utf8=may
+*.adoc                   typo.long-line=may typo.very-long-line=may typo.non-ascii=may
+*.md                     typo.long-line=may typo.very-long-line=may typo.non-ascii=may
 
 # Github templates and scripts lack headers, have long lines
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may
-/.github/workflows/*.yml typo.utf8=may
+/.github/workflows/*.yml typo.non-ascii=may
 
-/.mailmap                typo.long-line typo.missing-header typo.utf8
-/CONTRIBUTING.md         typo.utf8
-/Changes                 typo.utf8 typo.missing-header
-/release-info/News       typo.utf8 typo.missing-header
+/.mailmap                typo.long-line typo.missing-header typo.non-ascii
+/CONTRIBUTING.md         typo.non-ascii
+/Changes                 typo.non-ascii typo.missing-header
+/release-info/News       typo.non-ascii typo.missing-header
 /LICENSE                 typo.very-long-line typo.missing-header
 # tools/ci/appveyor/appveyor_build.cmd only has missing-header because
 # dra27 too lazy to update check-typo to interpret Cmd-style comments!
-/tools/ci/appveyor/appveyor_build.cmd       typo.very-long-line typo.missing-header typo.utf8
+/tools/ci/appveyor/appveyor_build.cmd       typo.very-long-line typo.missing-header typo.non-ascii
 /tools/ci/inria/bootstrap/remove-sinh-primitive.patch typo.prune
 /release-info/howto.md                    typo.missing-header typo.long-line
 /release-info/templates/*.md              typo.missing-header typo.very-long-line=may
@@ -83,8 +83,8 @@ Makefile*                typo.makefile-whitespace=may
 asmcomp/*/emit.mlp       typo.tab=may typo.long-line=may
 
 # Unicode character used for graphical debugging and box drawing
-typing/gprinttyp.mli     typo.utf8
-typing/gprinttyp.ml      typo.utf8
+typing/gprinttyp.mli     typo.non-ascii
+typing/gprinttyp.ml      typo.non-ascii
 
 # The build-aux directory contains bundled files so do not check it
 build-aux                typo.prune
@@ -107,22 +107,22 @@ otherlibs/unix/stat_win32.c        typo.long-line
 otherlibs/unix/symlink_win32.c     typo.long-line
 
 # Some Unicode characters here and there
-utils/misc.ml            typo.utf8
-runtime/sak.c            typo.utf8
+utils/misc.ml            typo.non-ascii
+runtime/sak.c            typo.non-ascii
 
 testsuite/tests/**                                      typo.missing-header typo.long-line=may
 testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab linguist-language=Fortran
 testsuite/tests/lib-unix/win-stat/fakeclock.c           typo.missing-header=false
 testsuite/tests/misc-unsafe/almabench.ml                typo.long-line
-testsuite/tests/parsing/latin9.ml                       typo.utf8 typo.very-long-line
-testsuite/tests/parsing/comments.ml                     typo.utf8
-testsuite/tests/tool-ocamldoc/Latin9.ml                 typo.utf8
-testsuite/tests/parsetree/source.ml                     typo.utf8
-testsuite/tests/typing-unicode/*.ml                     typo.utf8
-testsuite/tests/tool-toplevel/strings.ml                typo.utf8
-testsuite/tests/win-unicode/*.ml                        typo.utf8
-testsuite/tests/unicode/見.ml                           typo.utf8
-testsuite/tests/lib-format/unicode.ml                   typo.utf8
+testsuite/tests/parsing/latin9.ml                       typo.non-ascii typo.very-long-line
+testsuite/tests/parsing/comments.ml                     typo.non-ascii
+testsuite/tests/tool-ocamldoc/Latin9.ml                 typo.non-ascii
+testsuite/tests/parsetree/source.ml                     typo.non-ascii
+testsuite/tests/typing-unicode/*.ml                     typo.non-ascii
+testsuite/tests/tool-toplevel/strings.ml                typo.non-ascii
+testsuite/tests/win-unicode/*.ml                        typo.non-ascii
+testsuite/tests/unicode/見.ml                           typo.non-ascii
+testsuite/tests/lib-format/unicode.ml                   typo.non-ascii
 testsuite/tests/lexing/reject_bad_encoding.ml           typo.prune
 testsuite/tests/asmgen/immediates.cmm                   typo.very-long-line
 testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line
@@ -153,7 +153,7 @@ tools/magic                       typo.missing-header
 /boot/menhir/** typo.long-line=may typo.very-long-line=may
 /boot/menhir/** typo.missing-header=may
 /boot/menhir/** typo.white-at-eol=may
-/boot/menhir/** typo.utf8=may
+/boot/menhir/** typo.non-ascii=may
 
 # Line-ending specifications, for Windows interoperability
 *.sh text eol=lf

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -85,8 +85,9 @@ jobs:
         run: tools/check-typo
         if: >-
           github.event_name == 'push'
-          && (startsWith(github.event.ref, 'refs/heads/4.')
-             || github.event.ref == 'refs/heads/trunk')
+          && (github.event.ref == 'refs/heads/trunk'
+              || startsWith(github.event.ref, 'refs/heads/4.')
+              || startsWith(github.event.ref, 'refs/heads/5.'))
           && always()
 
       - name: Check that labelled/unlabelled .mli files are in sync

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -67,6 +67,7 @@ jobs:
         if: ${{ always() }}
 
       - name: check-typo revered
+        id: revered
         run: >-
           tools/ci/actions/check-typo.sh
           '${{ github.ref }}'
@@ -84,10 +85,11 @@ jobs:
       - name: check-typo on whole tree
         run: tools/check-typo
         if: >-
-          github.event_name == 'push'
-          && (github.event.ref == 'refs/heads/trunk'
-              || startsWith(github.event.ref, 'refs/heads/4.')
-              || startsWith(github.event.ref, 'refs/heads/5.'))
+          ((github.event_name == 'push'
+            && (github.event.ref == 'refs/heads/trunk'
+                || startsWith(github.event.ref, 'refs/heads/4.')
+                || startsWith(github.event.ref, 'refs/heads/5.')))
+            || steps.revered.outputs.full_check_needed == 'true')
           && always()
 
       - name: Check that labelled/unlabelled .mli files are in sync

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -363,7 +363,7 @@ EXIT_CODE=0
         match($0, /[\200-\377]/) \
         && state != "authors" && state != "copyright" {
           if (is_err("utf8")) {
-            err("non-ascii", "non-ASCII character(s)");
+            err("non-ascii", "non-ASCII character(s): missing utf8 attribute?");
             if (header_utf8 && !is_err("non-ascii")) {
               err("non-ascii-utf8", \
                   "non-ASCII character(s) AND UTF-8 encountered");

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -243,7 +243,7 @@ EXIT_CODE=0
         # presence of lines containing malformed UTF-8. It may be tested using
         # https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
         if $OCAML_CT_CAT "$OCAML_CT_PREFIX$f" \
-             | LC_ALL=en_US.UTF8 grep -qaxv '.*' ; then
+             | LC_ALL=C.UTF-8 grep -qaxv '.*' ; then
           echo "File \"$f\" is not correctly encoded in UTF-8"
           exit 2
         fi

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -236,17 +236,14 @@ EXIT_CODE=0
     rules=" $(echo $rules) "
     attr_rules=" $(echo $attr_rules) "
 
-    if test -n "$(echo "$rules $attr_rules" | grep " utf8 ")"
-    then
-        # grep -a is used to force the file to be considered as text and -x
-        # requires the entire line to match. This specifically detects the
-        # presence of lines containing malformed UTF-8. It may be tested using
-        # https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
-        if $OCAML_CT_CAT "$OCAML_CT_PREFIX$f" \
-             | LC_ALL=C.UTF-8 grep -qaxv '.*' ; then
-          echo "File \"$f\" is not correctly encoded in UTF-8"
-          exit 2
-        fi
+    # grep -a is used to force the file to be considered as text and -x
+    # requires the entire line to match. This specifically detects the
+    # presence of lines containing malformed UTF-8. It may be tested using
+    # https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+    if $OCAML_CT_CAT "$OCAML_CT_PREFIX$f" \
+         | LC_ALL=C.UTF-8 grep -qaxv '.*' ; then
+      echo "File \"$f\" is not correctly encoded in UTF-8"
+      exit 2
     fi
     if ! \
     ($OCAML_CT_CAT "$OCAML_CT_PREFIX$f" | tr -d '\r'; echo) \

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -64,9 +64,11 @@
 # You can ignore a rule by giving the option -<rule> on the command
 # line (before any file names).
 
-# Files which include the utf8 rule will be validated using grep and line-length
-# computations will take UTF-8 sequences into account. As a special case, UTF-8
-# sequences are always allowed in the copyright headers.
+# Files which include the non-ascii rule will be validated using grep and
+# line-length computations will take UTF-8 sequences into account. As a special
+# case, UTF-8 sequences are always allowed in the copyright headers. Files which
+# include the non-ascii rule must still be valid UTF-8 (the only alternative is
+# to mark the file as binary).
 
 # First prevent i18n from messing up everything.
 export LC_ALL=C
@@ -291,14 +293,14 @@ EXIT_CODE=0
         }
 
         function utf8_decode(str) {
-          if (is_err("utf8")) {
+          if (is_err("non-ascii")) {
             return str;
           } else {
             # This script assumes that the UTF-8 has been externally validated
             t = str;
             gsub(/[\300-\367][\200-\277]+/, "?", t);
             if (t != str) {
-              ++ counts["utf8"];
+              ++ counts["non-ascii"];
             }
             return t;
           }
@@ -362,14 +364,10 @@ EXIT_CODE=0
 
         match($0, /[\200-\377]/) \
         && state != "authors" && state != "copyright" {
-          if (is_err("utf8")) {
-            err("non-ascii", "non-ASCII character(s): missing utf8 attribute?");
-            if (header_utf8 && !is_err("non-ascii")) {
-              err("non-ascii-utf8", \
-                  "non-ASCII character(s) AND UTF-8 encountered");
-            }
+          if (is_err("non-ascii")) {
+            err("non-ascii", "non-ASCII character(s)");
           } else {
-            ++ counts["utf8"];
+            ++ counts["non-ascii"];
           }
         }
 
@@ -416,16 +414,6 @@ EXIT_CODE=0
           sub(/https?:[A-Za-z0-9._~:\/?#\[\]@!$&\047()*+,;=%-]{125,}/, "", t);
           if (length(t) > 132) {
             err("very-long-line", "line is over 132 columns");
-          }
-        }
-
-        # Record that the header contained UTF-8 sequences
-        match($0, /[\300-\367][\200-\277]+/) \
-        && (state == "authors" || state == "copyright") {
-          header_utf8 = 1;
-          if (counts["non-ascii"] > 0 && is_err("non-ascii")) {
-            err("non-ascii-utf8", \
-                "non-ASCII character(s) AND UTF-8 encountered");
           }
         }
 


### PR DESCRIPTION
While rebasing #13494, which adds `typo.utf8` to `.github/workflows/build-msvc.yml`, I noticed that #13526 had instead used `typo.non-ascii` for `.github/workflows/build-cross.yml` (there were already other files using non-ascii). The utf8 attribute is simply younger (it was added in #1828.

This pre-spring-cleaning rationalises things by requiring all text files to be valid UTF-8 (i.e. prohibit any old 8-bit encodings). Files which actually contain utf8 sequences still have to be marked as such.