### PR TITLE
#13778: `module S with type t = int` uses type t

### DIFF
--- a/Changes
+++ b/Changes
@@ -406,6 +406,10 @@ Working version
 - #13763: Track type of variables bound by as-patterns
   (Leo White, review by Gabriel Scherer, port by Vincent Laviron)
 
+- #13778, #13811: do not warn for unused type declarations when the type is used
+  in a first-class module type (`module S with type t = int)`.
+  (Florian Angeletti, report by Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 - #13790: Fix bytecode-only build of Cygwin when flexlink is being bootstrapped
   with the compiler.
   (David Allsopp, review by Antonin Décimo and Miod Vallat)

--- a/testsuite/tests/typing-modules/package_constraint.ml
+++ b/testsuite/tests/typing-modules/package_constraint.ml
@@ -239,3 +239,14 @@ Line 1, characters 13-61:
 Error: In the constrained signature, type "t" is defined to be "[< `A ]".
        Package "with" constraints may only be used on abstract types.
 |}]
+
+(** Issue 13778: constraining a type should count as using it *)
+module X: sig
+  type t
+end = struct
+  module type S = sig type s end
+  type t = (module S with type s = int)
+end
+[%%expect {|
+module X : sig type t end
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -570,6 +570,7 @@ let merge_constraint initial_env loc sg lid constr =
         | Some ty ->
           raise (Error(loc, outer_sig_env, With_package_manifest (lid.txt, ty)))
         end;
+        Env.mark_type_used sig_decl.type_uid;
         let tdecl =
           Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
         in


### PR DESCRIPTION
This small PR fixes a point that I had missed when reviewing #12930 : a constrained type in first-class module types should be marked as used. 
This one line patch fixes #13778 .