### PR TITLE
Skip running native debugger tests when TSan is enabled.

### DIFF
--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    arch_amd64;
    script = "sh ${test_source_directory}/has_gdb.sh";

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    arch_arm64;
    script = "sh ${test_source_directory}/has_gdb.sh";

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.ml
@@ -1,6 +1,7 @@
 (* TEST
    native-compiler;
    linux;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    arch_riscv;
    script = "sh ${test_source_directory}/has_gdb.sh";
    script;

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    arch_amd64;
    script = "sh ${test_source_directory}/has_lldb.sh linux";

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    arch_arm64;
    script = "sh ${test_source_directory}/has_lldb.sh linux";

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    macos;
    arch_amd64;
    script = "sh ${test_source_directory}/has_lldb.sh macos";

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    macos;
    arch_arm64;
    script = "sh ${test_source_directory}/has_lldb.sh macos";


### PR DESCRIPTION
Using TSan adds extra frames into backtraces as part of the design of this feature. For now disable these tests with TSan, it would be possible in future to modify these tests to handle this combination.

Fixes #13799 cc @OlivierNicole 

