### PR TITLE
Do not use Obj.Extension_constructor.of_val in Type.Id

### DIFF
--- a/Changes
+++ b/Changes
@@ -156,8 +156,8 @@ Working version
 - #13740: Improve performance of Weak.find_aux
   (Josh Berdine, review by Gabriel Scherer)
 
-- #15049: Improve performance of Type.Id by using [%extension_constructor]
-  instead of Obj.Extension_constructor.of_val.
+- #15049: Improve performance and type safety of Type.Id by using
+  [%extension_constructor] instead of Obj.Extension_constructor.of_val.
   (Basile Clément, review by Vincent Laviron and Nicolás Ojeda Bär)
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -156,6 +156,9 @@ Working version
 - #13740: Improve performance of Weak.find_aux
   (Josh Berdine, review by Gabriel Scherer)
 
+- #15049: Do not use Obj.Extension_constructor.of_val in Type.Id
+  (Basile Clément, review by ???)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/Changes
+++ b/Changes
@@ -157,7 +157,7 @@ Working version
   (Josh Berdine, review by Gabriel Scherer)
 
 - #15049: Do not use Obj.Extension_constructor.of_val in Type.Id
-  (Basile Clément, review by ???)
+  (Basile Clément, review by Vincent Laviron)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -156,8 +156,9 @@ Working version
 - #13740: Improve performance of Weak.find_aux
   (Josh Berdine, review by Gabriel Scherer)
 
-- #15049: Do not use Obj.Extension_constructor.of_val in Type.Id
-  (Basile Clément, review by Vincent Laviron)
+- #15049: Improve performance of Type.Id by using [%extension_constructor]
+  instead of Obj.Extension_constructor.of_val.
+  (Basile Clément, review by Vincent Laviron and Nicolás Ojeda Bär)
 
 ### Other libraries:
 

--- a/stdlib/type.ml
+++ b/stdlib/type.ml
@@ -32,7 +32,12 @@ module Id = struct
     (module struct type t = a type _ id += Id : t id end)
 
   let[@inline] uid (type a) ((module A) : a t) =
-    Obj.Extension_constructor.id (Obj.Extension_constructor.of_val A.Id)
+    (* [A.Id] is statically known to be a nullary extension variant, and hence
+       is its own extension constructor.
+
+       Don't go through [Obj.Extension_constructor.of_val] as it performs
+       expensive checks. *)
+    Obj.Extension_constructor.id (Obj.magic A.Id : extension_constructor)
 
   let provably_equal
       (type a b) ((module A) : a t) ((module B) : b t) : (a, b) eq option

--- a/stdlib/type.ml
+++ b/stdlib/type.ml
@@ -32,12 +32,7 @@ module Id = struct
     (module struct type t = a type _ id += Id : t id end)
 
   let[@inline] uid (type a) ((module A) : a t) =
-    (* [A.Id] is statically known to be a nullary extension variant, and hence
-       is its own extension constructor.
-
-       Don't go through [Obj.Extension_constructor.of_val] as it performs
-       expensive checks. *)
-    Obj.Extension_constructor.id (Obj.magic A.Id : extension_constructor)
+    Obj.Extension_constructor.id [%extension_constructor A.Id]
 
   let provably_equal
       (type a b) ((module A) : a t) ((module B) : b t) : (a, b) eq option


### PR DESCRIPTION
The `Type.Id.uid` function converts a type identifier to an integer by going through `Obj.Extension_constructor.of_val`. In this context, `Obj.Extension_constructor.of_val` is just an expensive way to compute the identity function: it performs multiple checks, including multiple calls to `caml_obj_tag`, in order to determine if it is passed a nullary extension variant, a non-nullary extension variant, or something that is not an extension variant at all (in which case it raises an Invalid_argument exception).

When called with a nullary extension variant (which is just represented as its constructor), `Obj.Extension_constructor.of_val` is always the identity. Since the usage in `Type.Id` is always with a nullary extension variant, use `Obj.magic` as a less expensive identity function.

For context, this came up while optimising code making *many* lookups in small heterogenous maps, such that it ended up being noticeable in profiling.