### PR TITLE
Unicode chars in error messages: respect the Unicode notation.

### DIFF
--- a/ocamldoc/odoc_lexer.mll
+++ b/ocamldoc/odoc_lexer.mll
@@ -98,9 +98,9 @@ let validate_ident raw_name =
   match Misc.Utf8_lexeme.validate_identifier name with
   | Misc.Utf8_lexeme.Valid -> name
   | Misc.Utf8_lexeme.Invalid_character u ->
-    failwith (Format.asprintf "Invalid character U+%X" (Uchar.to_int u))
+    failwith (Format.asprintf "Invalid character U+%04X" (Uchar.to_int u))
   | Misc.Utf8_lexeme.Invalid_beginning u  ->
-    failwith (Format.asprintf "Invalid first character U+%X" (Uchar.to_int u))
+    failwith (Format.asprintf "Invalid first character U+%04X" (Uchar.to_int u))
 
  let validate_exception_uident raw_name =
     let name = validate_ident raw_name in

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -419,7 +419,7 @@ let prepare_error loc = function
   | Invalid_encoding s ->
     Location.errorf ~loc "Invalid encoding of identifier %s." s
   | Invalid_char_in_ident u ->
-      Location.errorf ~loc "Invalid character U+%X in identifier"
+      Location.errorf ~loc "Invalid character U+%04X in identifier"
          (Uchar.to_int u)
   | Capitalized_raw_identifier lbl ->
       Location.errorf ~loc


### PR DESCRIPTION
I was just subjected to this error message:

```
Error: Invalid character U+444 in identifier
```

which is horrifying in terms of [Unicode typography](https://www.unicode.org/versions/Unicode16.0.0/core-spec/appendix-a/#G12668). 
