### PR TITLE
Add a Repr module to the standard library

### DIFF
--- a/Changes
+++ b/Changes
@@ -170,8 +170,9 @@ Working version
   (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
    and Gabriel Scherer)
 
-- #13753: Add Stdlib.phys_equal
-  (Thomas Blanc and Léo Andrès, review by Gabriel Scherer and Florian Angeletti)
+- #13753 #13755: Add Stdlib.Repr
+  (Kate Deplaix, Thomas Blanc and Léo Andrès, review by Gabriel Scherer,
+   Florian Angeletti, Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
 
 - #13731: Add Either.retract
   (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)

--- a/manual/src/library/stdlib-blurb.etex
+++ b/manual/src/library/stdlib-blurb.etex
@@ -118,6 +118,8 @@ be called from C \\
 \begin{tabular}{lll}
 "Fun" & p.~\stdpageref{Fun} & function values \\
 "Type" & p.~\stdpageref{Type} & type introspection \\
+"Repr" & p.~\stdpageref{Repr} & functions defined on the low-level
+representation of values \\
 \end{tabular}
 \end{latexonly}
 
@@ -171,6 +173,7 @@ be called from C \\
 \stddocitem{Printf}{formatting printing functions}
 \stddocitem{Queue}{first-in first-out queues}
 \stddocitem{Random}{pseudo-random number generator (PRNG)}
+\stddocitem{Repr}{functions defined on the low-level representation of values}
 \stddocitem{Result}{result values}
 \stddocitem{Scanf}{formatted input functions}
 \stddocitem{Seq}{functional iterators}

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -695,6 +695,13 @@ stdlib__Random.cmi : random.mli \
     stdlib__Nativeint.cmi \
     stdlib__Int64.cmi \
     stdlib__Int32.cmi
+stdlib__Repr.cmo : repr.ml \
+    stdlib.cmi \
+    stdlib__Repr.cmi
+stdlib__Repr.cmx : repr.ml \
+    stdlib.cmx \
+    stdlib__Repr.cmi
+stdlib__Repr.cmi : repr.mli
 stdlib__Result.cmo : result.ml \
     stdlib__Seq.cmi \
     stdlib__Result.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -64,6 +64,7 @@ STDLIB_MODULE_BASENAMES = \
   nativeint \
   lexing \
   parsing \
+  repr \
   set \
   map \
   stack \

--- a/stdlib/repr.ml
+++ b/stdlib/repr.ml
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                              Kate Deplaix                              *)
+(*                                                                        *)
+(*   Copyright 2025 Kate Deplaix                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+external phys_equal : 'a -> 'a -> bool = "%eq"
+
+external equal : 'a -> 'a -> bool = "%equal"
+external compare : 'a -> 'a -> int = "%compare"
+
+let min = Stdlib.min
+let max = Stdlib.max

--- a/stdlib/repr.mli
+++ b/stdlib/repr.mli
@@ -1,0 +1,70 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                              Kate Deplaix                              *)
+(*                                                                        *)
+(*   Copyright 2025 Kate Deplaix                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functions defined on the low-level representations of values.
+
+    @since 5.4 *)
+
+(** {1 Physical comparison} *)
+
+external phys_equal : 'a -> 'a -> bool = "%eq"
+(** [phys_equal e1 e2] tests for physical equality of [e1] and [e2].
+    On mutable types such as references, arrays, byte sequences, records with
+    mutable fields and objects with mutable instance variables,
+    [phys_equal e1 e2] is true if and only if physical modification of [e1]
+    also affects [e2].
+    On non-mutable types, the behavior of [phys_equal] is
+    implementation-dependent; however, it is guaranteed that
+    [phys_equal e1 e2] implies [compare e1 e2 = 0]. *)
+
+(** {1 Polymorphic comparison} *)
+
+external equal : 'a -> 'a -> bool = "%equal"
+(** [equal e1 e2] tests for structural equality of [e1] and [e2].
+    Mutable structures (e.g. references and arrays) are equal
+    if and only if their current contents are structurally equal,
+    even if the two mutable objects are not the same physical object.
+    Equality between functional values raises [Invalid_argument].
+    Equality between cyclic data structures may not terminate.
+    Left-associative operator, see {!Ocaml_operators} for more information. *)
+
+external compare : 'a -> 'a -> int = "%compare"
+(** [compare x y] returns [0] if [x] is equal to [y],
+    a negative integer if [x] is less than [y], and a positive integer
+    if [x] is greater than [y].  The ordering implemented by [compare]
+    is compatible with the comparison predicates {!Stdlib.( = )},
+    {!Stdlib.( < )} and {!Stdlib.( > )}, as well as the [equal] function
+    defined above,  with one difference on the treatment of the float value
+    {!Stdlib.nan}.  Namely, the comparison predicates treat [nan]
+    as different from any other float value, including itself;
+    while [repr] treats [nan] as equal to itself and less than any
+    other float value.  This treatment of [nan] ensures that [compare]
+    defines a total ordering relation.
+
+    [compare] applied to functional values may raise [Invalid_argument].
+    [compare] applied to cyclic structures may not terminate.
+
+    The [compare] function can be used as the comparison function
+    required by the {!Set.Make} and {!Map.Make} functors, as well as
+    the {!List.sort} and {!Array.sort} functions. *)
+
+val min : 'a -> 'a -> 'a
+(** Return the smaller of the two arguments.
+    The result is unspecified if one of the arguments contains
+    the float value {!Stdlib.nan}. *)
+
+val max : 'a -> 'a -> 'a
+(** Return the greater of the two arguments.
+    The result is unspecified if one of the arguments contains
+    the float value {!Stdlib.nan}. *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -74,7 +74,6 @@ external compare : 'a -> 'a -> int = "%compare"
 let min x y = if x <= y then x else y
 let max x y = if x >= y then x else y
 
-external phys_equal : 'a -> 'a -> bool = "%eq"
 external ( == ) : 'a -> 'a -> bool = "%eq"
 external ( != ) : 'a -> 'a -> bool = "%noteq"
 
@@ -634,6 +633,7 @@ module Printf         = Printf
 module Queue          = Queue
 module Random         = Random
 module Result         = Result
+module Repr           = Repr
 module Scanf          = Scanf
 module Semaphore      = Semaphore
 module Seq            = Seq

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -119,16 +119,10 @@ exception Undefined_recursive_module of (string * int * int)
 (** {1 Comparisons} *)
 
 external ( = ) : 'a -> 'a -> bool = "%equal"
-(** [e1 = e2] tests for structural equality of [e1] and [e2].
-   Mutable structures (e.g. references and arrays) are equal
-   if and only if their current contents are structurally equal,
-   even if the two mutable objects are not the same physical object.
-   Equality between functional values raises [Invalid_argument].
-   Equality between cyclic data structures may not terminate.
-   Left-associative operator, see {!Ocaml_operators} for more information. *)
+(** Alias of {!Repr.equal} *)
 
 external ( <> ) : 'a -> 'a -> bool = "%notequal"
-(** Negation of {!Stdlib.( = )}.
+(** Negation of {!Repr.equal}.
     Left-associative operator, see {!Ocaml_operators} for more information.
 *)
 
@@ -152,61 +146,29 @@ external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
    the usual orderings over integers, characters, strings, byte sequences
    and floating-point numbers, and extend them to a
    total ordering over all types.
-   The ordering is compatible with [( = )]. As in the case
-   of [( = )], mutable structures are compared by contents.
+   The ordering is compatible with {!Repr.equal}. As in the case
+   of {!Repr.equal}, mutable structures are compared by contents.
    Comparison between functional values raises [Invalid_argument].
    Comparison between cyclic structures may not terminate.
    Left-associative operator, see {!Ocaml_operators} for more information.
 *)
 
 external compare : 'a -> 'a -> int = "%compare"
-(** [compare x y] returns [0] if [x] is equal to [y],
-   a negative integer if [x] is less than [y], and a positive integer
-   if [x] is greater than [y].  The ordering implemented by [compare]
-   is compatible with the comparison predicates [=], [<] and [>]
-   defined above,  with one difference on the treatment of the float value
-   {!Stdlib.nan}.  Namely, the comparison predicates treat [nan]
-   as different from any other float value, including itself;
-   while [compare] treats [nan] as equal to itself and less than any
-   other float value.  This treatment of [nan] ensures that [compare]
-   defines a total ordering relation.
-
-   [compare] applied to functional values may raise [Invalid_argument].
-   [compare] applied to cyclic structures may not terminate.
-
-   The [compare] function can be used as the comparison function
-   required by the {!Set.Make} and {!Map.Make} functors, as well as
-   the {!List.sort} and {!Array.sort} functions. *)
+(** Alias of {!Repr.compare}. *)
 
 val min : 'a -> 'a -> 'a
-(** Return the smaller of the two arguments.
-    The result is unspecified if one of the arguments contains
-    the float value [nan]. *)
+(** Alias of {!Repr.min}. *)
 
 val max : 'a -> 'a -> 'a
-(** Return the greater of the two arguments.
-    The result is unspecified if one of the arguments contains
-    the float value [nan]. *)
-
-external phys_equal : 'a -> 'a -> bool = "%eq"
-(** [phys_equal e1 e2] tests for physical equality of [e1] and [e2].
-   On mutable types such as references, arrays, byte sequences, records with
-   mutable fields and objects with mutable instance variables,
-   [phys_equal e1 e2] is true if and only if physical modification of [e1]
-   also affects [e2].
-   On non-mutable types, the behavior of [phys_equal] is
-   implementation-dependent; however, it is guaranteed that
-   [phys_equal e1 e2] implies [compare e1 e2 = 0].
-   @since 5.4
-*)
+(** Alias of {!Repr.max}. *)
 
 external ( == ) : 'a -> 'a -> bool = "%eq"
-(** Operator alias to {!Stdlib.phys_equal}.
+(** Operator alias to {!Repr.phys_equal}.
    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
 external ( != ) : 'a -> 'a -> bool = "%noteq"
-(** Negation of {!Stdlib.phys_equal}.
+(** Negation of {!Repr.phys_equal}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
@@ -1451,6 +1413,7 @@ module Printf         = Printf
 module Queue          = Queue
 module Random         = Random
 module Result         = Result
+module Repr           = Repr
 module Scanf          = Scanf
 module Semaphore      = Semaphore
 module Seq            = Seq

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 406, characters 28-54
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 405, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 406, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 411, characters 2-45
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 405, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 410, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41


### PR DESCRIPTION
First proposed in https://github.com/ocaml/ocaml/pull/13753#issuecomment-2612534919

As previously extensively discussed in https://github.com/ocaml/ocaml/pull/9928, https://github.com/ocaml/ocaml/pull/9080 and in many tickets or forum posts, both the physical equality operator `==` and the polymorphic comparison functions `compare` and `=` are known footguns for OCaml developers of all levels.

Similarly to https://github.com/ocaml/ocaml/pull/9080 / https://github.com/ocaml/ocaml/pull/13753, this PR hopes to be a first step towards a world where OCaml does not have this footgun anymore by encouraging people to use functions from this new module (which is more explicit than using it directly from `Stdlib` and thus less prone to footgunning), then deprecating `==`, `compare`, … when they are less used.

Note for reviewers: i'll add documentation to the functions once/if the interface is agreed