### PR TITLE
Removed abstraction of module types when a field triggers avoidance

### DIFF
--- a/.depend
+++ b/.depend
@@ -1090,7 +1090,6 @@ typing/mtype.cmo : \
     typing/types.cmi \
     typing/subst.cmi \
     typing/path.cmi \
-    parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1102,7 +1101,6 @@ typing/mtype.cmx : \
     typing/types.cmx \
     typing/subst.cmx \
     typing/path.cmx \
-    parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
     typing/ctype.cmx \

--- a/Changes
+++ b/Changes
@@ -1227,8 +1227,16 @@ OCaml 5.3.0 (8 January 2025)
   identifier `\#mod`.
   (Florian Angeletti, report by Chris Casinghino, review by Gabriel Scherer)
 
-* #13830: removed abstraction of whole module types when trying to avoid a
-  single type, failing instead.
+* #13830: fail rather than silently create abstract module types when avoiding
+  (i.e. hiding) signature items, as in:
+  ```ocaml
+    module N = struct
+      open (struct type t = A | B end)
+      module type T = sig type u = t * int end
+    end
+  ```
+  Before, it was succeeding with `module N : sig module type T end`, now it
+  fails. Similarly for anonymous functor calls (of the form `F(struct ... end))
   (Clement Blaudeau, review by Gabriel Scherer)
 
 OCaml 5.2.0 (13 May 2024)

--- a/Changes
+++ b/Changes
@@ -1227,6 +1227,10 @@ OCaml 5.3.0 (8 January 2025)
   identifier `\#mod`.
   (Florian Angeletti, report by Chris Casinghino, review by Gabriel Scherer)
 
+* #13830: removed abstraction of whole module types when trying to avoid a
+  single type, failing instead.
+  (Clement Blaudeau, review by Gabriel Scherer)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -163,20 +163,18 @@ module type Module_type_fail = sig
 end
 ;;
 [%%expect{|
-module type Module_type_fail =
-  sig
-    module type U
-    type t
-    val unit : unit
-    external e : unit -> unit = "%identity"
-    module M : sig type t end
-    module type T
-    exception E
-    type ext = ..
-    type ext += C
-    class c : object  end
-    class type ct = object  end
-  end
+Line 4, characters 2-11:
+4 |   include S
+      ^^^^^^^^^
+Error: Illegal shadowing of included module type "T/2" by "T".
+Line 2, characters 2-11:
+2 |   include S
+      ^^^^^^^^^
+  Module type "T/2" came from this include.
+Line 3, characters 2-19:
+3 |   module type U = T
+      ^^^^^^^^^^^^^^^^^
+  The module type "U" has no valid type if "T/2" is shadowed.
 |}]
 
 module type Module_type_fail = sig

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -156,14 +156,14 @@ Line 3, characters 2-26:
 |}]
 
 
-module type Module_type = sig
+module type Module_type_fail = sig
   include S
   module type U = T
   include S
 end
 ;;
 [%%expect{|
-module type Module_type =
+module type Module_type_fail =
   sig
     module type U
     type t

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -62,5 +62,12 @@ module Avoidance_fail = (functor (Y:sig type t end) -> struct
            end)(struct type t end)
 
 [%%expect{|
-module Avoidance_fail : sig module type A end
+Lines 1-3, characters 24-34:
+1 | ........................(functor (Y:sig type t end) -> struct
+2 |              module type A = sig type u = Y.t end
+3 |            end)(struct type t end)
+Error: This functor has type
+       "(Y : sig type t end) -> sig module type A = sig type u = Y.t end end"
+       The parameter cannot be eliminated in the result type.
+       Please bind the argument to a module identifier.
 |}]

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -56,3 +56,11 @@ module M :
     module Not_ok : sig type t end
   end
 |}]
+
+module Avoidance_fail = (functor (Y:sig type t end) -> struct
+             module type A = sig type u = Y.t end
+           end)(struct type t end)
+
+[%%expect{|
+module Avoidance_fail : sig module type A end
+|}]

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -238,14 +238,7 @@ and nondep_sig_item env va ids = function
       let pres, mty = nondep_mty_with_presence env va ids pres md.md_type in
       Sig_module(id, pres, {md with md_type = mty}, rs, vis)
   | Sig_modtype(id, d, vis) ->
-      begin try
-        Sig_modtype(id, nondep_modtype_decl env ids d, vis)
-      with Ctype.Nondep_cannot_erase _ as exn ->
-        match va with
-          Co -> Sig_modtype(id, {mtd_type=None; mtd_loc=Location.none;
-                                 mtd_attributes=[]; mtd_uid = d.mtd_uid}, vis)
-        | _  -> raise exn
-      end
+      Sig_modtype(id, nondep_modtype_decl env ids d, vis)
   | Sig_class(id, d, rs, vis) ->
       Sig_class(id, Ctype.nondep_class_declaration env ids d, rs, vis)
   | Sig_class_type(id, d, rs, vis) ->


### PR DESCRIPTION
When a field must be avoided, abstracting a whole signature is prone to errors: even in covariant positions, it can lead to an invalid signature (see https://github.com/ocaml/ocaml/issues/10491). This PR fixes this issue by throwing an error instead of abstracting whole module types. 
It makes the behavior coherent with the corresponding cases when using `open`.
Its not backward compatible, as some code could rely on the (implicit) over-abstraction that happened.