### PR TITLE
dynlink: cannot open dll error: always escape error message

### DIFF
--- a/otherlibs/dynlink/dynlink_types.ml
+++ b/otherlibs/dynlink/dynlink_types.ml
@@ -98,7 +98,7 @@ let () =
       | Corrupted_interface s ->
         Printf.sprintf "Corrupted_interface %S" s
       | Cannot_open_dynamic_library exn ->
-        Printf.sprintf "Cannot_open_dll %s" (Printexc.to_string exn)
+        Printf.sprintf "Cannot_open_dll %S" (Printexc.to_string exn)
       | Inconsistent_implementation s ->
         Printf.sprintf "Inconsistent_implementation %S" s
       | Library's_module_initializers_failed exn ->


### PR DESCRIPTION
The `dynlink` library register an exception printer for its exceptions. For one error in particular (`Cannot_open_dynamic_library`), the formatting of the payload was switched from using `%S` to `%s` in #12213 (cc @shym) with the goal of improving the legibility of the string that results from calling `Printexc.to_string` on the dynlink exception.

However, the payload can be generated by the underlying OS and the error message may be localized and encoded in arbitrary ways (not only in ASCII and/or UTF-8), meaning that `Printexc.to_string` is liable to inject arbitrary binary data into the user program, which may not be expecting it, causing problems. We have one such issue at LexiFi where the string returned by `Printexc.to_string` is encoded in Latin-1 (running on Windows) which makes a .NET/OCaml FFI bridge complain about it (one must always specify an encoding when creating a string in .NET from a sequence of bytes).

Also,

- I find it puzzling that only this one error case was adapted in this way and every other constructor continues to escape its argument (even `Library's_module_initializers_failed` which has the same payload as `Cannot_open_dynamic_library`).

- There's another function, `Dynlink.error_message` that returns a human-readable (unescaped) version of the error message, so in principle one could consider that the point of `Printexc.to_string` is to return a perfectly accurate representation of the error, with legibility a secondary concern.

Given this, I think we should revert this one change. This is what is done in this PR.