### PR TITLE
Add examples to Stdlib.Option documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -234,7 +234,7 @@ Working version
 - #13732: Document that custom finalizers must not access the OCaml heap, etc.
   (Josh Berdine, review by Stephen Dolan and Guillaume Munch-Maccagnoni)
 
-- #NNNNN: Add examples to Stdlib.Option documentation, update tests to match.
+- #13792: Add examples to Stdlib.Option documentation, update tests to match.
   (Noah Bogart)
 
 ### Compiler user-interface and warnings:

--- a/Changes
+++ b/Changes
@@ -234,7 +234,7 @@ Working version
 - #13732: Document that custom finalizers must not access the OCaml heap, etc.
   (Josh Berdine, review by Stephen Dolan and Guillaume Munch-Maccagnoni)
 
-- #13792: Add examples to Stdlib.Option documentation, update tests to match.
+- #13792: Add examples to Stdlib.Option documentation.
   (Noah Bogart)
 
 ### Compiler user-interface and warnings:

--- a/Changes
+++ b/Changes
@@ -234,6 +234,9 @@ Working version
 - #13732: Document that custom finalizers must not access the OCaml heap, etc.
   (Josh Berdine, review by Stephen Dolan and Guillaume Munch-Maccagnoni)
 
+- #NNNNN: Add examples to Stdlib.Option documentation, update tests to match.
+  (Noah Bogart)
+
 ### Compiler user-interface and warnings:
 
 - #13428: support dump=[source | parsetree | lambda | ... | cmm | ...]

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -17,8 +17,7 @@
 
     Option values explicitly indicate the presence or absence of a value. If the
     value exists, then the option will be [Some value]; otherwise, it will be
-    [None]. Option values have a variety of uses but they are primarily a safe
-    means of dealing with data that may or may not exist.
+    [None].
 
     Option values are typically used with pattern matching to access the
     contents:
@@ -30,9 +29,10 @@
       else
         Some (num / denom)
 
-    match divide 2 5 with
-    | None -> print_endline "Given 0!"
-    | Some v -> Printf.printf "The result is %f." v
+    let () =
+      match divide 2 4 with
+      | None -> print_endline "Given 0!"
+      | Some v -> Printf.printf "The result is %d." v
     ]}
 
     @since 4.08 *)

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -15,7 +15,25 @@
 
 (** Option values.
 
-    Option values explicitly indicate the presence or absence of a value.
+    Option values explicitly indicate the presence or absence of a value. If the
+    value exists, then the option will be [Some value]; otherwise, it will be
+    [None]. Option values have a variety of uses but they are primarily a safe
+    means of dealing with data that may or may not exist.
+
+    Option values are typically used with pattern matching to access the
+    contents:
+
+    {[
+    let divide num denom =
+      if denom = 0 then
+        None
+      else
+        Some (num / denom)
+
+    match divide 2 5 with
+    | None -> print_endline "Given 0!"
+    | Some v -> Printf.printf "The result is %f." v
+    ]}
 
     @since 4.08 *)
 
@@ -31,36 +49,129 @@ val some : 'a -> 'a option
 (** [some v] is [Some v]. *)
 
 val value : 'a option -> default:'a -> 'a
-(** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
+(** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise.
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.value ~default:5 o = 3);
+
+    let o = None in
+    assert (Option.value ~default:5 o = 5);
+    ]} *)
 
 val get : 'a option -> 'a
 (** [get o] is [v] if [o] is [Some v] and raise otherwise.
 
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.get o = 3);
+
+    let o = None in
+    assert (Option.get o = 5); (* raises [Invalid_argument] *)
+    ]}
+
     @raise Invalid_argument if [o] is [None]. *)
 
 val bind : 'a option -> ('a -> 'b option) -> 'b option
-(** [bind o f] is [f v] if [o] is [Some v] and [None] if [o] is [None]. *)
+(** [bind o f] is [f v] if [o] is [Some v] and [None] if [o] is [None].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.bind o (fun x -> Some (succ x)) = Some 4);
+    assert (Option.bind o (fun _ -> None) = None);
+
+    let o = None in
+    assert (Option.bind o (fun x -> Some (succ x)) = None);
+    assert (Option.bind o (fun _ -> None) = None);
+    ]} *)
 
 val join : 'a option option -> 'a option
-(** [join oo] is [Some v] if [oo] is [Some (Some v)] and [None] otherwise. *)
+(** [join oo] is [Some v] if [oo] is [Some (Some v)] and [None] otherwise.
+
+    {b Examples}
+    {[
+    let oo = Some (Some 3) in
+    assert (Option.join oo = Some 3);
+
+    let oo = Some None in
+    assert (Option.join oo = None);
+
+    let oo = None in
+    assert (Option.join oo = None);
+    ]} *)
 
 val map : ('a -> 'b) -> 'a option -> 'b option
-(** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v]. *)
+(** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.map succ o = Some 4);
+
+    let o = None in
+    assert (Option.map succ o = None);
+    ]} *)
 
 val fold : none:'a -> some:('b -> 'a) -> 'b option -> 'a
 (** [fold ~none ~some o] is [none] if [o] is [None] and [some v] if [o] is
-    [Some v]. *)
+    [Some v].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.fold ~none:0 ~some:succ o = 4);
+    assert (Option.(fold ~none ~some) o = (Some 3));
+
+    let o = None in
+    assert (Option.fold ~none:0 ~some:succ o = 0);
+    assert (Option.(fold ~none ~some) o = None);
+    ]} *)
 
 val iter : ('a -> unit) -> 'a option -> unit
-(** [iter f o] is [f v] if [o] is [Some v] and [()] otherwise. *)
+(** [iter f o] is [f v] if [o] is [Some v] and [()] otherwise.
+
+    {b Examples}
+    {[
+    let count = ref 0 in
+    let set_count x = count := x in
+
+    let o = Some 3 in
+    Option.iter set_count o;
+    assert (!count = 3);
+
+    let o = None in
+    Option.iter set_count o;
+    assert (!count = 3);
+    ]} *)
 
 (** {1:preds Predicates and comparisons} *)
 
 val is_none : 'a option -> bool
-(** [is_none o] is [true] if and only if [o] is [None]. *)
+(** [is_none o] is [true] if and only if [o] is [None].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.is_none o = false);
+
+    let o = None in
+    assert (Option.is_none o = true);
+    ]} *)
 
 val is_some : 'a option -> bool
-(** [is_some o] is [true] if and only if [o] is [Some o]. *)
+(** [is_some o] is [true] if and only if [o] is [Some o].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.is_some o = true);
+
+    let o = None in
+    assert (Option.is_some o = false);
+    ]} *)
 
 val equal : ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
 (** [equal eq o0 o1] is [true] if and only if [o0] and [o1] are both [None]
@@ -74,11 +185,38 @@ val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int
 
 val to_result : none:'e -> 'a option -> ('a, 'e) result
 (** [to_result ~none o] is [Ok v] if [o] is [Some v] and [Error none]
-    otherwise. *)
+    otherwise.
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.to_result ~none:6 o = Ok 3);
+
+    let o = None in
+    assert (Option.to_result ~none:6 o = Error 6);
+    ]} *)
 
 val to_list : 'a option -> 'a list
-(** [to_list o] is [[]] if [o] is [None] and [[v]] if [o] is [Some v]. *)
+(** [to_list o] is [[]] if [o] is [None] and [[v]] if [o] is [Some v].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.to_list o = [3]);
+
+    let o = None in
+    assert (Option.to_list o = []);
+    ]} *)
 
 val to_seq : 'a option -> 'a Seq.t
 (** [to_seq o] is [o] as a sequence. [None] is the empty sequence and
-    [Some v] is the singleton sequence containing [v]. *)
+    [Some v] is the singleton sequence containing [v].
+
+    {b Examples}
+    {[
+    let o = Some 3 in
+    assert (Option.to_seq o |> List.of_seq = [3]);
+
+    let o = None in
+    assert (Option.to_seq o |> List.of_seq = []);
+    ]} *)

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -53,26 +53,26 @@ val value : 'a option -> default:'a -> 'a
 
     {b Examples}
     {[
-    let o = Some 3 in
-    assert (Option.value ~default:5 o = 3);
+    let o = Some "foo" in
+    assert (Option.value ~default:"bar" o = "foo");
 
     let o = None in
-    assert (Option.value ~default:5 o = 5);
+    assert (Option.value ~default:"bar" o = "bar");
     ]} *)
 
 val get : 'a option -> 'a
 (** [get o] is [v] if [o] is [Some v] and raise otherwise.
 
+    @raise Invalid_argument if [o] is [None]. 
+
     {b Examples}
     {[
-    let o = Some 3 in
-    assert (Option.get o = 3);
+    let o = Some "foo" in
+    assert (Option.get o = "foo");
 
     let o = None in
-    assert (Option.get o = 5); (* raises [Invalid_argument] *)
-    ]}
-
-    @raise Invalid_argument if [o] is [None]. *)
+    assert (Option.get o = "bar"); (* raises [Invalid_argument] *)
+    ]} *)
 
 val bind : 'a option -> ('a -> 'b option) -> 'b option
 (** [bind o f] is [f v] if [o] is [Some v] and [None] if [o] is [None].
@@ -93,8 +93,8 @@ val join : 'a option option -> 'a option
 
     {b Examples}
     {[
-    let oo = Some (Some 3) in
-    assert (Option.join oo = Some 3);
+    let oo = Some (Some "foo") in
+    assert (Option.join oo = Some "foo");
 
     let oo = Some None in
     assert (Option.join oo = None);
@@ -138,13 +138,13 @@ val iter : ('a -> unit) -> 'a option -> unit
     let count = ref 0 in
     let set_count x = count := x in
 
-    let o = Some 3 in
+    let o = Some "foo" in
     Option.iter set_count o;
-    assert (!count = 3);
+    assert (!count = "foo");
 
     let o = None in
     Option.iter set_count o;
-    assert (!count = 3);
+    assert (!count = "foo");
     ]} *)
 
 (** {1:preds Predicates and comparisons} *)
@@ -154,7 +154,7 @@ val is_none : 'a option -> bool
 
     {b Examples}
     {[
-    let o = Some 3 in
+    let o = Some "foo" in
     assert (Option.is_none o = false);
 
     let o = None in
@@ -162,11 +162,11 @@ val is_none : 'a option -> bool
     ]} *)
 
 val is_some : 'a option -> bool
-(** [is_some o] is [true] if and only if [o] is [Some o].
+(** [is_some o] is [true] if and only if [o] is [Some v].
 
     {b Examples}
     {[
-    let o = Some 3 in
+    let o = Some "foo" in
     assert (Option.is_some o = true);
 
     let o = None in
@@ -189,11 +189,11 @@ val to_result : none:'e -> 'a option -> ('a, 'e) result
 
     {b Examples}
     {[
-    let o = Some 3 in
-    assert (Option.to_result ~none:6 o = Ok 3);
+    let o = Some "foo" in
+    assert (Option.to_result ~none:"bar" o = Ok "foo");
 
     let o = None in
-    assert (Option.to_result ~none:6 o = Error 6);
+    assert (Option.to_result ~none:"bar" o = Error "bar");
     ]} *)
 
 val to_list : 'a option -> 'a list
@@ -201,8 +201,8 @@ val to_list : 'a option -> 'a list
 
     {b Examples}
     {[
-    let o = Some 3 in
-    assert (Option.to_list o = [3]);
+    let o = Some "foo" in
+    assert (Option.to_list o = ["foo"]);
 
     let o = None in
     assert (Option.to_list o = []);
@@ -214,8 +214,8 @@ val to_seq : 'a option -> 'a Seq.t
 
     {b Examples}
     {[
-    let o = Some 3 in
-    assert (Option.to_seq o |> List.of_seq = [3]);
+    let o = Some "foo" in
+    assert (Option.to_seq o |> List.of_seq = ["foo"]);
 
     let o = None in
     assert (Option.to_seq o |> List.of_seq = []);

--- a/testsuite/tests/lib-option/test.ml
+++ b/testsuite/tests/lib-option/test.ml
@@ -11,87 +11,53 @@ let test_none_some () =
   ()
 
 let test_value () =
-  let o = Some 3 in
-  assert (Option.value ~default:5 o = 3);
-
-  let o = None in
-  assert (Option.value ~default:5 o = 5);
+  assert (Option.value None ~default:5 = 5);
+  assert (Option.value (Some 3) ~default:5 = 3);
   ()
 
 let test_get () =
-  let o = Some 3 in
-  assert (Option.get o = 3);
-
-  let o = None in
-  assert_raise_invalid_argument Option.get o;
+  assert_raise_invalid_argument Option.get None;
+  assert (Option.get (Some 2) = 2);
   ()
 
 let test_bind () =
-  let o = Some 3 in
-  assert (Option.bind o (fun x -> Some (succ x)) = Some 4);
-  assert (Option.bind o (fun _ -> None) = None);
-
-  let o = None in
-  assert (Option.bind o (fun x -> Some (succ x)) = None);
-  assert (Option.bind o (fun _ -> None) = None);
+  assert (Option.bind (Some 3) (fun x -> Some (succ x)) = Some 4);
+  assert (Option.bind (Some 3) (fun _ -> None) = None);
+  assert (Option.bind None (fun x -> Some (succ x)) = None);
+  assert (Option.bind None (fun _ -> None) = None);
   ()
 
 let test_join () =
-  let oo = Some (Some 3) in
-  assert (Option.join oo = Some 3);
-
-  let oo = Some None in
-  assert (Option.join oo = None);
-
-  let oo = None in
-  assert (Option.join oo = None);
+  assert (Option.join (Some (Some 3)) = Some 3);
+  assert (Option.join (Some None) = None);
+  assert (Option.join None = None);
   ()
 
 let test_map () =
-  let o = Some 3 in
-  assert (Option.map succ o = Some 4);
-
-  let o = None in
-  assert (Option.map succ o = None);
+  assert (Option.map succ (Some 3) = Some 4);
+  assert (Option.map succ None = None);
   ()
 
 let test_fold () =
-  let o = Some 3 in
-  assert (Option.fold ~none:0 ~some:succ o = 4);
-  assert (Option.(fold ~none ~some) o = (Some 3));
-
-  let o = None in
-  assert (Option.fold ~none:0 ~some:succ o = 0);
-  assert (Option.(fold ~none ~some) o = None);
+  assert (Option.fold ~none:3 ~some:succ (Some 1) = 2);
+  assert (Option.fold ~none:3 ~some:succ None = 3);
+  assert (Option.(fold ~none ~some) (Some 1) = (Some 1));
+  assert (Option.(fold ~none ~some) None = None);
   ()
 
 let test_iter () =
   let count = ref 0 in
   let set_count x = count := x in
-
-  let o = Some 3 in
-  Option.iter set_count o;
-  assert (!count = 3);
-
-  let o = None in
-  Option.iter set_count o;
-  assert (!count = 3);
+  assert (!count = 0);
+  Option.iter set_count (Some 2); assert (!count = 2);
+  Option.iter set_count None; assert (!count = 2);
   ()
 
-let test_is_none () =
-  let o = Some 3 in
-  assert (Option.is_none o = false);
-
-  let o = None in
-  assert (Option.is_none o = true);
-  ()
-
-let test_is_some () =
-  let o = Some 3 in
-  assert (Option.is_some o = true);
-
-  let o = None in
-  assert (Option.is_some o = false);
+let test_is_none_some () =
+  assert (Option.is_none None = true);
+  assert (Option.is_some None = false);
+  assert (Option.is_none (Some 2) = false);
+  assert (Option.is_some (Some 2) = true);
   ()
 
 let test_equal () =
@@ -139,8 +105,7 @@ let tests () =
   test_map ();
   test_fold ();
   test_iter ();
-  test_is_none ();
-  test_is_some ();
+  test_is_none_some ();
   test_equal ();
   test_compare ();
   test_to_option_list_seq ();

--- a/testsuite/tests/lib-option/test.ml
+++ b/testsuite/tests/lib-option/test.ml
@@ -11,53 +11,87 @@ let test_none_some () =
   ()
 
 let test_value () =
-  assert (Option.value None ~default:5 = 5);
-  assert (Option.value (Some 3) ~default:5 = 3);
+  let o = Some 3 in
+  assert (Option.value ~default:5 o = 3);
+
+  let o = None in
+  assert (Option.value ~default:5 o = 5);
   ()
 
 let test_get () =
-  assert_raise_invalid_argument Option.get None;
-  assert (Option.get (Some 2) = 2);
+  let o = Some 3 in
+  assert (Option.get o = 3);
+
+  let o = None in
+  assert_raise_invalid_argument Option.get o;
   ()
 
 let test_bind () =
-  assert (Option.bind (Some 3) (fun x -> Some (succ x)) = Some 4);
-  assert (Option.bind (Some 3) (fun _ -> None) = None);
-  assert (Option.bind None (fun x -> Some (succ x)) = None);
-  assert (Option.bind None (fun _ -> None) = None);
+  let o = Some 3 in
+  assert (Option.bind o (fun x -> Some (succ x)) = Some 4);
+  assert (Option.bind o (fun _ -> None) = None);
+
+  let o = None in
+  assert (Option.bind o (fun x -> Some (succ x)) = None);
+  assert (Option.bind o (fun _ -> None) = None);
   ()
 
 let test_join () =
-  assert (Option.join (Some (Some 3)) = Some 3);
-  assert (Option.join (Some None) = None);
-  assert (Option.join None = None);
+  let oo = Some (Some 3) in
+  assert (Option.join oo = Some 3);
+
+  let oo = Some None in
+  assert (Option.join oo = None);
+
+  let oo = None in
+  assert (Option.join oo = None);
   ()
 
 let test_map () =
-  assert (Option.map succ (Some 3) = Some 4);
-  assert (Option.map succ None = None);
+  let o = Some 3 in
+  assert (Option.map succ o = Some 4);
+
+  let o = None in
+  assert (Option.map succ o = None);
   ()
 
 let test_fold () =
-  assert (Option.fold ~none:3 ~some:succ (Some 1) = 2);
-  assert (Option.fold ~none:3 ~some:succ None = 3);
-  assert (Option.(fold ~none ~some) (Some 1) = (Some 1));
-  assert (Option.(fold ~none ~some) None = None);
+  let o = Some 3 in
+  assert (Option.fold ~none:0 ~some:succ o = 4);
+  assert (Option.(fold ~none ~some) o = (Some 3));
+
+  let o = None in
+  assert (Option.fold ~none:0 ~some:succ o = 0);
+  assert (Option.(fold ~none ~some) o = None);
   ()
 
 let test_iter () =
   let count = ref 0 in
   let set_count x = count := x in
-  assert (!count = 0);
-  Option.iter set_count (Some 2); assert (!count = 2);
-  Option.iter set_count None; assert (!count = 2);
+
+  let o = Some 3 in
+  Option.iter set_count o;
+  assert (!count = 3);
+
+  let o = None in
+  Option.iter set_count o;
+  assert (!count = 3);
   ()
 
-let test_is_none_some () =
-  assert (Option.is_none None = true);
-  assert (Option.is_some None = false);
-  assert (Option.is_none (Some 2) = false);
-  assert (Option.is_some (Some 2) = true);
+let test_is_none () =
+  let o = Some 3 in
+  assert (Option.is_none o = false);
+
+  let o = None in
+  assert (Option.is_none o = true);
+  ()
+
+let test_is_some () =
+  let o = Some 3 in
+  assert (Option.is_some o = true);
+
+  let o = None in
+  assert (Option.is_some o = false);
   ()
 
 let test_equal () =
@@ -105,7 +139,8 @@ let tests () =
   test_map ();
   test_fold ();
   test_iter ();
-  test_is_none_some ();
+  test_is_none ();
+  test_is_some ();
   test_equal ();
   test_compare ();
   test_to_option_list_seq ();


### PR DESCRIPTION
I found the Stdlib.Option documentation (docstrings) a little sparse and unhelpful, so I've added clarifying examples to each as a means of demonstrating their potential usage. I also added some additional text and a larger example to the module documentation which is closer to "normal code".