### PR TITLE
Fixes for Power arch instr_size calculations.

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,6 +95,11 @@ Working version
   (Stephen Dolan and Tim McGilchrist, review by Xavier Leroy
   and David Allsopp)
 
+- #13746 Fix instr_size computation on power. Uses the
+  --enable-codegen-invariants configuration option to check
+  instr_size calculations are correct at assembly compile time.
+  (Tim McGilchrist, review by ????)
+
 ### Standard library:
 
 - #13729: Add Either.retract

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -372,8 +372,7 @@ let name_for_specific = function
   | _ -> Misc.fatal_error "Emit.Ispecific"
 
 (* Relaxation of branches that exceed the span of a relative branch. *)
-
-module BR = Branch_relaxation.Make (struct
+module Size = struct
   type distance = int
 
   module Cond_branch = struct
@@ -424,22 +423,27 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Imove | Ispill | Ireload) -> 1
     | Lop(Iconst_int n) ->
       if is_native_immediate n then 1
-      else if (let (_lo, hi) = native_low_high_s n in
-               hi >= -0x8000 && hi <= 0x7FFF) then 2
-      else if (let (_lo, hi) = native_low_high_u n in
-               hi >= -0x8000 && hi <= 0x7FFF) then 2
-      else tocload_size
+      else
+        let (lo, hi) = native_low_high_s n in
+        if (hi >= -0x8000 && hi <= 0x7FFF)
+        then (1 + (if lo <> 0 then 1 else 0))
+        else begin
+          let (lo, hi) = native_low_high_u n in
+          if (hi >= -0x8000 && hi <= 0x7FFF)
+          then (1 + (if lo <> 0 then 1 else 0))
+          else tocload_size
+        end
     | Lop(Iconst_float _) -> tocload_size
     | Lop(Iconst_symbol _) -> tocload_size
     | Lop(Icall_ind) -> 4
     | Lop(Icall_imm _) -> 3
-    | Lop(Itailcall_ind) -> 6
+    | Lop(Itailcall_ind) -> 2 + (if f.fun_frame_required then 3 else 0) + 1
     | Lop(Itailcall_imm { func; _ }) ->
         if func = f.fun_name
         then 1
-        else 6 + tocload_size
+        else 2 + (if f.fun_frame_required then 3 else 0) + tocload_size
     | Lop(Iextcall { alloc; stack_ofs; _}) ->
-        if stack_ofs > 0 then tocload_size + 4
+        if stack_ofs > 0 then tocload_size + 3
         else if alloc then tocload_size + 2
         else 5
     | Lop(Istackoffset _) -> 1
@@ -455,17 +459,44 @@ module BR = Branch_relaxation.Make (struct
         load_store_size storeinstr addr
     | Lop(Ialloc _) -> 5
     | Lop(Ispecific(Ialloc_far _)) -> 6
-    | Lop(Ipoll { return_label = Some(_) }) -> 5
+    | Lop(Ipoll { return_label = Some(_) }) -> 4
     | Lop(Ipoll { return_label = None }) -> 3
     | Lop(Ispecific(Ipoll_far { return_label = Some(_) } )) -> 5
     | Lop(Ispecific(Ipoll_far { return_label = None } )) -> 4
     | Lop(Iintop Imod) -> 3
-    | Lop(Iintop(Icomp _)) -> 4
+    | Lop(Iintop(Icomp c)) ->
+       let int_cmp = match c with
+         | Isigned c -> c
+         | Iunsigned c -> c
+       in
+       let negated = match int_cmp with
+         | Cne | Cle | Cge -> 1
+         | Ceq | Clt | Cgt -> 0
+       in
+       1 + 2 + negated
     | Lop(Iintop(Icheckbound)) -> 2
     | Lop(Ispecific(Icheckbound_far)) -> 3
-    | Lop(Icompf _) -> 5
+    | Lop(Icompf cmp) ->
+       let negated = match cmp with
+         | CFneq | CFngt | CFnge | CFnlt | CFnle -> 1
+         | CFeq | CFgt | CFge | CFlt | CFle -> 0
+       in
+       let cror_s = match cmp with
+         | CFle | CFnle | CFge | CFnge -> 1
+         | _ -> 0
+       in
+       1 + cror_s + 2 + negated
     | Lop(Iintop _) -> 1
-    | Lop(Iintop_imm(Icomp _, _)) -> 4
+    | Lop(Iintop_imm(Icomp c, _)) ->
+       let cmp = match c with
+         | Isigned c -> c
+         | Iunsigned c -> c
+       in
+       let negated = match cmp with
+         | Cne | Cle | Cge -> 1
+         | Ceq | Clt | Cgt -> 0
+       in
+       1 + 2 + negated
     | Lop(Iintop_imm(Icheckbound, _)) -> 2
     | Lop(Ispecific(Icheckbound_imm_far _)) -> 3
     | Lop(Iintop_imm _) -> 1
@@ -477,15 +508,21 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Idls_get) -> 1
     | Lop(Ireturn_addr) -> 1
     | Lreloadretaddr -> 2
-    | Lreturn -> 2
+    | Lreturn -> 1 + if f.fun_frame_required then 1 else 0
     | Llabel _ -> 0
     | Lbranch _ -> 1
+    | Lcondbranch ((Ifloattest c), _) ->
+       let cror_s = match c with
+         | CFle | CFnle  | CFge | CFnge -> 1
+         | _ -> 0
+       in
+       1 + 1 + cror_s
     | Lcondbranch _ -> 2
     | Lcondbranch3(lbl0, lbl1, lbl2) ->
       1 + (if lbl0 = None then 0 else 1)
         + (if lbl1 = None then 0 else 1)
         + (if lbl2 = None then 0 else 1)
-    | Lswitch _ -> 7 + tocload_size
+    | Lswitch _ -> 6 + tocload_size
     | Lentertrap -> 1
     | Ladjust_trap_depth _ -> 0
     | Lpushtrap _ -> 4 + tocload_size
@@ -508,7 +545,8 @@ module BR = Branch_relaxation.Make (struct
   (* [classify_addr], above, never identifies these instructions as needing
      relaxing.  As such, these functions should never be called. *)
   let relax_specific_op _ = assert false
-end)
+end
+module BR = Branch_relaxation.Make (Size)
 
 (* Assembly code for inlined allocation *)
 
@@ -957,12 +995,40 @@ let emit_instr env i =
             `	bctr\n`
         end
 
-(* Emit a sequence of instructions *)
 
-let rec emit_all env i =
-  match i.desc with
-  | Lend -> ()
-  |  _   -> emit_instr env i; emit_all env i.next
+
+(* Emit assertions for debugging instr_size errors. *)
+ let emit_instr_debug env i =
+   let lbl = new_label () in
+   `{emit_label lbl}:\n`;
+   emit_instr env i;
+   let sz = Size.instr_size env.f i.desc * 4 in
+   `	.ifne (. - {emit_label lbl}) - {emit_int sz}\n`;
+   `	.error \"Emit.instr_size: instruction length mismatch\"\n`;
+   `	.endif\n`
+
+ let rec emit_all env lbl_start acc i =
+   let debug = Config.with_codegen_invariants in
+   match i.desc with
+   | Lend ->
+      if debug then begin
+        (* acc measures in units of 32-bit instructions *)
+        let sz = acc * 4 in
+        `	.ifne (. - {emit_label lbl_start}) - {emit_int sz}\n`;
+        `	.error \"Emit.instr_size: instruction length mismatch\"\n`;
+        `	.endif\n`;
+        end
+      else
+        ()
+   | _ ->
+      if debug then emit_instr_debug env i else emit_instr env i;
+      emit_all env lbl_start (acc + Size.instr_size env.f i.desc) i.next
+
+ (* Emit a sequence of instructions *)
+ let emit_all env i =
+   let lbl = new_label () in
+   `{emit_label lbl}:\n`;
+   emit_all env lbl 0 i
 
 (* On this target, the possible "out of line" code blocks are:
    - a single "call GC" point, which comes immediately after the


### PR DESCRIPTION
Uses the --enable-codegen-invariants to check instr_size calculations are correct at assembly compile time.

This follows on from https://github.com/ocaml/ocaml/pull/13667 and applies the same solution to the Power assembly, where I found a number of bugs in the instruction size calculations. The full test suite passes on the Ubuntu 24.04 ppc64le machines at Tarides.

Test suite summary:
```shell
List of skipped tests:
    tests/afl-instrumentation
    tests/asmcomp/lift_mutable_let_flambda.ml
    tests/asmcomp/unrolling_flambda.ml
    tests/asmcomp/unrolling_flambda2.ml
    tests/asmgen/integr.cmm
    tests/ephe-c-api
    tests/flambda/afl_lazy.ml
    tests/flambda/specialise.ml
    tests/frame-pointers
    tests/letrec-check/no_flat_float_array.ml
    tests/lib-bigarray-2/bigarrfml.ml
    tests/lib-dynlink-csharp
    tests/lib-unix/isatty/isatty_tty.ml
    tests/lib-unix/unix-execvpe
    tests/lib-unix/win-channel-of
    tests/lib-unix/win-createprocess
    tests/lib-unix/win-env
    tests/lib-unix/win-socketpair
    tests/lib-unix/win-stat
    tests/lib-unix/win-symlink
    tests/manual-intf-c
    tests/native-debugger
    tests/tsan
    tests/typing-misc/pr6939-no-flat-float-array.ml
    tests/typing-unboxed-types/test_no_flat.ml
    tests/unwind
    tests/win-unicode

Summary:
  1426 tests passed
    52 tests skipped
     0 tests failed
     0 tests not started (parent test skipped or failed)
     0 unexpected errors
  1478 tests considered
make[1]: Leaving directory '/home/tsmc/ocaml/testsuite'
make: Leaving directory '/home/tsmc/ocaml/testsuite'
```