### PR TITLE
Go backward in caml_string_equal

### DIFF
--- a/runtime/str.c
+++ b/runtime/str.c
@@ -280,8 +280,11 @@ CAMLprim value caml_string_equal(value s1, value s2)
   sz1 = Wosize_val(s1);
   sz2 = Wosize_val(s2);
   if (sz1 != sz2) return Val_false;
-  for(p1 = Op_val(s1), p2 = Op_val(s2); sz1 > 0; sz1--, p1++, p2++)
+  for(p1 = Op_val(s1) + sz1, p2 = Op_val(s2) + sz1; sz1 > 0; sz1--) {
+    p1--;
+    p2--;
     if (*p1 != *p2) return Val_false;
+  }
   return Val_true;
 }
 


### PR DESCRIPTION
Because the last word will always differ for strings whose byte-length are different (but the word lengths are the same), this will likely lead to more early exits and better performances.