### PR TITLE
Allow unboxing of static catch parameters with flambda

### DIFF
--- a/Changes
+++ b/Changes
@@ -102,6 +102,9 @@ Working version
   (Stephen Dolan and Tim McGilchrist, review by Xavier Leroy
   and David Allsopp)
 
+- #13758: Propagate more value kinds in Flambda to allow more unboxing
+  (Vincent Laviron, review by Pierre Chambart)
+
 ### Standard library:
 
 - #13731: Add Either.retract

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -476,10 +476,16 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Lstaticcatch (body, (i, ids), handler) ->
     let st_exn = Static_exception.create () in
     let env = Env.add_static_exception env i st_exn in
-    let ids = List.map fst ids in
-    let vars = List.map Variable.create_with_same_name_as_ident ids in
+    let vars =
+      List.map (fun (id, kind) ->
+          Variable.create_with_same_name_as_ident id, kind)
+        ids
+    in
+    let env_handler =
+      Env.add_vars env (List.map fst ids) (List.map fst vars)
+    in
     Static_catch (st_exn, vars, close t env body,
-      close t (Env.add_vars env ids vars) handler)
+      close t env_handler handler)
   | Ltrywith (body, id, handler) ->
     let var = Variable.create_with_same_name_as_ident id in
     Try_with (close t env body, var, close t (Env.add_var env id var) handler)

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -101,7 +101,8 @@ type t =
   | String_switch of Variable.t * (string * t) list * t option
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t
+  | Static_catch of
+      Static_exception.t * (Variable.t * Lambda.value_kind) list * t * t
   | Try_with of t * Variable.t * t
   | While of t * t
   | For of for_loop

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -131,7 +131,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       var_env, mut_var_env, Symbol.Set.add sym sym_env
   in
   let add_binding_occurrences env vars =
-    List.fold_left (fun env var -> add_binding_occurrence env var) env vars
+    List.fold_left (fun env (var, _) -> add_binding_occurrence env var) env vars
   in
   let check_variable_is_bound (var_env, _, _) var =
     if not (Variable.Set.mem var var_env) then raise (Unbound_variable var)

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -304,9 +304,9 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
       List.map (subst_var env) args)
   | Static_catch (static_exn, vars, body, handler) ->
     let env_handler, ids =
-      List.fold_right (fun var (env, ids) ->
+      List.fold_right (fun (var, kind) (env, ids) ->
           let id, env = Env.add_fresh_ident env var in
-          env, (VP.create id, Lambda.Pgenval) :: ids)
+          env, (VP.create id, kind) :: ids)
         vars (env, [])
     in
     Ucatch (Static_exception.to_int static_exn, ids,

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -123,7 +123,10 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   | Static_raise _, _ | _, Static_raise _ -> false
   | Static_catch (s1, v1, a1, b1), Static_catch (s2, v2, a2, b2) ->
     Static_exception.equal s1 s2
-      && Misc.Stdlib.List.equal Variable.equal v1 v2
+      && Misc.Stdlib.List.equal
+        (fun (v1, k1) (v2, k2) -> Variable.equal v1 v2
+                                  && Lambda.equal_value_kind k1 k2)
+        v1 v2
       && same a1 a2
       && same b1 b2
   | Static_catch _, _ | _, Static_catch _ -> false

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -246,7 +246,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2
     | Static_catch (_,ids,f1,f2) ->
-      List.iter (fun id -> mark_curr [Var id]) ids;
+      List.iter (fun (id, _) -> mark_curr [Var id]) ids;
       mark_curr curr;
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1160,17 +1160,17 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
           | Static_raise (j, args) ->
             assert (Static_exception.equal i j);
             let handler =
-              List.fold_left2 (fun body var arg ->
+              List.fold_left2 (fun body (var, _) arg ->
                   Flambda.create_let var (Expr (Var arg)) body)
                 handler vars args
             in
             let r = R.exit_scope_catch r i in
             simplify env r handler
           | _ ->
-            let vars, sb = Freshening.add_variables' (E.freshening env) vars in
+            let vars, sb = Freshening.add_variables (E.freshening env) vars in
             let approx = R.approx r in
             let env =
-              List.fold_left (fun env id ->
+              List.fold_left (fun env (id, _) ->
                   E.add env id (A.value_unknown Other))
                 (E.set_freshening env sb) vars
             in

--- a/testsuite/tests/asmcomp/static_catch_unboxing.ml
+++ b/testsuite/tests/asmcomp/static_catch_unboxing.ml
@@ -1,0 +1,18 @@
+(* TEST
+ native;
+*)
+
+let[@inline never][@local never] f b x =
+  let[@local] g y =
+    y +. x > 0.
+  in
+  if b then g x else g (x +. 1.)
+
+let () =
+  let x0 = Gc.allocated_bytes () in
+  let x1 = Gc.allocated_bytes () in
+  ignore (f true 1.);
+  ignore (f false 1.);
+  let x2 = Gc.allocated_bytes () in
+  assert(x1 -. x0 = x2 -. x1)
+

--- a/testsuite/tests/asmcomp/static_catch_unboxing.ml
+++ b/testsuite/tests/asmcomp/static_catch_unboxing.ml
@@ -15,4 +15,3 @@ let () =
   ignore (f false 1.);
   let x2 = Gc.allocated_bytes () in
   assert(x1 -. x0 = x2 -. x1)
-


### PR DESCRIPTION
While investigating an issue in Flambda2, I noticed that Flambda1 does not propagate type annotations (more accurately value kinds from `Lambda`) on static catch handlers.
This PR fixes this oversight, and adds a test case showing some missed unboxing opportunities recovered thanks to this patch.
