### PR TITLE
Document that custom finalizers must not resurrect their argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -161,6 +161,9 @@ Working version
 - #13694: Fix name for caml_hash_variant in the C interface.
   (Michael Hendricks)
 
+- #13732: Document that custom finalizers must not access the OCaml heap, etc.
+  (Josh Berdine, review by Stephen Dolan and Guillaume Munch-Maccagnoni)
+
 ### Compiler user-interface and warnings:
 
 - #13428: support dump=[source | parsetree | lambda | ... | cmm | ...]

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2045,11 +2045,9 @@ when the block becomes unreachable and is about to be reclaimed.
 The block is passed as first argument to the function.
 The "finalize" field can also be "custom_finalize_default" to indicate that no
 finalization function is associated with the block.
-Note the caution below: there are many restrictions on the behaviour
-of these custom block finalizers; they must not allocate on the Caml
-heap, or call OCaml code or allow it to be called (for example, they
-should not call "caml_release_runtime_system()"). For more powerful
-and flexible finalization, use "Gc.finalise" (see \stdmoduleref{Gc}).
+Note the caution below: there are many restrictions on the
+behaviour of these custom block finalizers. For more powerful and
+flexible finalization, use "Gc.finalise" (see \stdmoduleref{Gc}).
 
 \item "int (*compare)(value v1, value v2)" \\
 The "compare" field contains a pointer to a C function that is
@@ -2139,17 +2137,25 @@ specified in the "fixed_length" structure, and do not consume space in
 the serialized output.
 \end{itemize}
 
-\emph{Caution}: the "finalize", "compare", "hash", "serialize", and "deserialize"
-functions attached to custom blocks descriptors are only allowed limited
-interactions with the OCaml runtime. Within these functions, do not call any of
-the OCaml allocation functions, and do not perform any callback into OCaml
-code. Do not use "CAMLparam" to register the parameters to these functions, and
-do not use "CAMLreturn" to return the result. Do not raise exceptions (to
-signal an error during deserialization, use "caml_deserialize_error"). When in
-doubt, err on the side of caution. However, note that "finalize" functions may
-freely use "caml_remove_global_root" and "caml_remove_generational_global_root",
-and "serialize" and "deserialize" functions may freely use the corresponding
-functions from section~\ref{ss:c-custom-serialization}.
+\emph{Caution}: the "finalize", "compare", "hash", "serialize", and
+"deserialize" functions attached to custom block descriptors are allowed
+only limited interactions with the OCaml runtime. Within these functions, do
+not call any of the OCaml allocation functions, and do not perform any
+callback into OCaml code or allow it to be called (for example, do not call
+"caml_release_runtime_system()"). Do not use "CAMLparam" to register the
+parameters to these functions, do not use "CAMLlocal" to register their
+local variables, and do not use "CAMLreturn" to return the result. Do not
+raise exceptions. To signal an error during deserialization, use
+"caml_deserialize_error", and "serialize" and "deserialize" functions may
+freely use the functions from section~\ref{ss:c-custom-serialization}.
+There are especially stringent restrictions on the behavior of custom block
+finalizers. In addition to the restrictions above, finalizers must not
+access the OCaml heap, or mutate the OCaml heap or any memory reachable from
+OCaml GC roots. However, note that "finalize" functions may freely use
+"caml_remove_global_root" and "caml_remove_generational_global_root". In
+short, if a custom block finalizer does anything with the "value" it
+receives other than call "Data_custom_val" on it, then it is probably
+unsafe. When in doubt, err on the side of caution.
 
 \subsection{ss:c-custom-alloc}{Allocating custom blocks}
 


### PR DESCRIPTION
Perhaps I am mistaken, but my understanding of the runtime implementation is
that there is no provision for custom block finalizers to resurrect their
arguments. In particular, if a custom block allocated in the minor heap dies
before being promoted, its finalizer will be run immediately after exiting
the STW barrier, when the minor GC has just finished. If a finalizer makes
its custom block live again at this point (e.g. storing it into a global
root), there is no further marking done, and the custom block will not be
promoted, and be in danger of being overwritten in the minor heap.

To wit:

```
> cat dodgy.c
#include <caml/custom.h>
#include <caml/memory.h>
#include <caml/mlvalues.h>

static value global = Val_none;

value init(value _unit) {
  caml_register_global_root(&global);
  return Val_unit;
}

typedef struct _block {
  int data;
} block;

static void finalize_block (value v) {
  global = v;
}

static struct custom_operations custom_ops = {
  NULL,
  finalize_block,
  custom_compare_default,
  custom_hash_default,
  custom_serialize_default,
  custom_deserialize_default,
  custom_compare_ext_default,
  custom_fixed_length_default
};

value box (value v) {
  int n = Int_val(v);
  value b = caml_alloc_custom(&custom_ops, sizeof(block), 0, 1);
  ((block*)Data_custom_val(b))->data = n;
  return b;
}

value get (value _unit) {
  if (global == Val_none) {
    return Val_int(0);
  } else {
    return Val_int(((block*)Data_custom_val(global))->data);
  }
}

> cat dodgy.ml
type t

external init : unit -> unit = "init"
external box : int -> t = "box"
external get : unit -> int = "get"

;;
init () ;
for i = 1 to 100000 do
  let _ = box i in
  ()
done ;
Gc.full_major () ;
Printf.eprintf "got %i\n" (get ())

> ocamlc -custom dodgy.c dodgy.ml && ./a.out
zsh: segmentation fault  ./a.out
```

Note that this crashes with 4.14, but I have not seen this crash with
trunk. If the analysis above is incorrect and this should be safe now, I am
happy to revise this PR to document that instead.