### PR TITLE
typing: stop propagating scope updates to type subexpressions

### DIFF
--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -12,26 +12,11 @@ let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w1 in let Refl = w2 in g 3;;
 [%%expect{|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
-|}, Principal{|
-Line 2, characters 37-40:
-2 |    let Refl = w1 in let Refl = w2 in g 3;;
-                                         ^^^
-Error: This expression has type "b" = "int"
-       but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in g 3;;
 [%%expect{|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
-|}, Principal{|
-Line 2, characters 37-40:
-2 |    let Refl = w2 in let Refl = w1 in g 3;;
-                                         ^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 
 (* Ok *)
@@ -46,11 +31,4 @@ let f (type a b) (w : (a, int -> int) eq) (g : a) =
    let Refl = w in g 3;;
 [%%expect{|
 val f : ('a, int -> int) eq -> 'a -> int = <fun>
-|}, Principal{|
-Line 2, characters 19-22:
-2 |    let Refl = w in g 3;;
-                       ^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -40,3 +40,17 @@ let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) : b =
 [%%expect{|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
 |}]
+
+(* This should work. *)
+let f (type a b) (w : (a, int -> int) eq) (g : a) =
+   let Refl = w in g 3;;
+[%%expect{|
+val f : ('a, int -> int) eq -> 'a -> int = <fun>
+|}, Principal{|
+Line 2, characters 19-22:
+2 |    let Refl = w in g 3;;
+                       ^^^
+Error: This expression has type "int" but an expression was expected of type "'a"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
+|}]

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -407,27 +407,12 @@ let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
   let Refl = w1 in let Refl = w2 in M.g 3;;
 [%%expect {|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
-|}, Principal{|
-Line 3, characters 36-41:
-3 |   let Refl = w1 in let Refl = w2 in M.g 3;;
-                                        ^^^^^
-Error: This expression has type "b" = "int"
-       but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let module M = struct let g = g end in
    let Refl = w2 in let Refl = w1 in M.g 3;;
 [%%expect{|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
-|}, Principal{|
-Line 3, characters 37-42:
-3 |    let Refl = w2 in let Refl = w1 in M.g 3;;
-                                         ^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 
 (* Ambivalance via packed module *)
@@ -444,15 +429,6 @@ module type S = sig type a val g : a end
 val f :
   ('a, 'b -> 'b) eq ->
   ('a, int -> int) eq -> (module S with type a = 'a) -> 'b = <fun>
-|}, Principal{|
-module type S = sig type a val g : a end
-Line 7, characters 36-41:
-7 |   let Refl = w1 in let Refl = w2 in M.g 3
-                                        ^^^^^
-Error: This expression has type "b" = "int"
-       but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq)
     (module M : S with type a = a) =
@@ -461,13 +437,6 @@ let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq)
 val f :
   ('a, 'b -> 'b) eq ->
   ('a, int -> int) eq -> (module S with type a = 'a) -> int = <fun>
-|}, Principal{|
-Line 3, characters 36-41:
-3 |   let Refl = w2 in let Refl = w1 in M.g 3
-                                        ^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 
 (* Ambivalance in module expression *)
@@ -478,14 +447,6 @@ let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
   M.res;;
 [%%expect {|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
-|}, Principal{|
-Line 4, characters 2-7:
-4 |   M.res;;
-      ^^^^^
-Error: The value "M.res" has type "b" = "int"
-       but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in
@@ -493,11 +454,4 @@ let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    M.res;;
 [%%expect{|
 val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
-|}, Principal{|
-Line 4, characters 3-8:
-4 |    M.res;;
-       ^^^^^
-Error: The value "M.res" has type "int" but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1099,14 +1099,6 @@ Line 3, characters 2-26:
 Error: This expression has type "< bar : int; foo : int; .. >"
        but an expression was expected of type "'a"
        The type constructor "$1" would escape its scope
-|}, Principal{|
-Line 3, characters 2-26:
-3 |   (x:<foo:int;bar:int;..>)
-      ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< bar : int; foo : int; .. >"
-       but an expression was expected of type "'a"
-       This instance of "$1" is ambiguous:
-       it would escape the scope of its equation
 |}];;
 
 let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) : t =
@@ -1123,14 +1115,6 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 ;;
 [%%expect{|
 val g : 't -> 't int_foo -> 't int_bar -> 't * int * int = <fun>
-|}, Principal{|
-Line 3, characters 5-10:
-3 |   x, x#foo, x#bar
-         ^^^^^
-Error: The method call "x#foo" has type "int"
-       but an expression was expected of type "'a"
-       This instance of "int" is ambiguous:
-       it would escape the scope of its equation
 |}];;
 
 (* PR#5554 *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -838,12 +838,10 @@ let check_scope_escape env level ty =
     raise (Escape { e with context = Some ty })
   end
 
-let rec update_scope scope ty =
+let update_scope scope ty =
   if get_scope ty < scope then begin
     if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
-    (* Only recurse in principal mode as this is not necessary for soundness *)
-    if !Clflags.principal then iter_type_expr (update_scope scope) ty
   end
 
 let update_scope_for tr_exn scope ty =


### PR DESCRIPTION
I ran into a strange bug while implementing #13770. Code such `let f (Foo r) = ...` would work fine, but `let f (Foo {x}) = ...` was rejected with an error on the field `x`... only in principal mode (non-principal mode works fine).

```ocaml
# type 'a t = Foo of {x : 'a};;

# let f (Foo {x}) = ();;
val f : 'a t -> unit = <fun>

# #principal true;;
# let f (Foo {x}) = ();;
              ^
Error: The record field x belongs to the type 'a t.Foo
       but is mixed here with fields of type 'b t.Foo
       This instance of 'b is ambiguous:
       it would escape the scope of its equation
```

I went on a debugging hunt, and I eventually realized that the cause was in the following code in ctype.ml, which is called by the unified to raise the scope of a type expression:

```ocaml
let rec update_scope scope ty =
  if get_scope ty < scope then begin
    if get_level ty < scope then raise_scope_escape_exn ty;
    set_scope ty scope;
    (* Only recurse in principal mode as this is not necessary for soundness *)
    if !Clflags.principal then iter_type_expr (update_scope scope) ty
  end
```

The problem is the last test, which propagates scope increases down within subexpressions, only in principal mode. In my use-case, this propagates the restricted scope of `r` down to its record fields in some cases.

I removed this line and my code works fine, and furthermore a lot of *other* weird failures that were already recorded in the testsuite are now removed. For example:

```ocaml
let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
   let Refl = w1 in let Refl = w2 in g 3;;
[%%expect{|
val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
|}, Principal{|
Line 2, characters 37-40:
2 |    let Refl = w1 in let Refl = w2 in g 3;;
                                         ^^^
Error: This expression has type "b" = "int"
       but an expression was expected of type "'a"
       This instance of "int" is ambiguous:
       it would escape the scope of its equation
|}]
```

This example is marked as "should fail" in the testsuite, but as far as I can tell it should in fact be accepted -- and it is in non-principal mode, because the equality `a = int -> int` lets us use `g` at the type `int -> int` (without using the ambivalent equality `int ~ b`), which produces a non-ambivalent return type `int` for `g 3`. Note that the simpler form also fails with a similar error in principal mode, when I think it is even easier to see that it should work:

```ocaml
let f (type a) (w : (a, int -> int) eq) (g : a) =
   let Refl = w in g 3;;
```

As far as I can tell, level decreases should be propagated down in type expressions, but scope increases should not, they could be propagated *up*: a scope denote a region of validity for a type expressions, so if the type (say) `foo t` is invalid, then the bigger type `int -> foo t` would also be invalid (as it contains an invalid subtype), but on the other hand the type expression `foo` may be perfectly valid and its scope should not be raised.
(Remark: *not* propagating scopes up is fine, because levels are propagated down. For example, if `(int -> foo t)` has level A and `foo t` has scope B with A < B we should fail, and we can notice the issue in two different ways, by propagating scopes up or by propagating levels down.)

So my intuition is that this line, propagating scopes down, is a bug, and that removing it is the right move. But if it is a bug, it is a very intentional one, so something worth discussing with @garrigue first to understand things better.