### PR TITLE
Add a `.editorconfig` file for basic editor auto-configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.ml*]
+indent_style = space
+
+[*.{c,h,h.in,sh,ac,m4}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,8 @@
 .gitattributes typo.long-line=may typo.utf8
 .gitmodules typo.long-line=may typo.tab=may
 
+.editorconfig typo.missing-header=may
+
 # Binary files
 /boot/ocamlc binary
 /boot/ocamllex binary
@@ -53,7 +55,7 @@ tools/mantis2gh_stripped.csv typo.missing-header
 META.in                  typo.missing-header
 
 # Hyperlinks and other markup features cause long lines
-*.adoc                   typo.long-line=may typo.very-long-line=may
+*.adoc                   typo.long-line=may typo.very-long-line=may typo.utf8=may
 *.md                     typo.long-line=may typo.very-long-line=may
 
 # Github templates and scripts lack headers, have long lines

--- a/Changes
+++ b/Changes
@@ -254,6 +254,9 @@ Working version
   (Ulysse Gérard, Leo White, review by Antonin Décimo, Gabriel Scherer,
    Samuel Vivien, Florian Angeletti and Jacques Garrigue)
 
+- #13748: Add a .editorconfig file for basic editor auto-configuration.
+  (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
+
 ### Build system:
 
 - #13431: Simplify github action responsible for flagging PRs with

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -237,6 +237,16 @@ the original commit in the commit message.
 git cherry-pick -x -m 1 <merge-commit-hash>
 ----
 
+=== Code style
+
+Keep the style of the code you’re modifying. We don’t enforce the use of
+automated formatters. For OCaml code,
+https://github.com/OCamlPro/ocp-indent[ocp-indent] has been used.
+We use https://editorconfig.org/[EditorConfig] for simple styling. Lots of
+editors support EditorConfig
+https://editorconfig.org/#pre-installed[out-of-the-box], or with
+https://editorconfig.org/#download[plugins].
+
 [#opam-switch]
 === Testing with `opam`
 


### PR DESCRIPTION
When I open a C file, my [dumb editor](https://www.gnu.org/software/emacs/) defaults to 4 spaces for indentation, which is not the default style of the C code in this repository. I thus need to run `(setq c-basic-offset 2)` each time I open a new C file. Could there be a simple way to automatically configure my editor and everyone else's to use the proper style? yes.

[What is EditorConfig?](https://editorconfig.org/)

> EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

Lots of editors support this [out-of-the-box](https://editorconfig.org/#pre-installed), or [with plugins](https://editorconfig.org/#download).

The EditorConfig specification is simple and supports just the most basic properties. It is *not* a formatter! I've only included directives for C code. I'm open to suggestions for other languages (OCaml, Make, sh, …).

Properties such as `insert_final_newline` and `trim_trailing_whitespace` tend to introduce unwanted noise in diffs if the files contain trailing whitespace, as the editor will remove them on a new change. A quick grep shows that this shouldn't be a problem here.