### PR TITLE
Add `Uchar.{utf_8_decode_length_of_byte,max_utf_8_decode_length}`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -124,6 +124,7 @@ testsuite/tests/win-unicode/*.ml                        typo.non-ascii
 testsuite/tests/unicode/見.ml                           typo.non-ascii
 testsuite/tests/lib-format/unicode.ml                   typo.non-ascii
 testsuite/tests/lib-string/test_string.ml               typo.non-ascii
+testsuite/tests/lib-uchar/test.ml                       typo.non-ascii
 testsuite/tests/lexing/reject_bad_encoding.ml           typo.prune
 testsuite/tests/asmgen/immediates.cmm                   typo.very-long-line
 testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line

--- a/Changes
+++ b/Changes
@@ -137,6 +137,10 @@ Working version
 
 ### Standard library:
 
+- #13796: Add Uchar.utf_8_decode_length_of_byte and
+  Uchar.max_utf_8_decode_length.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Florian Angeletti)
+
 - #12871: Add the Pqueue module to the stdlib. It implements priority queues.
   (Jean-Christophe Filliâtre, review by Daniel Bünzli, Léo Andrès and
   Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -135,8 +135,11 @@ Working version
   `.size` and `.type` directives and the `.note.GNU-stack` section
   (Samuel Hym, review by Miod Vallat, Antonin Décimo and Gabriel Scherer)
 
-
 ### Standard library:
+
+- #12871: Add the Pqueue module to the stdlib. It implements priority queues.
+  (Jean-Christophe Filliâtre, review by Daniel Bünzli, Léo Andrès and
+  Gabriel Scherer)
 
 - #13760: Add String.{edit_distance,spellcheck}
   (Daniel Bünzli, review by wikku, Nicolás Ojeda Bär, Gabriel Scherer and
@@ -642,10 +645,6 @@ OCaml 5.3.0 (8 January 2025)
 - #13296: Add mem, memq, find_opt, find_index, find_map and find_mapi
   to Dynarray.
   (Jake H, review by Gabriel Scherer and Florian Angeletti)
-
-- #12871: Add the Pqueue module to the stdlib. It implements priority queues.
-  (Jean-Christophe Filliâtre, review by Daniel Bünzli, Léo Andrès and
-  Gabriel Scherer)
 
 ### Other libraries:
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -283,19 +283,11 @@ let get_int64_be s i = B.get_int64_be (bos s) i
 
 (* Spellchecking *)
 
-let uchar_utf_8_byte_decode_length = function
-  | '\x00' .. '\x7F' -> 1
-  | '\x80' .. '\xC1' -> 0
-  | '\xC2' .. '\xDF' -> 2
-  | '\xE0' .. '\xEF' -> 3
-  | '\xF0' .. '\xF4' -> 4
-  | _ -> 0
-
 let utf_8_uchar_length s =
   let slen = length s in
   let i = ref 0 and ulen = ref 0 in
   while (!i < slen) do
-    let dec_len = uchar_utf_8_byte_decode_length (unsafe_get s !i) in
+    let dec_len = Uchar.utf_8_decode_length_of_byte (unsafe_get s !i) in
     i := (!i + if dec_len = 0 then 1 (* count one Uchar.rep *) else dec_len);
     incr ulen;
   done;

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -80,6 +80,16 @@ let[@inline] utf_decode_uchar d = unsafe_of_int (d land 0xFFFFFF)
 let[@inline] utf_decode n u = ((8 lor n) lsl decode_bits) lor (to_int u)
 let[@inline] utf_decode_invalid n = (n lsl decode_bits) lor rep
 
+let utf_8_decode_length_of_byte = function
+  | '\x00' .. '\x7F' -> 1
+  | '\x80' .. '\xC1' -> 0
+  | '\xC2' .. '\xDF' -> 2
+  | '\xE0' .. '\xEF' -> 3
+  | '\xF0' .. '\xF4' -> 4
+  | _ -> 0
+
+let max_utf_8_decode_length = 4
+
 let utf_8_byte_length u = match to_int u with
 | u when u < 0 -> assert false
 | u when u <= 0x007F -> 1

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -143,6 +143,20 @@ val utf_decode_invalid : int -> utf_decode
     smaller or equal to [4] (this is not checked by the module). The
     resulting decode has {!rep} as the decoded Unicode character. *)
 
+val utf_8_decode_length_of_byte : char -> int
+(** [utf_8_decode_length_of_byte byte] is the number of bytes, from 1
+    to {!max_utf8_decode_length}, that a valid UTF-8 decode starting
+    with byte [byte] would consume or [0] if [byte] cannot start a
+    valid decode.
+
+    @since 5.4 *)
+
+val max_utf_8_decode_length : int
+(** [max_utf_8_decode_length] is [4], the maximal number of bytes
+    a valid or invalid UTF-8 decode can consume.
+
+    @since 5.4 *)
+
 val utf_8_byte_length : t -> int
 (** [utf_8_byte_length u] is the number of bytes needed to encode
     [u] in UTF-8. *)

--- a/testsuite/tests/lib-uchar/test.ml
+++ b/testsuite/tests/lib-uchar/test.ml
@@ -94,6 +94,15 @@ let test_utf_decode () =
   assert (Uchar.equal (Uchar.utf_decode_uchar invalid) Uchar.rep);
   ()
 
+let test_utf_8_decode_length_of_byte () =
+  assert (Uchar.utf_8_decode_length_of_byte "a".[0] = 1);
+  assert (Uchar.utf_8_decode_length_of_byte "é".[0] = 2);
+  assert (Uchar.utf_8_decode_length_of_byte "‘".[0] = 3);
+  assert (Uchar.utf_8_decode_length_of_byte "🐫".[0] =
+          Uchar.max_utf_8_decode_length);
+  assert (Uchar.utf_8_decode_length_of_byte "\xFF".[0] = 0);
+  ()
+
 let test_utf_x_byte_length () =
   assert (Uchar.utf_8_byte_length Uchar.min = 1);
   assert (Uchar.utf_16_byte_length Uchar.min = 2);
@@ -119,6 +128,7 @@ let tests () =
   test_compare ();
   test_hash ();
   test_utf_decode ();
+  test_utf_8_decode_length_of_byte ();
   test_utf_x_byte_length ();
   ()
 


### PR DESCRIPTION
As said in #13760 I'm moving and exposing some UTF-8 decoding functionality from `string.ml` to `Uchar`.

In general `Uchar.utf_8_decode_length_of_byte` is useful when you arrive in the last `Uchar.max_utf_8_decode_length` bytes of a fixed sized buffer and want to determine if decodes will stay in the current buffer or not.

(There's a also a commit that moves the Pqueue changes entry in the working version, it was added to 5.3)


