### PR TITLE
Update the scope of ancestors in Ctype.unify2_rec

### DIFF
--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -473,3 +473,47 @@ let foo (type s) x (Refl : (s, u) eq) =
 [%%expect{|
 val foo : 's -> ('s, u) eq -> t = <fun>
 |}]
+
+(* interaction with expansion *)
+
+let f : type a b c. (a,b) eq -> (b,c) eq -> _ =
+ fun ab bc ->
+   let Refl = ab in
+   let g () =
+     let Refl = bc in
+     let h y =
+       ignore (y : b);
+       ignore (y : c);
+       y
+     in
+     h
+   in ignore g;;
+[%%expect{|
+Line 11, characters 5-6:
+11 |      h
+          ^
+Error: The value "h" has type "b -> b" but an expression was expected of type "'a"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+let f : type a b c. (a,b) eq -> (b,c) eq -> _ =
+ fun ab bc ->
+   let Refl = ab in
+   let g () =
+     let Refl = bc in
+     let h y =
+       ignore (y : c);
+       ignore (y : b);
+       y
+     in
+     h
+   in ignore g;;
+[%%expect{|
+Line 11, characters 5-6:
+11 |      h
+          ^
+Error: The value "h" has type "c -> c" but an expression was expected of type "'a"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2784,7 +2784,7 @@ let rec unify uenv t1 t2 =
         update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2
     | (Tconstr _, Tconstr _) when Env.has_local_constraints (get_env uenv) ->
-        unify2_rec uenv t1 t1 t2 t2
+        unify2_rec uenv t1 [] t1 t2 [] t2
     | _ ->
         unify2 uenv t1 t2
     end;
@@ -2795,7 +2795,7 @@ let rec unify uenv t1 t2 =
 
 and unify2 uenv t1 t2 = unify2_expand uenv t1 t1 t2 t2
 
-and unify2_rec uenv t10 t1 t20 t2 =
+and unify2_rec uenv t10 t1s t1 t20 t2s t2 =
   if unify_eq uenv t1 t2 then () else
   try match (get_desc t1, get_desc t2) with
   | (Tconstr (p1, tl1, a1), Tconstr (p2, tl2, a2)) ->
@@ -2803,13 +2803,14 @@ and unify2_rec uenv t10 t1 t20 t2 =
       && not (has_cached_expansion p1 !a1 || has_cached_expansion p2 !a2)
       then begin
         update_level_for Unify (get_env uenv) (get_level t1) t2;
-        update_scope_for Unify (get_scope t1) t2;
+        let scope = Int.max (get_scope t1) (get_scope t2) in
+        List.iter (update_scope_for Unify scope) (t2 :: t1s @ t2s);
         link_type t1 t2
       end else
         let env = get_env uenv in
         if find_expansion_scope env p1 > find_expansion_scope env p2
-        then unify2_rec uenv t10 t1 t20 (try_expand_safe env t2)
-        else unify2_rec uenv t10 (try_expand_safe env t1) t20 t2
+        then unify2_rec uenv t10 t1s t1 t20 (t2::t2s) (try_expand_safe env t2)
+        else unify2_rec uenv t10 (t1::t1s) (try_expand_safe env t1) t20 t2s t2
   | _ ->
       raise Cannot_expand
   with Cannot_expand ->


### PR DESCRIPTION
The detection of ambivalence can be confused in presence of multiple equations on the same node.
This PR makes the behavior more regular, but it does not solve the fundamental problem.

Here is the example fix by this PR.
It is clearly ambivalent, but this used to go undetected.
There does not seem to be a soundness problem here.
```ocaml
let f : type a b c. (a,b) eq -> (b,c) eq -> _ =
 fun ab bc ->
   let Refl = ab in
   let g () =
     let Refl = bc in
     let h y =
       ignore (y : b);
       ignore (y : c);
       y
     in
     h
   in ignore g;;
```