### PR TITLE
Fix forgotten check on validity of a type variable name

### DIFF
--- a/Changes
+++ b/Changes
@@ -407,6 +407,10 @@ Working version
   with the compiler.
   (David Allsopp, review by Antonin Décimo and Miod Vallat)
 
+- #XXXXX: Add forgotten check about the validity of the type variable name on
+  the right-hand side of `_ as _`.
+  (Samuel Vivien, review by ...)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/Changes
+++ b/Changes
@@ -407,9 +407,9 @@ Working version
   with the compiler.
   (David Allsopp, review by Antonin Décimo and Miod Vallat)
 
-- #XXXXX: Add forgotten check about the validity of the type variable name on
+- #13812: Add forgotten check about the validity of the type variable name on
   the right-hand side of `_ as _`.
-  (Samuel Vivien, review by ...)
+  (Samuel Vivien, review by Gabriel Scherer)
 
 OCaml 5.3.0 (8 January 2025)
 ----------------------------

--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -32,6 +32,14 @@ Line 1, characters 6-9:
 Error: The type variable name "'_a" is not allowed in programs
 |}]
 
+type underscored_bis = (int -> int as '_a)
+[%%expect{|
+Line 1, characters 38-41:
+1 | type underscored_bis = (int -> int as '_a)
+                                          ^^^
+Error: The type variable name "'_a" is not allowed in programs
+|}]
+
 (* The next two hit the unification error case at the end of
    Typetexp.globalize_used_variables. *)
 let f (x: int as 'a) (y: float as 'a) = (x,y)

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -518,6 +518,9 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
   | Ptyp_alias(st, alias) ->
       let cty =
         try
+          if not (valid_tyvar_name alias.txt) then
+            raise (Error (alias.loc, env,
+              Invalid_variable_name ("'" ^ alias.txt)));
           let t = TyVarEnv.lookup_local ~row_context alias.txt in
           let ty = transl_type env ~policy ~aliased:true ~row_context st in
           begin try unify_var env t ty.ctyp_type with Unify err ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -369,6 +369,10 @@ let newvar ?name () =
 let valid_tyvar_name name =
   name <> "" && name.[0] <> '_'
 
+let check_tyvar_name env loc name =
+  if not (valid_tyvar_name name) then
+    raise (Error (loc, env, Invalid_variable_name ("'" ^ name)))
+
 let transl_type_param env styp =
   let loc = styp.ptyp_loc in
   match styp.ptyp_desc with
@@ -378,8 +382,7 @@ let transl_type_param env styp =
           ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
   | Ptyp_var name ->
       let ty =
-          if not (valid_tyvar_name name) then
-            raise (Error (loc, Env.empty, Invalid_variable_name ("'" ^ name)));
+          check_tyvar_name Env.empty loc name;
           if TyVarEnv.is_in_scope name then
             raise Already_bound;
           let v = new_global_var ~name () in
@@ -420,8 +423,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       ctyp Ttyp_any ty
   | Ptyp_var name ->
     let ty =
-      if not (valid_tyvar_name name) then
-        raise (Error (styp.ptyp_loc, env, Invalid_variable_name ("'" ^ name)));
+      check_tyvar_name env styp.ptyp_loc name;
       begin try
         TyVarEnv.lookup_local ~row_context:row_context name
       with Not_found ->
@@ -518,9 +520,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
   | Ptyp_alias(st, alias) ->
       let cty =
         try
-          if not (valid_tyvar_name alias.txt) then
-            raise (Error (alias.loc, env,
-              Invalid_variable_name ("'" ^ alias.txt)));
+          check_tyvar_name env alias.loc alias.txt;
           let t = TyVarEnv.lookup_local ~row_context alias.txt in
           let ty = transl_type env ~policy ~aliased:true ~row_context st in
           begin try unify_var env t ty.ctyp_type with Unify err ->


### PR DESCRIPTION
In an `_ as _` constraint the code didn't check if the type variable name was valid.

As such we could write the following function.

```ocaml
let f1 (y : int as '_a) x = 3
```

However the next one was rejected because `The type variable name "'_a" is not allowed in programs`.

```ocaml
let f2 (y : int as '_a) (x : '_a) = 3
```

This PR fixes this problem by adding the omitted test.