### PR TITLE
Add String.{edit_distance,spellcheck}, UTF-8 aware spellchecking functions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -113,6 +113,7 @@ runtime/sak.c            typo.non-ascii
 testsuite/tests/**                                      typo.missing-header typo.long-line=may
 testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab linguist-language=Fortran
 testsuite/tests/lib-unix/win-stat/fakeclock.c           typo.missing-header=false
+testsuite/tests/lib-string/test_string.ml               typo.utf8
 testsuite/tests/misc-unsafe/almabench.ml                typo.long-line
 testsuite/tests/parsing/latin9.ml                       typo.non-ascii typo.very-long-line
 testsuite/tests/parsing/comments.ml                     typo.non-ascii

--- a/.gitattributes
+++ b/.gitattributes
@@ -123,7 +123,7 @@ testsuite/tests/tool-toplevel/strings.ml                typo.non-ascii
 testsuite/tests/win-unicode/*.ml                        typo.non-ascii
 testsuite/tests/unicode/見.ml                           typo.non-ascii
 testsuite/tests/lib-format/unicode.ml                   typo.non-ascii
-testsuite/tests/lib-string/test_string.ml               type.non-ascii
+testsuite/tests/lib-string/test_string.ml               typo.non-ascii
 testsuite/tests/lexing/reject_bad_encoding.ml           typo.prune
 testsuite/tests/asmgen/immediates.cmm                   typo.very-long-line
 testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line

--- a/.gitattributes
+++ b/.gitattributes
@@ -123,6 +123,7 @@ testsuite/tests/tool-toplevel/strings.ml                typo.non-ascii
 testsuite/tests/win-unicode/*.ml                        typo.non-ascii
 testsuite/tests/unicode/見.ml                           typo.non-ascii
 testsuite/tests/lib-format/unicode.ml                   typo.non-ascii
+testsuite/tests/lib-string/test_string.ml               type.non-ascii
 testsuite/tests/lexing/reject_bad_encoding.ml           typo.prune
 testsuite/tests/asmgen/immediates.cmm                   typo.very-long-line
 testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line

--- a/.gitattributes
+++ b/.gitattributes
@@ -113,7 +113,6 @@ runtime/sak.c            typo.non-ascii
 testsuite/tests/**                                      typo.missing-header typo.long-line=may
 testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab linguist-language=Fortran
 testsuite/tests/lib-unix/win-stat/fakeclock.c           typo.missing-header=false
-testsuite/tests/lib-string/test_string.ml               typo.utf8
 testsuite/tests/misc-unsafe/almabench.ml                typo.long-line
 testsuite/tests/parsing/latin9.ml                       typo.non-ascii typo.very-long-line
 testsuite/tests/parsing/comments.ml                     typo.non-ascii

--- a/Changes
+++ b/Changes
@@ -137,9 +137,6 @@ Working version
 
 - #13570, #13794: Format, add an out_width function to Format device for
    approximating unicode width.
-
-- #13570, Format: add an out_width function to Format device for approximating
-   unicode width.
   (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
    and Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -128,11 +128,18 @@ Working version
 
 ### Standard library:
 
+- #13760: Add String.{edit_distance,spellcheck}
+  (Daniel Bünzli, review by wikku, Nicolás Ojeda Bär, Gabriel Scherer and
+   Florian Angeletti)
+
 - #13768: Add Either.get_left and Either.get_right
   (T. Kinsart, review by Nicolás Ojeda Bär and Florian Angeletti)
 
 - #13570, #13794: Format, add an out_width function to Format device for
    approximating unicode width.
+
+- #13570, Format: add an out_width function to Format device for approximating
+   unicode width.
   (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
    and Gabriel Scherer)
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -784,6 +784,7 @@ std_exit.cmi :
 stdlib__String.cmo : string.ml \
     stdlib__Uchar.cmi \
     stdlib.cmi \
+    stdlib__List.cmi \
     stdlib__Int.cmi \
     stdlib__Bytes.cmi \
     stdlib__Array.cmi \
@@ -791,6 +792,7 @@ stdlib__String.cmo : string.ml \
 stdlib__String.cmx : string.ml \
     stdlib__Uchar.cmx \
     stdlib.cmx \
+    stdlib__List.cmx \
     stdlib__Int.cmx \
     stdlib__Bytes.cmx \
     stdlib__Array.cmx \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -18,11 +18,9 @@ stdlib__Arg.cmx : arg.ml \
     stdlib__Arg.cmi
 stdlib__Arg.cmi : arg.mli
 stdlib__Array.cmo : array.ml \
-    stdlib__String.cmi \
     stdlib__Seq.cmi \
     stdlib__Array.cmi
 stdlib__Array.cmx : array.ml \
-    stdlib__String.cmx \
     stdlib__Seq.cmx \
     stdlib__Array.cmi
 stdlib__Array.cmi : array.mli \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -782,12 +782,18 @@ std_exit.cmx : \
     std_exit.cmi
 std_exit.cmi :
 stdlib__String.cmo : string.ml \
+    stdlib__Uchar.cmi \
     stdlib.cmi \
+    stdlib__Int.cmi \
     stdlib__Bytes.cmi \
+    stdlib__Array.cmi \
     stdlib__String.cmi
 stdlib__String.cmx : string.ml \
+    stdlib__Uchar.cmx \
     stdlib.cmx \
+    stdlib__Int.cmx \
     stdlib__Bytes.cmx \
+    stdlib__Array.cmx \
     stdlib__String.cmi
 stdlib__String.cmi : string.mli \
     stdlib__Uchar.cmi \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -52,12 +52,12 @@ STDLIB_MODULE_BASENAMES = \
   uchar \
   list \
   int \
+  array \
+  iarray \
   bytes \
   string \
   unit \
   marshal \
-  array \
-  iarray \
   float \
   int32 \
   int64 \

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -441,12 +441,10 @@ let fast_sort = stable_sort
 
 let shuffle_contract_violation i j =
   let int = string_of_int in
-  String.concat "" [
-    "Array.shuffle: 'rand "; int (i + 1);
-    "' returned "; int j;
-    ", out of expected range [0; "; int i; "]"
-  ]
-  |> invalid_arg
+  invalid_arg
+    ("Array.shuffle: 'rand " ^ int (i + 1) ^
+     "' returned " ^ int j ^
+     ", out of expected range [0; " ^ int i ^ "]")
 
 let shuffle ~rand a = (* Fisher-Yates *)
   for i = length a - 1 downto 1 do

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -326,12 +326,16 @@ let edit_distance' ?(limit = Int.max_int) s (s0, len0) s1 =
     let len1 = Array.length row - 1 in
     let row_min = ref Int.max_int in
     row.(0) <- i;
-    for j = Int.max 1 (i - limit - 1) to Int.min len1 (i + limit + 1) do
+    for j = Int.max 1 (i - limit) to Int.min len1 (i + limit - 1) do
       let cost = if Uchar.equal s0.(i-1) s1.(j-1) then 0 else 1 in
       let min = minimum
           (row_minus1.(j-1) + cost) (* substitute *)
           (row_minus1.(j) + 1)      (* delete *)
           (row.(j-1) + 1)           (* insert *)
+          (* Note when j = i - limit, the latter [row] read makes a bogus read
+             on the value that was in the matrix at d.(i-2).(i - limit - 1).
+             Since by induction for all i,j, d.(i).(j) >= abs (i - j),
+             (row.(j-1) + 1) is greater or equal to [limit]. *)
       in
       let min =
         if (i > 1 && j > 1 &&

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -313,7 +313,7 @@ let uchar_array_of_utf_8_string s =
   done;
   uchars, !k
 
-let _edit_distance ?(limit = Int.max_int) s (s0, len0) s1 =
+let edit_distance' ?(limit = Int.max_int) s (s0, len0) s1 =
   if limit <= 1 then (if equal s s1 then 0 else limit) else
   let[@inline] minimum a b c = Int.min a (Int.min b c) in
   let s1, len1 = uchar_array_of_utf_8_string s1 in
@@ -359,7 +359,7 @@ let _edit_distance ?(limit = Int.max_int) s (s0, len0) s1 =
 
 let edit_distance ?limit s0 s1 =
   let us0 = uchar_array_of_utf_8_string s0 in
-  _edit_distance ?limit s0 us0 s1
+  edit_distance' ?limit s0 us0 s1
 
 let default_max_dist s = match utf_8_uchar_length s with
   | 0 | 1 | 2 -> 0
@@ -368,7 +368,7 @@ let default_max_dist s = match utf_8_uchar_length s with
 
 let spellcheck ?(max_dist = default_max_dist) dict s =
   let select_words s us (min, acc) word =
-    let d = _edit_distance ~limit:(min + 1) s us word in
+    let d = edit_distance' ~limit:(min + 1) s us word in
     if d = min then min, (word :: acc) else
     if d < min then d, [word] else min, acc
   in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -303,7 +303,7 @@ let edit_distance ?(limit = Int.max_int) s0 s1 =
   if Int.abs (len1 - len0) > limit then limit else
   let s0, s1 = if len0 > len1 then s0, s1 else s1, s0 in
   let len0, len1 = if len0 > len1 then len0, len1 else len1, len0 in
-  let rec loop row_minus2 row_minus1 row i len0 limit =
+  let rec loop row_minus2 row_minus1 row i len0 limit s0 s1 =
     if i > len0 then row_minus1.(Array.length row_minus1 - 1) else
     let len1 = Array.length row - 1 in
     let row_min = ref Int.max_int in
@@ -326,7 +326,7 @@ let edit_distance ?(limit = Int.max_int) s0 s1 =
       row_min := Int.min !row_min min;
     done;
     if !row_min >= limit then (* can no longer decrease *) limit else
-    loop row_minus1 row row_minus2 (i + 1) len0 limit
+    loop row_minus1 row row_minus2 (i + 1) len0 limit s0 s1
   in
   let ignore =
     (* Value used to make the values around the diagonal stripe ignored
@@ -336,7 +336,7 @@ let edit_distance ?(limit = Int.max_int) s0 s1 =
   let row_minus2 = Array.make (len1 + 1) ignore in
   let row_minus1 = Array.init (len1 + 1) (fun x -> x) in
   let row = Array.make (len1 + 1) ignore in
-  let d = loop row_minus2 row_minus1 row 1 len0 limit in
+  let d = loop row_minus2 row_minus1 row 1 len0 limit s0 s1 in
   if d > limit then limit else d
 
 let spellcheck ?(max_dist = fun _ -> 2) dict s =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -326,7 +326,11 @@ let edit_distance' ?(limit = Int.max_int) s (s0, len0) s1 =
     let len1 = Array.length row - 1 in
     let row_min = ref Int.max_int in
     row.(0) <- i;
-    for j = Int.max 1 (i - limit) to Int.min len1 (i + limit - 1) do
+    let jmax =
+      let jmax = Int.min len1 (i + limit - 1) in
+      if jmax < 0 then (* overflow *) len1 else jmax
+    in
+    for j = Int.max 1 (i - limit) to jmax do
       let cost = if Uchar.equal s0.(i-1) s1.(j-1) then 0 else 1 in
       let min = minimum
           (row_minus1.(j-1) + cost) (* substitute *)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -338,3 +338,12 @@ let edit_distance ?(limit = Int.max_int) s0 s1 =
   let row = Array.make (len1 + 1) ignore in
   let d = loop row_minus2 row_minus1 row 1 len0 limit in
   if d > limit then limit else d
+
+let spellcheck ?(max_dist = fun _ -> 2) dict s =
+  let select_words (min, acc) word =
+    let d = edit_distance ~limit:(min + 1) s word in
+    if d = min then min, (word :: acc) else
+    if d < min then d, [word] else min, acc
+  in
+  let _min, words = List.fold_left select_words (max_dist s, []) dict in
+  List.rev words

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -314,6 +314,7 @@ let uchar_array_of_utf_8_string s =
   uchars, !k
 
 let edit_distance ?(limit = Int.max_int) s0 s1 =
+  if limit <= 1 then (if equal s0 s1 then 0 else limit) else
   let[@inline] minimum a b c = Int.min a (Int.min b c) in
   let s0, len0 = uchar_array_of_utf_8_string s0 in
   let s1, len1 = uchar_array_of_utf_8_string s1 in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -318,7 +318,7 @@ let edit_distance' ?(limit = Int.max_int) s (s0, len0) s1 =
   let[@inline] minimum a b c = Int.min a (Int.min b c) in
   let s1, len1 = uchar_array_of_utf_8_string s1 in
   let limit = Int.min (Int.max len0 len1) limit in
-  if Int.abs (len1 - len0) > limit then limit else
+  if Int.abs (len1 - len0) >= limit then limit else
   let s0, s1 = if len0 > len1 then s0, s1 else s1, s0 in
   let len0, len1 = if len0 > len1 then len0, len1 else len1, len0 in
   let rec loop row_minus2 row_minus1 row i len0 limit s0 s1 =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -339,7 +339,8 @@ let edit_distance' ?(limit = Int.max_int) s (s0, len0) s1 =
           (* Note when j = i - limit, the latter [row] read makes a bogus read
              on the value that was in the matrix at d.(i-2).(i - limit - 1).
              Since by induction for all i,j, d.(i).(j) >= abs (i - j),
-             (row.(j-1) + 1) is greater or equal to [limit]. *)
+             (row.(j-1) + 1) is greater or equal to [limit] and thus does
+             not affect adversely the minimum computation. *)
       in
       let min =
         if (i > 1 && j > 1 &&

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -402,16 +402,16 @@ val edit_distance : ?limit:int -> t -> t -> int
     (understood as insertion, deletion, substitution, transposition)
     that are needed to change [s0] into [s1].
 
+    If [limit] is provided the function returns with [limit] as soon
+    as it was determined that [s0] and [s1] have distance of at least
+    [limit]. This is faster if you have a fixed limit, for example for
+    spellchecking.
+
     The function assumes the strings are UTF-8 encoded and uses {!Uchar.t}
     for the notion of character. Decoding errors are replaced by
     {!Uchar.rep}. Normalizing the strings to
     {{:https://unicode.org/glossary/#normalization_form_c}NFC} gives
     better results.
-
-    If [limit] is provided the function returns with [limit] as soon
-    as it was determined that [s0] and [s1] have distance of at least
-    [limit]. This is faster if you have a fixed limit, for example for
-    spellchecking.
 
     {b Note.} This implements the simpler optimal string alignement
     distance, not the Damerau-Levenshtein distance. With this function

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -421,16 +421,21 @@ val edit_distance : ?limit:int -> t -> t -> int
 *)
 
 val spellcheck :
-  ?max_dist:(string -> int) -> string list -> string -> string list
-(** [spellcheck dict s] are the elements of [dict] whose
-    {{!edit_distance}edit distance} to [s] is the smallest and at most
-    [max_dist s]. If multiple corrections are returned their order is
-    as given in [dict]. The default [max_dist s] is:
+  ?max_dist:(string -> int) -> ((string -> unit) -> unit) -> string ->
+  string list
+(** [spellcheck iter_dict s] are the strings enumerated by the
+    iterator [iter_dict] whose {{!edit_distance}edit distance} to [s]
+    is the smallest and at most [max_dist s]. If multiple corrections
+    are returned their order is as found in [iter_dict]. The default
+    [max_dist s] is:
 
     {ul
     {- [0] if [s] has 0 to 2 Unicode characters.}
     {- [1] if [s] has 3 to 4 Unicode characters.}
     {- [2] otherwise.}}
+
+    If your dictionary is a list [l], a suitable [iter_dict] is given
+    by [(fun yield -> List.iter yield l)].
 
     All strings are assumed to be UTF-8 encoded, decoding
     errors are replaced by {!Uchar.rep} characters.

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -395,6 +395,10 @@ val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
     UTF-16LE data. *)
 
+(** {1:spellchecking Spellchecking} *)
+
+val edit_distance : t -> t -> int
+
 (** {1 Binary decoding of integers} *)
 
 (** The functions in this section binary decode integers from strings.

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -397,7 +397,28 @@ val is_valid_utf_16le : t -> bool
 
 (** {1:spellchecking Spellchecking} *)
 
-val edit_distance : t -> t -> int
+val edit_distance : ?limit:int -> t -> t -> int
+(** [edit_distance s0 s1] is the number of single character edits
+    (understood as insertion, deletion, substitution, transposition)
+    that are needed to change [s0] into [s1].
+
+    The function assumes the strings are UTF-8 encoded and uses {!Uchar.t}
+    for the notion of character. Decoding errors are replaced by
+    {!Uchar.rep}. Normalizing the strings to
+    {{:https://unicode.org/glossary/#normalization_form_c}NFC} gives
+    better results.
+
+    If [limit] is provided the function returns with [limit] as soon
+    as it was determined that [s0] and [s1] have distance of at least
+    [limit]. This is faster if you have a fixed limit, for example for
+    spellchecking.
+
+    {b Note.} This implements the simpler optimal string alignement
+    distance, not the Damerau-Levenshtein distance. With this function
+    ["ca"] and ["abc"] have a distance of 3 not 2.
+
+    @since 5.4
+*)
 
 (** {1 Binary decoding of integers} *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -424,10 +424,16 @@ val spellcheck :
   ?max_dist:(string -> int) -> string list -> string -> string list
 (** [spellcheck dict s] are the elements of [dict] whose
     {{!edit_distance}edit distance} to [s] is the smallest and at most
-    [max_dist s] (default is [Fun.const 2], this is subject to change
-    in the future, use your own function if you want to rely on
-    that). If multiple corrections are returned their order is as
-    given in [dict].
+    [max_dist s]. If multiple corrections are returned their order is
+    as given in [dict]. The default [max_dist s] is:
+
+    {ul
+    {- [0] if [s] has 0 to 2 Unicode characters.}
+    {- [1] if [s] has 3 to 4 Unicode characters.}
+    {- [2] otherwise.}}
+
+    All strings are assumed to be UTF-8 encoded, decoding
+    errors are replaced by {!Uchar.rep} characters.
 
     @since 5.4 *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -413,7 +413,7 @@ val edit_distance : ?limit:int -> t -> t -> int
     {{:https://unicode.org/glossary/#normalization_form_c}NFC} gives
     better results.
 
-    {b Note.} This implements the simpler optimal string alignement
+    {b Note.} This implements the simpler Optimal String Alignement (OSA)
     distance, not the Damerau-Levenshtein distance. With this function
     ["ca"] and ["abc"] have a distance of 3 not 2.
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -420,6 +420,17 @@ val edit_distance : ?limit:int -> t -> t -> int
     @since 5.4
 *)
 
+val spellcheck :
+  ?max_dist:(string -> int) -> string list -> string -> string list
+(** [spellcheck dict s] are the elements of [dict] whose
+    {{!edit_distance}edit distance} to [s] is the smallest and at most
+    [max_dist s] (default is [Fun.const 2], this is subject to change
+    in the future, use your own function if you want to rely on
+    that). If multiple corrections are returned their order is as
+    given in [dict].
+
+    @since 5.4 *)
+
 (** {1 Binary decoding of integers} *)
 
 (** The functions in this section binary decode integers from strings.

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -402,16 +402,16 @@ val edit_distance : ?limit:int -> t -> t -> int
     (understood as insertion, deletion, substitution, transposition)
     that are needed to change [s0] into [s1].
 
+    If [limit] is provided the function returns with [limit] as soon
+    as it was determined that [s0] and [s1] have distance of at least
+    [limit]. This is faster if you have a fixed limit, for example for
+    spellchecking.
+
     The function assumes the strings are UTF-8 encoded and uses {!Uchar.t}
     for the notion of character. Decoding errors are replaced by
     {!Uchar.rep}. Normalizing the strings to
     {{:https://unicode.org/glossary/#normalization_form_c}NFC} gives
     better results.
-
-    If [limit] is provided the function returns with [limit] as soon
-    as it was determined that [s0] and [s1] have distance of at least
-    [limit]. This is faster if you have a fixed limit, for example for
-    spellchecking.
 
     {b Note.} This implements the simpler optimal string alignement
     distance, not the Damerau-Levenshtein distance. With this function

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -421,16 +421,21 @@ val edit_distance : ?limit:int -> t -> t -> int
 *)
 
 val spellcheck :
-  ?max_dist:(string -> int) -> string list -> string -> string list
-(** [spellcheck dict s] are the elements of [dict] whose
-    {{!edit_distance}edit distance} to [s] is the smallest and at most
-    [max_dist s]. If multiple corrections are returned their order is
-    as given in [dict]. The default [max_dist s] is:
+  ?max_dist:(string -> int) -> ((string -> unit) -> unit) -> string ->
+  string list
+(** [spellcheck iter_dict s] are the strings enumerated by the
+    iterator [iter_dict] whose {{!edit_distance}edit distance} to [s]
+    is the smallest and at most [max_dist s]. If multiple corrections
+    are returned their order is as found in [iter_dict]. The default
+    [max_dist s] is:
 
     {ul
     {- [0] if [s] has 0 to 2 Unicode characters.}
     {- [1] if [s] has 3 to 4 Unicode characters.}
     {- [2] otherwise.}}
+
+    If your dictionary is a list [l], a suitable [iter_dict] is given
+    by [(fun yield -> List.iter yield l)].
 
     All strings are assumed to be UTF-8 encoded, decoding
     errors are replaced by {!Uchar.rep} characters.

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -395,6 +395,10 @@ val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
     UTF-16LE data. *)
 
+(** {1:spellchecking Spellchecking} *)
+
+val edit_distance : t -> t -> int
+
 (** {1 Binary decoding of integers} *)
 
 (** The functions in this section binary decode integers from strings.

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -397,7 +397,28 @@ val is_valid_utf_16le : t -> bool
 
 (** {1:spellchecking Spellchecking} *)
 
-val edit_distance : t -> t -> int
+val edit_distance : ?limit:int -> t -> t -> int
+(** [edit_distance s0 s1] is the number of single character edits
+    (understood as insertion, deletion, substitution, transposition)
+    that are needed to change [s0] into [s1].
+
+    The function assumes the strings are UTF-8 encoded and uses {!Uchar.t}
+    for the notion of character. Decoding errors are replaced by
+    {!Uchar.rep}. Normalizing the strings to
+    {{:https://unicode.org/glossary/#normalization_form_c}NFC} gives
+    better results.
+
+    If [limit] is provided the function returns with [limit] as soon
+    as it was determined that [s0] and [s1] have distance of at least
+    [limit]. This is faster if you have a fixed limit, for example for
+    spellchecking.
+
+    {b Note.} This implements the simpler optimal string alignement
+    distance, not the Damerau-Levenshtein distance. With this function
+    ["ca"] and ["abc"] have a distance of 3 not 2.
+
+    @since 5.4
+*)
 
 (** {1 Binary decoding of integers} *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -424,10 +424,16 @@ val spellcheck :
   ?max_dist:(string -> int) -> string list -> string -> string list
 (** [spellcheck dict s] are the elements of [dict] whose
     {{!edit_distance}edit distance} to [s] is the smallest and at most
-    [max_dist s] (default is [Fun.const 2], this is subject to change
-    in the future, use your own function if you want to rely on
-    that). If multiple corrections are returned their order is as
-    given in [dict].
+    [max_dist s]. If multiple corrections are returned their order is
+    as given in [dict]. The default [max_dist s] is:
+
+    {ul
+    {- [0] if [s] has 0 to 2 Unicode characters.}
+    {- [1] if [s] has 3 to 4 Unicode characters.}
+    {- [2] otherwise.}}
+
+    All strings are assumed to be UTF-8 encoded, decoding
+    errors are replaced by {!Uchar.rep} characters.
 
     @since 5.4 *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -413,7 +413,7 @@ val edit_distance : ?limit:int -> t -> t -> int
     {{:https://unicode.org/glossary/#normalization_form_c}NFC} gives
     better results.
 
-    {b Note.} This implements the simpler optimal string alignement
+    {b Note.} This implements the simpler Optimal String Alignement (OSA)
     distance, not the Damerau-Levenshtein distance. With this function
     ["ca"] and ["abc"] have a distance of 3 not 2.
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -420,6 +420,17 @@ val edit_distance : ?limit:int -> t -> t -> int
     @since 5.4
 *)
 
+val spellcheck :
+  ?max_dist:(string -> int) -> string list -> string -> string list
+(** [spellcheck dict s] are the elements of [dict] whose
+    {{!edit_distance}edit distance} to [s] is the smallest and at most
+    [max_dist s] (default is [Fun.const 2], this is subject to change
+    in the future, use your own function if you want to rely on
+    that). If multiple corrections are returned their order is as
+    given in [dict].
+
+    @since 5.4 *)
+
 (** {1 Binary decoding of integers} *)
 
 (** The functions in this section binary decode integers from strings.

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -112,16 +112,22 @@ let () =
   let test ?max_dist dict s res =
     assert (String.spellcheck ?max_dist dict s = res)
   in
-  test ["abcd"; "abca"; "abcdef"] "" [];
-  test ["abcd"; "abca"; "abcdef"] "a" [];
-  test ["abcd"; "abca"; "abcdef"] "ag" [];
-  test ["abcd"; "abca"; "abcdef"] "ab" ["abcd"; "abca"];
-  test ["abcd"; "abca"; "abcdef"] "ac" ["abcd"; "abca"];
-  test ["abcd"; "abca"; "abcdef"] "abc" ["abcd"; "abca"];
-  test ["abcd"; "abca"; "abcdef"] "aba" ["abca"];
-  test ["abcd"; "abca"; "abcdef"] "abcd" ["abcd"];
+  (* max_dist = 0 *)
+  test [""] "" [""];
+  test ["a"; "b"] "" [];
+  test ["a"; "b"] "a" ["a"];
+  test ["a"; "b"] "d" [];
+  test ["a"; "b"] "é" [];
+  test ["aa"; "aé"] "aé" ["aé"];
+  test ["aa"; "aé"] "ad" [];
+  (* max_dist = 1 *)
+  test ["abc"; "abcé"] "abc" ["abc"];
+  test ["abc"; "abcé"; "abcéd"] "abé" ["abc"; "abcé"];
+  test ["abcdé"; "abcdéf"] "abcd" ["abcdé"];
+  (* max_dist = 2 *)
+  test ["abcdéf"] "abcde" ["abcdéf"];
+  test ["abcdéf"] "ubcde" [];
   let max_dist s = if String.length s <= 1 then 1 else 2 in
-  test ["abc"] "a" ["abc"];
   test ~max_dist ["abc"] "a" [];
   test ~max_dist ["abc"; "ab"; "b"] "a" ["ab"; "b"];
   ()

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -76,3 +76,27 @@ let () =
   assert(not (String.ends_with ~suffix:"foo" ""));
   assert(not (String.ends_with ~suffix:"obaz" "foobar"));
 ;;
+
+
+let () =
+  let test x y d =
+    assert (String.edit_distance x y = d);
+    assert (String.edit_distance y x = d);
+    assert (String.edit_distance x x = 0);
+    assert (String.edit_distance y y = 0);
+  in
+  test "" "" 0;
+  test "" "ab" 2;
+  test "function" "function" 0;
+  test "function" "fanction" 1;  (* substitute *)
+  test "function" "fnction" 1;   (* delete *)
+  test "function" "funiction" 1; (* insert *)
+  test "function" "funtcion" 1;  (* transpose *)
+  test "function" "fantcion" 2;  (* substitute + transpose *)
+  test "function" "fantcio" 3;   (* substitute + transpose + delete *)
+  test "function" "efantcio" 4;  (* all *)
+  test "fun" "function" 5;
+  test "ca" "abc" 3 (* Damerau-Levenshtein would be 2 *);
+  test "élément" "élment" 1;
+  test "OCaml🐫" "O'Caml🐪" 2;
+;;

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -107,3 +107,21 @@ let () =
   test "élément" "élment" 1;
   test "OCaml🐫" "O'Caml🐪" 2;
 ;;
+
+let () =
+  let test ?max_dist dict s res =
+    assert (String.spellcheck ?max_dist dict s = res)
+  in
+  test ["abcd"; "abca"; "abcdef"] "" [];
+  test ["abcd"; "abca"; "abcdef"] "a" [];
+  test ["abcd"; "abca"; "abcdef"] "ag" [];
+  test ["abcd"; "abca"; "abcdef"] "ab" ["abcd"; "abca"];
+  test ["abcd"; "abca"; "abcdef"] "ac" ["abcd"; "abca"];
+  test ["abcd"; "abca"; "abcdef"] "abc" ["abcd"; "abca"];
+  test ["abcd"; "abca"; "abcdef"] "aba" ["abca"];
+  test ["abcd"; "abca"; "abcdef"] "abcd" ["abcd"];
+  let max_dist s = if String.length s <= 1 then 1 else 2 in
+  test ["abc"] "a" ["abc"];
+  test ~max_dist ["abc"] "a" [];
+  test ~max_dist ["abc"; "ab"; "b"] "a" ["ab"; "b"];
+  ()

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -110,6 +110,7 @@ let () =
 
 let () =
   let test ?max_dist dict s res =
+    let dict = fun yield -> List.iter yield dict in
     assert (String.spellcheck ?max_dist dict s = res)
   in
   (* max_dist = 0 *)

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -79,11 +79,11 @@ let () =
 
 
 let () =
-  let test x y d =
-    assert (String.edit_distance x y = d);
-    assert (String.edit_distance y x = d);
-    assert (String.edit_distance x x = 0);
-    assert (String.edit_distance y y = 0);
+  let test ?limit x y d =
+    assert (String.edit_distance ?limit x y = d);
+    assert (String.edit_distance ?limit y x = d);
+    assert (String.edit_distance ?limit x x = 0);
+    assert (String.edit_distance ?limit y y = 0);
   in
   test "" "" 0;
   test "" "ab" 2;
@@ -96,6 +96,13 @@ let () =
   test "function" "fantcio" 3;   (* substitute + transpose + delete *)
   test "function" "efantcio" 4;  (* all *)
   test "fun" "function" 5;
+  test "fun" "function" ~limit:0 0;
+  test "fun" "function" ~limit:1 1;
+  test "fun" "function" ~limit:2 2;
+  test "fun" "function" ~limit:3 3;
+  test "fun" "function" ~limit:4 4;
+  test "fun" "function" ~limit:5 5;
+  test "fun" "function" ~limit:6 5;
   test "ca" "abc" 3 (* Damerau-Levenshtein would be 2 *);
   test "élément" "élment" 1;
   test "OCaml🐫" "O'Caml🐪" 2;


### PR DESCRIPTION
*Note to reviewers, there's quite a bit of stdlib related PR's these days I don't mind if this doesn't get reviewed for 5.4, I did it now because I had to go over this again and the material is in my mind.*

This PR adds two new functions to the String module for devising “did you mean?” spell-checking functions on UTF-8 text:

```ocaml
val String.edit_distance : ?limit:int -> string -> string -> int 
val String.spellcheck : ?max_dist:(string -> int) -> string list -> string -> string list
```

Almost any program which deals with user provided input that needs to be matched against known strings can have its usability improved on errors by a simple mindless call to `String.spellcheck`, so it feels worth having them at hand in the Stdlib with good defaults.

The OCaml compiler itself has a form of these functions in [`Misc.edit_distance`] and [`Misc.spellcheck`]. This PR makes sure that at least the `Misc.edit_function` function can be replaced by the one proposed here. This in turn can fix the (unreported AFAIK) bug that these functions do not work meaningfully with the new [modest support for Unicode letters in
identifiers](https://github.com/ocaml/ocaml/pull/12664).


[`Misc.edit_distance`]: https://github.com/ocaml/ocaml/blob/trunk/utils/misc.ml#L941

[`Misc.spellcheck`]: https://github.com/ocaml/ocaml/blob/trunk/utils/misc.ml#L986

# `String.edit_distance` 

Like `Misc.edit_distance`, we use the [optimal string alignement distance][OSA] except we do it on arrays of `Uchar.t`. In contrast to the Levenshtein distance, OSA allows two letter transpositions to be counted as 1 edit rather than 2. In contrast to Damerau-Levenshtein, OSA does not allow the same subsequence to be modified twice. We do not compute Damerau-Levenshtein distance as this requires a counter per letter occuring in the string which is a bit more costly and unconvenient given that, we work on `Uchar.t` letters (vs. say bytes), the data structures we have in the Stdlib, and the module dependency constraints.

Like in `Misc.edit_distance` we add a `limit` parameter to limit the computation to a distance threshold. In this case only the values on a stripe of length `2*limit+1` around the diagonal of the dynamic programming matrix need to be computed. This significantly reduces the work done when you are interested in selecting strings that are not further away than a given limit which is usually the case in spellchecking tasks.

Unlike `Misc.edit_distance`, the proposed function has an unconditional allocation cost due to the internal conversion to `Uchar.t` arrays on which the distance is effectively computed. To compensate this we reduce the dynamic programming matrix as is often suggested but not done in `Misc.edit_distance` (you only need a ring buffer of 3 rows) .

Since the raw implementation result may be a bit difficult to understand, its implementation is introduced by a succession of three commits.

1. The first commit adds a classical OSA distance computation between two UTF-8 strings. It should be easy to match this implementation on pseudo code or the recurrence definition of the dynamic programming matrix that can be found e.g. [on wikipedia][OSA]. By looking at the indexation operations in the loop it is also easy to see that you don't need the full dynamic programming matrix but only a ring buffer of three rows.
   
2. The second commit makes the optimisation of only keeping a ring buffer of three rows of the smallest string. This makes the space requirements of the dynamic programming matrix `3*length(s)` with `s` the smallest string rather than `length(s0)*length(s1)`.
   
3. The third commit adds a `limit` parameter to stop the computation once a maximal distance is reached. This involves computing the dynamic programming array only on a stripe of length `2*limit+1` around the diagonal and compute the minimal in a row for early exit (not present in `Misc.edit_distance`). This makes the algorithm `O(limit*length(s))` time.

[OSA]: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance#Optimal_string_alignment_distance

# `String.spellcheck`

This is a ready made spell-checking function that can be used with small dictionaries represented by a list of string for correcting user input.  Given a string `s` to correct it simply returns the list of words in the dictionary whose edit distance is the smallest and at most at a user provided `max_dist s` value. Note that this favours corrections to shorter words (this can be disputed but the aim here is to have an easy function one can quickly reach for. More elaborate schemes, e.g. based on word probability, can be devised by using the `String.edit_distance` primitive).

The `max_dist` function ~~defaults to `Fun.const 2`~~ (this is no longer the case see discussion below). This default can be discussed, especially on small strings. The problem is that it likely depends on application usage. For example `Misc.spellcheck` adapts the distance according to identifiers length. I would have liked to find some pragmatic user study for a good default, but except for the internet rumor that users make generally no more than 2 of edit errors per word, nothing really came out. My aim with the current definition is that programmers can simply use the function without thinking and have a good enougth and easy to predict default behaviour. I mention in the docs that the default is subject to change, in case we do want to change it later (e.g. make it more like `Misc.spellcheck`).

# Comments 

- Note that in contrast to `Misc.edit_distance` which is able to bail out immediately on large string differences, `String.edit_distance` has to create the `Uchar.t` arrays for the strings before being able to bail out on that check. This has an impact on the gc behaviour of `Misc.spellcheck`'s performance if `env` is large.

- It would have been nice to define `edit_distance` in the API of `Array` but we use it on subarrays here and we rather do not do an additional copy. This would have worked on `Dynarray` but I didn't want to introduce a dependency of `String` on `Dynarray` (though given that `Dynarray` are good `Buffer.t` for `Uchar.t` that's not entirely absurd). I'm willing to do this change if people think there's interest (i.e. have `Dynarray.edit_distance ?equal:('a -> 'a -> bool) -> ?limit:int -> 'a t -> 'a t -> int`) but I rather do the factorization in a subsequent PR.
        
- This PR adds a dependencies to `String` on the `Int`, `List` and `Array` modules (and `Uchar` but that was already a transitive dependency).  Any of these dependencies can be removed (some at the cost of code repetition) Please tell me if there's the desire to trim any of these.

