### PR TITLE
Standard library: rename Format.utf8_scalar_width to utf_8_scalar_width

### DIFF
--- a/Changes
+++ b/Changes
@@ -131,8 +131,8 @@ Working version
 - #13768: Add Either.get_left and Either.get_right
   (T. Kinsart, review by Nicolás Ojeda Bär and Florian Angeletti)
 
-- #13570, Format: add an out_width function to Format device for approximating
-   unicode width.
+- #13570, #13794: Format, add an out_width function to Format device for
+   approximating unicode width.
   (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
    and Gabriel Scherer)
 

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -970,7 +970,7 @@ let default_pp_mark_close_tag = function
 let default_pp_print_open_tag = ignore
 let default_pp_print_close_tag = ignore
 
-let utf8_scalar_width s ~pos ~len =
+let utf_8_scalar_width s ~pos ~len =
   let rec width s count current stop =
     if current >= stop then count
     else
@@ -993,7 +993,7 @@ let pp_make_formatter f g h i j =
   let scan_stack = Stack.create () in
   initialize_scan_stack scan_stack;
   Stack.push { left_total = 1; queue_elem = sys_tok } scan_stack;
-  let pp_out_width = utf8_scalar_width in
+  let pp_out_width = utf_8_scalar_width in
   let pp_margin = 78
   and pp_min_space_left = 10 in
   {

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -895,7 +895,7 @@ type formatter_out_functions = {
    {!Stdlib.out_channel} device, or [Buffer.add_substring] and
    {!Stdlib.ignore} for a [Buffer.t] output device),
 - field [out_width] is the number of unicode scalar values
-  (see {!utf8_scalar_width}) in the substring.
+  (see {!utf_8_scalar_width}) in the substring.
 - field [out_newline] is equivalent to [out_string "\n" 0 1];
 - fields [out_spaces] and [out_indent] are equivalent to
   [out_string (String.make n ' ') 0 n].
@@ -916,7 +916,7 @@ val set_formatter_out_functions : formatter_out_functions -> unit
 
   Reasonable defaults for functions [out_spaces], [out_newline], and [out_width]
   are respectively [out_funs.out_string (String.make n ' ') 0 n],
-  [out_funs.out_string "\n" 0 1] and {!utf8_scalar_width}.
+  [out_funs.out_string "\n" 0 1] and {!utf_8_scalar_width}.
   @since 4.01
 *)
 
@@ -929,8 +929,8 @@ val get_formatter_out_functions : unit -> formatter_out_functions
   @since 4.01
 *)
 
-val utf8_scalar_width: string -> pos:int -> len:int -> int
-(** [utf8_scalar_width s ~pos ~len] is the number of unicode scalar values in
+val utf_8_scalar_width: string -> pos:int -> len:int -> int
+(** [utf_8_scalar_width s ~pos ~len] is the number of unicode scalar values in
     the substring [String.sub s pos len]. Invalid byte sequences are implictly
     replaced by [U+FFFD] since this yields a better width approximation for
     other ascii-based encoding scheme like ISO-8859-15. This is the default

--- a/testsuite/tests/lib-format/unicode.ml
+++ b/testsuite/tests/lib-format/unicode.ml
@@ -34,7 +34,7 @@ val test :
 
 (** Alphabetic scripts *)
 let () =
-  test ~out_width:Format.utf8_scalar_width 40
+  test ~out_width:Format.utf_8_scalar_width 40
   "Μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος οὐλομένην, ἣ μυρί᾿ Ἀχαιοῖς ἄλγε᾿ ἔθηκε, \
    πολλὰς δ᾿ ἰφθίμους ψυχὰς Ἄϊδι προΐαψεν ἡρώων, αὐτοὺς δὲ ἑλώρια τεῦχε κύνεσσιν \
    οἰωνοῖσί τε πᾶσι· Διὸς δ᾿ ἐτελείετο βουλή ἐξ οὗ δὴ τὰ πρῶτα διαστήτην \
@@ -51,7 +51,7 @@ let () =
 |}]
 
 let () =
-  setup ~out_width:Format.utf8_scalar_width 40;
+  setup ~out_width:Format.utf_8_scalar_width 40;
   Format.printf
     "@[Μῆνιν@ ἄειδε@ θεὰ@ Πηληϊάδεω@ Ἀχιλῆος@ οὐλομένην,@ ἣ@ μυρί᾿@ Ἀχαιοῖς@ ἄλγε᾿@ ἔθηκε,@ \
      πολλὰς@ δ᾿@ ἰφθίμους@ ψυχὰς@ Ἄϊδι@ προΐαψεν@ ἡρώων,@ αὐτοὺς@ δὲ@ ἑλώρια@ τεῦχε@ \
@@ -96,7 +96,7 @@ let () =
 
 (** Vietnamese tends to use many combining diacritics *)
 let () =
-  test ~out_width:Format.utf8_scalar_width 40
+  test ~out_width:Format.utf_8_scalar_width 40
     "Trăm năm trong cõi người ta, \
      Chữ tài chữ mệnh khéo là ghét nhau. \
      Trải qua một cuộc bể dâu, \
@@ -135,7 +135,7 @@ let () =
 |}]
 
 let () =
-  test ~out_width:Format.utf8_scalar_width 40
+  test ~out_width:Format.utf_8_scalar_width 40
     "めぐり逢ひ \
      見しやそれとも \
      わかぬ間に \
@@ -150,7 +150,7 @@ let () =
     abugida scripts, but those scripts width tend to be really dependent on
     shaping anyway. *)
 let () =
-  test  ~out_width:Format.utf8_scalar_width 40
+  test  ~out_width:Format.utf_8_scalar_width 40
     "अग्निमीळे पुरोहितं यज्ञस्य देवं रत्वीजम होतारं रत्नधातमम अग्निः \
      पूर्वेभिर्र्षिभिरीड्यो नूतनैरुत स देवानेह वक्षति"
 [%%expect{|


### PR DESCRIPTION
A nomenclature blunder sneaked inside #13570: the standard library only uses utf_8 and not utf8 for the unicode encoding, whereas my PR added a `utf8_scalar_width`.

This PR fixes this mistake while there is still time for consistency.