### PR TITLE
Print warning when set thread name fails.

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -18,6 +18,8 @@
 #define _GNU_SOURCE /* helps to find pthread_setname_np() */
 #include "caml/config.h"
 
+#include <string.h>
+
 #if defined(_WIN32)
 #  include <windows.h>
 #  include <processthreadsapi.h>
@@ -978,6 +980,13 @@ static st_retcode caml_threadstatus_wait (value wrapper)
   CAMLreturnT(st_retcode, retcode);
 }
 
+#define caml_set_current_thread_name_warning(w) { \
+  if (caml_runtime_warnings_active()) { \
+    fprintf(stderr, "Could not set thread name: %s\n", w); \
+    fflush(stderr); \
+  } \
+}
+
 /* Set the current thread's name. */
 CAMLprim value caml_set_current_thread_name(value name)
 {
@@ -985,33 +994,40 @@ CAMLprim value caml_set_current_thread_name(value name)
 
 #  if defined(HAS_SETTHREADDESCRIPTION)
   wchar_t *thread_name = caml_stat_strdup_to_utf16(String_val(name));
-  SetThreadDescription(GetCurrentThread(), thread_name);
+  HRESULT hr = SetThreadDescription(GetCurrentThread(), thread_name);
   caml_stat_free(thread_name);
+  if (FAILED(hr))
+    caml_set_current_thread_name_warning(strerror(HRESULT_CODE(hr)));
 #  endif
 
 #  if defined(HAS_PTHREAD_SETNAME_NP)
   // We are using both methods.
   // See: https://github.com/ocaml/ocaml/pull/13504#discussion_r1786358928
-  pthread_setname_np(pthread_self(), String_val(name));
+  int ret = pthread_setname_np(pthread_self(), String_val(name));
+  if (ret != 0) caml_set_current_thread_name_warning(strerror(ret));
 #  endif
 
 #elif defined(HAS_PRCTL)
-  prctl(PR_SET_NAME, String_val(name));
+  int ret = prctl(PR_SET_NAME, String_val(name));
+  if (ret == -1) caml_set_current_thread_name_warning(strerror(errno));
 #elif defined(HAS_PTHREAD_SETNAME_NP)
 #  if defined(__APPLE__)
+  // Darwin implementation does not return any error code.
   pthread_setname_np(String_val(name));
 #  elif defined(__NetBSD__)
-  pthread_setname_np(pthread_self(), "%s", String_val(name));
+  int ret = pthread_setname_np(pthread_self(), "%s", String_val(name));
+  if (ret != 0) caml_set_current_thread_name_warning(strerror(ret));
 #  else
-  pthread_setname_np(pthread_self(), String_val(name));
+  // Both linux and freebsd document return value as 0 or error
+  // code.
+  int ret = pthread_setname_np(pthread_self(), String_val(name));
+  if (ret != 0) caml_set_current_thread_name_warning(strerror(ret));
 #  endif
 #elif defined(HAS_PTHREAD_SET_NAME_NP)
+  // pthread_set_name_np seems to be the no-error alternative.
   pthread_set_name_np(pthread_self(), String_val(name));
 #else
-  if (caml_runtime_warnings_active()) {
-    fprintf(stderr, "set thread name not implemented\n");
-    fflush(stderr);
-  }
+  caml_set_current_thread_name_warning("set thread name not implemented");
 #endif
 
   return Val_unit;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -981,7 +981,7 @@ static st_retcode caml_threadstatus_wait (value wrapper)
 #define caml_set_current_thread_name_warning(w)                                \
   do {                                                                         \
     if (caml_runtime_warnings_active()) {                                      \
-      fprintf(stderr, "Error while setting thread name: %s\n", w);             \
+      fprintf(stderr, "[ocaml] error while setting thread name: %s\n", w);     \
       fflush(stderr);                                                          \
     }                                                                          \
   } while (0)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -980,12 +980,12 @@ static st_retcode caml_threadstatus_wait (value wrapper)
   CAMLreturnT(st_retcode, retcode);
 }
 
-#define caml_set_current_thread_name_warning(w) { \
-  if (caml_runtime_warnings_active()) { \
-    fprintf(stderr, "Could not set thread name: %s\n", w); \
-    fflush(stderr); \
-  } \
-}
+#define caml_set_current_thread_name_warning(w) do {            \
+  if (caml_runtime_warnings_active()) {                         \
+    fprintf(stderr, "Could not set thread name: %s\n", w);      \
+    fflush(stderr);                                             \
+  }                                                             \
+} while (0)
 
 /* Set the current thread's name. */
 CAMLprim value caml_set_current_thread_name(value name)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -18,8 +18,6 @@
 #define _GNU_SOURCE /* helps to find pthread_setname_np() */
 #include "caml/config.h"
 
-#include <string.h>
-
 #if defined(_WIN32)
 #  include <windows.h>
 #  include <processthreadsapi.h>
@@ -980,48 +978,57 @@ static st_retcode caml_threadstatus_wait (value wrapper)
   CAMLreturnT(st_retcode, retcode);
 }
 
-#define caml_set_current_thread_name_warning(w) do {            \
-  if (caml_runtime_warnings_active()) {                         \
-    fprintf(stderr, "Could not set thread name: %s\n", w);      \
-    fflush(stderr);                                             \
-  }                                                             \
-} while (0)
+#define caml_set_current_thread_name_warning(w)                                \
+  do {                                                                         \
+    if (caml_runtime_warnings_active()) {                                      \
+      fprintf(stderr, "Error while setting thread name: %s\n", w);             \
+      fflush(stderr);                                                          \
+    }                                                                          \
+  } while (0)
 
 /* Set the current thread's name. */
 CAMLprim value caml_set_current_thread_name(value name)
 {
 #if defined(_WIN32)
-
 #  if defined(HAS_SETTHREADDESCRIPTION)
   wchar_t *thread_name = caml_stat_strdup_to_utf16(String_val(name));
   HRESULT hr = SetThreadDescription(GetCurrentThread(), thread_name);
   caml_stat_free(thread_name);
   if (FAILED(hr))
-    caml_set_current_thread_name_warning(strerror(HRESULT_CODE(hr)));
+    caml_set_current_thread_name_warning("SetThreadDescription failed!");
 #  endif
 
 #  if defined(HAS_PTHREAD_SETNAME_NP)
   // We are using both methods.
   // See: https://github.com/ocaml/ocaml/pull/13504#discussion_r1786358928
+  char buf[1024];
   int ret = pthread_setname_np(pthread_self(), String_val(name));
-  if (ret != 0) caml_set_current_thread_name_warning(strerror(ret));
+  if (ret != 0)
+    caml_set_current_thread_name_warning(caml_strerror(ret, buf, sizeof(buf)));
 #  endif
 
 #elif defined(HAS_PRCTL)
+  char buf[1024];
   int ret = prctl(PR_SET_NAME, String_val(name));
-  if (ret == -1) caml_set_current_thread_name_warning(strerror(errno));
+  if (ret == -1)
+    caml_set_current_thread_name_warning(
+      caml_strerror(errno, buf, sizeof(buf)));
 #elif defined(HAS_PTHREAD_SETNAME_NP)
 #  if defined(__APPLE__)
   // Darwin implementation does not return any error code.
   pthread_setname_np(String_val(name));
 #  elif defined(__NetBSD__)
+  char buf[1024];
   int ret = pthread_setname_np(pthread_self(), "%s", String_val(name));
-  if (ret != 0) caml_set_current_thread_name_warning(strerror(ret));
+  if (ret != 0)
+    caml_set_current_thread_name_warning(caml_strerror(ret, buf, sizeof(buf)));
 #  else
+  char buf[1024];
   // Both linux and freebsd document return value as 0 or error
   // code.
   int ret = pthread_setname_np(pthread_self(), String_val(name));
-  if (ret != 0) caml_set_current_thread_name_warning(strerror(ret));
+  if (ret != 0)
+    caml_set_current_thread_name_warning(caml_strerror(ret, buf, sizeof(buf)));
 #  endif
 #elif defined(HAS_PTHREAD_SET_NAME_NP)
   // pthread_set_name_np seems to be the no-error alternative.

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -52,6 +52,8 @@ val set_current_thread_name : string -> unit
     This does nothing if the functionality is not implemented but will
     print a warning on the standard error if enabled.
 
+    Likewise, a warning is printed if the operation fails.
+
     @since 5.4 *)
 
 exception Exit

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -682,7 +682,7 @@ void caml_gc_log (const char *, ...)
 
 /* Runtime warnings */
 extern uintnat caml_runtime_warnings;
-int caml_runtime_warnings_active(void);
+CAMLextern int caml_runtime_warnings_active(void);
 
 #ifdef DEBUG
 #ifdef ARCH_SIXTYFOUR

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -261,7 +261,7 @@ CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 uintnat caml_runtime_warnings = 0;
 static int caml_runtime_warnings_first = 1;
 
-int caml_runtime_warnings_active(void)
+CAMLextern int caml_runtime_warnings_active(void)
 {
   if (!caml_runtime_warnings) return 0;
   if (caml_runtime_warnings_first) {


### PR DESCRIPTION
This is a follow-up to https://github.com/ocaml/ocaml/pull/13504

It turns out that platforms such as linux have a hard-coded maximum of `16` characters for thread names.

I just spent a _lot_ of time trying to understand why my threads were no longer properly named until I found this out.

This should spare any other dev the same waste of time..