### PR TITLE
Reset the major GC's pacing clock after any synchronous GC work.

### DIFF
--- a/Changes
+++ b/Changes
@@ -70,6 +70,9 @@ Working version
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, tests by
   Jan Midtgaard)
 
+- #13736: Fix major GC pacing bug triggered by synchronous collections.
+  (Nick Barnes, review by ?)
+
 ### Code generation and optimizations:
 
 * #13050: Use '$' instead of '.' to separate module names in symbol names.

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -42,6 +42,11 @@ void caml_darken_cont(value);
 void caml_mark_root(value, value*);
 void caml_empty_mark_stack(void);
 void caml_finish_major_cycle(int force_compaction);
+/* Reset any internal accounting the GC uses to set collection pacing.
+ * For use at times when we have disturbed the usual pacing, for
+ * example, after any synchronous major collection.
+ */
+void caml_reset_major_pacing(void);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);
 #endif

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -247,6 +247,7 @@ static caml_result gc_major_res(int force_compaction)
   caml_gc_log ("Major GC cycle requested");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(force_compaction);
+  caml_reset_major_pacing();
   caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return result;
@@ -267,6 +268,7 @@ static caml_result gc_full_major_res(void)
      currently-unreachable object to be collected. */
   for (int i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
+    caml_reset_major_pacing();
     caml_result res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) return res;
   }
@@ -302,6 +304,7 @@ CAMLprim value caml_gc_compaction(value v)
      why this needs three iterations. */
   for (int i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
+    caml_reset_major_pacing();
     result = caml_process_pending_actions_res();
     if (caml_result_is_exception(result)) break;
   }


### PR DESCRIPTION
The major GC has `alloc_counter` and `work_counter` clocks to decide whether and how much work to do in the usual slices. In normal operation the `work_counter` tracks the `alloc_counter`. If a large amount of major GC work is done synchronously (e.g. by calling `Gc.full_major()` or `Gc.compact()` then the `work_counter` is advanced a lot without any allocation, so it gets well ahead of the `alloc_counter`. This has the effect of turning off major GC until such time as allocation "catches up". If the heap is quite large, it's easy to get to OOM before that happens.
This PR fixes this by adding a function to reset the major GC's pacing clock, and calling it after any synchronously-invoked major GC work.