### PR TITLE
Avoid re-marking ephemerons with trivial data

### DIFF
--- a/Changes
+++ b/Changes
@@ -103,6 +103,10 @@ Working version
   (Tim McGilchrist, review by Nick Barnes, Antonin Décimo,
    Stephen Dolan and Miod Vallat)
 
+- #13827: Avoid re-marking ephemerons with trivial data.
+  (Stephen Dolan, review by Nick Barnes and Josh Berdine, benchmarking by
+   Nicolás Ojeda Bär)
+
 ### Code generation and optimizations:
 
 * #13050: Use '$' instead of '.' to separate module names in symbol names.

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -318,7 +318,7 @@ static intnat ephe_mark (intnat budget, uintnat for_cycle,
   mlsize_t size, i;
   caml_domain_state* domain_state = Caml_state;
   int alive_data;
-  intnat marked = 0, made_live = 0;
+  intnat marked = 0, trivial_data = 0, made_live = 0;
 
   if (domain_state->ephe_info->cursor.cycle == for_cycle &&
       !force_alive) {
@@ -368,17 +368,30 @@ static intnat ephe_mark (intnat budget, uintnat for_cycle,
     }
     budget -= Whsize_wosize(i);
 
-    if (force_alive || alive_data) {
-      if (data != caml_ephe_none && Is_block(data)) {
-        caml_darken (domain_state, data, 0);
-      }
+    bool keep;
+    if (data == caml_ephe_none || Is_long(data)) {
+      /* Not yet known whether this ephemeron's keys/block will be marked,
+         but since the data is trivial nothing will happen if they are,
+         so remove it from the todo list */
+      trivial_data++;
+      keep = false;
+    } else if (force_alive || alive_data) {
+      /* This ephemeron's keys & block are marked, so mark the data,
+         and remove it from the todo list */
+      caml_darken (domain_state, data, 0);
+      made_live++;
+      keep = false;
+    } else {
+      /* Leave this ephemeron on the todo list */
+      keep = true;
+    }
+
+    if (keep) {
+      prev_linkp = &Ephe_link(v);
+    } else {
       Ephe_link(v) = domain_state->ephe_info->live;
       domain_state->ephe_info->live = v;
       *prev_linkp = todo;
-      made_live++;
-    } else {
-      /* Leave this ephemeron on the todo list */
-      prev_linkp = &Ephe_link(v);
     }
     marked++;
   }
@@ -386,10 +399,11 @@ static intnat ephe_mark (intnat budget, uintnat for_cycle,
   caml_gc_log
   ("Mark Ephemeron: %s. Ephemeron cycle=%"ARCH_INTNAT_PRINTF_FORMAT"d "
    "examined=%"ARCH_INTNAT_PRINTF_FORMAT"d "
+   "trivial_data=%"ARCH_INTNAT_PRINTF_FORMAT"d "
    "marked=%"ARCH_INTNAT_PRINTF_FORMAT"d",
    domain_state->ephe_info->cursor.cycle == for_cycle ?
      "Continued from cursor" : "Discarded cursor",
-   for_cycle, marked, made_live);
+   for_cycle, marked, trivial_data, made_live);
 
   domain_state->ephe_info->cursor.cycle = for_cycle;
   domain_state->ephe_info->cursor.todop = prev_linkp;


### PR DESCRIPTION
In general, ephemerons may need to be marked more than once, if new marking has occurred since ephemeron marking began. This patch optimises this logic: re-marking is never necessary if the data field of the ephemeron is trivial. This optimisation was present in OCaml 4, and is important for Stdlib.Weak, which only uses ephemerons with trivial data.

This means that programs using `Weak` will only do one pass over the ephemeron set, since the ephemerons backing weak tables will be removed from the todo list once they are scanned.

cc @nojb who's interested in testing this: could you report the `OCAMLRUNPARAM=v=0xfff` GC logs on your test case before and after this patch, as well as timings?