### PR TITLE
Add an unused warning on certain type variables

### DIFF
--- a/.depend
+++ b/.depend
@@ -2204,6 +2204,7 @@ typing/types.cmi : \
     typing/ident.cmi \
     parsing/asttypes.cmi
 typing/typetexp.cmo : \
+    utils/warnings.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/printtyp.cmi \
@@ -2227,6 +2228,7 @@ typing/typetexp.cmo : \
     parsing/ast_helper.cmi \
     typing/typetexp.cmi
 typing/typetexp.cmx : \
+    utils/warnings.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/printtyp.cmx \

--- a/Changes
+++ b/Changes
@@ -322,6 +322,10 @@ Working version
   change locations of error messages when `S` is ill-typed in `(module S)`
   (Samuel Vivien, review by Florian Angeletti and Gabriel Scherer)
 
+- #13814: Add an `unused-type-declaration` when using a `t as 'a` with no other
+  occurences of `'a`
+  (Samuel Vivien, review by Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #13314: Comment the code of Translclass

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -679,12 +679,12 @@ let f (x1 : int as 'unused1) (x2 : int as 'unused2)
 Line 1, characters 19-27:
 1 | let f (x1 : int as 'unused1) (x2 : int as 'unused2)
                        ^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type "'unused1".
+Warning 34 [unused-type-declaration]: unused type alias "'unused1".
 
 Line 1, characters 42-50:
 1 | let f (x1 : int as 'unused1) (x2 : int as 'unused2)
                                               ^^^^^^^^
-Warning 34 [unused-type-declaration]: unused type "'unused2".
+Warning 34 [unused-type-declaration]: unused type alias "'unused2".
 
 val f : int -> int -> int -> int -> 'used2 -> int * int * int * int * 'used2 =
   <fun>

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -676,14 +676,14 @@ let f (x1 : int as 'unused1) (x2 : int as 'unused2)
       (x3 : int as 'used1) (x4 : 'used1) (x5 : 'used2) = (x1, x2, x3, x4, x5)
 
 [%%expect{|
-Line 1, characters 12-27:
+Line 1, characters 19-27:
 1 | let f (x1 : int as 'unused1) (x2 : int as 'unused2)
-                ^^^^^^^^^^^^^^^
+                       ^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type "'unused1".
 
-Line 1, characters 35-50:
+Line 1, characters 42-50:
 1 | let f (x1 : int as 'unused1) (x2 : int as 'unused2)
-                                       ^^^^^^^^^^^^^^^
+                                              ^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type "'unused2".
 
 val f : int -> int -> int -> int -> 'used2 -> int * int * int * int * 'used2 =

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -671,3 +671,21 @@ Warning 34 [unused-type-declaration]: unused type "unused2".
 
 val f : 'a -> 'a = <fun>
 |}]
+
+let f (x1 : int as 'unused1) (x2 : int as 'unused2)
+      (x3 : int as 'used1) (x4 : 'used1) (x5 : 'used2) = (x1, x2, x3, x4, x5)
+
+[%%expect{|
+Line 1, characters 12-27:
+1 | let f (x1 : int as 'unused1) (x2 : int as 'unused2)
+                ^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type "'unused1".
+
+Line 1, characters 35-50:
+1 | let f (x1 : int as 'unused1) (x2 : int as 'unused2)
+                                       ^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type "'unused2".
+
+val f : int -> int -> int -> int -> 'used2 -> int * int * int * int * 'used2 =
+  <fun>
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2004,7 +2004,7 @@ and store_type ~check id info shape env =
   let loc = info.type_loc in
   if check then
     check_usage loc id info.type_uid
-      (fun s -> Warnings.Unused_type_declaration s)
+      (fun s -> Warnings.Unused_type_declaration (s, Warnings.Declaration))
       !type_declarations;
   let descrs, env =
     let path = Pident id in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1125,7 +1125,7 @@ let transl_type_decl env rec_flag sdecl_list =
       (* Translate each declaration. *)
       let current_slot = ref None in
       let warn_unused =
-        Warnings.is_active (Warnings.Unused_type_declaration "") in
+        Warnings.(is_active (Unused_type_declaration ("", Declaration))) in
       let ids_slots (id, _uid as ids) =
         match rec_flag with
         | Asttypes.Recursive when warn_unused ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -281,10 +281,11 @@ end = struct
     assert (not_generic v);
     let unused = match check with
       | Some check_loc
-          when Warnings.is_active (Warnings.Unused_type_declaration "") ->
+          when Warnings.(is_active (Unused_type_declaration ("", Alias))) ->
         let unused = ref true in
         !Env.add_delayed_check_forward begin fun () ->
-            let warn = Warnings.Unused_type_declaration ("'" ^ name) in
+            let warn = Warnings.(Unused_type_declaration ("'" ^ name, Alias))
+            in
             if !unused && Warnings.is_active warn
             then Location.prerr_warning check_loc warn
           end;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -57,7 +57,7 @@ module TyVarEnv : sig
 
   val is_in_scope : string -> bool
 
-  val add : string -> type_expr -> unit
+  val add : check:bool -> Location.t -> string -> type_expr -> unit
   (* add a global type variable to the environment *)
 
   val with_local_scope : (unit -> 'a) -> 'a
@@ -104,7 +104,7 @@ module TyVarEnv : sig
     row_context:type_expr option ref list -> string -> type_expr
     (* look up a local type variable; throws Not_found if it isn't in scope *)
 
-  val remember_used : string -> type_expr -> Location.t -> unit
+  val remember_used : check:bool -> string -> type_expr -> Location.t -> unit
     (* remember that a given name is bound to a given type *)
 
   val globalize_used_variables : policy -> Env.t -> unit -> unit
@@ -127,13 +127,13 @@ end = struct
   (* These are the "global" type variables: they were in scope before
      we started processing the current type.
   *)
-  let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
+  let type_variables = ref (TyVarMap.empty : (type_expr * bool ref) TyVarMap.t)
 
   (* These are variables that have been used in the currently-being-checked
      type.
   *)
   let used_variables =
-    ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+    ref (TyVarMap.empty : (type_expr * Location.t * bool ref) TyVarMap.t)
 
   (* These are variables we expect to become univars (they were introduced with
      e.g. ['a .]), but we need to make sure they don't unify first.  Why not
@@ -165,9 +165,16 @@ end = struct
   let is_in_scope name =
     TyVarMap.mem name !type_variables
 
-  let add name v =
+  let add ~check loc name v =
     assert (not_generic v);
-    type_variables := TyVarMap.add name v !type_variables
+    let unused = ref check in
+    if check then
+      !Env.add_delayed_check_forward begin fun () ->
+          let warn = Warnings.Unused_type_declaration ("'" ^ name) in
+          if !unused && Warnings.is_active warn
+          then Location.prerr_warning loc warn
+        end;
+    type_variables := TyVarMap.add name (v, unused) !type_variables
 
   let narrow () =
     (increase_global_level (), !type_variables)
@@ -184,7 +191,9 @@ end = struct
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_global_type_variable name =
-    TyVarMap.find name !type_variables
+    let (v, unused) = TyVarMap.find name !type_variables in
+    unused := false;
+    v
 
   let get_in_scope_names () =
     let add_name name _ l =
@@ -267,14 +276,16 @@ end = struct
       associate row_context p;
       p.univar
     with Not_found ->
-      instance (fst (TyVarMap.find name !used_variables))
+      let (v, _, unused) = TyVarMap.find name !used_variables in
+      unused := false;
+      instance v
       (* This call to instance might be redundant; all variables
          inserted into [used_variables] are non-generic, but some
          might get generalized. *)
 
-  let remember_used name v loc =
+  let remember_used ~check name v loc =
     assert (not_generic v);
-    used_variables := TyVarMap.add name (v, loc) !used_variables
+    used_variables := TyVarMap.add name (v, loc, ref check) !used_variables
 
 
   type flavor = Unification | Universal
@@ -309,7 +320,7 @@ end = struct
   let globalize_used_variables { flavor; extensibility } env =
     let r = ref [] in
     TyVarMap.iter
-      (fun name (ty, loc) ->
+      (fun name (ty, loc, c) ->
         if flavor = Unification || is_in_scope name then
           let v = new_global_var () in
           let snap = Btype.snapshot () in
@@ -327,7 +338,7 @@ end = struct
                                                  get_in_scope_names ())));
             let v2 = new_global_var () in
             r := (loc, v, v2) :: !r;
-            add name v2)
+            add ~check:!c loc name v2)
       !used_variables;
     used_variables := TyVarMap.empty;
     fun () ->
@@ -386,7 +397,7 @@ let transl_type_param env styp =
           if TyVarEnv.is_in_scope name then
             raise Already_bound;
           let v = new_global_var ~name () in
-          TyVarEnv.add name v;
+          TyVarEnv.add ~check:false loc name v;
           v
       in
         { ctyp_desc = Ttyp_var name; ctyp_type = ty; ctyp_env = env;
@@ -428,7 +439,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         TyVarEnv.lookup_local ~row_context:row_context name
       with Not_found ->
         let v = TyVarEnv.new_var ~name policy in
-        TyVarEnv.remember_used name v styp.ptyp_loc;
+        TyVarEnv.remember_used ~check:false name v styp.ptyp_loc;
         v
       end
     in
@@ -533,7 +544,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
             with_local_level_generalize_structure_if_principal begin fun () ->
               let t = newvar () in
               (* Use the whole location, which is used by [Type_mismatch]. *)
-              TyVarEnv.remember_used alias.txt t styp.ptyp_loc;
+              TyVarEnv.remember_used ~check:true alias.txt t styp.ptyp_loc;
               let ty = transl_type env ~policy ~row_context st in
               begin try unify_var env t ty.ctyp_type with Unify err ->
                 let err = Errortrace.swap_unification_error err in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -280,8 +280,8 @@ end = struct
   let remember_used ?check name v loc =
     assert (not_generic v);
     let unused = match check with
-      | None -> ref false
-      | Some check_loc ->
+      | Some check_loc
+          when Warnings.is_active (Warnings.Unused_type_declaration "") ->
         let unused = ref true in
         !Env.add_delayed_check_forward begin fun () ->
             let warn = Warnings.Unused_type_declaration ("'" ^ name) in
@@ -289,6 +289,7 @@ end = struct
             then Location.prerr_warning check_loc warn
           end;
         unused
+      | _ -> ref false
     in
     used_variables := TyVarMap.add name (v, loc, unused) !used_variables
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -34,6 +34,10 @@ type constructor_usage_warning =
   | Not_constructed
   | Only_exported_private
 
+type type_declaration_usage_warning =
+  | Declaration
+  | Alias
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -69,7 +73,7 @@ type t =
      was turned into a hard error *)
   | Unused_value_declaration of string      (* 32 *)
   | Unused_open of string                   (* 33 *)
-  | Unused_type_declaration of string       (* 34 *)
+  | Unused_type_declaration of string * type_declaration_usage_warning (* 34 *)
   | Unused_for_index of string              (* 35 *)
   | Unused_ancestor of string               (* 36 *)
   | Unused_constructor of string * constructor_usage_warning (* 37 *)
@@ -1011,7 +1015,10 @@ let message = function
       msg "unused value %a." Style.inline_code v
   | Unused_open s -> msg "unused open %a." Style.inline_code s
   | Unused_open_bang s -> msg "unused open! %a." Style.inline_code s
-  | Unused_type_declaration s -> msg "unused type %a." Style.inline_code s
+  | Unused_type_declaration (s, Declaration) ->
+      msg "unused type %a." Style.inline_code s
+  | Unused_type_declaration (s, Alias) ->
+      msg "unused type alias %a." Style.inline_code s
   | Unused_for_index s -> msg "unused for-loop index %a." Style.inline_code s
   | Unused_ancestor s -> msg "unused ancestor variable %a." Style.inline_code s
   | Unused_constructor (s, Unused) ->

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -39,6 +39,10 @@ type constructor_usage_warning =
   | Not_constructed
   | Only_exported_private
 
+type type_declaration_usage_warning =
+  | Declaration
+  | Alias
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -76,7 +80,7 @@ type t =
   | Duplicate_definitions of string * string * string * string (* 30 *)
   | Unused_value_declaration of string      (* 32 *)
   | Unused_open of string                   (* 33 *)
-  | Unused_type_declaration of string       (* 34 *)
+  | Unused_type_declaration of string * type_declaration_usage_warning (* 34 *)
   | Unused_for_index of string              (* 35 *)
   | Unused_ancestor of string               (* 36 *)
   | Unused_constructor of string * constructor_usage_warning (* 37 *)


### PR DESCRIPTION
The `t as 'a` pattern allows to create a local name for a type `t` in order to avoid rewriting a same name multiple times.

For example :
```ocaml
let f (x : a:int -> b:bool -> float as 'a) (y : 'a) = ...
```

This is also useful when writing code using recursive types such as `(int -> 'a) as 'a`.

As such using an `_  as _` without ever reusing the type variable on the right hand side is most likely an error from the programmer. This PR thus raises a warning in cases such as.

```ocaml
let f (x : a:int -> b:bool -> float as 'a) y = ...
```

This check can easily be extended to handle more cases :

- Putting a type annotation that creates a never reused unification variable
```ocaml
(* 'a appears only once *)
let f (x : 'a) = x + 1
```

- Parametric type declaration such as `t1` because people could write `t2`. However adding this warning would break the standard library
```ocaml
type 'a t1 = unit
type _ t2 = unit
```
