### PR TITLE
Add `filteri` to `Seq`

### DIFF
--- a/Changes
+++ b/Changes
@@ -93,6 +93,9 @@ Working version
 
 ### Standard library:
 
+- #13729: Add Seq.filteri
+  (Tima Kinsart, review by Nicolás Ojeda Bär and Daniel Bünzli)
+
 - #13721: Add Result.retract
   (Daniel Bünzli, review by Gabriel Scherer)
 

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -50,6 +50,17 @@ let rec filter f seq () = match seq() with
       then Cons (x, filter f next)
       else filter f next ()
 
+let rec filteri_aux f i seq () = match seq() with
+  | Nil -> Nil
+  | Cons (x, next) ->
+      let i' = i + 1 in
+      if f i x
+      then Cons (x, filteri_aux f i' next)
+      else filteri_aux f i' next ()
+
+let[@inline] filteri f seq () =
+  filteri_aux f 0 seq ()
+
 let rec concat seq () = match seq () with
   | Nil -> Nil
   | Cons (x, next) ->

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -456,6 +456,14 @@ val filter : ('a -> bool) -> 'a t -> 'a t
     In other words, [filter p xs] is the sequence [xs],
     deprived of the elements [x] such that [p x] is false. *)
 
+val filteri : (int -> 'a -> bool) -> 'a t -> 'a t
+(** Same as {!filter}, but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   @since 5.4
+*)
+
 val filter_map : ('a -> 'b option) -> 'a t -> 'b t
 (** [filter_map f xs] is the sequence of the elements [y] such that
     [f x = Some y], where [x] ranges over [xs].

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -20,6 +20,16 @@ let () =
   ()
 ;;
 
+(* filteri *)
+let () =
+  assert
+    ([5;4] =
+      (List.to_seq [5;4;3;2;1;]
+      |> Seq.filteri (fun i _ -> i < 2)
+     |> List.of_seq));
+  ()
+;;
+
 (* unfold *)
 let () =
   let range first last =


### PR DESCRIPTION
The `List` module has functions `filter` and `filteri`. The `Seq` module has `filter` but not `filteri`. It has `map` and `mapi` though, so I think it would be more consistent to have `filteri` as well.

The implementation was adapted from that of the `List` module, with very minor changes.
