### PR TITLE
Fix escaping of `runtime/build_config.h` when cross-compiling

### DIFF
--- a/Changes
+++ b/Changes
@@ -322,6 +322,12 @@ Working version
   (Samuel Hym, review by Miod Vallat, Xavier Leroy, Antonin Décimo and Sébastien
   Hinderer)
 
+- #13789: Strictly validate the host and target triplets when building for the
+  Windows ports to be *-*-cygwin, *-w64-mingw32* or *-pc-windows. Other Cygwin
+  variants used to be rejected - other MSVC and mingw-w64 variants are now
+  rejected too.
+  (David Allsopp, review by Antonin Décimo and Gabriel Scherer)
+
 ### Bug fixes:
 
 - #13691: Make four globals underlying Gc.control atomic to avoid C data

--- a/Changes
+++ b/Changes
@@ -316,7 +316,7 @@ Working version
   disk usage considerably.
   (David Allsopp, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
-* #13526: Simplify the build of cross compilers
+* #13526, #13789: Simplify the build of cross compilers
   This replaces the configure `--with-target-bindir` option by an equivalent
   `TARGET_BINDIR` variable
   (Samuel Hym, review by Miod Vallat, Xavier Leroy, Antonin Décimo and Sébastien

--- a/Makefile
+++ b/Makefile
@@ -1393,9 +1393,12 @@ runtime/sak.$(O): runtime/sak.c runtime/caml/misc.h runtime/caml/config.h
 C_LITERAL = $(shell $(SAK) $(ENCODE_C_LITERAL) '$(1)')
 
 runtime/build_config.h: $(ROOTDIR)/Makefile.config $(SAK)
-	$(V_GEN)echo '/* This file is generated from $(ROOTDIR)/Makefile.config */' > $@ && \
-	echo '#define OCAML_STDLIB_DIR $(call C_LITERAL,$(TARGET_LIBDIR))' >> $@ && \
-	echo '#define HOST "$(HOST)"' >> $@
+	$(V_GEN){ \
+	  echo '/* This file is generated from $(ROOTDIR)/Makefile.config */'; \
+	  printf '#define OCAML_STDLIB_DIR %s\n' \
+	         '$(call C_LITERAL,$(TARGET_LIBDIR))'; \
+	  echo '#define HOST "$(HOST)"'; \
+	} > $@
 
 ## Runtime libraries and programs
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -136,6 +136,9 @@ PACKAGE_TARNAME = @PACKAGE_TARNAME@
 datarootdir = @datarootdir@
 DOCDIR=@docdir@
 
+### Where to look for the standard library on target
+TARGET_LIBDIR=@TARGET_LIBDIR@
+
 unix_directory = @unix_directory@
 unix_library = @unix_library@
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -49,9 +49,6 @@ datarootdir=@datarootdir@
 ### Where to install the standard library on host
 LIBDIR=@libdir@
 
-### Where to look for the standard library on target
-TARGET_LIBDIR=@TARGET_LIBDIR@
-
 ### Where to install the stub code for the standard library
 STUBLIBDIR=@libdir@/stublibs
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -308,7 +308,7 @@ AC_DEFUN([OCAML_TEST_FLEXLINK], [
     # flexlink can cope. The reverse test is unnecessary (a Cygwin-compiled
     # flexlink can read anything).
     mv conftest.$ac_objext conftest1.$ac_objext
-    AS_CASE([$4],[*-pc-cygwin],
+    AS_CASE([$4],[*-*-cygwin],
       [ln -s conftest1.$ac_objext conftest2.$ac_objext],
       [cp conftest1.$ac_objext conftest2.$ac_objext])
 
@@ -459,7 +459,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
     AS_CASE([$enable_imprecise_c99_float_ops,$target],
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
-      [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin*], [hard_error=false],
+      [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin], [hard_error=false],
       [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
@@ -468,7 +468,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
       [AC_MSG_WARN(m4_normalize([
         fma does not work; emulation enabled]))])],
     [AS_CASE([$target],
-      [x86_64-w64-mingw32*|x86_64-*-cygwin*],
+      [x86_64-w64-mingw32*|x86_64-*-cygwin],
         [AC_MSG_RESULT([cross-compiling; assume not])],
       [AC_MSG_RESULT([cross-compiling; assume yes])
       AC_DEFINE([HAS_WORKING_FMA], [1])])])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -628,3 +628,16 @@ AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
   )
   AC_MSG_RESULT([$ln])
 ])
+
+AC_DEFUN([OCAML_CHECK_WINDOWS_TRIPLET], [
+  AS_CASE([$1],
+    [i686-*-cygwin|x86_64-*-cygwin],[],
+    [*-*-cygwin*],
+      [AC_MSG_ERROR([unknown Cygwin variant])],
+    [i686-w64-mingw32*|x86_64-w64-mingw32*],[],
+    [*-*-mingw*],
+      [AC_MSG_ERROR([unknown mingw-w64 variant])],
+    [i686-pc-windows|x86_64-pc-windows],[],
+    [*-pc-windows*],
+      [AC_MSG_ERROR([unknown MSVC variant])])
+])

--- a/configure
+++ b/configure
@@ -3766,6 +3766,55 @@ case $host in #(
      ;;
 esac
 
+# Sanitize the Windows target triplets. After this block, the patterns are:
+# *-*-cygwin - Cygwin (the vendor part is always ignored, though it should
+#              always be 'pc')
+# *-w64-mingw32* - mingw-w64. The vendor part is always matched because
+#                  *-pc-mingw* is a likely misconfiguration and the triplet
+#                  matters both for flexlink and for prefixed compilers/tools.
+#                  mingw32* is matched (rather than just mingw32) because some
+#                  cross-compilation environments from Linux may add additional
+#                  information after the mingw32
+# *-pc-windows - MSVC. The full -pc-windows is matched because that's a suffix
+#                which is specifically recognised by our build system (since
+#                autotools still doesn't have full support for recognising MSVC)
+
+  case $target in #(
+  i686-*-cygwin|x86_64-*-cygwin) :
+     ;; #(
+  *-*-cygwin*) :
+    as_fn_error $? "unknown Cygwin variant" "$LINENO" 5 ;; #(
+  i686-w64-mingw32*|x86_64-w64-mingw32*) :
+     ;; #(
+  *-*-mingw*) :
+    as_fn_error $? "unknown mingw-w64 variant" "$LINENO" 5 ;; #(
+  i686-pc-windows|x86_64-pc-windows) :
+     ;; #(
+  *-pc-windows*) :
+    as_fn_error $? "unknown MSVC variant" "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+
+
+  case $host in #(
+  i686-*-cygwin|x86_64-*-cygwin) :
+     ;; #(
+  *-*-cygwin*) :
+    as_fn_error $? "unknown Cygwin variant" "$LINENO" 5 ;; #(
+  i686-w64-mingw32*|x86_64-w64-mingw32*) :
+     ;; #(
+  *-*-mingw*) :
+    as_fn_error $? "unknown mingw-w64 variant" "$LINENO" 5 ;; #(
+  i686-pc-windows|x86_64-pc-windows) :
+     ;; #(
+  *-pc-windows*) :
+    as_fn_error $? "unknown MSVC variant" "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+
+
 # Systems that are known not to work, even in bytecode only.
 
 case $target in #(
@@ -16501,8 +16550,6 @@ case $target in #(
   x86_64-*-cygwin) :
     flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
-  *-*-cygwin*) :
-    as_fn_error $? "unknown cygwin variant" "$LINENO" 5 ;; #(
   i686-w64-mingw32*) :
     flexdll_chain='mingw'
     flexlink_flags='-stack 16777216' ;; #(

--- a/configure
+++ b/configure
@@ -3843,7 +3843,7 @@ fi
 if test -n "$csc"
 then :
   case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     CSC=csc
       CSCFLAGS="/nologo /nowarn:1668"
       case $host_cpu in #(
@@ -14893,7 +14893,7 @@ ocamlsrcdir=$(unset CDPATH; cd -- "$srcdir" && printf %sX "$PWD") || fail
 ocamlsrcdir=${ocamlsrcdir%X}
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -sf" >&5
 printf %s "checking for a workable solution for ln -sf... " >&6; }
@@ -14924,7 +14924,7 @@ esac
 # Libraries to build depending on the target
 
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     unix_or_win32="win32"
     ocamltest_libunix="Some false"
     ocamlyacc_wstr_module="yacc/wstr" ;; #(
@@ -14935,7 +14935,7 @@ case $target in #(
 esac
 
 case $target in #(
-  *-*-cygwin*|*-*-mingw32*|*-pc-windows) :
+  *-*-cygwin|*-w64-mingw32*|*-pc-windows) :
     exeext=".exe" ;; #(
   *) :
     exeext='' ;;
@@ -15018,7 +15018,7 @@ then :
 then :
   target_launch_method='exe'
 fi ;; #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     shebangscripts=true
@@ -16216,7 +16216,7 @@ fi
 # sak command to use to encode C literal strings
 
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     encode_C_literal="encode-C-utf16-literal" ;; #(
   *) :
     encode_C_literal="encode-C-utf8-literal" ;;
@@ -16351,7 +16351,7 @@ case $enable_warn_error,true in #(
 esac
 
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     case $WINDOWS_UNICODE_MODE in #(
   ansi) :
     windows_unicode=0 ;; #(
@@ -16455,7 +16455,7 @@ esac
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 case $target in #(
-  i686-*-mingw32*) :
+  i686-w64-mingw32*) :
     internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
   *) :
      ;;
@@ -16465,7 +16465,7 @@ esac
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64" ;;
@@ -16532,7 +16532,7 @@ printf "%s\n" "disabled" >&6; }
 else $as_nop
   flexmsg=''
     case $target in #(
-  *-*-cygwin*|*-w64-mingw32*|*-pc-windows) :
+  *-*-cygwin|*-w64-mingw32*|*-pc-windows) :
                                              if test x"$with_flexdll" = 'x' || test x"$with_flexdll" = 'xflexdll'
 then :
   if test -f 'flexdll/flexdll.h'
@@ -16581,7 +16581,7 @@ esac
 fi
 
   case $target in #(
-  *-*-cygwin*|*-w64-mingw32*|*-pc-windows) :
+  *-*-cygwin|*-w64-mingw32*|*-pc-windows) :
     # Extract the first word of "flexlink", so it can be a program name with args.
 set dummy flexlink; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -16659,7 +16659,7 @@ then :
     # flexlink can read anything).
     mv conftest.$ac_objext conftest1.$ac_objext
     case $host in #(
-  *-pc-cygwin) :
+  *-*-cygwin) :
     ln -s conftest1.$ac_objext conftest2.$ac_objext ;; #(
   *) :
     cp conftest1.$ac_objext conftest2.$ac_objext ;;
@@ -16718,7 +16718,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 then :
 
       case $build in #(
-  *-pc-msys|*-pc-cygwin*) :
+  *-pc-msys|*-*-cygwin) :
     flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
           if test -z "$flexlink_where"
 then :
@@ -16844,7 +16844,7 @@ fi
 fi
 
 case $have_flexdll_h,$supports_shared_libraries,$target in #(
-  no,true,*-*-cygwin*) :
+  no,true,*-*-cygwin) :
     supports_shared_libraries=false
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;} ;; #(
@@ -16855,7 +16855,7 @@ printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disa
 esac
 
 case $flexdll_source_dir,$supports_shared_libraries,$flexlink,$target in #(
-  ,true,,*-*-cygwin*) :
+  ,true,,*-*-cygwin) :
     supports_shared_libraries=false
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexlink not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexlink not found: shared library support disabled." >&2;} ;; #(
@@ -16875,7 +16875,7 @@ case $ocaml_cc_vendor,$target in #(
   *,aarch64-*-darwin*|*,arm64-*-darwin*) :
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  *,*-*-cygwin*) :
+  *,*-*-cygwin) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries
 then :
@@ -16888,7 +16888,7 @@ else $as_nop
 
 fi
     ostype="Cygwin" ;; #(
-  *,*-*-mingw32*) :
+  *,*-w64-mingw32*) :
     case $target in #(
   i686-*-*) :
     oc_dll_ldflags="-static-libgcc" ;; #(
@@ -18096,7 +18096,7 @@ fi
 # macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 case $target in #(
-  *-apple-darwin*|*-mingw32*|*-pc-windows) :
+  *-apple-darwin*|*-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     printf "%s\n" "#define HAS_FULL_THREAD_VARIABLES 1" >>confdefs.h
@@ -18124,7 +18124,7 @@ then :
   aarch64-apple-darwin*|arm64-apple-darwin*) :
     mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true ;; #(
-  *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
+  *-w64-mingw32*|*-pc-windows|*-*-cygwin) :
     mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="flexlink ${mkdll_flags}"
@@ -18213,9 +18213,9 @@ natdynlink=false
 if test x"$supports_shared_libraries" = 'xtrue'
 then :
   case "$target" in #(
-  *-*-cygwin*) :
+  *-*-cygwin) :
     natdynlink=true ;; #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     natdynlink=true ;; #(
   *-pc-windows) :
     natdynlink=true ;; #(
@@ -18424,7 +18424,7 @@ case $target in #(
     arch=i386; system=beos ;; #(
   i[3456]86-*-cygwin) :
     arch=i386; system=cygwin ;; #(
-  i[3456]86-*-mingw32*) :
+  i[3456]86-w64-mingw32*) :
     arch=i386; system=mingw ;; #(
   i[3456]86-*-gnu*) :
     arch=i386; system=gnu ;; #(
@@ -18491,7 +18491,7 @@ case $target in #(
     has_native_backend=yes; arch=arm64; system=macosx ;; #(
   x86_64-*-darwin*) :
     has_native_backend=yes; arch=amd64; system=macosx ;; #(
-  x86_64-*-mingw32*) :
+  x86_64-w64-mingw32*) :
     has_native_backend=yes; arch=amd64; system=mingw64 ;; #(
   aarch64-*-linux*) :
     if $arch64
@@ -18506,7 +18506,7 @@ fi ;; #(
     has_native_backend=yes; arch=arm64; system=openbsd ;; #(
   aarch64-*-netbsd*) :
     has_native_backend=yes; arch=arm64; system=netbsd ;; #(
-  x86_64-*-cygwin*) :
+  x86_64-*-cygwin) :
     has_native_backend=yes; arch=amd64; system=cygwin ;; #(
   riscv64-*-linux*) :
     has_native_backend=yes; arch=riscv; model=riscv64; system=linux ;; #(
@@ -19120,7 +19120,7 @@ fi
   if test "$cross_compiling" = yes
 then :
   case $target in #(
-  x86_64-w64-mingw32*|x86_64-*-cygwin*) :
+  x86_64-w64-mingw32*|x86_64-*-cygwin) :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross-compiling; assume not" >&5
 printf "%s\n" "cross-compiling; assume not" >&6; } ;; #(
   *) :
@@ -19181,7 +19181,7 @@ printf "%s\n" "no" >&6; }
     hard_error=true ;; #(
   yes,*) :
     hard_error=false ;; #(
-  *,x86_64-w64-mingw32*|*,x86_64-*-cygwin*) :
+  *,x86_64-w64-mingw32*|*,x86_64-*-cygwin) :
     hard_error=false ;; #(
   *) :
     hard_error=true ;;
@@ -19275,7 +19275,7 @@ fi
 ## On MacOS clock_gettime's CLOCK_MONOTONIC flag is not actually monotonic.
 
 case $target in #(
-  *-*-windows) :
+  *-pc-windows) :
     has_monotonic_clock=true ;; #(
   *-apple-darwin*) :
 
@@ -19340,7 +19340,7 @@ then :
     case $target in #(
   sparc-sun-solaris*) :
     instrumented_runtime=false ;; #(
-  *-*-windows) :
+  *-pc-windows) :
     instrumented_runtime=true ;; #(
   *-apple-darwin*) :
 
@@ -19724,7 +19724,7 @@ fi
 sockets=true
 
 case $target in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     cclibs="$cclibs -lws2_32"
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
 printf %s "checking for library containing socket... " >&6; }
@@ -20072,7 +20072,7 @@ fi
 ## socklen_t
 
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <ws2tcpip.h>
 "
 if test "x$ac_cv_type_socklen_t" = xyes
@@ -20103,7 +20103,7 @@ fi
 ## Unix domain sockets support on Windows
 
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
            for ac_header in afunix.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "afunix.h" "ac_cv_header_afunix_h" "#include <winsock2.h>
@@ -20125,7 +20125,7 @@ esac
 ipv6=true
 
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     ac_fn_c_check_type "$LINENO" "struct sockaddr_in6" "ac_cv_type_struct_sockaddr_in6" "#include <ws2tcpip.h>
 "
 if test "x$ac_cv_type_struct_sockaddr_in6" = xyes
@@ -20223,7 +20223,7 @@ fi
 # seem to detect it properly on Windows so we hardcode the definition
 # of HAS_UTIME on Windows but this will probably need to be clarified
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
  ;; #(
   *) :
@@ -20438,7 +20438,7 @@ fi
 # Note: detection fails on Windows so hardcoding the result
 # (should be debugged later)
 case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
  ;; #(
   *) :
@@ -20494,7 +20494,7 @@ fi
 ## setsid
 
 case $target in #(
-  *-cygwin|*-*-mingw32*|*-pc-windows) :
+  *-*-cygwin|*-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "setsid" "ac_cv_func_setsid"
@@ -20607,7 +20607,7 @@ esac
 if $supports_shared_libraries
 then :
   case $target in #(
-  *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
+  *-w64-mingw32*|*-pc-windows|*-*-cygwin) :
     DLLIBS="" ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
@@ -20707,7 +20707,7 @@ fi
 
 ## -fdebug-prefix-map support by the C compiler
 case $ocaml_cc_vendor,$target in #(
-  *,*-*-mingw32*) :
+  *,*-w64-mingw32*) :
     cc_has_debug_prefix_map=false ;; #(
   *,*-pc-windows) :
     cc_has_debug_prefix_map=false ;; #(
@@ -21841,7 +21841,7 @@ esac
 ## Determine how to link with the POSIX threads library
 
 case $target in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     link_gcc_eh=''
      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for printf in -lgcc_eh" >&5
 printf %s "checking for printf in -lgcc_eh... " >&6; }
@@ -22809,7 +22809,7 @@ asm_cfi_supported=false
 if $native_compiler
 then :
   case $target in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
 
@@ -23347,7 +23347,7 @@ else $as_nop
   amd64|arm64|power|riscv|s390x) :
     # not supported on arm32, see issue #9124.
      case $target in #(
-  *-cygwin*|*-mingw*|*-windows|*-apple-darwin*) :
+  *-*-cygwin|*-w64-mingw32*|*-pc-windows|*-apple-darwin*) :
     function_sections=false;
            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: No support for function sections on $target." >&5
 printf "%s\n" "$as_me: No support for function sections on $target." >&6;} ;; #(
@@ -23427,7 +23427,7 @@ bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
 native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
 
 case $target in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization" ;; #(
   *-pc-windows) :
     # For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
@@ -23472,7 +23472,7 @@ then :
 esac
 else $as_nop
   case $build,$host in #(
-  *-pc-cygwin,*-*-mingw32*|*-pc-cygwin,*-pc-windows) :
+  *-*-cygwin,*-w64-mingw32*|*-*-cygwin,*-pc-windows) :
     prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")" ;; #(
   *) :
      ;;
@@ -23483,7 +23483,7 @@ fi
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 case $target in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,21 @@ AS_CASE([$host],
       [export CYGWIN="\$CYGWIN\${CYGWIN:+ }winsymlinks:nativestrict"
       export MSYS="\$MSYS\${MSYS:+ }winsymlinks:nativestrict"])])
 
+# Sanitize the Windows target triplets. After this block, the patterns are:
+# *-*-cygwin - Cygwin (the vendor part is always ignored, though it should
+#              always be 'pc')
+# *-w64-mingw32* - mingw-w64. The vendor part is always matched because
+#                  *-pc-mingw* is a likely misconfiguration and the triplet
+#                  matters both for flexlink and for prefixed compilers/tools.
+#                  mingw32* is matched (rather than just mingw32) because some
+#                  cross-compilation environments from Linux may add additional
+#                  information after the mingw32
+# *-pc-windows - MSVC. The full -pc-windows is matched because that's a suffix
+#                which is specifically recognised by our build system (since
+#                autotools still doesn't have full support for recognising MSVC)
+OCAML_CHECK_WINDOWS_TRIPLET([$target])
+OCAML_CHECK_WINDOWS_TRIPLET([$host])
+
 # Systems that are known not to work, even in bytecode only.
 
 AS_CASE([$target],
@@ -1041,8 +1056,6 @@ AS_CASE([$target],
   [x86_64-*-cygwin],
     [flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216'],
-  [*-*-cygwin*],
-    [AC_MSG_ERROR([unknown cygwin variant])],
   [i686-w64-mingw32*],
     [flexdll_chain='mingw'
     flexlink_flags='-stack 16777216'],

--- a/configure.ac
+++ b/configure.ac
@@ -354,7 +354,7 @@ AS_CASE([$target],
 AC_CHECK_PROG([csc],[csc],[csc])
 AS_IF([test -n "$csc"],
   [AS_CASE([$host],
-    [*-*-mingw32*|*-pc-windows],
+    [*-w64-mingw32*|*-pc-windows],
       [CSC=csc
       CSCFLAGS="/nologo /nowarn:1668"
       AS_CASE([$host_cpu], [i*86], [CSCFLAGS="$CSCFLAGS /platform:x86"])],
@@ -777,7 +777,7 @@ ocamlsrcdir=$(unset CDPATH; cd -- "$srcdir" && printf %sX "$PWD") || fail
 ocamlsrcdir=${ocamlsrcdir%X}
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [OCAML_CHECK_LN_ON_WINDOWS
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"],
   [ln='ln -sf'])
@@ -791,7 +791,7 @@ AS_CASE([$lt_cv_ar_at_file],
 # Libraries to build depending on the target
 
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [unix_or_win32="win32"
     ocamltest_libunix="Some false"
     ocamlyacc_wstr_module="yacc/wstr"],
@@ -800,7 +800,7 @@ AS_CASE([$target],
   ocamlyacc_wstr_module=""])
 
 AS_CASE([$target],
-  [*-*-cygwin*|*-*-mingw32*|*-pc-windows],
+  [*-*-cygwin|*-w64-mingw32*|*-pc-windows],
     [exeext=".exe"],
   [exeext=''])
 
@@ -854,7 +854,7 @@ AS_IF([test "x$interpval" = "xyes"],
       launch_method='sh'
       AS_IF([test x"$target_launch_method" = 'x'],
         [target_launch_method='exe'])],
-    [*-*-mingw32*|*-pc-windows], [],
+    [*-w64-mingw32*|*-pc-windows], [],
     [shebangscripts=true
     launch_method='sh']
   )]
@@ -895,7 +895,7 @@ AS_IF(
 # sak command to use to encode C literal strings
 
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [encode_C_literal="encode-C-utf16-literal"],
   [encode_C_literal="encode-C-utf8-literal"])
 
@@ -945,7 +945,7 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AS_CASE([$WINDOWS_UNICODE_MODE],
       [ansi],
         [windows_unicode=0],
@@ -1007,14 +1007,14 @@ AS_CASE([$ocaml_cc_vendor],
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 AS_CASE([$target],
-  [i686-*-mingw32*],
+  [i686-w64-mingw32*],
     [internal_cflags="$internal_cflags -mfpmath=sse -msse2"])
 
 # Use 64-bit file offset if possible
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows], [],
+  [*-w64-mingw32*|*-pc-windows], [],
   [common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64"])
 
 # Adjust according to target
@@ -1064,7 +1064,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     AC_MSG_RESULT([disabled])],
     [flexmsg=''
     AS_CASE([$target],
-      [*-*-cygwin*|*-w64-mingw32*|*-pc-windows],
+      [*-*-cygwin|*-w64-mingw32*|*-pc-windows],
       [dnl When bootstrapping from the git submodule (flexdll directory), just
        dnl use that, however if another directory has been specified with
        dnl --with-flexdll=<path> then copy the contents of <path> to
@@ -1096,7 +1096,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
         AC_MSG_ERROR([exiting])])])])
 
   AS_CASE([$target],
-    [*-*-cygwin*|*-w64-mingw32*|*-pc-windows],
+    [*-*-cygwin|*-w64-mingw32*|*-pc-windows],
       [AC_CHECK_PROG([flexlink],[flexlink],[flexlink])])
 
   AS_IF([test -n "$flexlink" && test -z "$flexdll_source_dir"],[
@@ -1109,7 +1109,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     # is only necessary when cross-compiling.
     AS_IF([test x"$build" != x"$host"],[
       AS_CASE([$build],
-        [*-pc-msys|*-pc-cygwin*],
+        [*-pc-msys|*-*-cygwin],
           [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
           AS_IF([test -z "$flexlink_where"],
             [AC_MSG_ERROR(m4_normalize([$flexlink is not executable from a
@@ -1127,14 +1127,14 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
 ])
 
 AS_CASE([$have_flexdll_h,$supports_shared_libraries,$target],
- [no,true,*-*-cygwin*],
+ [no,true,*-*-cygwin],
    [supports_shared_libraries=false
    AC_MSG_WARN([flexdll.h not found: shared library support disabled.])],
  [no,*,*-w64-mingw32*|no,*,*-pc-windows],
    [AC_MSG_ERROR([flexdll.h is required for native Win32])])
 
 AS_CASE([$flexdll_source_dir,$supports_shared_libraries,$flexlink,$target],
-  [,true,,*-*-cygwin*],
+  [,true,,*-*-cygwin],
     [supports_shared_libraries=false
     AC_MSG_WARN([flexlink not found: shared library support disabled.])],
   [,*,,*-w64-mingw32*|,*,,*-pc-windows],
@@ -1148,7 +1148,7 @@ AS_CASE([$ocaml_cc_vendor,$target],
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [*,aarch64-*-darwin*|*,arm64-*-darwin*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
-  [*,*-*-cygwin*],
+  [*,*-*-cygwin],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
       [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
@@ -1158,7 +1158,7 @@ AS_CASE([$ocaml_cc_vendor,$target],
       oc_ldflags='-Wl,--stack,16777216']
     )
     ostype="Cygwin"],
-  [*,*-*-mingw32*],
+  [*,*-w64-mingw32*],
     [AS_CASE([$target],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
     ostype="Win32"
@@ -1352,7 +1352,7 @@ AS_IF([! $cc_supports_atomic],
 # macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 AS_CASE([$target],
-  [*-apple-darwin*|*-mingw32*|*-pc-windows], [],
+  [*-apple-darwin*|*-w64-mingw32*|*-pc-windows], [],
   [AC_DEFINE([HAS_FULL_THREAD_VARIABLES], [1])]
 )
 
@@ -1375,7 +1375,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
       [mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true],
-    [*-*-mingw32*|*-pc-windows|*-*-cygwin*],
+    [*-w64-mingw32*|*-pc-windows|*-*-cygwin],
       [mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="flexlink ${mkdll_flags}"
@@ -1442,8 +1442,8 @@ natdynlink=false
 
 AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
   [AS_CASE(["$target"],
-    [*-*-cygwin*], [natdynlink=true],
-    [*-*-mingw32*], [natdynlink=true],
+    [*-*-cygwin], [natdynlink=true],
+    [*-w64-mingw32*], [natdynlink=true],
     [*-pc-windows], [natdynlink=true],
     [[i[3456]86-*-linux*]], [natdynlink=true],
     [[x86_64-*-linux*]], [natdynlink=true],
@@ -1510,7 +1510,7 @@ AS_CASE([$target],
     [arch=i386; system=beos],
   [[i[3456]86-*-cygwin]],
     [arch=i386; system=cygwin],
-  [[i[3456]86-*-mingw32*]],
+  [[i[3456]86-w64-mingw32*]],
     [arch=i386; system=mingw],
   [[i[3456]86-*-gnu*]],
     [arch=i386; system=gnu],
@@ -1577,7 +1577,7 @@ AS_CASE([$target],
     [has_native_backend=yes; arch=arm64; system=macosx],
   [x86_64-*-darwin*],
     [has_native_backend=yes; arch=amd64; system=macosx],
-  [x86_64-*-mingw32*],
+  [x86_64-w64-mingw32*],
     [has_native_backend=yes; arch=amd64; system=mingw64],
   [aarch64-*-linux*],
     [AS_IF([$arch64],
@@ -1589,7 +1589,7 @@ AS_CASE([$target],
     [has_native_backend=yes; arch=arm64; system=openbsd],
   [aarch64-*-netbsd*],
     [has_native_backend=yes; arch=arm64; system=netbsd],
-  [x86_64-*-cygwin*],
+  [x86_64-*-cygwin],
     [has_native_backend=yes; arch=amd64; system=cygwin],
   [riscv64-*-linux*],
     [has_native_backend=yes; arch=riscv; model=riscv64; system=linux],
@@ -1802,7 +1802,7 @@ AC_CHECK_FUNC([issetugid], [AC_DEFINE([HAS_ISSETUGID], [1])])
 ## On MacOS clock_gettime's CLOCK_MONOTONIC flag is not actually monotonic.
 
 AS_CASE([$target],
-  [*-*-windows],
+  [*-pc-windows],
     [has_monotonic_clock=true],
   [*-apple-darwin*], [
     AC_CHECK_FUNCS([clock_gettime_nsec_np],
@@ -1836,7 +1836,7 @@ AS_IF([test "x$enable_instrumented_runtime" != "xno" ],
     AS_CASE([$target],
     [sparc-sun-solaris*],
       [instrumented_runtime=false],
-    [*-*-windows],
+    [*-pc-windows],
       [instrumented_runtime=true],
     [*-apple-darwin*], [
       AS_CASE([$enable_instrumented_runtime,$has_monotonic_clock],
@@ -2025,7 +2025,7 @@ AS_IF([$tsan],
 sockets=true
 
 AS_CASE([$target],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [cclibs="$cclibs -lws2_32"
     AC_SEARCH_LIBS([socket], [ws2_32])
     AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR], [1])])],
@@ -2053,7 +2053,7 @@ AS_IF([$sockets], [AC_DEFINE([HAS_SOCKETS], [1])])
 ## socklen_t
 
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T], [1])], [],
       [#include <ws2tcpip.h>])],
   [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T], [1])], [],
@@ -2064,7 +2064,7 @@ AC_CHECK_FUNC([inet_aton], [AC_DEFINE([HAS_INET_ATON], [1])])
 ## Unix domain sockets support on Windows
 
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AC_CHECK_HEADERS([afunix.h], [AC_DEFINE([HAS_AFUNIX_H], [1])], [],
       [#include <winsock2.h>])])
 
@@ -2073,7 +2073,7 @@ AS_CASE([$target],
 ipv6=true
 
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AC_CHECK_TYPE(
       [struct sockaddr_in6], [], [ipv6=false], [#include <ws2tcpip.h>])],
   [AC_CHECK_TYPE(
@@ -2107,7 +2107,7 @@ AC_CHECK_FUNC([system], [AC_DEFINE([HAS_SYSTEM], [1])])
 # seem to detect it properly on Windows so we hardcode the definition
 # of HAS_UTIME on Windows but this will probably need to be clarified
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_UTIME], [1])],
+  [*-w64-mingw32*|*-pc-windows], [AC_DEFINE([HAS_UTIME], [1])],
   [AC_CHECK_HEADER([sys/types.h],
     [AC_CHECK_HEADER([utime.h],
       [AC_CHECK_FUNC([utime], [AC_DEFINE([HAS_UTIME], [1])])])])])
@@ -2183,7 +2183,7 @@ AC_CHECK_FUNC([setitimer],
 # Note: detection fails on Windows so hardcoding the result
 # (should be debugged later)
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME], [1])],
+  [*-w64-mingw32*|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME], [1])],
   [AC_CHECK_FUNC([gethostname], [AC_DEFINE([HAS_GETHOSTNAME], [1])])])
 
 ## uname
@@ -2207,7 +2207,7 @@ AC_CHECK_FUNC([mktime], [AC_DEFINE([HAS_MKTIME], [1])])
 ## setsid
 
 AS_CASE([$target],
-  [*-cygwin|*-*-mingw32*|*-pc-windows], [],
+  [*-*-cygwin|*-w64-mingw32*|*-pc-windows], [],
   [AC_CHECK_FUNC([setsid], [AC_DEFINE([HAS_SETSID], [1])])])
 
 ## putenv
@@ -2244,7 +2244,7 @@ AS_CASE([$target],
 ## shared library support
 AS_IF([$supports_shared_libraries],
   [AS_CASE([$target],
-    [*-*-mingw32*|*-pc-windows|*-*-cygwin*],
+    [*-w64-mingw32*|*-pc-windows|*-*-cygwin],
       [DLLIBS=""],
     [AC_CHECK_FUNC([dlopen],
       [supports_shared_libraries=true DLLIBS=""],
@@ -2270,7 +2270,7 @@ AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE], [1])])
 
 ## -fdebug-prefix-map support by the C compiler
 AS_CASE([$ocaml_cc_vendor,$target],
-  [*,*-*-mingw32*], [cc_has_debug_prefix_map=false],
+  [*,*-w64-mingw32*], [cc_has_debug_prefix_map=false],
   [*,*-pc-windows], [cc_has_debug_prefix_map=false],
   [xlc*,powerpc-ibm-aix*], [cc_has_debug_prefix_map=false],
   [sunc*,sparc-sun-*], [cc_has_debug_prefix_map=false],
@@ -2457,7 +2457,7 @@ AS_CASE([$enable_codegen_invariants],
 ## Determine how to link with the POSIX threads library
 
 AS_CASE([$target],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [link_gcc_eh=''
      AC_CHECK_LIB([gcc_eh], [printf], [link_gcc_eh="-lgcc_eh"])
      PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh"],
@@ -2551,7 +2551,7 @@ as_has_debug_prefix_map=false
 asm_cfi_supported=false
 AS_IF([$native_compiler],
   [AS_CASE([$target],
-    [*-*-mingw32*|*-pc-windows], [],
+    [*-w64-mingw32*|*-pc-windows], [],
     [OCAML_AS_HAS_DEBUG_PREFIX_MAP
     OCAML_AS_HAS_CFI_DIRECTIVES])])
 
@@ -2685,7 +2685,7 @@ AS_IF([test x"$enable_function_sections" = "xno"],
   [AS_CASE([$arch],
     [amd64|arm64|power|riscv|s390x], # not supported on arm32, see issue #9124.
      [AS_CASE([$target],
-        [*-cygwin*|*-mingw*|*-windows|*-apple-darwin*],
+        [*-*-cygwin|*-w64-mingw32*|*-pc-windows|*-apple-darwin*],
           [function_sections=false;
            AC_MSG_NOTICE([No support for function sections on $target.])],
         [AS_CASE([$ocaml_cc_vendor],
@@ -2740,7 +2740,7 @@ bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
 native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
 
 AS_CASE([$target],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization"],
   [*-pc-windows],
     [# For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
@@ -2767,14 +2767,14 @@ AS_IF([test x"$prefix" = "xNONE"],
     [i686-pc-windows], [prefix='C:/ocamlms'],
     [x86_64-pc-windows], [prefix='C:/ocamlms64'])],
   [AS_CASE([$build,$host],
-    [*-pc-cygwin,*-*-mingw32*|*-pc-cygwin,*-pc-windows],
+    [*-*-cygwin,*-w64-mingw32*|*-*-cygwin,*-pc-windows],
       [prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")"])])
 
 # Define a few macros that were defined in config/m-nt.h
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 AS_CASE([$target],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [AC_DEFINE([HAS_BROKEN_PRINTF], [1])
     AC_DEFINE([HAS_IPV6], [1])
     AC_DEFINE([HAS_NICE], [1])],


### PR DESCRIPTION
This fixes a small issue with #13526 which @shym and I diagnosed in December, but for which I realise I hadn't pushed a fix.

The issue is easy to reproduce on Ubuntu (or anything else where `sh` is `dash` rather than `bash`, which can be simulated by adding `export SHELL = dash` to the top of `Makefile.common`):

```console
$ ./configure --prefix $PWD/local --disable-ocamldoc --disable-dependency-generation && make -j && make install
$ make distclean
$ git submodule update --init flexdll
$ PATH=$PWD/local/bin:$PATH ./configure --prefix $PWD/cross --target=x86_64-w64-mingw32 TARGET_LIBDIR='C:\OCaml' --disable-dependency-generation
$ make -j
...
runtime/dynlink.c: In function ‘caml_get_stdlib_location’:
runtime/dynlink.c:91:48: error: unknown escape sequence: '\O' [-Werror]
   91 |   if (stdlib == NULL) stdlib = OCAML_STDLIB_DIR;
      |                                                ^
```

The underlying problem can easily be seen in `runtime/build_config.h`:
```console
$ cat runtime/build_config.h
/* This file is generated from ./Makefile.config */
#define OCAML_STDLIB_DIR L"C:\OCaml"
#define HOST "x86_64-pc-linux-gnu"
```

@shym diagnosed that we're hitting the absurdity that is the `echo` built-in in POSIX (echoing strings containing backslashes is not portable, because CP/M didn't come along until a few months after Unix......):
```console
$ dash -c "echo '\\\\'"
\
$ bash -c "echo '\\\\'"
\\
```

Both shells are correct 🤦. The best fix for now (which is @shym's), is to use `printf` instead.

In passing, because this is something I missed in #13526, I've moved `TARGET_BINDIR` from `Makefile.config` to `Makefile.build_config`, because it's only used in the build, so shouldn't be installed (especially as it's potentially a string containing awkward characters, from a make/sh perspective).

Finally, the first two commits do some tidying w.r.t. the Windows triplets and cross-compilation, as it's all confusing enough without the precise triplets being used in `configure.ac` being differently liberal in different places! cf. #11973 for why we match any suffix on `*-w64-mingw32*` but don't at present do that for MSVC or Cygwin.