### PR TITLE
PDF manual: add section titles to right-hand page headers

### DIFF
--- a/manual/src/macros.tex
+++ b/manual/src/macros.tex
@@ -164,7 +164,8 @@
 
 \pagestyle{myheadings}
 \def\partmark#1{\markboth{Part \thepart. \ #1}{}}
-\def\chaptermark#1{\markright{Chapter \thechapter. \ #1}}
+\def\chaptermark#1{\markboth{Chapter \thechapter. \ #1}{}}
+\def\sectionmark#1{\markright{\thesection. \ #1}}
 
 % nth
 


### PR DESCRIPTION
Note that currently (= before this PR), chapter titles are set on the headers of the right-hand pages. They have been moved to the left-hand pages, which I believe is a bit more standard (at least according to TeX conventions).

Fixes #13800

![image](https://github.com/user-attachments/assets/6c166eda-8aa8-4dfc-ab08-dd3ae05c8982)
