### PR TITLE
Implement `get_left` & `get_right` in `Either`

### DIFF
--- a/Changes
+++ b/Changes
@@ -124,6 +124,9 @@ Working version
 
 ### Standard library:
 
+- #13768: Add Either.get_left and Either.get_right
+  (T. Kinsart, review by Nicolás Ojeda Bär and Florian Angeletti)
+
 - #13570, Format: add an out_width function to Format device for approximating
    unicode width.
   (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,

--- a/stdlib/either.ml
+++ b/stdlib/either.ml
@@ -26,6 +26,14 @@ let is_right = function
 | Left _ -> false
 | Right _ -> true
 
+let get_left = function
+| Left v -> v
+| Right _ -> invalid_arg "Either.t is Right _"
+
+let get_right = function
+| Left _ -> invalid_arg "Either.t is Left _"
+| Right v -> v
+
 let find_left = function
 | Left v -> Some v
 | Right _ -> None

--- a/stdlib/either.mli
+++ b/stdlib/either.mli
@@ -69,6 +69,20 @@ val is_left : ('a, 'b) t -> bool
 val is_right : ('a, 'b) t -> bool
 (** [is_right (Left v)] is [false], [is_right (Right v)] is [true]. *)
 
+val get_left : ('a, 'b) t -> 'a
+(** [get_left e] is [v] if [e] is [Left v] and raise otherwise.
+
+    @raise Invalid_argument if [e] is [Right _].
+
+    @since 5.4 *)
+
+val get_right : ('a, 'b) t -> 'b
+(** [get_right e] is [v] if [e] is [Right v] and raise otherwise.
+
+    @raise Invalid_argument if [e] is [Left _].
+
+    @since 5.4 *)
+
 val find_left : ('a, 'b) t -> 'a option
 (** [find_left (Left v)] is [Some v], [find_left (Right _)] is [None] *)
 

--- a/testsuite/tests/lib-either/test.ml
+++ b/testsuite/tests/lib-either/test.ml
@@ -19,6 +19,21 @@ List.map is_right [left 1; right true];;
 - : bool list = [false; true]
 |}];;
 
+[get_left (Left 1); get_right (Right 2)];;
+[%%expect {|
+- : int list = [1; 2]
+|}];;
+
+ignore (get_left (Right 1));;
+[%%expect {|
+Exception: Invalid_argument "Either.t is Right _".
+|}];;
+
+ignore (get_right (Left 1));;
+[%%expect {|
+Exception: Invalid_argument "Either.t is Left _".
+|}];;
+
 [find_left (Left 1); find_left (Right 1)];;
 [%%expect {|
 - : int option list = [Some 1; None]


### PR DESCRIPTION
This PR implements functions `get_left` and `get_right` for `Either` with the following signatures:

```ocaml
val get_left : ('a, 'b) t -> 'a
val get_right : ('a, 'b) t -> 'b
```

They were initially proposed during the introduction of the `Either` module itself in PR https://github.com/ocaml/ocaml/pull/9066, but were postponed for later, to the best of my understanding. Introduction of these functions will
 - Make it easier for the users to obtain the left/right value when you have a code invariant that your `Either.t` value is exactly of this tag.
 - Improve consistency with the `Option`, `Result`, and `Dynarray` modules (and perhaps others?)
