### PR TITLE
Don't trash the backtraces in `Sys.getenv_opt`

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,10 @@ Working version
   (Christophe Raffalli, review by Nicolás Ojeda Bär and Gabriel Scherer and
    Hugo Heuzard)
 
+- #13727: Reimplement Sys.getenv_opt not to use exceptions internally, meaning
+  that the current backtrace is preserved when Sys.getenv_opt returns None.
+  (David Allsopp, review by Nicolás Ojeda Bär, Josh Berdine and Gabriel Scherer
+
 - #13737: Avoid closure allocations in Weak.Make.add when resizing the
   table
   (Vincent Laviron, review by Gabriel Scherer and Daniel Bünzli)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -434,12 +434,15 @@ CAMLprim value caml_sys_unsafe_getenv(value var)
   return val;
 }
 
-CAMLprim value caml_sys_getenv(value var)
+/* Returns either a string or Val_none on error (i.e. the tag is used to encode
+   error conditions */
+static value sys_getenv(value var)
 {
   char_os * res, * p;
   value val;
 
-  if (! caml_string_is_c_safe(var)) caml_raise_not_found();
+  if (! caml_string_is_c_safe(var))
+    return Val_none;
   p = caml_stat_strdup_to_os(String_val(var));
 #ifdef _WIN32
   res = caml_win32_getenv(p);
@@ -447,12 +450,33 @@ CAMLprim value caml_sys_getenv(value var)
   res = caml_secure_getenv(p);
 #endif
   caml_stat_free(p);
-  if (res == 0) caml_raise_not_found();
+  if (res == 0)
+    return Val_none;
   val = caml_copy_string_of_os(res);
 #ifdef _WIN32
   caml_stat_free(res);
 #endif
   return val;
+}
+
+CAMLprim value caml_sys_getenv(value var)
+{
+  value res = sys_getenv(var);
+
+  if (Is_none(res))
+    caml_raise_not_found();
+
+  return res;
+}
+
+CAMLprim value caml_sys_getenv_opt(value var)
+{
+  value res = sys_getenv(var);
+
+  if (!Is_none(res))
+    res = caml_alloc_some(res);
+
+  return res;
 }
 
 static value main_argv;

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -55,11 +55,7 @@ external is_regular_file : string -> bool = "caml_sys_is_regular_file"
 external remove: string -> unit = "caml_sys_remove"
 external rename : string -> string -> unit = "caml_sys_rename"
 external getenv: string -> string = "caml_sys_getenv"
-
-let getenv_opt s =
-  (* TODO: expose a non-raising primitive directly. *)
-  try Some (getenv s)
-  with Not_found -> None
+external getenv_opt: string -> string option = "caml_sys_getenv_opt"
 
 external command: string -> int = "caml_sys_system_command"
 external time: unit -> (float [@unboxed]) =


### PR DESCRIPTION
Or "Implement `Sys.getenv_opt` with `caml_sys_getenv_opt`"

While adding something else to `Sys`, I spotted this TODO leftover from #885, and apparently today was the day. The inliner means that `caml_sys_getenv` is very nearly the same as it was before. The internal `sys_getenv` returns a string on success (correct for `caml_sys_getenv`; wrong for `caml_sys_getenv_opt`) and `Val_none` on error (wrong for `caml_sys_getenv`; correct for `caml_sys_getenv_opt`) and each of the actual primitives then does the right thing with its erroneous value.

Users who do non-trivial processing prior to re-raising an exception should ideally be using `Printexc.raise_with_backtrace`, but it's nonetheless a bit embarrassing to explain that in:
```ocaml
try raise Not_found
with Not_found as e ->
  if Option.value ~default:"" (Sys.getenv_opt "MY_DEBUGGING") <> "" then
    print_endline "Some debugging here";
  raise e
```
you get the wrong backtrace from the re-raised exception because the "non-raising" `Sys.getenv_opt` in fact raised an exception internally...