### PR TITLE
Add support for unaligned accesses on arm64

### DIFF
--- a/Changes
+++ b/Changes
@@ -135,6 +135,9 @@ Working version
   `.size` and `.type` directives and the `.note.GNU-stack` section
   (Samuel Hym, review by Miod Vallat, Antonin Décimo and Gabriel Scherer)
 
+- #13807: Allow unaligned memory accesses on ARM64. (Matthew Else, review by
+  Xavier Leroy)
+
 ### Standard library:
 
 - #13796: Add Uchar.utf_8_decode_length_of_byte and

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -74,7 +74,7 @@ let size_addr = 8
 let size_int = 8
 let size_float = 8
 
-let allow_unaligned_access = false
+let allow_unaligned_access = true
 
 (* Behavior of division *)
 


### PR DESCRIPTION
Resolves #13631

Per the discussion in #13631, it seems like not supporting aligned accesses on arm64 has been unnecessarily conservative. This PR makes the trivial change to flip `allow_unaligned_access` on arm64. As it turns out, this only affects a handful of code-paths in cmm_helpers.ml, but makes a noticeable difference to performance in code that processes bigstrings, amongst other things.

Testing:
I've been using this as a local build from time to time on my M2 Mac over the last few months, and I've run the test suite locally. I've also documented the behaviour of other compilers (clang and GCC) in the corresponding issue. I've also manually audited the handful of use-cases of `allow_unaligned_access`, and nothing looks suspicious to my untrained eye.
