### PR TITLE
Set scope in expand_abbrev rather than rely on update_scope

### DIFF
--- a/Changes
+++ b/Changes
@@ -412,6 +412,10 @@ Working version
   (Ulysse Gérard and Jules Aguillon, review by Jules Aguillon
    and Florian Angeletti)
 
+- #13781: Set scope of internal type nodes during abbreviation expansion
+  rather than recursing during unification.
+  (Jacques Garrigue, review by Gabriel Scherer)
+
 - #13820: Add a new option -i-variance to print the variance of every
   type parameter; bivariance is printed as `+-`, and for consistency,
   parser is modified too to accept `+-` and `-+` as `type_variance`.

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -225,7 +225,9 @@ let with_local_level_gen ~begin_def ~structure ?before_generalize f =
         (* In structure mode, we do do not generalize type variables,
            so we need to lower their level, and move them to an outer pool.
            The goal of this mode is to allow unsharing inner nodes
-           without introducing polymorphism *)
+           without introducing polymorphism.
+           We do not check the scope here, as scope is only restricted for
+           GADT equations, and they do not contain type variables. *)
         if ty.level >= level then Transient_expr.set_level ty !current_level;
         add_to_pool ~level:ty.level ty
     | Tlink _ -> ()
@@ -845,12 +847,10 @@ let check_scope_escape env level ty =
     raise (Escape { e with context = Some ty })
   end
 
-let rec update_scope scope ty =
+let update_scope scope ty =
   if get_scope ty < scope then begin
     if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
-    (* Only recurse in principal mode as this is not necessary for soundness *)
-    if !Clflags.principal then iter_type_expr (update_scope scope) ty
   end
 
 let update_scope_for tr_exn scope ty =
@@ -1146,8 +1146,8 @@ let abbreviations = ref (ref Mnil)
 
 (* partial: we may not wish to copy the non generic types
    before we call type_pat *)
-let rec copy ?partial ?keep_names copy_scope ty =
-  let copy = copy ?partial ?keep_names copy_scope in
+let rec copy ?partial ?keep_names ?scope copy_scope ty =
+  let copy = copy ?partial ?keep_names ?scope copy_scope in
   match get_desc ty with
     Tsubst (ty, _) -> ty
   | desc ->
@@ -1165,7 +1165,13 @@ let rec copy ?partial ?keep_names copy_scope ty =
           else generic_level
     in
     if forget <> generic_level then newty2 ~level:forget (Tvar None) else
-    let t = newstub ~scope:(get_scope ty) in
+    let scope =
+      match scope, desc with
+      | None, _
+      | _, Tvar _ -> get_scope ty
+      | Some scope, _ -> max scope (get_scope ty)
+    in
+    let t = newstub ~scope in
     For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
     let desc' =
       match desc with
@@ -1354,10 +1360,11 @@ let instance_constructor existential_treatment cstr =
     (ty_args, ty_res, ty_ex)
   )
 
-let instance_parameterized_type ?keep_names sch_args sch =
+let instance_parameterized_type ?keep_names ?scope sch_args sch =
   For_copy.with_scope (fun copy_scope ->
-    let ty_args = List.map (fun t -> copy ?keep_names copy_scope t) sch_args in
-    let ty = copy copy_scope sch in
+    let ty_args =
+      List.map (fun t -> copy ?keep_names ?scope copy_scope t) sch_args in
+    let ty = copy ?scope copy_scope sch in
     (ty_args, ty)
   )
 
@@ -1529,7 +1536,7 @@ let instance_label ~fixed lbl =
 let unify_var' = (* Forward declaration *)
   ref (fun _env _ty1 _ty2 -> assert false)
 
-let subst env level priv abbrev oty params args body =
+let subst ~env ~level ?scope ~priv ~abbrev ?oty ~params ~args body =
   if List.length params <> List.length args then raise Cannot_subst;
   with_level ~level begin fun () ->
     let body0 = newvar () in          (* Stub *)
@@ -1545,7 +1552,7 @@ let subst env level priv abbrev oty params args body =
           | _ -> assert false
     in
     abbreviations := abbrev;
-    let (params', body') = instance_parameterized_type params body in
+    let (params', body') = instance_parameterized_type ?scope params body in
     abbreviations := ref Mnil;
     let uenv = Expression {env; in_subst = true} in
     try
@@ -1567,7 +1574,7 @@ let apply ?(use_current_level = false) env params body args =
   simple_abbrevs := Mnil;
   let level = if use_current_level then !current_level else generic_level in
   try
-    subst env level Public (ref Mnil) None params args body
+    subst ~env ~level ~priv:Public ~abbrev:(ref Mnil) ~params ~args body
   with
     Cannot_subst -> raise Cannot_apply
 
@@ -1627,7 +1634,8 @@ let expand_abbrev_gen kind find_type_expansion env ty =
         (* prerr_endline
            ("found a "^string_of_kind kind^" expansion for "^Path.name path);*)
         if level <> generic_level then update_level env level ty';
-        update_scope scope ty';
+        if not !Clflags.principal then update_scope scope ty'
+        else if get_scope ty' <> scope then raise_scope_escape_exn ty;
         Some ty'
     with Escape _ ->
       (* in case of Escape, discard the stale expansion and re-expand *)
@@ -1643,19 +1651,23 @@ let expand_abbrev_gen kind find_type_expansion env ty =
           (* another way to expand is to normalize the path itself *)
           let path' = Env.normalize_type_path None env path in
           if Path.same path path' then raise Cannot_expand
-          else newty2 ~level (Tconstr (path', args, abbrev))
-      | (params, body, lv) ->
+          else newty3 ~level ~scope (Tconstr (path', args, abbrev))
+      | (params, body, expansion_scope) ->
           (* prerr_endline
              ("add a "^string_of_kind kind^" expansion for "^Path.name path);*)
+          let scope = Int.max expansion_scope (get_scope ty) in
           let ty' =
             try
-              subst env level kind abbrev (Some ty) params args body
+              (* Only enforce scope recursively in principal mode
+                 as this is not necessary for soundness *)
+              let scope = if !Clflags.principal then Some scope else None in
+              subst ~env ~level ?scope ~priv:kind ~abbrev ~oty:ty
+                ~params ~args body
             with Cannot_subst -> raise_escape_exn Constraint
           in
           (* For gadts, remember type as non exportable *)
           (* The ambiguous level registered for ty' should be the highest *)
           (* if !trace_gadt_instances then begin *)
-          let scope = Int.max lv (get_scope ty) in
           update_scope scope ty;
           update_scope scope ty';
           ty'
@@ -4805,8 +4817,8 @@ let rec build_subtype env (visited : transient_expr list)
           let cl_abbr, body = find_cltype_for_path env p in
           let ty =
             try
-              subst env !current_level Public abbrev None
-                cl_abbr.type_params tl body
+              subst ~env ~level:!current_level ~priv:Public ~abbrev
+                ~params:cl_abbr.type_params ~args:tl body
             with Cannot_subst -> assert false in
           let ty1, tl1 =
             match get_desc ty with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1169,7 +1169,7 @@ let rec copy ?partial ?keep_names ?scope copy_scope ty =
       match scope, desc with
       | None, _
       | _, Tvar _ -> get_scope ty
-      | Some scope, _ -> max scope (get_scope ty)
+      | Some scope, _ -> Int.max scope (get_scope ty)
     in
     let t = newstub ~scope in
     For_copy.redirect_desc copy_scope ty (Tsubst (t, None));

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -200,7 +200,7 @@ val instance_constructor:
 (* Same, for a constructor. Also returns existentials. *)
 
 val instance_parameterized_type:
-        ?keep_names:bool ->
+        ?keep_names:bool -> ?scope:int ->
         type_expr list -> type_expr -> type_expr list * type_expr
 val instance_declaration: type_declaration -> type_declaration
 val generic_instance_declaration: type_declaration -> type_declaration


### PR DESCRIPTION
Having `update_scope` raise scopes recursively limits the usages of the scope field (see #13770, #13771).
However, the scope must be propagated to children when expanding GADT equations in order to check principality.

This PR modifies `Ctype.expand_abbrev_gen` so that it sets the scope of non-variable type nodes when expanding a type abbreviation, only in principal mode (but not limited to GADTs).
In turn, this requires adding a `?scope` argument to `Ctype.subst`, `Ctype.instance_parameterized_type` and `Ctype.copy` (where the real work is done).
I also switched to labelled arguments for the former (there are now 9 arguments).

The testsuite is left unchanged, and hopefully this should satsify @gasche 's need.

An open issue is whether to also apply this to non-principal mode.
The cost of setting the scope being low (it just requires re-expanding cached type abbreviations when the scope has changed, a supposedly rare situation), performance does not seem to be the problem.
This may break some (strange) existing programs, but is conservatism worth the discrepancy between the modes.

Two more points:
* There are some small concerns about the interaction with the abbreviation mechanism, which does not properly feedbacks scope updates on the expanded form to the original type, but this was already the case before; need to go back to keep_expansion for that.
* I also merged a comment into `with_local_level_generalize`, which may be of interest if someone plans to use the scope field for type variables. Namely, the scope of type variables is not checked when lowering their level in structure mode.