### PR TITLE
Fix ocamltest line numbers after multiline comments, strings

### DIFF
--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -112,6 +112,7 @@ and string acc = parse
     { let space =
         match blank with None -> "" | Some blank -> String.make 1 blank
       in
+      Lexing.new_line lexbuf;
       string (acc ^ space) lexbuf }
   | '\\'
     {string (acc ^ "\\") lexbuf}
@@ -138,6 +139,11 @@ and comment = parse
       let message = Printf.sprintf "%s:%d:%d: unterminated comment"
         file line column in
       lexer_error message
+    }
+  | newline
+    {
+      Lexing.new_line lexbuf;
+      comment lexbuf
     }
   | _
     {


### PR DESCRIPTION
Any multiline string or comment in an ocamltest throws off the line numbers in output:

    (* TEST
     (* This is
        a long comment *)

     fail; (* this is line 5 *)
    *)

     ... testing 'main.ml' with line 4 (fail) => failed (the fail action always fails)

This PR fixes both strings and comments.