### PR TITLE
Use `nanosleep` when available for the tick thread

### DIFF
--- a/Changes
+++ b/Changes
@@ -267,7 +267,7 @@ Working version
   inference of type-directed disambiguation in principal mode.
   (Richard Eisenberg, review by Jacques Garrigue)
 
-- #13539: Use nanosleep instead of usleep, if available.
+- #13539, #13776: Use nanosleep instead of usleep or select, if available.
   (Antonin Décimo, review by Miod Vallat and Gabriel Scherer)
 
 - #13606: Fix Numbers.Int_base.compare

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -15,14 +15,42 @@
 
 /* POSIX thread implementation of the "st" interface */
 
+#define CAML_INTERNALS
+#include "caml/misc.h"
+
+#ifdef HAS_NANOSLEEP
+
+#include <time.h>
+
+typedef struct timespec st_timeout;
+
+Caml_inline st_timeout st_timeout_of_msec(int msec)
+{
+  return (st_timeout){ .tv_sec = 0, .tv_nsec = msec * NSEC_PER_MSEC };
+}
+
+Caml_inline void st_msleep(const st_timeout *timeout)
+{
+  nanosleep(timeout, NULL);
+}
+
+#else
+
 #ifdef HAS_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 
-Caml_inline void st_msleep(int msec)
+typedef struct timeval st_timeout;
+
+Caml_inline st_timeout st_timeout_of_msec(int msec)
 {
-  struct timeval timeout = {0, msec * 1000};
-  select(0, NULL, NULL, NULL, &timeout);
+  return (st_timeout){ .tv_sec = 0, .tv_usec = msec * USEC_PER_MSEC };
 }
+
+Caml_inline void st_msleep(st_timeout *timeout)
+{
+  select(0, NULL, NULL, NULL, timeout);
+}
+#endif
 
 #include "st_pthreads.h"

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -15,13 +15,19 @@
 
 /* Win32 implementation of the "st" interface */
 
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0400
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-Caml_inline void st_msleep(int msec)
+typedef DWORD st_timeout;
+
+Caml_inline st_timeout st_timeout_of_msec(int msec)
 {
-  Sleep(msec);
+  return msec;
+}
+
+Caml_inline void st_msleep(const st_timeout *timeout)
+{
+  Sleep(*timeout);
 }
 
 #include "st_pthreads.h"

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -772,6 +772,7 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #define CAML_GENSYM(name) CAML_GENSYM_2(name, __LINE__)
 
 #define MSEC_PER_SEC  UINT64_C(1000)
+#define USEC_PER_MSEC UINT64_C(1000)
 #define USEC_PER_SEC  UINT64_C(1000000)
 #define NSEC_PER_USEC UINT64_C(1000)
 #define NSEC_PER_MSEC UINT64_C(1000000)


### PR DESCRIPTION
A missed opportunity from #13539. Cf #13700, https://github.com/ocaml/ocaml/pull/10505#issuecomment-1072295655, https://github.com/ocaml/ocaml/pull/11115#discussion_r828125690, and https://github.com/dra27/ocaml/commit/4d25406f75763cd81ff9123bedcd1aa110f595fd.