### PR TITLE
Stabilise the native-debugger tests

### DIFF
--- a/testsuite/tests/native-debugger/linux-gdb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.reference
@@ -4,7 +4,6 @@ Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/$ARCH-linux-gnu/libthread_db.so.1".
-
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common
@@ -13,7 +12,6 @@ frame 3: caml_startup_exn
 frame 4: caml_startup
 frame 5: caml_main
 frame 6: main
-
 Breakpoint 2, 0x00000000000000 in caml_program ()
 frame 0: caml_program
 frame 1: caml_start_program
@@ -23,7 +21,6 @@ frame 4: caml_startup_exn
 frame 5: caml_startup
 frame 6: caml_main
 frame 7: main
-
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 4	value ocaml_to_c (value unit) {
 frame 0: ocaml_to_c
@@ -38,7 +35,6 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-
 Breakpoint 4, camlMeander$c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
 frame 0: camlMeander$c_to_ocaml

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.reference
@@ -4,7 +4,6 @@ Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
-
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common
@@ -13,7 +12,6 @@ frame 3: caml_startup_exn
 frame 4: caml_startup
 frame 5: caml_main
 frame 6: main
-
 Breakpoint 2, 0x00000000000000 in caml_program ()
 frame 0: caml_program
 frame 1: caml_start_program
@@ -23,7 +21,6 @@ frame 4: caml_startup_exn
 frame 5: caml_startup
 frame 6: caml_main
 frame 7: main
-
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
@@ -38,7 +35,6 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-
 Breakpoint 4, camlMeander$c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
 frame 0: camlMeander$c_to_ocaml

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.reference
@@ -4,7 +4,6 @@ Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/$ARCH-linux-gnu/libthread_db.so.1".
-
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common
@@ -13,7 +12,6 @@ frame 3: caml_startup_exn
 frame 4: caml_startup
 frame 5: caml_main
 frame 6: main
-
 Breakpoint 2, 0x00000000000000 in caml_program ()
 frame 0: caml_program
 frame 1: caml_start_program
@@ -23,7 +21,6 @@ frame 4: caml_startup_exn
 frame 5: caml_startup
 frame 6: caml_main
 frame 7: main
-
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
@@ -38,7 +35,6 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-
 Breakpoint 4, camlMeander$c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
 frame 0: camlMeander$c_to_ocaml

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -75,7 +75,6 @@ frame 12: libc.so.6`__libc_start_call_main
 frame 13: libc.so.6`__libc_start_main_impl
 frame 14: meander`_start
 (lldb) continue
-
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 3.1

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -47,5 +47,7 @@
     gsub("This version of LLDB has no plugin for the language \"assembler\". Inspection of frame variables will be limited.", "")
     # Replace printed match results
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
-    print $0
+
+    if ($0 != "")
+      print $0
 }


### PR DESCRIPTION
We've been getting regular enough failures on the linux-lldb-amd64 test to be more than a little irritating:

- https://github.com/ocaml/ocaml/actions/runs/13012933175/job/36295250726#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12978631699/job/36193489764#step:5:2622
- https://github.com/ocaml/ocaml/actions/runs/12935009722/job/36077683805#step:5:2809
- https://github.com/ocaml/ocaml/actions/runs/12910636079/job/36001473051#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12885077628/job/35923099031#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12873284364/job/35890718249#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12872662631/job/35888923357#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12842027260/job/35812524438#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12836103624/job/35797281601#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12830549176/job/35779358253#step:5:744
- https://github.com/ocaml/ocaml/actions/runs/12826852127/job/35767977123#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12818199865/job/35743392322#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12810732281/job/35718794821#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12791173576/job/35707481210#step:5:744
- https://github.com/ocaml/ocaml/actions/runs/12745906289/job/35521219210#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12745477540/job/35519842858#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12710933229/job/35433495658#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12692639317/job/35378831954#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12671907956/job/35315013802#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12668328699/job/35303822430#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12635687261/job/35206394173#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12632799665/job/35197383985#step:5:742
- https://github.com/ocaml/ocaml/actions/runs/12552834186/job/34999466088#step:5:740
- https://github.com/ocaml/ocaml/actions/runs/12469634002/job/34803435300#step:5:934
- https://github.com/ocaml/ocaml/actions/runs/12430708813/job/34706878710#step:5:740
- https://github.com/ocaml/ocaml/actions/runs/12407020019/job/34636503003#step:5:740
- https://github.com/ocaml/ocaml/actions/runs/12369372621/job/34521455031#step:5:739
- https://github.com/ocaml/ocaml/actions/runs/12361384868/job/34498735257#step:5:739
- https://github.com/ocaml/ocaml/actions/runs/12361333886/job/34498586475#step:5:739
- https://github.com/ocaml/ocaml/actions/runs/12358010489/job/34487930189#step:5:739

What's odd is that it seems that when it fails, it fails repeatably on that workflow 🤷

The underlying problem is actually visible in https://github.com/ocaml/ocaml/actions/runs/12247121114/job/34164592459 from #13665 which is that the exact appearance of the line `This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.` seems to be unstable. #13665 attempted to address it with:
https://github.com/ocaml/ocaml/blob/662ad7a5ed774de544b4bd08f67561ddb57c3e1a/testsuite/tests/native-debugger/sanitize.awk#L47

but this isn't correct because it still prints a blank line, and I think that's what we're still seeing here - this blank line moving around, instead of the message.

Blank lines are uninteresting in general in these tests - we're looking at the traces and so forth as the interesting part, so I propose a simple blanket removal of all blank lines as part of the sanitisation.

There remains something stranger going on with the gdb test, but this is much less frequent and may actually be a canary for something that is not right (or at least not stable) in the runtime:
- https://github.com/ocaml/ocaml/actions/runs/12966144331/job/36166671399
- https://github.com/ocaml/ocaml/actions/runs/12196881129/job/34025679511

giving:
```diff
--- a/linux-gdb-amd64.reference
+++ b/linux-gdb-amd64.opt.output
@@ -25,7 +25,7 @@
 frame 7: main
 
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
-5	    caml_callback(*caml_named_value
+4	value ocaml_to_c (value unit) {
 frame 0: ocaml_to_c
 frame 1: caml_c_call
 frame 2: camlMeander$omain

)
```