### PR TITLE
Use an [instance] to avoid affecting a master copy

### DIFF
--- a/Changes
+++ b/Changes
@@ -226,6 +226,9 @@ Working version
   (Ulysse Gérard, Leo White, review by Antonin Décimo, Gabriel Scherer,
    Samuel Vivien, Florian Angeletti and Jacques Garrigue)
 
+- #13725: Add a missing `instance` to type-declaration checking
+  (Richard Eisenberg, review by ???)
+
 ### Build system:
 
 - #13431: Simplify github action responsible for flagging PRs with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -544,7 +544,7 @@ let rec check_constraints_rec env loc visited ty =
            *already* violate the constraints -- we need to report a problem with
            the unexpanded types, or we get errors that talk about the same type
            twice.  This is generally true for constraint errors. *)
-        try Ctype.matches ~expand_error_trace:false env ty ty'
+        try Ctype.matches ~expand_error_trace:false env (Ctype.instance ty) ty'
         with Ctype.Matches_failure (env, err) ->
           raise (Error(loc, Constraint_failed (env, err)))
       end;


### PR DESCRIPTION
In the Jane Street branch, we noticed an `instance` missing. As written, this check will work with a master copy of a type; the new `instance` makes a copy first before running `matches`.