### PR TITLE
Add `Sys.runtime_executable` and `caml_sys_proc_self_exe`

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ Working version
 
 ### Standard library:
 
+- #13728: Add Sys.runtime_executable containing the full path (if available) to
+  the currently executing runtime.
+  (David Allsopp, review by Nicolás Ojeda Bär and Daniel Bünzli)
+
 - #13916: Add Option.product and Option.Syntax.
   (Nicolás Ojeda Bär, review by Daniel Bünzli, Gabriel Scherer and David
   Allsopp)

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -25,6 +25,12 @@ extern void caml_free_locale(void);
 
 /* readonly after startup */
 struct caml_params {
+  /* The result of caml_executable_name, which is always called at startup. In
+     native mode, this is either NULL or the same as exe_name. In bytecode, it
+     is either NULL or the path of the interpreter, rather than the file which
+     contained the bytecode image. */
+  const char_os* proc_self_exe;
+  /* The string to return for caml_sys_executable_name. Never NULL. */
   const char_os* exe_name;
 
   /* for meta.c */
@@ -63,7 +69,7 @@ extern void caml_parse_ocamlrunparam (void);
    If [pooling] is 0, [caml_stat_*] functions will not be backed by a pool. */
 extern int caml_startup_aux (int pooling);
 
-void caml_init_exe_name(const char_os* exe_name);
+void caml_init_exe_name(const char_os* proc_self_exe, const char_os* exe_name);
 void caml_init_section_table(const char* section_table,
                              asize_t section_table_size);
 

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -29,7 +29,9 @@ CAMLnoret CAMLextern void caml_sys_error (value);
 CAMLnoret CAMLextern void caml_sys_io_error (value);
 
 CAMLextern double caml_sys_time_unboxed(value);
-CAMLextern void caml_sys_init (const char_os * exe_name, char_os ** argv);
+CAMLextern void caml_sys_init (const char_os * proc_self_exe,
+                               const char_os * exe_name,
+                               char_os ** argv);
 
 CAMLnoret CAMLextern void caml_do_exit (int);
 

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -213,8 +213,9 @@ CAMLexport void caml_shutdown(void)
   shutdown_happened = 1;
 }
 
-void caml_init_exe_name(const char_os* exe_name)
+void caml_init_exe_name(const char_os* proc_self_exe, const char_os* exe_name)
 {
+  params.proc_self_exe = proc_self_exe;
   params.exe_name = exe_name;
 }
 

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -122,7 +122,7 @@ value caml_startup_common(char_os **argv, int pooling)
     exe_name = proc_self_exe;
   else
     exe_name = caml_search_exe_in_path(exe_name);
-  caml_sys_init(exe_name, argv);
+  caml_sys_init(proc_self_exe, exe_name, argv);
   caml_maybe_expand_stack();
   res = caml_start_program(Caml_state);
   caml_terminate_signals();

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -508,7 +508,17 @@ CAMLprim value caml_sys_executable_name(value unit)
   return caml_copy_string_of_os(caml_params->exe_name);
 }
 
-void caml_sys_init(const char_os * exe_name, char_os **argv)
+CAMLprim value caml_sys_proc_self_exe(value unit)
+{
+  if (caml_params->proc_self_exe == NULL)
+    return Val_none;
+  else
+    return caml_alloc_some(caml_copy_string_of_os(caml_params->proc_self_exe));
+}
+
+void caml_sys_init(const char_os * proc_self_exe,
+                   const char_os * exe_name,
+                   char_os **argv)
 {
 #ifdef _WIN32
   /* Initialises the caml_win32_* globals on Windows with the version of
@@ -518,7 +528,7 @@ void caml_sys_init(const char_os * exe_name, char_os **argv)
   caml_setup_win32_terminal();
 #endif
 #endif
-  caml_init_exe_name(exe_name);
+  caml_init_exe_name(proc_self_exe, exe_name);
   main_argv = caml_alloc_array((void *)caml_copy_string_of_os,
                                (char const **) argv);
   caml_register_generational_global_root(&main_argv);

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -23,6 +23,7 @@ type backend_type =
 
 external get_config: unit -> string * int * bool = "caml_sys_get_config"
 external get_executable_name : unit -> string = "caml_sys_executable_name"
+external get_proc_self_exe : unit -> string option = "caml_sys_proc_self_exe"
 external argv : string array = "%sys_argv"
 external big_endian : unit -> bool = "%big_endian"
 external word_size : unit -> int = "%word_size"
@@ -34,6 +35,10 @@ external cygwin : unit -> bool = "%ostype_cygwin"
 external get_backend_type : unit -> backend_type = "%backend_type"
 
 let executable_name = get_executable_name()
+let runtime_executable =
+  match get_proc_self_exe () with
+  | None -> executable_name
+  | Some proc_self_exe -> proc_self_exe
 let (os_type, _, _) = get_config()
 let backend_type = get_backend_type ()
 let big_endian = big_endian ()

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -32,6 +32,16 @@ val executable_name : string
     on the platform and whether the program was compiled to bytecode or a native
     executable. *)
 
+val runtime_executable : string
+(** The name of the file containing the runtime currently running. For
+    native code, this is always {!executable_name}, but in bytecode it may be
+    ocamlrun, for example. This name may be absolute or relative to the current
+    directory, depending on the platform (Linux, Windows and macOS should all
+    return absolute paths).
+
+    @since 5.5
+*)
+
 external file_exists : string -> bool = "caml_sys_file_exists"
 (** Test if a file with the given name exists. *)
 


### PR DESCRIPTION
In bytecode, `Sys.executable_name` goes to some lengths to refer to the path to whereever the bytecode image came from. However, in both bytecode and native code, on most platforms, the runtime has `caml_executable_name` which does whatever's the appropriate equivalent of reading `/proc/self/exe`.

For some additional testing that I wish to add, I need to know whether the runtime implements `caml_executable_name` or just returns `NULL` (because it significantly affects the handling of bytecode startup when `argv[0]` is being altered). One way to do this is to record the fact in `Config.has_caml_executable_name`, but this involves a lot of tedious plumbing and duplication between `configure.ac`, `utils/config.generated.ml.in` and `runtime/unix.c`, and that's just to support a test harness. Another way is simply to wrap `caml_executable_name` as a primitive (although, confusingly, we already have `caml_sys_executable_name` meaning something else). That seems a bit daft, though - `caml_executable_name` is (with only one exception) always called during startup anyway. The value should not change during execution of a program, but the ability to query the running execcutable's name in theory can disappear (!!). The simplest approach, therefore, seems to be to squirrel it away at the same time as the derived executable name in `caml_sys_init` which is what the first commit does, exposing the squirreled value via `caml_sys_proc_self_exe`. Usefully, in native code, that squirreled-away value is in fact the same pointer as `exe_name`, so it doesn't even cost any space 😁

As part of the original work on Relocatable OCaml, I found it useful to be able to identify which ocamlrun was being executed from within a bytecode program itself, which is where the second commit originates from. `Sys.interpreter` uses this primitive in order to provide the path to the _actually_ executing program. With this primitive, one then has in `make runtop`:

```
OCaml version 5.4.0+dev0-2024-08-25
Enter #help;; for help.

# Sys.executable_name;;
- : string = "./ocaml"
# Sys.runtime_executable;;
- : string = "/home/dra/relocatable/ocaml/boot/ocamlrun"
```

As ever, completely open to naming suggestions - the primitive goes with the Linux name for the feature, as I figured `caml_sys_GetModuleFileName` might be less popular and it's worth having a name which is very distinct from `argv[0]` or `caml_sys_executable_name`, etc. `Sys.runtime` might be slightly better than `Sys.interpreter` as that sounds more consistent in native mode (and we do have `Sys.runtime_variant`, etc., already).