### PR TITLE
Expose a way to get current timestamp in runtime events

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,9 @@ Working version
 
 ### Runtime system:
 
+- #13785: Add `Runtime_events.Timestamp.current_timestamp`.
+  (Simon Cruanes)
+
 - #13774: Fix for inaccurate live blocks/words stats in compaction.
   (Sadiq Jaffer, report by KC Sivaramakrishnan and Jan Midtgaard, review by
   Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -17,7 +17,7 @@ Working version
 
 ### Runtime system:
 
-- #13785: Add `Runtime_events.Timestamp.current_timestamp`.
+- #13785: Add `Runtime_events.Timestamp.get_current`.
   (Simon Cruanes)
 
 - #13774: Fix for inaccurate live blocks/words stats in compaction.

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -221,6 +221,11 @@ module Timestamp = struct
 
   let to_int64 t =
     t
+
+  external current_timestamp : unit -> (int64 [@unboxed]) =
+    "caml_ml_runtime_current_timestamp_byte"
+    "caml_ml_runtime_current_timestamp"
+    [@@noalloc]
 end
 
 module Type = struct

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -222,7 +222,7 @@ module Timestamp = struct
   let to_int64 t =
     t
 
-  external current_timestamp : unit -> (int64 [@unboxed]) =
+  external get_current : unit -> (int64 [@unboxed]) =
     "caml_ml_runtime_current_timestamp_byte"
     "caml_ml_runtime_current_timestamp"
     [@@noalloc]

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -223,8 +223,8 @@ module Timestamp = struct
     t
 
   external get_current : unit -> (int64 [@unboxed]) =
-    "caml_ml_runtime_current_timestamp_byte"
     "caml_ml_runtime_current_timestamp"
+    "caml_ml_runtime_current_timestamp_unboxed"
     [@@noalloc]
 end
 

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -222,7 +222,7 @@ module Timestamp = struct
   let to_int64 t =
     t
 
-  external get_current : unit -> (int64 [@unboxed]) =
+  external get_current : unit -> (t [@unboxed]) =
     "caml_ml_runtime_current_timestamp"
     "caml_ml_runtime_current_timestamp_unboxed"
     [@@noalloc]

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -521,6 +521,11 @@ module Timestamp : sig
     (** Type for the int64 timestamp to allow for future changes. *)
 
     val to_int64 : t -> int64
+
+    val current_timestamp : unit -> int64
+    (** Access the current timestamp. Timestamps are monotonic but otherwise
+        unspecified.
+        @since 5.4 *)
 end
 
 module Type : sig

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -522,7 +522,7 @@ module Timestamp : sig
 
     val to_int64 : t -> int64
 
-    val current_timestamp : unit -> int64
+    val get_current : unit -> int64
     (** Access the current timestamp. Timestamps are monotonic but otherwise
         unspecified.
         @since 5.4 *)

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -522,7 +522,7 @@ module Timestamp : sig
 
     val to_int64 : t -> int64
 
-    val get_current : unit -> int64
+    val get_current : unit -> t
     (** Access the current timestamp. The timestamp is incremented by one
         every nanosecond, but the starting point is unspecified.
         @since 5.4 *)

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -523,8 +523,8 @@ module Timestamp : sig
     val to_int64 : t -> int64
 
     val get_current : unit -> int64
-    (** Access the current timestamp. Timestamps are monotonic but otherwise
-        unspecified.
+    (** Access the current timestamp. The timestamp is incremented by one
+        every nanosecond, but the starting point is unspecified.
         @since 5.4 *)
 end
 

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1335,10 +1335,10 @@ CAMLprim value caml_ml_runtime_events_read_poll(value wrapper,
   CAMLreturn(Val_int(events_consumed));
 }
 
-CAMLprim uint64_t caml_ml_runtime_current_timestamp(value unit) {
+CAMLprim uint64_t caml_ml_runtime_current_timestamp_unboxed(value unit) {
   return caml_time_counter();
 }
 
-CAMLprim value caml_ml_runtime_current_timestamp_byte(value unit) {
+CAMLprim value caml_ml_runtime_current_timestamp(value unit) {
   return caml_copy_int64(caml_time_counter());
 }

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1334,3 +1334,15 @@ CAMLprim value caml_ml_runtime_events_read_poll(value wrapper,
 
   CAMLreturn(Val_int(events_consumed));
 }
+
+CAMLprim uint64_t caml_ml_runtime_current_timestamp(value unit) {
+  CAMLparam0();
+  uint64_t ts = caml_time_counter();
+  CAMLreturn(ts);
+}
+
+CAMLprim value caml_ml_runtime_current_timestamp_byte(value unit) {
+  CAMLparam0();
+  uint64_t ts = caml_time_counter();
+  CAMLreturn(Val_long(ts));
+}

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1336,13 +1336,9 @@ CAMLprim value caml_ml_runtime_events_read_poll(value wrapper,
 }
 
 CAMLprim uint64_t caml_ml_runtime_current_timestamp(value unit) {
-  CAMLparam0();
-  uint64_t ts = caml_time_counter();
-  CAMLreturn(ts);
+  return caml_time_counter();
 }
 
 CAMLprim value caml_ml_runtime_current_timestamp_byte(value unit) {
-  CAMLparam0();
-  uint64_t ts = caml_time_counter();
-  CAMLreturn(Val_long(ts));
+  return caml_copy_int64(caml_time_counter());
 }

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -147,7 +147,7 @@ CAMLextern value caml_win32_get_temp_path(void);
    millisecond). This makes it useful for benchmarking and timeouts, but not
    for telling the time. The units are always nanoseconds, but the achieved
    resolution may be less. The starting point is unspecified. */
-extern uint64_t caml_time_counter(void);
+CAMLextern uint64_t caml_time_counter(void);
 
 extern void caml_init_os_params(void);
 

--- a/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
+++ b/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
@@ -12,4 +12,4 @@ let () =
     ignore (Sys.opaque_identity _i : int)
   done;
   let t2 = Timestamp.get_current() in
-  assert (t2 > t1)
+  assert (Int64.succ t2 > Int64.succ t1)

--- a/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
+++ b/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
@@ -7,9 +7,9 @@ open Runtime_events
 let () =
   start();
 
-  let t1 = Timestamp.get_current() in
+  let t1 = Timestamp.get_current() |> Timestamp.to_int64 in
   for _i  = 0 to 1_000_000 do
     ignore (Sys.opaque_identity _i : int)
   done;
-  let t2 = Timestamp.get_current() in
+  let t2 = Timestamp.get_current() |> Timestamp.to_int64 in
   assert (Int64.succ t2 > Int64.succ t1)

--- a/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
+++ b/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
@@ -7,9 +7,9 @@ open Runtime_events
 let () =
   start();
 
-  let t1 = Timestamp.current_timestamp() in
+  let t1 = Timestamp.get_current() in
   for _i  = 0 to 1_000_000 do
     ignore (Sys.opaque_identity _i : int)
   done;
-  let t2 = Timestamp.current_timestamp() in
+  let t2 = Timestamp.get_current() in
   assert (t2 > t1)

--- a/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
+++ b/testsuite/tests/lib-runtime-events/test_timestamp_monotonic.ml
@@ -1,0 +1,15 @@
+
+(* TEST
+ include runtime_events;
+*)
+open Runtime_events
+
+let () =
+  start();
+
+  let t1 = Timestamp.current_timestamp() in
+  for _i  = 0 to 1_000_000 do
+    ignore (Sys.opaque_identity _i : int)
+  done;
+  let t2 = Timestamp.current_timestamp() in
+  assert (t2 > t1)


### PR DESCRIPTION
I have existing tracing libraries that rely on `mtime` to get timestamps, and runtime events don't really suffice to replace them. I'd still like to use runtime events to collect GC spans/GC events, but my problem is that the timestamps are totally opaque and it's not really possible to correlate them with `mtime` (since the instant I observe an event is not the timestamp at which the event was created). By exposing the timestamp, I can compute the offset (if any) with mtime and use that as a way to translate `Runtime_events.Timestamp.t` into `Mtime.t`.