### PR TITLE
Support build of cross compilers to native freestanding targets

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,6 +95,9 @@ Working version
 
 ### Build system:
 
+- #13810: Support build of cross compilers to native freestanding targets
+  (Samuel Hym, review by Antonin Décimo and Romain Calascibetta)
+
 ### Bug fixes:
 
 - #13853: Format breaks some line too early when there

--- a/configure
+++ b/configure
@@ -15770,6 +15770,8 @@ esac
  ;; #(
   gcc-*,powerpc-*-linux*) :
     oc_ldflags="-mbss-plt" ;; #(
+  *,*-*-none|*,*-*-elf*) :
+    ostype="None" ;; #(
   *) :
      ;;
 esac
@@ -18566,7 +18568,19 @@ fi ;; #(
   riscv64-*-linux*) :
     has_native_backend=yes; arch=riscv; model=riscv64; system=linux ;; #(
   x86_64-*-gnu*) :
-    has_native_backend=yes; arch=amd64; system=gnu
+    has_native_backend=yes; arch=amd64; system=gnu ;; #(
+  aarch64-*-none|arm64-*-none|aarch64-*-elf*|arm64-*-elf*) :
+    has_native_backend=yes; arch=arm64; system=none ;; #(
+  powerpc64le*-*-none|powerpc64le*-*-elf*) :
+    has_native_backend=yes; arch=power; model=ppc64le; system=none ;; #(
+  powerpc64*-*-none|powerpc64*-*-elf*) :
+    has_native_backend=yes; arch=power; model=ppc64; system=none ;; #(
+  riscv64-*-none|riscv64-*-elf*) :
+    has_native_backend=yes; arch=riscv; model=riscv64; system=none ;; #(
+  s390x*-*-none|s390x*-*-elf*) :
+    has_native_backend=yes; arch=s390x; model=z10; system=none ;; #(
+  x86_64-*-none|x86_64-*-elf*) :
+    has_native_backend=yes; arch=amd64; system=none
  ;; #(
   *) :
      ;;

--- a/configure
+++ b/configure
@@ -3690,6 +3690,21 @@ IFS=$ac_save_IFS
 case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
+# Allow "ocaml" to be used as the last component of the target triplet in case
+# we are using a custom toolchain for a freestanding target. To do so, the
+# target triplet is temporarily rewritten to "<arch>-none" to compute the
+# canonical target
+save_target_alias="$target_alias"
+case $target_alias in #(
+  *-*-ocaml) :
+    ac_save_IFS=$IFS
+    IFS='-'
+    set x $target_alias
+    target_alias="$2-none"
+    IFS=$ac_save_IFS ;; #(
+  *) :
+     ;;
+esac
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking target system type" >&5
 printf %s "checking target system type... " >&6; }
 if test ${ac_cv_target+y}
@@ -3730,6 +3745,7 @@ test -n "$target_alias" &&
   test "$program_prefix$program_suffix$program_transform_name" = \
     NONENONEs,x,x, &&
   program_prefix=${target_alias}-
+target_alias="$save_target_alias"
 
 # Override cross_compiling and ac_tool_prefix variables since the C toolchain is
 # used to generate target code when building a cross compiler

--- a/configure.ac
+++ b/configure.ac
@@ -302,7 +302,20 @@ AC_CONFIG_COMMANDS_PRE(OCAML_QUOTED_STRING_ID)
 
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
+# Allow "ocaml" to be used as the last component of the target triplet in case
+# we are using a custom toolchain for a freestanding target. To do so, the
+# target triplet is temporarily rewritten to "<arch>-none" to compute the
+# canonical target
+save_target_alias="$target_alias"
+AS_CASE([$target_alias],
+  [*-*-ocaml],
+    [ac_save_IFS=$IFS
+    IFS='-'
+    set x $target_alias
+    target_alias="$2-none"
+    IFS=$ac_save_IFS])
 AC_CANONICAL_TARGET
+target_alias="$save_target_alias"
 
 # Override cross_compiling and ac_tool_prefix variables since the C toolchain is
 # used to generate target code when building a cross compiler

--- a/configure.ac
+++ b/configure.ac
@@ -1169,7 +1169,9 @@ AS_CASE([$ocaml_cc_vendor,$target],
     [oc_ldflags='-brtl -bexpfull'
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [gcc-*,powerpc-*-linux*],
-    [oc_ldflags="-mbss-plt"])
+    [oc_ldflags="-mbss-plt"],
+  [*,*-*-none|*,*-*-elf*],
+    [ostype="None"])
 
 # How to build sak
 
@@ -1603,7 +1605,19 @@ AS_CASE([$target],
   [riscv64-*-linux*],
     [has_native_backend=yes; arch=riscv; model=riscv64; system=linux],
   [x86_64-*-gnu*],
-    [has_native_backend=yes; arch=amd64; system=gnu]
+    [has_native_backend=yes; arch=amd64; system=gnu],
+  [aarch64-*-none|arm64-*-none|aarch64-*-elf*|arm64-*-elf*],
+    [has_native_backend=yes; arch=arm64; system=none],
+  [powerpc64le*-*-none|powerpc64le*-*-elf*],
+    [has_native_backend=yes; arch=power; model=ppc64le; system=none],
+  [powerpc64*-*-none|powerpc64*-*-elf*],
+    [has_native_backend=yes; arch=power; model=ppc64; system=none],
+  [riscv64-*-none|riscv64-*-elf*],
+    [has_native_backend=yes; arch=riscv; model=riscv64; system=none],
+  [s390x*-*-none|s390x*-*-elf*],
+    [has_native_backend=yes; arch=s390x; model=z10; system=none],
+  [x86_64-*-none|x86_64-*-elf*],
+    [has_native_backend=yes; arch=amd64; system=none]
 )
 
 AS_CASE([$arch],


### PR DESCRIPTION
This PR is the last in my series of patches for cross compilation. It brings the last changes still needed to build a cross compiler to native freestanding targets, for instance to create MirageOS unikernels. It is just a matter of adding those use cases to the validation made by `configure`!

It contains:

- A commit to accept `*-none` and `*-elf*` target triplets in the configuration of the native-code compiler; I chose those suffixes by looking at what the `autoconf` validation script accepts and what I had the impression is commonly used (a bit biased by the C cross compilers packaged in Debian, maybe)
  - f0dccbb69f Accept native freestanding targets at configure time
- A commit to recognize `*-ocaml` target triplets as `*-none` ones when computing the canonical targets, so that one can use for instance the `x86_64-solo5-ocaml-*` prefix for a toolchain dedicated to building freestanding OCaml applications; this is inspired by the fact that `build-aux/config.sub` accepts triplets such as `x86_64-windows-msvc` or `javascript-unknown-ghcjs`
  - 6cd07149df Allow `*-ocaml` as target triplets to build freestanding cross compilers
- A commit to build a cross compiler to the Solo5 freestanding backend in CI to make sure that all the necessary patches have been upstreamed; this is not meant to be merged as it uses a created-just-for-that branch of `ocaml-solo5` to add C stubs that are necessary to build with `trunk` (but not for OCaml 5.2.1, which is the latest version currently supported by `ocaml-solo5`)
  - a3ffadfe80 DROPME Test the cross compiler to Solo5 in CI

The `run-crosscompiler-tests` label should be added to this PR to get the Solo5 test running in CI.