### PR TITLE
Ensure that pool owners are correctly set on pool adoption

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,9 @@ Working version
   (Sadiq Jaffer, report by KC Sivaramakrishnan and Jan Midtgaard, review by
   Gabriel Scherer)
 
+- #13773: Ensure that shared pool owners are correctly set on pool adoption.
+  (Stephen Dolan, review by Sadiq Jaffer and Gabriel Scherer)
+
 * #11449, #13497: Add caml_stat_char_array_{to,of}_os functions allowing
   conversion of string data which may contain NUL characters. Correct
   implementation of caml_stat_strdup_to_utf16 to raise Out_of_memory instead of

--- a/testsuite/tests/compaction/test_compact_manydomains.ml
+++ b/testsuite/tests/compaction/test_compact_manydomains.ml
@@ -1,0 +1,16 @@
+(* TEST
+*)
+
+let num_domains = 20
+
+let go () =
+  let n = 50_000 in
+  let c = Array.make n None in
+  for i = 0 to n-1 do
+    c.(i) <- Some (i, i)
+  done;
+  Gc.compact ()
+
+let () =
+  Array.init num_domains (fun _ -> Domain.spawn go)
+  |> Array.iter Domain.join


### PR DESCRIPTION
Pulls fix from https://github.com/ocaml-flambda/flambda-backend/pull/3521 , originally by @stedolan 

When pools are given up (by a terminating domain) they can be adopted by other domains but we currently fail to update their ownership. This doesn't cause any problems on trunk, just the potential for some stats to be off (unrelated to https://github.com/ocaml/ocaml/issues/13090).