### PR TITLE
Fix for inaccurate live blocks/words stats in compaction

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,9 @@ Working version
 
 ### Runtime system:
 
+- #13774: Fix for inaccurate live blocks/words stats in compaction.
+  (Sadiq Jaffer, review by ?)
+
 * #11449, #13497: Add caml_stat_char_array_{to,of}_os functions allowing
   conversion of string data which may contain NUL characters. Correct
   implementation of caml_stat_strdup_to_utf16 to raise Out_of_memory instead of

--- a/Changes
+++ b/Changes
@@ -15,7 +15,8 @@ Working version
 ### Runtime system:
 
 - #13774: Fix for inaccurate live blocks/words stats in compaction.
-  (Sadiq Jaffer, review by ?)
+  (Sadiq Jaffer, report by KC Sivaramakrishnan and Jan Midtgaard, review by
+  Gabriel Scherer)
 
 * #11449, #13497: Add caml_stat_char_array_{to,of}_os functions allowing
   conversion of string data which may contain NUL characters. Correct

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1249,6 +1249,10 @@ void caml_compact_heap(caml_domain_state* domain_state,
               if (final_fun) final_fun(Val_hp(p));
             }
 
+            heap->stats.pool_live_blocks--;
+            heap->stats.pool_live_words -= Whsize_hd(hd);
+            heap->stats.pool_frag_words -= (wh - Whsize_hd(hd));
+
             /* In the DEBUG runtime, we should overwrite the fields of swept
                blocks. Note: this pool can't be allocated in to again and so
                we overwrite the header and first fields too. */


### PR DESCRIPTION
During compaction we effectively sweep garbage blocks in evacuated shared pools but do not correctly update stats. This change fixes #13090 .

With this the test in #13773 will also pass.