### PR TITLE
Add `unsigned_max_int` to `Int32` & `Int64`

### DIFF
--- a/Changes
+++ b/Changes
@@ -97,6 +97,9 @@ Working version
 
 ### Standard library:
 
+- #13743: Add `Int32.unsigned_max_int` and `Int64.unsigned_max_int`
+  (Tima Kinsart, review by ???)
+
 - #13729: Add Either.retract
   (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
 

--- a/stdlib/int32.ml
+++ b/stdlib/int32.ml
@@ -50,6 +50,7 @@ let pred n = sub n 1l
 let abs n = if n >= 0l then n else neg n
 let min_int = 0x80000000l
 let max_int = 0x7FFFFFFFl
+let unsigned_max_int = 0xFFFFFFFFl
 let lognot n = logxor n (-1l)
 
 let unsigned_to_int =

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -95,6 +95,10 @@ val max_int : int32
 val min_int : int32
 (** The smallest representable 32-bit integer, -2{^31}. *)
 
+val unsigned_max_int: int32
+(** The greatest representable {e unsigned} 32-bit integer, 2{^32} - 1.
+
+    @since 5.4 *)
 
 external logand : int32 -> int32 -> int32 = "%int32_and"
 (** Bitwise logical and. *)

--- a/stdlib/int64.ml
+++ b/stdlib/int64.ml
@@ -48,6 +48,7 @@ let pred n = sub n 1L
 let abs n = if n >= 0L then n else neg n
 let min_int = 0x8000000000000000L
 let max_int = 0x7FFFFFFFFFFFFFFFL
+let unsigned_max_int = 0xFFFFFFFFFFFFFFFFL
 let lognot n = logxor n (-1L)
 
 let unsigned_to_int =

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -95,6 +95,11 @@ val max_int : int64
 val min_int : int64
 (** The smallest representable 64-bit integer, -2{^63}. *)
 
+val unsigned_max_int: int64
+(** The greatest representable {e unsigned} 64-bit integer, 2{^64} - 1.
+
+    @since 5.4 *)
+
 external logand : int64 -> int64 -> int64 = "%int64_and"
 (** Bitwise logical and. *)
 


### PR DESCRIPTION
PR https://github.com/ocaml/ocaml/pull/1458 introduced several operations for unsigned integer arithmetic to `Int32` and `Int64`. However, I miss `unsigned_max_int` from these modules. Introducing the functions from the current PR would avoid magic numbers in user code that stand for maximum unsigned integer values.
