### PR TITLE
Add `mem` and `memq` to the `Seq` module

### DIFF
--- a/Changes
+++ b/Changes
@@ -114,6 +114,9 @@ Working version
 
 ### Standard library:
 
+- #13750: Add Seq.mem and Seq.memq
+  (T. Kinsart, review by ???)
+
 - #13731: Add Either.retract
   (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
 

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -154,6 +154,20 @@ let rec exists p xs =
   | Cons (x, xs) ->
       p x || exists p xs
 
+let rec mem x xs =
+  match xs() with
+  | Nil ->
+      false
+  | Cons (x', xs) ->
+      compare x' x = 0 || mem x xs
+
+let rec memq x xs =
+  match xs() with
+  | Nil ->
+      false
+  | Cons (x', xs) ->
+      x' == x || memq x xs
+
 let rec find p xs =
   match xs() with
   | Nil ->

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -210,6 +210,19 @@ val exists : ('a -> bool) -> 'a t -> bool
 
     @since 4.14 *)
 
+val mem : 'a -> 'a t -> bool
+(** [mem x xs] is true if and only if [x] is equal to an element of [xs].
+
+    May not terminate if [xs] is infinite.
+
+    @since 5.4 *)
+
+val memq : 'a -> 'a t -> bool
+(** Same as {!mem}, but uses physical equality instead of structural equality to
+    compare sequence elements.
+
+    @since 5.4 *)
+
 val find : ('a -> bool) -> 'a t -> 'a option
 (** [find p xs] returns [Some x], where [x] is the first element of the
     sequence [xs] that satisfies [p x], if there is such an element.

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -101,6 +101,18 @@ let () =
     Seq.fold_lefti (fun acc i x -> (i, x) :: acc) [] xs = [ 1, "b"; 0, "a" ]
   )
 
+(* [mem] *)
+let () =
+  let xs = List.to_seq [1;2;3;4;5] in
+  assert (Seq.mem 1 xs = true);
+  assert (Seq.mem 7 xs = false)
+
+(* [memq] *)
+let () =
+  let five = 5 in
+  let xs = List.to_seq [five; 6; 7] in
+  assert (Seq.memq five xs = true)
+
 (* [scan] *)
 let () =
   let xs = Seq.(scan (+) 0 !?[1;2;3;4;5]) in


### PR DESCRIPTION
Considering that `mem` and `memq` are present in `Array`, `Dynarray`, and `List`, it would be also reasonable to find these functions in `Seq`. This PR addresses this only concern.

The implementation was adapted from the `List` module with style adjustments.

The tests are almost copy-pasted from those of the `Dynarray` module.
