### PR TITLE
#13764 ocamldep: keywords flag mirroring the ocaml{c,opt} one

### DIFF
--- a/.depend
+++ b/.depend
@@ -8106,10 +8106,12 @@ tools/ocamlcp.cmi :
 tools/ocamlcp_common.cmo : \
     driver/main_args.cmi \
     driver/compenv.cmi \
+    utils/clflags.cmi \
     tools/ocamlcp_common.cmi
 tools/ocamlcp_common.cmx : \
     driver/main_args.cmx \
     driver/compenv.cmx \
+    utils/clflags.cmx \
     tools/ocamlcp_common.cmi
 tools/ocamlcp_common.cmi : \
     driver/main_args.cmi
@@ -8152,12 +8154,14 @@ tools/ocamlprof.cmo : \
     parsing/parsetree.cmi \
     parsing/parse.cmi \
     parsing/location.cmi \
+    utils/clflags.cmi \
     tools/ocamlprof.cmi
 tools/ocamlprof.cmx : \
     utils/warnings.cmx \
     parsing/parsetree.cmi \
     parsing/parse.cmx \
     parsing/location.cmx \
+    utils/clflags.cmx \
     tools/ocamlprof.cmi
 tools/ocamlprof.cmi :
 tools/ocamltex.cmo : \

--- a/Changes
+++ b/Changes
@@ -194,6 +194,9 @@ Working version
   (Tim McGilchrist and Sebastien Hinderer, review by Sebastien Hinderer,
    Gabriel Scherer and Antonin Décimo)
 
+- #13764, #13779: add missing "-keywords" flag to ocamldep and ocamlprof
+  (Florian Angeletti, report by Prashanth Mundkur, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #13694: Fix name for caml_hash_variant in the C interface.

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -594,6 +594,9 @@ let run_main argv =
         "<f>  Process <f> as a .ml file";
       "-intf", Arg.String (add_dep_arg (fun f -> Src (f, Some MLI))),
         "<f>  Process <f> as a .mli file";
+      "-keywords", Arg.String (fun s -> Clflags.keyword_edition := Some s ),
+      "<version+list>  set keywords following the <version+list> spec \
+       (see ocamlc)";
       "-map", Arg.String (add_dep_arg (fun f -> Map f)),
         "<f>  Read <f> and propagate delayed dependencies to following files";
       "-ml-synonym", Arg.String(add_to_synonym_list ml_synonyms),

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -111,6 +111,11 @@ Process
 .IR file
 as a .mli file.
 .TP
+.BI \-keywords " version+list"
+Set keywords according to the
+.IR version+list
+specification.
+.TP
 .BI \-map " file"
 Read an propagate the delayed dependencies for module aliases in
 .IR file ,

--- a/man/ocamlprof.1
+++ b/man/ocamlprof.1
@@ -71,6 +71,11 @@ Compile the file
 .I filename
 as an interface file, even if its extension is not .mli.
 .TP
+.BI \-keywords " version+list"
+Set keywords according to the
+.IR version+list
+specification.
+.TP
 .B \-version
 Print version string and exit.
 .TP

--- a/manual/src/cmds/ocamldep.etex
+++ b/manual/src/cmds/ocamldep.etex
@@ -80,6 +80,21 @@ Process \var{file} as a ".ml" file.
 \item["-intf" \var{file}]
 Process \var{file} as a ".mli" file.
 
+
+\item["-keywords" \var{version+list}]
+Set keywords according to the \var{version+list}
+specification.
+
+This specification starts with an optional version number, defining the base set
+of keywords, followed by a \var{+}-separated list of additional keywords to add
+to this base set.
+
+Without an explicit version number, the base set of keywords is the
+set of keywords in the current version of OCaml.
+Additional keywords that do not match any known keyword in the current
+version of the language trigger an error whenever they are present in the
+source code.
+
 \item["-map" \var{file}]
 Read and propagate the delayed dependencies for module aliases in
 \var{file}, so that the following files will depend on the

--- a/manual/src/cmds/profil.etex
+++ b/manual/src/cmds/profil.etex
@@ -125,6 +125,10 @@ extension is not ".ml".
 Process the file \var{filename} as an interface file, even if its
 extension is not ".mli".
 
+\item["-keywords" \var{version+list}]
+Set keywords according to the \var{version+list}
+specification.
+
 \item["-version"]
 Print version string and exit.
 

--- a/tools/ocamlcp_common.ml
+++ b/tools/ocamlcp_common.ml
@@ -106,6 +106,11 @@ module Make(T: OCAMLCP) = struct
       cannot_deal_with "-intf" ".ml files";
     if !with_impl then rev_profargs := "-impl" :: !rev_profargs;
     if !with_intf then rev_profargs := "-intf" :: !rev_profargs;
+    begin match !Clflags.keyword_edition with
+    | None -> ()
+    | Some k ->
+       rev_profargs := ("-keywords " ^ k) :: !rev_profargs
+    end;
     let status =
       let profiling_object =
         if T.bytecode then "profiling.cmo" else "profiling.cmx" in

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -505,6 +505,8 @@ let main () =
        "-instrument", Arg.Set instr_mode, "  (undocumented)";
        "-intf", Arg.String process_intf_file,
                 "<file>  Process <file> as a .mli file";
+       "-keywords", Arg.String (fun s -> Clflags.keyword_edition := Some s),
+       "<version+keywords> Specify keyword set.";
        "-m", Arg.String (fun s -> modes := s), "<flags>    (undocumented)";
        "-version", Arg.Unit print_version,
                    "     Print version and exit";


### PR DESCRIPTION
This small PR adds the missing `-keywords` flag to ocamldep and ocamlprof.