### PR TITLE
[CI] Bump multicoretests to version 0.6

### DIFF
--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -36,14 +36,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml-multicore/multicoretests
-          ref: 0.4
+          ref: 0.6
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck
         uses: actions/checkout@v4
         with:
           repository: c-cube/qcheck
-          ref: v0.22
+          ref: v0.23
           path: multicoretests/qcheck
           persist-credentials: false
       - name: Checkout dune


### PR DESCRIPTION
This bumps the `multicoretests` version to 0.6, that adds tests of the `Dynarray` and `Gc` modules.

The `Dynarray` tests were useful in https://github.com/ocaml/ocaml/pull/12885#discussion_r1568976695.

The `Gc` tests found outdated documentation (https://github.com/ocaml/ocaml/pull/13424, https://github.com/ocaml/ocaml/pull/13440) and have since been useful in https://github.com/ocaml/ocaml/pull/13616.

No change entry needed.