### PR TITLE
Add Linux ARM64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
             os: ubuntu-latest
             config_arg: CFLAGS='-O0'
           - name: linux-arm64
-             os: ubuntu-24.04-arm
+            os: ubuntu-24.04-arm
           - name: macos-x86_64
             os: macos-13
           - name: macos-arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,8 @@ jobs:
           - name: linux-O0
             os: ubuntu-latest
             config_arg: CFLAGS='-O0'
+          - name: linux-arm64
+             os: ubuntu-24.04-arm
           - name: macos-x86_64
             os: macos-13
           - name: macos-arm64


### PR DESCRIPTION
Using the [newly announced Linux arm64](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) support, this change adds a build for this platform. I don't think this warrants a changelog entry.

Note: this build will run `--enable-codegen-invariants`.