### PR TITLE
Improve documentation of C interface

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -847,10 +847,10 @@ length \var{n} bytes. The sequence initially contains uninitialized bytes.
 (or string) value of length \var{n} bytes.  The value is initialized from the
 \var{n} bytes starting at address \var{p}.
 \item
-"caml_copy_string("\var{s}")" returns a string or byte sequence value
+"caml_copy_string("\var{s}")" allocates and returns a string or byte sequence value
 containing a copy of the null-terminated C string \var{s} (a "char *").
 \item
-"caml_copy_double("\var{d}")" returns a floating-point value initialized
+"caml_copy_double("\var{d}")" allocates and returns a floating-point value initialized
 with the "double" \var{d}.
 \item
 "caml_copy_int32("\var{i}")", "caml_copy_int64("\var{i}")" and
@@ -869,7 +869,8 @@ an array of floating-point numbers.)
 \item
 "caml_copy_string_array("\var{p}")" allocates an array of strings or byte
 sequences, copied from the pointer to a string array \var{p}
-(a "char **").  \var{p} must be NULL-terminated.
+(a "char **").  \var{p} must be a NULL-terminated array of pointers, each of which must
+   point to a null-terminated C string.
 \item "caml_alloc_float_array("\var{n}")" allocates an array of floating point
   numbers of size \var{n}. The array initially contains uninitialized values.
 \item "caml_alloc_unboxed("\var{v}")" returns the value (of any unboxed

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -471,7 +471,7 @@ and tag this block using "Abstract_tag" or "Custom_tag", thereby
 indicating to the OCaml runtime that the bytes should
 not be interpreted in a standard way. "Abstract_tag" makes the block
 entirely opaque to the runtime, while blocks tagged with "Custom_tag"
-must provide additional operations that can be used by the runtime to,
+can provide additional operations that can be used by the runtime to,
 for instance, compare, hash, or serialize the block.
 
 Here is an example of encapsulation of out-of-heap pointers of C type

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -462,12 +462,17 @@ floating-point numbers.}
 In earlier versions of OCaml, it was possible to use
 word-aligned pointers to addresses outside the heap as OCaml values,
 just by casting the pointer to type "value".  This usage is no longer
-supported since OCaml 5.0.
+supported since OCaml 5.0. There are now three canonical ways of
+manipulating such out-of-heap values.
 
-A correct way to manipulate pointers to out-of-heap blocks from
-OCaml is to store those pointers in OCaml blocks with tag
-"Abstract_tag" or "Custom_tag", then use the blocks as the OCaml
-values.
+{\bf Copying to the OCaml heap:} The first correct way is to copy out-of-heap objects to the OCaml heap.
+To do so safely, one must allocate a fresh block on the OCaml heap
+and tag this block using "Abstract_tag" or "Custom_tag", thereby
+indicating to the OCaml runtime that the bytes should
+not be interpreted in a standard way. "Abstract_tag" makes the block
+entirely opaque to the runtime, while blocks tagged with "Custom_tag"
+must provide additional operations that can be used by the runtime to,
+for instance, compare, hash, or serialize the block.
 
 Here is an example of encapsulation of out-of-heap pointers of C type
 "ty *" inside "Abstract_tag" blocks.  Section~\ref{s:c-intf-example}
@@ -476,17 +481,31 @@ gives a more complete example using "Custom_tag" blocks.
 /* Create an OCaml value encapsulating the pointer p */
 static value val_of_typtr(ty * p)
 {
-  value v = caml_alloc(1, Abstract_tag);
+  CAMLParam0();
+  CAMLlocal1(v);
+  v = caml_alloc(1, Abstract_tag);
+  // Data_abstract_val provides a pointer to the data area of the block
   *((ty **) Data_abstract_val(v)) = p;
-  return v;
+  CAMLreturn(v);
 }
 
 /* Extract the pointer encapsulated in the given OCaml value */
 static ty * typtr_of_val(value v)
 {
-  return *((ty **) Data_abstract_val(v));
+  CAMLparam1(v);
+  CAMLreturnT(ty *, *((ty **) Data_abstract_val(v)));
 }
 \end{verbatim}
+Note: the "CAML*" macros are used to register and unregister local values as
+GC roots, preventing their collection during the execution of the function.
+Usage of these macros is further explained in Section~\ref{s:c-gc-harmony}.
+In addition, you may find conversation functions such as "typtr_of_val" defined
+in existing codebases without using "CAML*" macros. That is because two above
+functions do not strictly require the use of these macros, as they do not trigger
+the GC. However, it is good practice to use them anyway, since understanding
+when the GC is triggered can be subtle.
+
+{\bf Treating pointers as ``native'' integers: }
 Alternatively, out-of-heap pointers can be treated as ``native''
 integers, that is, boxed 32-bit integers on a 32-bit platform and
 boxed 64-bit integers on a 64-bit platform.
@@ -494,30 +513,39 @@ boxed 64-bit integers on a 64-bit platform.
 /* Create an OCaml value encapsulating the pointer p */
 static value val_of_typtr(ty * p)
 {
-  return caml_copy_nativeint((intnat) p);
+  CAMLparam0();
+  CAMLreturn(caml_copy_nativeint((intnat) p));
 }
 
 /* Extract the pointer encapsulated in the given OCaml value */
 static ty * typtr_of_val(value v)
 {
-  return (ty *) Nativeint_val(v);
+  CAMLparam1(v);
+  CAMLParamT(ty *, (ty *) Nativeint_val(v))
 }
 \end{verbatim}
-For pointers that are at least 2-aligned (the low bit is guaranteed to
-be zero), we have yet another valid representation as an OCaml tagged
-integer.
+
+{\bf Treating pointers as tagged integers: }
+For pointers that are \emph{at least 2-aligned} (the low bit is guaranteed to
+be zero), we can modify the low bit so that the OCaml runtime considers it an integer.
 \begin{verbatim}
 /* Create an OCaml value encapsulating the pointer p */
 static value val_of_typtr(ty * p)
 {
+  CAMLparam0();
   assert (((uintptr_t) p & 1) == 0);  /* check correct alignment */
-  return (value) p | 1;
+  /* update the low bit from 0 (indicating a pointer to the OCaml heap)
+     to 1 (indicating an integer) */
+  CAMLreturn((value) p | 1);
 }
 
 /* Extract the pointer encapsulated in the given OCaml value */
 static ty * typtr_of_val(value v)
 {
-  return (ty *) (v & ~1);
+  CAMLparam1(v);
+  /* update the low bit from 1 to 0,
+     recovering the original pointer */
+  CAMLreturnT(ty *, (ty *) (v & ~1));
 }
 \end{verbatim}
 
@@ -947,8 +975,11 @@ safety bugs, so it is strongly recommended to follow the rules below in most
 cases. The implementation of the root registration mechanism is efficient and
 will not typically result in any performance penalty.
 
-All the macros described in this section are declared in the
-"<caml/memory.h>" header file.
+The "<caml/memory.h>" header file exposes a collection of macros that are used
+to register values with the garbage collector when entering a function,
+and unregister when the function terminates. Strictly adhering to the
+following rules ensures correct behaviour.
+
 
 \begin{gcrule}
 A function that has parameters or local variables of type "value" must

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -153,8 +153,8 @@ CAMLprim value caml_int64_float_of_bits(value vi)
 macros for the type "value", that will be described later.  The "CAMLprim" macro
 expands to the required compiler directives to ensure that the
 function is exported and accessible from OCaml.)
-The hard work is performed by the function "caml_int64_float_of_bits_unboxed", which is
-declared as:
+The hard work is performed by the function "caml_int64_float_of_bits_unboxed",
+which is declared as:
 \begin{verbatim}
 double caml_int64_float_of_bits_unboxed(int64_t i)
 {
@@ -328,7 +328,8 @@ Using this mechanism, users of the library "mylib.cma" do not need to
 know that it references C code, nor whether this C code must be
 statically linked (using "-custom") or dynamically linked.
 
-\subsection{ss:c-static-vs-dynamic}{Choosing between static linking and dynamic linking}
+\subsection{ss:c-static-vs-dynamic}
+{Choosing between static linking and dynamic linking}
 
 After having described two different ways of linking C code with OCaml
 code, we now review the pros and cons of each, to help developers of
@@ -465,7 +466,8 @@ just by casting the pointer to type "value".  This usage is no longer
 supported since OCaml 5.0. There are now three canonical ways of
 manipulating such out-of-heap values.
 
-{\bf Copying to the OCaml heap:} The first correct way is to copy out-of-heap objects to the OCaml heap.
+{\bf Copying to the OCaml heap:} The first correct way is to copy out-of-heap
+objects to the OCaml heap.
 To do so safely, one must allocate a fresh block on the OCaml heap
 and tag this block using "Abstract_tag" or "Custom_tag", thereby
 indicating to the OCaml runtime that the bytes should
@@ -501,8 +503,9 @@ GC roots, preventing their collection during the execution of the function.
 Usage of these macros is further explained in Section~\ref{s:c-gc-harmony}.
 In addition, you may find conversion functions such as "typtr_of_val" defined
 in existing codebases without using "CAML*" macros. That is because two above
-functions do not strictly require the use of these macros, as they do not trigger
-the GC. However, it is good practice to use them anyway, since understanding
+functions do not strictly require the use of these macros,
+as they do not trigger the GC.
+However, it is good practice to use them anyway, since understanding
 when the GC is triggered can be subtle.
 
 {\bf Treating pointers as ``native'' integers: }
@@ -527,7 +530,8 @@ static ty * typtr_of_val(value v)
 
 {\bf Treating pointers as tagged integers: }
 For pointers that are \emph{at least 2-aligned} (the low bit is guaranteed to
-be zero), we can modify the low bit so that the OCaml runtime considers it an integer.
+be zero), we can modify the low bit so that the OCaml runtime considers it
+an integer.
 \begin{verbatim}
 /* Create an OCaml value encapsulating the pointer p */
 static value val_of_typtr(ty * p)
@@ -847,11 +851,11 @@ length \var{n} bytes. The sequence initially contains uninitialized bytes.
 (or string) value of length \var{n} bytes.  The value is initialized from the
 \var{n} bytes starting at address \var{p}.
 \item
-"caml_copy_string("\var{s}")" allocates and returns a string or byte sequence value
-containing a copy of the null-terminated C string \var{s} (a "char *").
+"caml_copy_string("\var{s}")" allocates and returns a string or byte sequence
+value containing a copy of the null-terminated C string \var{s} (a "char *").
 \item
-"caml_copy_double("\var{d}")" allocates and returns a floating-point value initialized
-with the "double" \var{d}.
+"caml_copy_double("\var{d}")" allocates and returns a floating-point value
+initialized with the "double" \var{d}.
 \item
 "caml_copy_int32("\var{i}")", "caml_copy_int64("\var{i}")" and
 "caml_copy_nativeint("\var{i}")" return a value of OCaml type "int32",
@@ -869,8 +873,8 @@ an array of floating-point numbers.)
 \item
 "caml_copy_string_array("\var{p}")" allocates an array of strings or byte
 sequences, copied from the pointer to a string array \var{p}
-(a "char **").  \var{p} must be a NULL-terminated array of pointers, each of which must
-   point to a null-terminated C string.
+(a "char **"). \var{p} must be a NULL-terminated array of pointers,
+each of which must point to a null-terminated C string.
 \item "caml_alloc_float_array("\var{n}")" allocates an array of floating point
   numbers of size \var{n}. The array initially contains uninitialized values.
 \item "caml_alloc_unboxed("\var{v}")" returns the value (of any unboxed

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -481,7 +481,7 @@ gives a more complete example using "Custom_tag" blocks.
 /* Create an OCaml value encapsulating the pointer p */
 static value val_of_typtr(ty * p)
 {
-  CAMLParam0();
+  CAMLparam0();
   CAMLlocal1(v);
   v = caml_alloc(1, Abstract_tag);
   // Data_abstract_val provides a pointer to the data area of the block
@@ -499,7 +499,7 @@ static ty * typtr_of_val(value v)
 Note: the "CAML*" macros are used to register and unregister local values as
 GC roots, preventing their collection during the execution of the function.
 Usage of these macros is further explained in Section~\ref{s:c-gc-harmony}.
-In addition, you may find conversation functions such as "typtr_of_val" defined
+In addition, you may find conversion functions such as "typtr_of_val" defined
 in existing codebases without using "CAML*" macros. That is because two above
 functions do not strictly require the use of these macros, as they do not trigger
 the GC. However, it is good practice to use them anyway, since understanding
@@ -521,7 +521,7 @@ static value val_of_typtr(ty * p)
 static ty * typtr_of_val(value v)
 {
   CAMLparam1(v);
-  CAMLParamT(ty *, (ty *) Nativeint_val(v))
+  CAMLreturnT(ty *, (ty *) Nativeint_val(v))
 }
 \end{verbatim}
 

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -108,7 +108,8 @@ CAMLextern value caml_alloc_tuple (mlsize_t);
    contains uninitialized values. */
 CAMLextern value caml_alloc_float_array(mlsize_t len);
 
-/* caml_alloc_string(n) returns a byte sequence (or string) value of length n bytes.
+/* caml_alloc_string(n) returns a byte sequence (or string)
+   value of length n bytes.
    The sequence initially contains uninitialized bytes.*/
 CAMLextern value caml_alloc_string (mlsize_t len);
 
@@ -131,13 +132,16 @@ CAMLextern value caml_copy_string_array (char const * const*);
    floating-point value initialized with the double d. */
 CAMLextern value caml_copy_double (double);
 
-/* caml_copy_int32(i) return a value of OCaml type int32 initialized with the integer i. */
+/* caml_copy_int32(i) return a value of OCaml type int32
+   initialized with the integer i. */
 CAMLextern value caml_copy_int32(int32_t); /* defined in [ints.c] */
 
-/* caml_copy_int64(i) return a value of OCaml type int64 initialized with the integer i. */
+/* caml_copy_int64(i) return a value of OCaml type int64
+   initialized with the integer i. */
 CAMLextern value caml_copy_int64 (int64_t);       /* defined in [ints.c] */
 
-/* caml_copy_nativeint(i) return a value of OCaml type nativeint initialized with the integer i. */
+/* caml_copy_nativeint(i) return a value of OCaml type nativeint
+   initialized with the integer i. */
 CAMLextern value caml_copy_nativeint (intnat);  /* defined in [ints.c] */
 
 /* caml_alloc_array(f, a) allocates an array of values,
@@ -147,7 +151,8 @@ CAMLextern value caml_copy_nativeint (intnat);  /* defined in [ints.c] */
    The function f receives each pointer as argument, and returns a value.
    The zero-tagged block returned by alloc_array(f, a)
    is filled with the values returned by the successive calls to f.
-   (This function must not be used to build an array of floating-point numbers.) */
+   (This function must not be used to build an array of
+   floating-point numbers.) */
 CAMLextern value caml_alloc_array (value (*funct) (char const *),
                                    char const * const * array);
 

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -90,9 +90,9 @@ CAMLextern value caml_alloc_8(tag_t, value, value, value, value,
 CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
                               value, value, value, value, value);
 
-/* caml_alloc_small(n, t) returns a fresh small block of size
-   n ≤ Max_young_wosize words, with tag t.
-   If this block is a structured block (i.e. if t < No_scan_tag),
+/* `caml_alloc_small(n, t)` returns a fresh small block of size
+   `n ≤ Max_young_wosize` words, with tag `t`.
+   If this block is a structured block (i.e. if `t < No_scan_tag`),
    then the fields of the block (initially containing garbage)
    must be initialized with legal values
    (using direct assignment to the fields of the block)
@@ -100,57 +100,57 @@ CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
 CAMLextern value caml_alloc_small (mlsize_t, tag_t);
 CAMLextern value caml_alloc_shr_check_gc (mlsize_t, tag_t);
 
-/* caml_alloc_tuple(n) returns a fresh block of size n words, with tag 0. */
+/* `caml_alloc_tuple(n)` returns a fresh block of size n words, with tag `0`. */
 CAMLextern value caml_alloc_tuple (mlsize_t);
 
-/* caml_alloc_float_array(n) allocates an array of
-   floating point numbers of size n.The array initially
+/* `caml_alloc_float_array(n)` allocates an array of
+   floating point numbers of size n. The array initially
    contains uninitialized values. */
 CAMLextern value caml_alloc_float_array(mlsize_t len);
 
-/* caml_alloc_string(n) returns a byte sequence (or string)
+/* `caml_alloc_string(n)` returns a byte sequence (or string)
    value of length n bytes.
    The sequence initially contains uninitialized bytes.*/
 CAMLextern value caml_alloc_string (mlsize_t len);
 
-/* caml_alloc_initialized_string(n, p) returns a byte sequence
+/* `caml_alloc_initialized_string(n, p)` returns a byte sequence
    (or string) value of length n bytes.
-   The value is initialized from the n bytes starting at address p. */
+   The value is initialized from the `n` bytes starting at address `p`. */
 CAMLextern value caml_alloc_initialized_string (mlsize_t len, const char *);
 
-/* caml_copy_string(s) allocates and returns a string or byte sequence value
-   containing a copy of the null - terminated C string s(a char *). */
+/* `caml_copy_string(s)` allocates and returns a string or byte sequence value
+   containing a copy of the null-terminated C string `s` (a `char *`). */
 CAMLextern value caml_copy_string(char const *);
 
-/* caml_copy_string_array(p) allocates an array of strings or byte sequences,
-   copied from the pointer to a string array p (a char **).
-   p must be a NULL-terminated array of pointers, each of which must
+/* `caml_copy_string_array(p)` allocates an array of strings or byte sequences,
+   copied from the pointer to a string array `p` (a `char **`).
+   `p` must be a null-terminated array of pointers, each of which must
    point to a null-terminated C string. */
 CAMLextern value caml_copy_string_array (char const * const*);
 
-/* caml_copy_double(d) returns a
-   floating-point value initialized with the double d. */
+/* `caml_copy_double(d)` returns a
+   floating-point value initialized with the `double` `d`. */
 CAMLextern value caml_copy_double (double);
 
-/* caml_copy_int32(i) return a value of OCaml type int32
-   initialized with the integer i. */
+/* `caml_copy_int32(i)` return a value of OCaml type `int32`
+   initialized with the integer `i`. */
 CAMLextern value caml_copy_int32(int32_t); /* defined in [ints.c] */
 
-/* caml_copy_int64(i) return a value of OCaml type int64
-   initialized with the integer i. */
+/* `caml_copy_int64(i)` return a value of OCaml type `int64`
+   initialized with the integer `i`. */
 CAMLextern value caml_copy_int64 (int64_t);       /* defined in [ints.c] */
 
-/* caml_copy_nativeint(i) return a value of OCaml type nativeint
-   initialized with the integer i. */
+/* `caml_copy_nativeint(i)` return a value of OCaml type `nativeint`
+   initialized with the integer `i`. */
 CAMLextern value caml_copy_nativeint (intnat);  /* defined in [ints.c] */
 
-/* caml_alloc_array(f, a) allocates an array of values,
-   calling function f over each element of the input array a
-   to transform it into a value. The array a is an array of pointers
+/* `caml_alloc_array(f, a)` allocates an array of values,
+   calling function `f` over each element of the input array `a`
+   to transform it into a value. The array `a` is an array of pointers
    terminated by the null pointer.
-   The function f receives each pointer as argument, and returns a value.
-   The zero-tagged block returned by alloc_array(f, a)
-   is filled with the values returned by the successive calls to f.
+   The function `f` receives each pointer as argument, and returns a value.
+   The zero-tagged block returned by `alloc_array(f, a)`
+   is filled with the values returned by the successive calls to `f`.
    (This function must not be used to build an array of
    floating-point numbers.) */
 CAMLextern value caml_alloc_array (value (*funct) (char const *),
@@ -162,7 +162,7 @@ CAMLextern value caml_alloc_sprintf(const char * format, ...)
 #endif
 ;
 
-/* caml_alloc_some(v) allocates a block representing Some(v). */
+/* `caml_alloc_some(v)` allocates a block representing `Some(v)`. */
 CAMLextern value caml_alloc_some(value);
 
 typedef void (*final_fun)(value);
@@ -175,12 +175,12 @@ CAMLextern int caml_convert_flag_list (value, const int *);
 
 /* Convenience functions to deal with unboxable types. */
 
-/* caml_alloc_unboxed(v) returns the value
-   (of any unboxed type) whose field is the value v. */
+/* `caml_alloc_unboxed(v)` returns the value
+   (of any unboxed type) whose field is the value `v`. */
 Caml_inline value caml_alloc_unboxed (value arg) { return arg; }
 
-/* caml_alloc_boxed(v) allocates and returns a value
-   (of any boxed type) whose field is the value v. */
+/* `caml_alloc_boxed(v)` allocates and returns a value
+   (of any boxed type) whose field is the value `v`. */
 Caml_inline value caml_alloc_boxed (value arg) {
   value result = caml_alloc_small (1, 0);
   Field (result, 0) = arg;
@@ -190,8 +190,8 @@ Caml_inline value caml_alloc_boxed (value arg) {
 Caml_inline value caml_field_unboxed (value arg) { return arg; }
 Caml_inline value caml_field_boxed (value arg) { return Field (arg, 0); }
 
-/* caml_alloc_unboxable(v) calls either caml_alloc_unboxed or
-   caml_alloc_boxed according to the default representation of unboxable
+/* `caml_alloc_unboxable(v)` calls either `caml_alloc_unboxed` or
+   `caml_alloc_boxed` according to the default representation of unboxable
    types in the current version of OCaml.
    Currently, unannotated unboxable types are boxed by default.
    (may change in the future) */

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -26,40 +26,138 @@ extern "C" {
 /* It is guaranteed that these allocation functions will not trigger
    any OCaml callback such as finalizers or signal handlers. */
 
+/* Allocates a block with given size with tag.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc (mlsize_t, tag_t);
+
+/* Allocates a block of size 1 with given tag,
+   and sets its only field to the given value.   
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_1(tag_t, value);
+
+/* Allocates a block of size 2 with given tag,
+   and sets its two field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_2(tag_t, value, value);
+
+/* Allocates a block of size 3 with given tag,
+   and sets its three field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_3(tag_t, value, value, value);
+
+/* Allocates a block of size 4 with given tag,
+   and sets its four field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_4(tag_t, value, value, value, value);
+
+/* Allocates a block of size 5 with given tag,
+   and sets its 5 field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_5(tag_t, value, value, value, value,
                               value);
+
+/* Allocates a block of size 6 with given tag,
+   and sets its six field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_6(tag_t, value, value, value, value,
                               value, value);
+
+/* Allocates a block of size 7 with given tag,
+   and sets its seven field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_7(tag_t, value, value, value, value,
                               value, value, value);
+
+/* Allocates a block of size 8 with given tag,
+   and sets its eight field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_8(tag_t, value, value, value, value,
                               value, value, value, value);
+
+/* Allocates a block of size 9 with given tag,
+   and sets its nine field to the given values.
+   Guaranteed to not trigger any OCaml callback such as
+   finalizers or signal handlers. */
 CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
                               value, value, value, value, value);
+
+/* caml_alloc_small(n, t) returns a fresh small block of size
+   n ≤ Max_young_wosize words, with tag t.
+   If this block is a structured block (i.e. if t < No_scan_tag),
+   then the fields of the block (initially containing garbage)
+   must be initialized with legal values
+   (using direct assignment to the fields of the block)
+   before the next allocation. */
 CAMLextern value caml_alloc_small (mlsize_t, tag_t);
 CAMLextern value caml_alloc_shr_check_gc (mlsize_t, tag_t);
+
+/* caml_alloc_tuple(n) returns a fresh block of size n words, with tag 0. */
 CAMLextern value caml_alloc_tuple (mlsize_t);
-CAMLextern value caml_alloc_float_array (mlsize_t len);
-CAMLextern value caml_alloc_string (mlsize_t len);  /* len in bytes (chars) */
+
+/* caml_alloc_float_array(n) allocates an array of
+   floating point numbers of size n.The array initially
+   contains uninitialized values. */
+CAMLextern value caml_alloc_float_array(mlsize_t len);
+
+/* caml_alloc_string(n) returns a byte sequence (or string) value of length n bytes.
+   The sequence initially contains uninitialized bytes.*/
+CAMLextern value caml_alloc_string (mlsize_t len);
+
+/* caml_alloc_initialized_string(n, p) returns a byte sequence
+   (or string) value of length n bytes.
+   The value is initialized from the n bytes starting at address p. */
 CAMLextern value caml_alloc_initialized_string (mlsize_t len, const char *);
-CAMLextern value caml_copy_string (char const *);
+
+/* caml_copy_string(s) allocates and returns a string or byte sequence value
+   containing a copy of the null - terminated C string s(a char *). */
+CAMLextern value caml_copy_string(char const *);
+
+/* caml_copy_string_array(p) allocates an array of strings or byte sequences,
+   copied from the pointer to a string array p (a char **).
+   p must be a NULL-terminated array of pointers, each of which must
+   point to a null-terminated C string. */
 CAMLextern value caml_copy_string_array (char const * const*);
+
+/* caml_copy_double(d) returns a
+   floating-point value initialized with the double d. */
 CAMLextern value caml_copy_double (double);
-CAMLextern value caml_copy_int32 (int32_t);       /* defined in [ints.c] */
+
+/* caml_copy_int32(i) return a value of OCaml type int32 initialized with the integer i. */
+CAMLextern value caml_copy_int32(int32_t); /* defined in [ints.c] */
+
+/* caml_copy_int64(i) return a value of OCaml type int64 initialized with the integer i. */
 CAMLextern value caml_copy_int64 (int64_t);       /* defined in [ints.c] */
+
+/* caml_copy_nativeint(i) return a value of OCaml type nativeint initialized with the integer i. */
 CAMLextern value caml_copy_nativeint (intnat);  /* defined in [ints.c] */
+
+/* caml_alloc_array(f, a) allocates an array of values,
+   calling function f over each element of the input array a
+   to transform it into a value. The array a is an array of pointers
+   terminated by the null pointer.
+   The function f receives each pointer as argument, and returns a value.
+   The zero-tagged block returned by alloc_array(f, a)
+   is filled with the values returned by the successive calls to f.
+   (This function must not be used to build an array of floating-point numbers.) */
 CAMLextern value caml_alloc_array (value (*funct) (char const *),
                                    char const * const * array);
+
 CAMLextern value caml_alloc_sprintf(const char * format, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
+
+/* caml_alloc_some(v) allocates a block representing Some(v). */
 CAMLextern value caml_alloc_some(value);
 
 typedef void (*final_fun)(value);
@@ -71,17 +169,27 @@ CAMLextern value caml_alloc_final (mlsize_t, /*size in words*/
 CAMLextern int caml_convert_flag_list (value, const int *);
 
 /* Convenience functions to deal with unboxable types. */
+
+/* caml_alloc_unboxed(v) returns the value
+   (of any unboxed type) whose field is the value v. */
 Caml_inline value caml_alloc_unboxed (value arg) { return arg; }
+
+/* caml_alloc_boxed(v) allocates and returns a value
+   (of any boxed type) whose field is the value v. */
 Caml_inline value caml_alloc_boxed (value arg) {
   value result = caml_alloc_small (1, 0);
   Field (result, 0) = arg;
   return result;
 }
+
 Caml_inline value caml_field_unboxed (value arg) { return arg; }
 Caml_inline value caml_field_boxed (value arg) { return Field (arg, 0); }
 
-/* Unannotated unboxable types are boxed by default. (may change in the
-   future) */
+/* caml_alloc_unboxable(v) calls either caml_alloc_unboxed or
+   caml_alloc_boxed according to the default representation of unboxable
+   types in the current version of OCaml.
+   Currently, unannotated unboxable types are boxed by default.
+   (may change in the future) */
 #define caml_alloc_unboxable caml_alloc_boxed
 #define caml_field_unboxable caml_field_boxed
 


### PR DESCRIPTION
Following up on [this discussion](https://discuss.ocaml.org/t/confusion-with-camlparam-in-c-bindings/16064), I created a small PR to slightly improve some documentation, providing additional context on the `CAML*` macros.

In addition, I updated examples of functions to make use of the macros even though they are not required as to follow the rules that should be enforced according to the same chapter.

I also annotated `alloc.h` with comments on each declaration (basically copy-pasting from the manual) so that it appears on hover when working with most editors.
<img width="410" alt="image" src="https://github.com/user-attachments/assets/912fab88-1fee-4198-a0ed-4c6e46664aed" />

This is an initial draft to see if maintainers are happy with such a change, but happy to improve/add more stuff. Typically I also wanted to add more C documentation on the CAML* macros