### PR TITLE
Optimize Weak.find_aux and Weak.merge

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,7 +127,7 @@ Working version
   (Vincent Laviron, review by Gabriel Scherer and Daniel Bünzli)
 
 - #13740: Improve performance of Weak.find_aux
-  (Josh Berdine, review by ???)
+  (Josh Berdine, review by Gabriel Scherer)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -126,6 +126,9 @@ Working version
   table
   (Vincent Laviron, review by Gabriel Scherer and Daniel Bünzli)
 
+- #13740: Improve performance of Weak.find_aux
+  (Josh Berdine, review by ???)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -816,6 +816,7 @@ stdlib__Unit.cmx : unit.ml \
 stdlib__Unit.cmi : unit.mli
 stdlib__Weak.cmo : weak.ml \
     stdlib__Sys.cmi \
+    stdlib__Option.cmi \
     stdlib__Obj.cmi \
     stdlib__Int.cmi \
     stdlib__Hashtbl.cmi \
@@ -823,6 +824,7 @@ stdlib__Weak.cmo : weak.ml \
     stdlib__Weak.cmi
 stdlib__Weak.cmx : weak.ml \
     stdlib__Sys.cmx \
+    stdlib__Option.cmx \
     stdlib__Obj.cmx \
     stdlib__Int.cmx \
     stdlib__Hashtbl.cmx \

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -270,21 +270,27 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
   (* General auxiliary function for searching for a particular value
    * in a hash-set, and acting according to whether or not it's found *)
 
-  let find_aux t d found notfound =
+  let find_aux t d k_found k_notfound =
     let h = H.hash d in
     let index = get_index t h in
     let bucket = t.table.(index) in
     let hashes = t.hashes.(index) in
     let sz = length bucket in
-    let rec loop i =
-      if i >= sz then notfound h index
-      else if h = hashes.(i) then begin
-        match get bucket i with
-        | Some v as opt when H.equal v d -> found bucket i opt v
-        | _ -> loop (i + 1)
-      end else loop (i + 1)
-    in
-    loop 0
+    let found = ref None in
+    let i = ref 0 in
+    while !i < sz && Option.is_none !found do
+      if h = hashes.(!i) then begin
+        match get bucket !i with
+        | Some v as opt ->
+           if H.equal v d then
+             found := opt
+           else incr i
+        | _ -> incr i
+      end else incr i
+    done;
+    match !found with
+    | Some v as opt -> k_found bucket !i opt v
+    | None -> k_notfound h index
 
   let find_opt t d = find_aux t d (fun _b _i  o _v -> o)
                                   (fun _h _i -> None)


### PR DESCRIPTION
This PR changes the Stdlib Weak module's find_aux function that is used by
find, find_opt, mem, merge, and remove to avoid a closure allocation by
converting a nested recursive function with a while loop.

The second commit goes a step further by specializing Weak.find_aux when
called in Weak.merge to avoid allocating a closure each time for the
notfound continuation.

The motivation for this PR is the same as
https://github.com/ocaml/ocaml/pull/13737, where in particular avoiding
allocations where possible in the implementation of Weak operations is
desirable since code using Weak tables is necessarily sensitive to
allocation.

Testing the effect of these changes using the sandmark ZDD benchmark shows,
in this particular case, a ~20% reduction in allocated_words, but no
significant difference in runtime:

```
> OCAMLRUNPARAM='v=0x400' /usr/bin/time -hl ./trunk.exe
nique table length: 300526 entries: 1738610 bucket lengths: sum: 2310206 min: 0 median: 7 max: 22
69
allocated_words: 206897164
minor_words: 173004304
promoted_words: 49109218
major_words: 83002078
minor_collections: 673
major_collections: 10
forced_major_collections: 0
heap_words: 68900473
top_heap_words: 68900473
        2.71s real              2.58s user              0.12s sys
           563937280  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               34550  page reclaims
                  17  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   0  voluntary context switches
                  18  involuntary context switches
         24446587703  instructions retired
         10235345925  cycles elapsed
           558614592  peak memory footprint

> OCAMLRUNPARAM='v=0x400' /usr/bin/time -hl ./pr.exe words.txt
Unique table length: 300526 entries: 1831324 bucket lengths: sum: 2426435 min: 0 median: 7 max: 22
69
allocated_words: 162735118
minor_words: 128717888
promoted_words: 49613358
major_words: 83630588
minor_collections: 503
major_collections: 9
forced_major_collections: 0
heap_words: 77904330
top_heap_words: 77904330
        2.65s real              2.56s user              0.08s sys
           637108224  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               39015  page reclaims
                  17  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   0  voluntary context switches
                  13  involuntary context switches
         24343131528  instructions retired
         10568913189  cycles elapsed
           636635328  peak memory footprint
```

In case anyone is curious, the result with just the first commit but not the second is:
```
OCAMLRUNPARAM='v=0x400' /usr/bin/time -hl ./step2.exe words.txt                                                       main !1 ?20  ✔
Unique table length: 300526 entries: 1879559 bucket lengths: sum: 2485585 min: 0 median: 7 max: 22
69
allocated_words: 174932707
minor_words: 140840769
promoted_words: 49939121
major_words: 84031059
minor_collections: 549
major_collections: 8
forced_major_collections: 0
heap_words: 82104017
top_heap_words: 82104017
        2.64s real              2.55s user              0.08s sys
           667959296  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               40898  page reclaims
                  17  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   0  voluntary context switches
                  12  involuntary context switches
         24427420879  instructions retired
         10485434464  cycles elapsed
           667469952  peak memory footprint
```
So ~15% allocated_words savings wrt trunk, and for whatever reason, fewer major collections.