### PR TITLE
Fix bytecode-only build of Cygwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -370,6 +370,10 @@ Working version
 - #13710: Support unicode identifiers in comments.
   (Pieter Goetschalckx, review by Florian Angeletti and Gabriel Scherer)
 
+- #13790: Fix bytecode-only build of Cygwin when flexlink is being bootstrapped
+  with the compiler.
+  (David Allsopp, review by Antonin Décimo and Miod Vallat)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -673,8 +673,9 @@ ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 # The recipe for runtime/ocamlruns$(EXE) also produces runtime/primitives
 boot/ocamlrun$(EXE): runtime/ocamlruns$(EXE)
 
-$(foreach runtime, ocamlrun ocamlrund ocamlruni, \
-  $(eval runtime/$(runtime)$(EXE): | $(BYTE_BINDIR)/flexlink$(EXE)))
+$(foreach runtime, ocamlrun$(EXE) ocamlrund$(EXE) ocamlruni$(EXE) \
+                   libcamlrun_shared$(EXT_DLL) libasmrun_shared$(EXT_DLL), \
+  $(eval runtime/$(runtime): | $(BYTE_BINDIR)/flexlink$(EXE)))
 
 tools/checkstack$(EXE): | $(BYTE_BINDIR)/flexlink$(EXE)
 else


### PR DESCRIPTION
The Cygwin build of OCaml currently fails in bytecode-only mode if flexdll is being bootstrapped with the compiler:

```console
$ git submodule update --init flexdll
$ ./configure --disable-native-compiler
$ make -j
...
rm -f flexlink.exe
../boot/ocamlrun.exe ../boot/ocamlc -use-prims ../runtime/primitives -nostdlib -I ../stdlib -o flexlink.exe -cclib "version_res.o" version.ml Compat.ml coff.ml cmdline.ml create_dll.ml reloc.ml
  MKLIB runtime/libcamlrun_pic.a
  MKDLL runtime/libcamlrun_shared.so
make[1]: flexlink: No such file or directory
make[1]: *** [Makefile:1430: runtime/libcamlrun_shared.so] Error 127
make[1]: *** Waiting for unfinished jobs....
```

The issue is a missing dependency - while the runtime executables depend on the presence of flexlink, the shared runtime DLLs do not (this only affects Cygwin, as the shared runtimes aren't built for mingw-w64 / MSVC).

This is a regression from #12278 (affecting 5.2.1 / 5.3.0)