### PR TITLE
Tweak the reproducibility of cmt{,i} format

### DIFF
--- a/Changes
+++ b/Changes
@@ -421,6 +421,10 @@ Working version
   parser is modified too to accept `+-` and `-+` as `type_variance`.
   (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
 
+- #13828: Apply BUILD_PATH_PREFIX_MAP to Sys.argv.(0) before storing it in .cmt
+  and .cmti files.
+  (David Allsopp, review by Daniel Bünzli and Gabriel Scherer)
+
 - #13848: Add all paths components to the cmt files indexes
   (Ulysse Gérard, review by Florian Angeletti)
 

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -477,12 +477,16 @@ let save_cmt target binary_annots initial_env cmi shape =
          let cmt_annots = clear_env binary_annots in
          let cmt_uid_to_decl = index_declarations cmt_annots in
          let source_digest = Option.map Digest.file sourcefile in
+         let cmt_args =
+           let cmt_args = Array.copy Sys.argv in
+           cmt_args.(0) <- Location.rewrite_absolute_path Sys.argv.(0);
+           cmt_args in
          let cmt = {
            cmt_modname = Unit_info.Artifact.modname target;
            cmt_annots;
            cmt_declaration_dependencies = !uids_deps;
            cmt_comments = Lexer.comments ();
-           cmt_args = Sys.argv;
+           cmt_args;
            cmt_sourcefile = sourcefile;
            cmt_builddir = Location.rewrite_absolute_path (Sys.getcwd ());
            cmt_loadpath = Load_path.get_paths ();

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -57,6 +57,8 @@ type cmt_infos = {
   cmt_declaration_dependencies : (dependency_kind * Uid.t * Uid.t) list;
   cmt_comments : (string * Location.t) list;
   cmt_args : string array;
+    (** {!Sys.argv} from the compiler invocation which created the file.
+        [Sys.argv.(0)] is rewritten using [BUILD_PATH_PREFIX_MAP]. *)
   cmt_sourcefile : string option;
   cmt_builddir : string;
   cmt_loadpath : Load_path.paths;


### PR DESCRIPTION
In amongst the various kitchen sinks which are put into cmt files, `Cmt_format.cmt_infos.cmt_args` includes a copy of `Sys.argv` from the compiler invocation. The user is in control of the arguments passed to a binary (`Sys.argv.(1)` and above) and can avoid embedding absolute paths, but `Sys.argv.(0)` on some platforms is converted to an absolute path, regardless of how the executable was invoked. In particular, when a Cygwin shell invokes a native Windows executable, `argv[0]` will always be the Windows absolute path[^1], thus on most platforms we record `../ocamlc.opt` but for mingw-w64 and MSVC we get `C:\path\to\build\ocamlc.opt.exe` instead.

This PR simply passes `Sys.argv.(0)` through `Filename.basename` and, while there, strips off any `.exe` as well. I've suggest doing this, rather than using `Location.rewrite_absolute_path`, because it's beyond our control whether `Sys.argv.(0)` is an absolute path or a relative path, so it seems more reproducible to strip it. More complex schemes are possible, but...

I did a quick check on GitHub search for uses of `cmt_args` - mostly, `cmt_args` is just printed for information or the list is being searched for the presence of a flag. The one place I found an actual use of `cmt_args` to _run_ the command, as expected, `cmt_args.(0)` is ignored, cf. [camlspotter/ocamloscope/oCamlDoc.ml#L133-L140](https://github.com/camlspotter/ocamloscope/blob/8e195157140f4f47ce1765f6f0250b33cee5ae62/oCamlDoc.ml#L133-L140):

```ocaml
  match filter_cmd & Array.to_list cmt.Cmt_format.cmt_args with
  | _com :: opts ->
      let dest = Filename.temp_file "ocamldoc" ".bin" in
      let command = 
        (* <:s<(ocamlc|ocamlopt)(\.opt)?/ocamldoc.opt>> com *)
        "ocamldoc.opt" :: opts
        @ [ (* "-v"; *) "-no-stop"; (* "-html"; *) "-dump"; dest ]
      in
```

My interest in this is that the testsuite for Relocatable OCaml includes a reproducibility check, which is being hampered specifically by the .cmt and .cmti files which are compiled by either `ocamlc.opt` and `ocamlopt.opt`, which causes the build path to be embedded (the files produced by the bytecode version of each compiler are invoked using `ocamlrun ../ocamlc`, and so `Sys.argv.(0)` is not changed by Cygwin).

[^1]: Cygwin does this on purpose and for good reasons, although in our specific case in the compiler's build, it _could_ choose to do something more complicated and determine that it can leave `argv[0]` alone