### PR TITLE
Display the `configure` command executed in AppVeyor runs

### DIFF
--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -52,32 +52,21 @@ function run {
 # $1:the Windows port. Recognized values: mingw, msvc and msvc64
 # $2: the prefix to use to install
 function set_configuration {
+  args=('--cache-file' "$CACHE_FILE" '--prefix' "$2" '--enable-ocamltest')
+
   case "$1" in
     cygwin*)
-      dep='--disable-dependency-generation'
-      man=''
-      ;;
+      args+=('--disable-dependency-generation');;
     mingw32)
-      host='--host=i686-w64-mingw32'
-      dep='--disable-dependency-generation'
-      man=''
-      ;;
+      args+=('--host=i686-w64-mingw32' '--disable-dependency-generation');;
     mingw64)
-      host='--host=x86_64-w64-mingw32'
-      dep='--disable-dependency-generation'
-      man='--disable-stdlib-manpages'
-      ;;
+      args+=('--host=x86_64-w64-mingw32' '--disable-dependency-generation' \
+             '--disable-stdlib-manpages');;
     msvc32)
-      host='--host=i686-pc-windows'
-      dep='--disable-dependency-generation'
-      man=''
-      ;;
+      args+=('--host=i686-pc-windows' '--disable-dependency-generation');;
     msvc64)
-      host='--host=x86_64-pc-windows'
       # Explicitly test dependency generation on msvc64
-      dep='--enable-dependency-generation'
-      man=''
-      ;;
+      args+=('--host=x86_64-pc-windows' '--enable-dependency-generation');;
   esac
 
   mkdir -p "$CACHE_DIRECTORY"
@@ -93,14 +82,12 @@ function set_configuration {
       rm -f -- "$CACHE_FILE_PREFIX"*
   fi
 
-  # Remove configure cache if the script has failed
-  if ! ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
-                   --prefix="$2" --enable-ocamltest ; then
+  echo './configure' "${args[@]@Q}"
+  if ! ./configure "${args[@]}"; then
+    # Remove configure cache if the script has failed
     rm -f -- "$CACHE_FILE"
     local failed
-    ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
-                --prefix="$2" --enable-ocamltest \
-        || failed=$?
+    ./configure "${args[@]}" || failed=$?
     if ((failed)) ; then cat config.log ; exit $failed ; fi
   fi
 

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -29,22 +29,22 @@ fi
 git config --global --add safe.directory '*'
 
 function run {
-    if [[ $1 = "--show" ]] ; then SHOW_CMD='true'; shift; else SHOW_CMD=''; fi
-    NAME=$1
-    shift
-    echo "-=-=- $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
-    if [[ -n $SHOW_CMD ]]; then (set -x; "$@"); else "$@"; fi
-    CODE=$?
-    if [[ $CODE -ne 0 ]] ; then
-        echo "-=-=- $NAME failed! -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
-        if [[ $BUILD_PID -ne 0 ]] ; then
-          kill -KILL $BUILD_PID 2>/dev/null
-          wait $BUILD_PID 2>/dev/null
-        fi
-        exit $CODE
-    else
-        echo "-=-=- End of $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+  if [[ $1 = "--show" ]] ; then SHOW_CMD='true'; shift; else SHOW_CMD=''; fi
+  NAME=$1
+  shift
+  echo "-=-=- $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+  if [[ -n $SHOW_CMD ]]; then (set -x; "$@"); else "$@"; fi
+  CODE=$?
+  if [[ $CODE -ne 0 ]] ; then
+    echo "-=-=- $NAME failed! -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    if [[ $BUILD_PID -ne 0 ]] ; then
+      kill -KILL $BUILD_PID 2>/dev/null
+      wait $BUILD_PID 2>/dev/null
     fi
+    exit $CODE
+  else
+    echo "-=-=- End of $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+  fi
 }
 
 # Function: set_configuration
@@ -52,60 +52,60 @@ function run {
 # $1:the Windows port. Recognized values: mingw, msvc and msvc64
 # $2: the prefix to use to install
 function set_configuration {
-    case "$1" in
-        cygwin*)
-            dep='--disable-dependency-generation'
-            man=''
-        ;;
-        mingw32)
-            host='--host=i686-w64-mingw32'
-            dep='--disable-dependency-generation'
-            man=''
-        ;;
-        mingw64)
-            host='--host=x86_64-w64-mingw32'
-            dep='--disable-dependency-generation'
-            man='--disable-stdlib-manpages'
-        ;;
-        msvc32)
-            host='--host=i686-pc-windows'
-            dep='--disable-dependency-generation'
-            man=''
-        ;;
-        msvc64)
-            host='--host=x86_64-pc-windows'
-            # Explicitly test dependency generation on msvc64
-            dep='--enable-dependency-generation'
-            man=''
-        ;;
-    esac
+  case "$1" in
+    cygwin*)
+      dep='--disable-dependency-generation'
+      man=''
+      ;;
+    mingw32)
+      host='--host=i686-w64-mingw32'
+      dep='--disable-dependency-generation'
+      man=''
+      ;;
+    mingw64)
+      host='--host=x86_64-w64-mingw32'
+      dep='--disable-dependency-generation'
+      man='--disable-stdlib-manpages'
+      ;;
+    msvc32)
+      host='--host=i686-pc-windows'
+      dep='--disable-dependency-generation'
+      man=''
+      ;;
+    msvc64)
+      host='--host=x86_64-pc-windows'
+      # Explicitly test dependency generation on msvc64
+      dep='--enable-dependency-generation'
+      man=''
+      ;;
+  esac
 
-    mkdir -p "$CACHE_DIRECTORY"
+  mkdir -p "$CACHE_DIRECTORY"
 
-    local CACHE_KEY CACHE_FILE_PREFIX CACHE_FILE
-    CACHE_KEY=$({ cat configure; uname; } | sha1sum | cut -c 1-7)
-    CACHE_FILE_PREFIX="$CACHE_DIRECTORY/config.cache-$1"
-    CACHE_FILE="$CACHE_FILE_PREFIX-$CACHE_KEY"
+  local CACHE_KEY CACHE_FILE_PREFIX CACHE_FILE
+  CACHE_KEY=$({ cat configure; uname; } | sha1sum | cut -c 1-7)
+  CACHE_FILE_PREFIX="$CACHE_DIRECTORY/config.cache-$1"
+  CACHE_FILE="$CACHE_FILE_PREFIX-$CACHE_KEY"
 
-    # Remove old configure cache if the configure script or the OS
-    # have changed
-    if [[ ! -f "$CACHE_FILE" ]] ; then
-        rm -f -- "$CACHE_FILE_PREFIX"*
-    fi
+  # Remove old configure cache if the configure script or the OS
+  # have changed
+  if [[ ! -f "$CACHE_FILE" ]] ; then
+      rm -f -- "$CACHE_FILE_PREFIX"*
+  fi
 
-    # Remove configure cache if the script has failed
-    if ! ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
-                     --prefix="$2" --enable-ocamltest ; then
-        rm -f -- "$CACHE_FILE"
-        local failed
-        ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
-                    --prefix="$2" --enable-ocamltest \
-            || failed=$?
-        if ((failed)) ; then cat config.log ; exit $failed ; fi
-    fi
+  # Remove configure cache if the script has failed
+  if ! ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
+                   --prefix="$2" --enable-ocamltest ; then
+    rm -f -- "$CACHE_FILE"
+    local failed
+    ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
+                --prefix="$2" --enable-ocamltest \
+        || failed=$?
+    if ((failed)) ; then cat config.log ; exit $failed ; fi
+  fi
 
-#    FILE=$(pwd | cygpath -f - -m)/Makefile.config
-#    run "Content of $FILE" cat Makefile.config
+#  FILE=$(pwd | cygpath -f - -m)/Makefile.config
+#  run "Content of $FILE" cat Makefile.config
 }
 
 PARALLEL_URL='https://git.savannah.gnu.org/cgit/parallel.git/plain/src/parallel'


### PR DESCRIPTION
The GitHub Actions runs very clearly display the `configure` command used to build the compiler (and therefore which flags have been passed to it). That's partly because those scripts run with `set +x` and partly because the workflow commands are clearer e.g.

```
Run MAKE_ARG=-j CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-codegen-invariants --enable-dependency-generation --enable-native-toplevel' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure`
```

Adding `set -x` to `tools/ci/appveyor/appveyor_build.sh` will add a _lot_ of noise to the logs (I'm not that big a fan of `set -x` anyway), but I propose a quick tweak here just to echo the configure command before running it.

GitHub makes this the overall diff of this PR look horrific - given where this change is being made, the first commit updates the indentation of the script, as some of it was indented with a mix of 2 and 4-space increments. In order to avoid copying-and-pasting the entire command a third time, the second commit slightly "modernises" the script by using an array to collect the arguments and then brings the script kicking and screaming into 2016 with the `"${args[@]@Q}"` bash 4.4 incantation to print each of the elements of `$args` with single quotes.