### PR TITLE
Fix field initialisation bug in runtime_events.c.

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ Working version
 
 ### Runtime system:
 
+- #13819: Fix field initialisation bug in runtime events subsystem.
+  (Nick Barnes, review by Gabriel Scherer).
+
 - #13785: Add `Runtime_events.Timestamp.get_current`.
   (Simon Cruanes)
 


### PR DESCRIPTION
`caml_ml_runtime_events_path` was calling `caml_copy_string_of_os` while there was an uninitialised field in a newly-allocated block (`res = caml_alloc_small(1, Tag_some)`).

@mshinwell found this while reviewing my port of #13419 as part of ocaml-flambda/flambda-backend#3596.