### PR TITLE
Track type of variables bound by `as`

### DIFF
--- a/Changes
+++ b/Changes
@@ -370,6 +370,9 @@ Working version
 - #13710: Support unicode identifiers in comments.
   (Pieter Goetschalckx, review by Florian Angeletti and Gabriel Scherer)
 
+- #13763: Track type of variables bound by as-patterns
+  (Leo White, review by Gabriel Scherer, port by Vincent Laviron)
+
 - #13790: Fix bytecode-only build of Cygwin when flexlink is being bootstrapped
   with the compiler.
   (David Allsopp, review by Antonin Décimo and Miod Vallat)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -213,8 +213,8 @@ end = struct
     | Tpat_any
     | Tpat_var _ ->
         p
-    | Tpat_alias (q, id, s, uid) ->
-        { p with pat_desc = Tpat_alias (simpl_under_orpat q, id, s, uid) }
+    | Tpat_alias (q, id, s, uid, ty) ->
+        { p with pat_desc = Tpat_alias (simpl_under_orpat q, id, s, uid, ty) }
     | Tpat_or (p1, p2, o) ->
         let p1, p2 = (simpl_under_orpat p1, simpl_under_orpat p2) in
         if le_pat p1 p2 then
@@ -237,8 +237,8 @@ end = struct
       in
       match p.pat_desc with
       | `Any -> stop p `Any
-      | `Var (id, s, uid) -> continue p (`Alias (Patterns.omega, id, s, uid))
-      | `Alias (p, id, _, _) ->
+      | `Var (id, s, uid) -> continue p (`Alias (Patterns.omega, id, s, uid, p.pat_type))
+      | `Alias (p, id, _, _, _) ->
           aux
             ( (General.view p, patl),
               bind_alias p id ~arg ~action )
@@ -333,10 +333,10 @@ end = struct
       match p.pat_desc with
       | `Or (p1, p2, _) ->
           split_explode p1 aliases (split_explode p2 aliases rem)
-      | `Alias (p, id, _, _) -> split_explode p (id :: aliases) rem
+      | `Alias (p, id, _, _, _) -> split_explode p (id :: aliases) rem
       | `Var (id, str, uid) ->
           explode
-            { p with pat_desc = `Alias (Patterns.omega, id, str, uid) }
+            { p with pat_desc = `Alias (Patterns.omega, id, str, uid, p.pat_type) }
             aliases rem
       | #view as view ->
           (* We are doing two things here:
@@ -595,7 +595,7 @@ end = struct
           match p.pat_desc with
           | `Or (p1, p2, _) ->
               filter_rec ((left, p1, right) :: (left, p2, right) :: rem)
-          | `Alias (p, _, _, _) -> filter_rec ((left, p, right) :: rem)
+          | `Alias (p, _, _, _, _) -> filter_rec ((left, p, right) :: rem)
           | `Var _ -> filter_rec ((left, Patterns.omega, right) :: rem)
           | #Simple.view as view -> (
               let p = { p with pat_desc = view } in
@@ -645,7 +645,7 @@ let rec flatten_pat_line size p k =
   | Tpat_tuple args -> (List.map snd args) :: k
   | Tpat_or (p1, p2, _) ->
       flatten_pat_line size p1 (flatten_pat_line size p2 k)
-  | Tpat_alias (p, _, _, _) ->
+  | Tpat_alias (p, _, _, _, _) ->
       (* Note: we are only called from flatten_matrix,
          which is itself only ever used in places
          where variables do not matter (default environments,
@@ -737,7 +737,7 @@ end = struct
       | (p, ps) :: rem -> (
           let p = General.view p in
           match p.pat_desc with
-          | `Alias (p, _, _, _) -> filter_rec ((p, ps) :: rem)
+          | `Alias (p, _, _, _, _) -> filter_rec ((p, ps) :: rem)
           | `Var _ -> filter_rec ((Patterns.omega, ps) :: rem)
           | `Or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
           | #Simple.view as view -> (
@@ -1432,7 +1432,7 @@ let rec omega_like p =
   | Tpat_any
   | Tpat_var _ ->
       true
-  | Tpat_alias (p, _, _, _) -> omega_like p
+  | Tpat_alias (p, _, _, _, _) -> omega_like p
   | Tpat_or (p1, p2, _) -> omega_like p1 || omega_like p2
   | _ -> false
 
@@ -3651,7 +3651,7 @@ let rec name_pattern default = function
   | ((pat, _), _) :: rem -> (
       match pat.pat_desc with
       | Tpat_var (id, _, _) -> id
-      | Tpat_alias (_, id, _, _) -> id
+      | Tpat_alias (_, id, _, _, _) -> id
       | _ -> name_pattern default rem
     )
   | _ -> Ident.create_local default
@@ -4246,7 +4246,7 @@ let for_let ~scopes loc param pat body =
       (* This eliminates a useless variable (and stack slot in bytecode)
          for "let _ = ...". See #6865. *)
       Lsequence (param, body)
-  | Tpat_var (id, _, _) | Tpat_alias ({ pat_desc = Tpat_any }, id, _, _) ->
+  | Tpat_var (id, _, _) | Tpat_alias ({ pat_desc = Tpat_any }, id, _, _, _) ->
       (* Fast path, and keep track of simple bindings to unboxable numbers.
 
          Note: the (Tpat_alias (Tpat_any, id)) case needs to be

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -237,7 +237,8 @@ end = struct
       in
       match p.pat_desc with
       | `Any -> stop p `Any
-      | `Var (id, s, uid) -> continue p (`Alias (Patterns.omega, id, s, uid, p.pat_type))
+      | `Var (id, s, uid) ->
+          continue p (`Alias (Patterns.omega, id, s, uid, p.pat_type))
       | `Alias (p, id, _, _, _) ->
           aux
             ( (General.view p, patl),
@@ -336,7 +337,8 @@ end = struct
       | `Alias (p, id, _, _, _) -> split_explode p (id :: aliases) rem
       | `Var (id, str, uid) ->
           explode
-            { p with pat_desc = `Alias (Patterns.omega, id, str, uid, p.pat_type) }
+            { p with pat_desc =
+                       `Alias (Patterns.omega, id, str, uid, p.pat_type) }
             aliases rem
       | #view as view ->
           (* We are doing two things here:

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -322,7 +322,7 @@ let create_object cl obj init =
 let name_pattern default p =
   match p.pat_desc with
   | Tpat_var (id, _, _) -> id
-  | Tpat_alias(_, id, _, _) -> id
+  | Tpat_alias(_, id, _, _, _) -> id
   | _ -> Ident.create_local default
 
 (*

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -159,7 +159,7 @@ let fuse_method_arity parent_params parent_body =
 let rec iter_exn_names f pat =
   match pat.pat_desc with
   | Tpat_var (id, _, _) -> f id
-  | Tpat_alias (p, id, _, _) ->
+  | Tpat_alias (p, id, _, _, _) ->
       f id;
       iter_exn_names f p
   | _ -> ()
@@ -974,7 +974,7 @@ and transl_let ~scopes ?(in_structure=false) rec_flag pat_expr_list =
         List.map
           (fun {vb_pat=pat} -> match pat.pat_desc with
               Tpat_var (id,_,_) -> id
-            | Tpat_alias ({pat_desc=Tpat_any}, id,_,_) -> id
+            | Tpat_alias ({pat_desc=Tpat_any}, id,_,_,_) -> id
             | _ -> assert false)
         pat_expr_list in
       let transl_case {vb_expr=expr; vb_attributes; vb_rec_kind = rkind;

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -51,7 +51,7 @@ module Typedtree_search =
     let iter_val_pattern = function
       | Typedtree.Tpat_any -> None
       | Typedtree.Tpat_var (name, _, _)
-      | Typedtree.Tpat_alias (_, name, _, _)  -> Some (Name.from_ident name)
+      | Typedtree.Tpat_alias (_, name, _, _, _)  -> Some (Name.from_ident name)
       | Typedtree.Tpat_tuple _ -> None (* FIXME when we will handle tuples *)
       | _ -> None
 
@@ -259,7 +259,7 @@ module Analyser =
                           sn_type = Odoc_env.subst_type env pat.pat_type
                         }
 
-        | Typedtree.Tpat_alias (pat, _, _, _) ->
+        | Typedtree.Tpat_alias (pat, _, _, _, _) ->
             iter_pattern pat
 
         | Typedtree.Tpat_tuple patlist ->
@@ -335,7 +335,7 @@ module Analyser =
        let (pat, exp) = pat_exp in
        let comment_opt = Odoc_sig.analyze_alerts comment_opt attrs in
        match pat.pat_desc with
-       | Tpat_var (ident, _, _) | Tpat_alias (_, ident, _, _) ->
+       | Tpat_var (ident, _, _) | Tpat_alias (_, ident, _, _, _) ->
           begin match exp.exp_desc with
           | Texp_function (params, body) ->
 

--- a/testsuite/tests/asmcomp/regression_value_kinds.ml
+++ b/testsuite/tests/asmcomp/regression_value_kinds.ml
@@ -1,0 +1,21 @@
+(* TEST
+ native;
+*)
+
+type r = { foo : float }
+
+type 'a t = Left of 'a | Right of r
+
+type 'a ty =
+  | Float : float ty
+  | Anything : 'a ty
+
+let f (type a) (ty : a ty) (x : a t) =
+  match ty, x with
+  | Float, Right { foo = (((3.5 : a) as a) : float) }
+  | _, Left a -> ignore (Sys.opaque_identity a)
+  | _, _ -> ()
+
+let f = Sys.opaque_identity f
+
+let () = f Anything (Left 0)

--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -23,7 +23,7 @@ let variables_iterator scope =
   let super = default_iterator in
   let pat sub (type k) (p : k general_pattern) =
     begin match p.pat_desc with
-    | Tpat_var (id, _, _) | Tpat_alias (_, id, _, _) ->
+    | Tpat_var (id, _, _) | Tpat_alias (_, id, _, _, _) ->
         Stypes.record (Stypes.An_ident (p.pat_loc,
                                         Ident.name id,
                                         Annot.Idef scope))

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -302,8 +302,8 @@ module Compat
   | ((Tpat_any|Tpat_var _),_)
   | (_,(Tpat_any|Tpat_var _)) -> true
 (* Structural induction *)
-  | Tpat_alias (p,_,_,_),_      -> compat p q
-  | _,Tpat_alias (q,_,_,_)      -> compat p q
+  | Tpat_alias (p,_,_,_,_),_      -> compat p q
+  | _,Tpat_alias (q,_,_,_,_)      -> compat p q
   | Tpat_or (p1,p2,_),_ ->
       (compat p1 q || compat p2 q)
   | _,Tpat_or (q1,q2,_) ->
@@ -1067,7 +1067,7 @@ let build_other ext env =
 let rec has_instance p = match p.pat_desc with
   | Tpat_variant (l,_,r) when is_absent l r -> false
   | Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_variant (_,None,_) -> true
-  | Tpat_alias (p,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
+  | Tpat_alias (p,_,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
   | Tpat_or (p1,p2,_) -> has_instance p1 || has_instance p2
   | Tpat_construct (_,_,ps,_) | Tpat_array (_, ps) ->
       has_instances ps
@@ -1523,7 +1523,7 @@ let is_var_column rs =
 (* Standard or-args for left-to-right matching *)
 let rec or_args p = match p.pat_desc with
 | Tpat_or (p1,p2,_) -> p1,p2
-| Tpat_alias (p,_,_,_)  -> or_args p
+| Tpat_alias (p,_,_,_,_)  -> or_args p
 | _                 -> assert false
 
 (* Just remove current column *)
@@ -1703,8 +1703,8 @@ and every_both pss qs q1 q2 =
 let rec le_pat p q =
   match (p.pat_desc, q.pat_desc) with
   | (Tpat_var _|Tpat_any),_ -> true
-  | Tpat_alias(p,_,_,_), _ -> le_pat p q
-  | _, Tpat_alias(q,_,_,_) -> le_pat p q
+  | Tpat_alias(p,_,_,_,_), _ -> le_pat p q
+  | _, Tpat_alias(q,_,_,_,_) -> le_pat p q
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
   | Tpat_construct(_,c1,ps,_), Tpat_construct(_,c2,qs,_) ->
       Data_types.equal_constr c1 c2 && le_pats ps qs
@@ -1755,8 +1755,8 @@ let get_mins le ps =
 *)
 
 let rec lub p q = match p.pat_desc,q.pat_desc with
-| Tpat_alias (p,_,_,_),_      -> lub p q
-| _,Tpat_alias (q,_,_,_)      -> lub p q
+| Tpat_alias (p,_,_,_,_),_      -> lub p q
+| _,Tpat_alias (q,_,_,_,_)      -> lub p q
 | (Tpat_any|Tpat_var _),_ -> q
 | _,(Tpat_any|Tpat_var _) -> p
 | Tpat_or (p1,p2,_),_     -> orlub p1 p2 q
@@ -1970,7 +1970,7 @@ let rec collect_paths_from_pat r p = match p.pat_desc with
     List.fold_left
       (fun r (_, _, p) -> collect_paths_from_pat r p)
       r lps
-| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_) ->
+| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_) ->
     collect_paths_from_pat r p
 | Tpat_or (p1,p2,_) ->
     collect_paths_from_pat (collect_paths_from_pat r p1) p2
@@ -2105,7 +2105,7 @@ let inactive ~partial pat =
             List.for_all (fun (_,p) -> loop p) ps
         | Tpat_construct (_, _, ps, _) | Tpat_array (Immutable, ps) ->
             List.for_all (fun p -> loop p) ps
-        | Tpat_alias (p,_,_,_) | Tpat_variant (_, Some p, _) ->
+        | Tpat_alias (p,_,_,_,_) | Tpat_variant (_, Some p, _) ->
             loop p
         | Tpat_record (ldps,_) ->
             List.for_all
@@ -2224,7 +2224,7 @@ type amb_row = { row : pattern list ; varsets : Ident.Set.t list; }
 let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
   let rec simpl head_bound_variables varsets p ps k =
     match (Patterns.General.view p).pat_desc with
-    | `Alias (p,x,_,_) ->
+    | `Alias (p,x,_,_,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
     | `Var (x,_,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -81,7 +81,7 @@ module General = struct
   type view = [
     | Half_simple.view
     | `Var of Ident.t * string loc * Uid.t
-    | `Alias of pattern * Ident.t * string loc * Uid.t
+    | `Alias of pattern * Ident.t * string loc * Uid.t * Types.type_expr
   ]
   type pattern = view pattern_data
 
@@ -90,8 +90,8 @@ module General = struct
        `Any
     | Tpat_var (id, str, uid) ->
        `Var (id, str, uid)
-    | Tpat_alias (p, id, str, uid) ->
-       `Alias (p, id, str, uid)
+    | Tpat_alias (p, id, str, uid, ty) ->
+       `Alias (p, id, str, uid, ty)
     | Tpat_constant cst ->
        `Constant cst
     | Tpat_tuple ps ->
@@ -112,7 +112,7 @@ module General = struct
   let erase_desc = function
     | `Any -> Tpat_any
     | `Var (id, str, uid) -> Tpat_var (id, str, uid)
-    | `Alias (p, id, str, uid) -> Tpat_alias (p, id, str, uid)
+    | `Alias (p, id, str, uid, ty) -> Tpat_alias (p, id, str, uid, ty)
     | `Constant cst -> Tpat_constant cst
     | `Tuple ps -> Tpat_tuple ps
     | `Construct (cstr, cst_descr, args) ->
@@ -130,7 +130,7 @@ module General = struct
 
   let rec strip_vars (p : pattern) : Half_simple.pattern =
     match p.pat_desc with
-    | `Alias (p, _, _, _) -> strip_vars (view p)
+    | `Alias (p, _, _, _, _) -> strip_vars (view p)
     | `Var _ -> { p with pat_desc = `Any }
     | #Half_simple.view as view -> { p with pat_desc = view }
 end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -67,7 +67,7 @@ module General : sig
   type view = [
     | Half_simple.view
     | `Var of Ident.t * string loc * Uid.t
-    | `Alias of pattern * Ident.t * string loc * Uid.t
+    | `Alias of pattern * Ident.t * string loc * Uid.t * Types.type_expr
   ]
   type pattern = view pattern_data
 

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -98,7 +98,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
       fprintf ppf "@[[| %a |]@]" (pretty_vals " ;") vs
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v
-  | Tpat_alias (v, x,_,_) ->
+  | Tpat_alias (v, x,_,_,_) ->
       fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.doc_print x
   | Tpat_value v ->
       fprintf ppf "%a" pretty_val (v :> pattern)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -244,7 +244,7 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   match x.pat_desc with
   | Tpat_any -> line i ppf "Tpat_any\n";
   | Tpat_var (s,_,_) -> line i ppf "Tpat_var \"%a\"\n" fmt_ident s;
-  | Tpat_alias (p, s,_,_) ->
+  | Tpat_alias (p, s,_,_,_) ->
       line i ppf "Tpat_alias \"%a\"\n" fmt_ident s;
       pattern i ppf p;
   | Tpat_constant (c) -> line i ppf "Tpat_constant %a\n" fmt_constant c;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -255,7 +255,7 @@ let pat
   | Tpat_record (l, _) ->
       List.iter (fun (lid, _, i) -> iter_loc sub lid; sub.pat sub i) l
   | Tpat_array (_, l) -> List.iter (sub.pat sub) l
-  | Tpat_alias (p, _, s, _) -> sub.pat sub p; iter_loc sub s
+  | Tpat_alias (p, _, s, _, _) -> sub.pat sub p; iter_loc sub s
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)
   | Tpat_exception p -> sub.pat sub p

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -291,8 +291,8 @@ let pat
     | Tpat_record (l, closed) ->
         Tpat_record (List.map (tuple3 (map_loc sub) id (sub.pat sub)) l, closed)
     | Tpat_array (mut, l) -> Tpat_array (mut, List.map (sub.pat sub) l)
-    | Tpat_alias (p, id, s, uid) ->
-        Tpat_alias (sub.pat sub p, id, map_loc sub s, uid)
+    | Tpat_alias (p, id, s, uid, ty) ->
+        Tpat_alias (sub.pat sub p, id, map_loc sub s, uid, ty)
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->
        (as_computation_pattern (sub.pat sub (p :> pattern))).pat_desc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -798,7 +798,7 @@ and build_as_type_extra env p = function
 
 and build_as_type_aux (env : Env.t) p =
   match p.pat_desc with
-    Tpat_alias(p1,_, _, _) -> build_as_type env p1
+    Tpat_alias(p1,_, _, _, _) -> build_as_type env p1
   | Tpat_tuple pl ->
       let labeled_tyl =
         List.map (fun (label, p) -> label, build_as_type env p) pl in
@@ -1885,7 +1885,7 @@ and type_pat_aux
         enter_variable
           ~is_as_variable:true tps name.loc name ty_var sp.ppat_attributes
       in
-      rvp { pat_desc = Tpat_alias(q, id, name, uid);
+      rvp { pat_desc = Tpat_alias(q, id, name, uid, ty_var);
             pat_loc = loc; pat_extra=[];
             pat_type = q.pat_type;
             pat_attributes = sp.ppat_attributes;
@@ -2184,7 +2184,7 @@ and type_pat_aux
             pat_type = ty;
             pat_desc =
             Tpat_alias
-              ({p with pat_desc = Tpat_any; pat_attributes = []}, id,s, uid);
+              ({p with pat_desc = Tpat_any; pat_attributes = []}, id, s, uid, ty);
             pat_extra = [extra];
           }
       | _, p ->
@@ -2564,7 +2564,7 @@ let rec check_counter_example_pat
           in
           check_rec ~info:(decrease 5) tp expected_ty k
       end
-  | Tpat_alias (p, _, _, _) -> check_rec ~info p expected_ty k
+  | Tpat_alias (p, _, _, _, _) -> check_rec ~info p expected_ty k
   | Tpat_constant cst ->
       let cst = constant_or_raise !!penv loc (Untypeast.constant cst) in
       k @@ solve_expected (mp (Tpat_constant cst) ~pat_type:(type_constant cst))
@@ -3571,7 +3571,7 @@ let rec name_pattern default = function
   | p :: rem ->
     match p.pat_desc with
       Tpat_var (id, _, _) -> id
-    | Tpat_alias(_, id, _, _) -> id
+    | Tpat_alias(_, id, _, _, _) -> id
     | _ -> name_pattern default rem
 
 let name_cases default lst =
@@ -6423,7 +6423,7 @@ and type_let ?check ?check_strict
     List.iter
       (fun {vb_pat=pat} -> match pat.pat_desc with
            Tpat_var _ -> ()
-         | Tpat_alias ({pat_desc=Tpat_any}, _, _, _) -> ()
+         | Tpat_alias ({pat_desc=Tpat_any}, _, _, _, _) -> ()
          | _ -> raise(Error(pat.pat_loc, env, Illegal_letrec_pat)))
       l;
   List.iter (fun vb ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2184,7 +2184,8 @@ and type_pat_aux
             pat_type = ty;
             pat_desc =
             Tpat_alias
-              ({p with pat_desc = Tpat_any; pat_attributes = []}, id, s, uid, ty);
+              ({p with pat_desc = Tpat_any; pat_attributes = []},
+               id, s, uid, ty);
             pat_extra = [extra];
           }
       | _, p ->

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -81,7 +81,8 @@ and 'k pattern_desc =
   | Tpat_var : Ident.t * string loc * Uid.t -> value pattern_desc
         (** x *)
   | Tpat_alias :
-      value general_pattern * Ident.t * string loc * Uid.t -> value pattern_desc
+      value general_pattern * Ident.t * string loc * Uid.t * Types.type_expr ->
+      value pattern_desc
         (** P as a *)
   | Tpat_constant : constant -> value pattern_desc
         (** 1, 'a', "true", 1.0, 1l, 1L, 1n *)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -310,11 +310,11 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
        The compiler transforms (x:t) into (_ as x : t).
        This avoids transforming a warning 27 into a 26.
      *)
-    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _)
+    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _, _ty)
          when pat_loc = pat.pat_loc ->
        Ppat_var name
 
-    | Tpat_alias (pat, _id, name, _) ->
+    | Tpat_alias (pat, _id, name, _, _ty) ->
         Ppat_alias (sub.pat sub pat, name)
     | Tpat_constant cst -> Ppat_constant (constant cst)
     | Tpat_tuple list ->
@@ -831,7 +831,7 @@ let core_type sub ct =
 
 let class_structure sub cs =
   let rec remove_self = function
-    | { pat_desc = Tpat_alias (p, id, _s, _) }
+    | { pat_desc = Tpat_alias (p, id, _s, _, _ty) }
       when String.starts_with ~prefix:"selfpat-" (Ident.name id) ->
         remove_self p
     | p -> p
@@ -861,7 +861,7 @@ let object_field sub {of_loc; of_desc; of_attributes;} =
   Of.mk ~loc ~attrs desc
 
 and is_self_pat = function
-  | { pat_desc = Tpat_alias(_pat, id, _, _) } ->
+  | { pat_desc = Tpat_alias(_pat, id, _, _, _ty) } ->
       String.starts_with ~prefix:"self-" (Ident.name id)
   | _ -> false
 

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -1349,7 +1349,7 @@ and is_destructuring_pattern : type k . k general_pattern -> bool =
   fun pat -> match pat.pat_desc with
     | Tpat_any -> false
     | Tpat_var (_, _, _) -> false
-    | Tpat_alias (pat, _, _, _) -> is_destructuring_pattern pat
+    | Tpat_alias (pat, _, _, _, _) -> is_destructuring_pattern pat
     | Tpat_constant _ -> true
     | Tpat_tuple _ -> true
     | Tpat_construct _ -> true


### PR DESCRIPTION
Port of https://github.com/ocaml-flambda/flambda-backend/pull/3507.

Short description: when typing `as` patterns, we separate the type of the pattern from the type of the variable.
This can be seen on this example from the original PR:
```ocaml
let f x =
  match x with
  | Error ( `A as error )
  | Ok ( `B () as error ) -> use_error error
  | Ok `C -> ()
```
In the first pattern, `` `A as error `` has pattern type ``[< `A ]``, but since `error` also appears in other patterns it will end up having type ``[> `A | `B of unit]`` on the right-hand side.
The code in `matching.ml` generates a static handler for the shared right-hand side, which has `error` as parameter, and generates a value kind annotation on this parameter from the type of `error` in the pattern.
Before this PR, this would look up the type of the variable in the first case below the or-pattern, and would find the type of the pattern, ``[< `A ]``, which is always an integer so `Pintval` is generated.
After this PR, we still look only in the first case, but since we get the type of the variable instead of the pattern, we get the correct type (which produces `Pgenval` in this case).

Compared to the original PR, the only relevant difference is in the `Ppat_constraint` case: the flambda-backend version has removed the code for translating `(var : t)` as `(_ as var : t)`, so I had to find what would be the correct type in this case.

I've chosen to add as a regression test for the native compiler the failing example from @lpw25's original PR, which fails both with Closure (since #8735) and Flambda (since #13758).