### PR TITLE
add `Stdlib.char_of_int_opt`

### DIFF
--- a/Changes
+++ b/Changes
@@ -104,6 +104,9 @@ Working version
 
 ### Standard library:
 
+- #13752: Add Stdlib.char_of_int_opt
+  (Léo Andrès, review by ?)
+
 - #13729: Add Either.retract
   (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -220,6 +220,8 @@ let ( ^ ) s1 s2 =
 
 external int_of_char : char -> int = "%identity"
 external unsafe_char_of_int : int -> char = "%identity"
+let char_of_int_opt n =
+  if n < 0 || n > 255 then None else Some (unsafe_char_of_int n)
 let char_of_int n =
   if n < 0 || n > 255 then invalid_arg "char_of_int" else unsafe_char_of_int n
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -703,11 +703,16 @@ val ( ^ ) : string -> string -> string
 external int_of_char : char -> int = "%identity"
 (** Return the ASCII code of the argument. *)
 
-val char_of_int : int -> char
-(** Return the character with the given ASCII code.
-   @raise Invalid_argument if the argument is
-   outside the range 0--255. *)
 
+val char_of_int_opt : int -> char option
+(** Return the character with the given ASCII code.
+    Return [None] if the argument is outside the range 0--255.
+    @since 5.4 *)
+
+val char_of_int : int -> char
+(** Same as {!Stdlib.char_of_int_opt}, but raise
+    [Invalid_argument "char_of_int"] instead of returning [None].
+    @raise Invalid_argument if the argument is outside the range 0--255. *)
 
 (** {1 Unit operations} *)
 


### PR DESCRIPTION
Hi,

Among all conversions functions in `Stdlib`, I think this is the only one that is missing a `_opt` variant. We have `bool_of_string_opt`, `int_of_string_opt` and `float_of_string_opt`. 