### PR TITLE
Translmod.transl_structure: remove unnecessary plumbing for module block size

### DIFF
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -515,7 +515,7 @@ and transl_module ~scopes cc rootpath mexp =
       apply_coercion loc Strict cc
         (transl_module_path loc mexp.mod_env path)
   | Tmod_structure str ->
-      fst (transl_struct ~scopes loc [] cc rootpath str)
+      transl_struct ~scopes loc [] cc rootpath str
   | Tmod_functor _ ->
       oo_wrap mexp.mod_env true (fun () ->
         compile_functor ~scopes mexp cc rootpath loc) ()
@@ -551,12 +551,11 @@ and transl_struct ~scopes loc fields cc rootpath {str_final_env; str_items; _} =
    warning by increasing locations. *)
 and transl_structure ~scopes loc fields cc rootpath final_env = function
     [] ->
-      let body, size =
+      let body =
         match cc with
           Tcoerce_none ->
             Lprim(Pmakeblock(0, Immutable, None),
-                  List.map (fun id -> Lvar id) (List.rev fields), loc),
-              List.length fields
+                  List.map (fun id -> Lvar id) (List.rev fields), loc)
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
                 (* Do not ignore id_pos_list ! *)
             (*Format.eprintf "%a@.@[" Includemod.print_coercion cc;
@@ -584,30 +583,28 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
               List.filter (fun (id,_,_) -> not (Ident.Set.mem id ids))
                 id_pos_list
             in
-            wrap_id_pos_list loc id_pos_list get_field lam,
-              List.length pos_cc_list
+            wrap_id_pos_list loc id_pos_list get_field lam
         | _ ->
             fatal_error "Translmod.transl_structure"
       in
       (* This debugging event provides information regarding the structure
          items. It is ignored by the OCaml debugger but is used by
          Js_of_ocaml to preserve variable names. *)
-      (if !Clflags.debug && not !Clflags.native_code then
-         Levent(body,
-                {lev_loc = loc;
-                 lev_kind = Lev_pseudo;
-                 lev_repr = None;
-                 lev_env = final_env})
-       else
-         body),
-      size
+      if !Clflags.debug && not !Clflags.native_code then
+        Levent(body,
+               {lev_loc = loc;
+                lev_kind = Lev_pseudo;
+                lev_repr = None;
+                lev_env = final_env})
+      else
+        body
   | item :: rem ->
       match item.str_desc with
       | Tstr_eval (expr, _) ->
-          let body, size =
+          let body =
             transl_structure ~scopes loc fields cc rootpath final_env rem
           in
-          Lsequence(transl_exp ~scopes expr, body), size
+          Lsequence(transl_exp ~scopes expr, body)
       | Tstr_value(rec_flag, pat_expr_list) ->
           (* Translate bindings first *)
           let mk_lam_let =
@@ -615,10 +612,10 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           let ext_fields =
             List.rev_append (let_bound_idents pat_expr_list) fields in
           (* Then, translate remainder of struct *)
-          let body, size =
+          let body =
             transl_structure ~scopes loc ext_fields cc rootpath final_env rem
           in
-          mk_lam_let body, size
+          mk_lam_let body
       | Tstr_primitive descr ->
           record_primitive descr.val_val;
           transl_structure ~scopes loc fields cc rootpath final_env rem
@@ -626,23 +623,22 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           transl_structure ~scopes loc fields cc rootpath final_env rem
       | Tstr_typext(tyext) ->
           let ids = List.map (fun ext -> ext.ext_id) tyext.tyext_constructors in
-          let body, size =
+          let body =
             transl_structure ~scopes loc (List.rev_append ids fields)
               cc rootpath final_env rem
           in
-          transl_type_extension ~scopes item.str_env rootpath tyext body, size
+          transl_type_extension ~scopes item.str_env rootpath tyext body
       | Tstr_exception ext ->
           let id = ext.tyexn_constructor.ext_id in
           let path = field_path rootpath id in
-          let body, size =
+          let body =
             transl_structure ~scopes loc (id::fields) cc rootpath final_env rem
           in
           Llet(Strict, Pgenval, id,
                transl_extension_constructor ~scopes
                                             item.str_env
                                             path
-                                            ext.tyexn_constructor, body),
-          size
+                                            ext.tyexn_constructor, body)
       | Tstr_module ({mb_presence=Mp_present} as mb) ->
           let id = mb.mb_id in
           (* Translate module first *)
@@ -658,17 +654,16 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                                                  mb.mb_attributes
           in
           (* Translate remainder second *)
-          let body, size =
+          let body =
             transl_structure ~scopes loc (cons_opt id fields)
               cc rootpath final_env rem
           in
           begin match id with
           | None ->
               Lsequence (Lprim(Pignore, [module_body],
-                               of_location ~scopes mb.mb_name.loc), body),
-              size
+                               of_location ~scopes mb.mb_name.loc), body)
           | Some id ->
-              Llet(pure_module mb.mb_expr, Pgenval, id, module_body, body), size
+              Llet(pure_module mb.mb_expr, Pgenval, id, module_body, body)
           end
       | Tstr_module ({mb_presence=Mp_absent}) ->
           transl_structure ~scopes loc fields cc rootpath final_env rem
@@ -677,7 +672,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             List.rev_append (List.filter_map (fun mb -> mb.mb_id) bindings)
               fields
           in
-          let body, size =
+          let body =
             transl_structure ~scopes loc ext_fields cc rootpath final_env rem
           in
           let lam =
@@ -690,14 +685,14 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                     Tcoerce_none (field_path rootpath id) modl
             ) bindings body
           in
-          lam, size
+          lam
       | Tstr_class cl_list ->
           let (ids, class_bindings) = transl_class_bindings ~scopes cl_list in
-          let body, size =
+          let body =
             transl_structure ~scopes loc (List.rev_append ids fields)
               cc rootpath final_env rem
           in
-          Value_rec_compiler.compile_letrec class_bindings body, size
+          Value_rec_compiler.compile_letrec class_bindings body
       | Tstr_include incl ->
           let ids = bound_value_identifiers incl.incl_type in
           let modl = incl.incl_mod in
@@ -706,18 +701,16 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
               [] ->
                 transl_structure ~scopes loc newfields cc rootpath final_env rem
             | id :: ids ->
-                let body, size =
+                let body =
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
                 Llet(Alias, Pgenval, id,
                      Lprim(Pfield (pos, Pointer, Mutable),
-                        [Lvar mid], of_location ~scopes incl.incl_loc), body),
-                size
+                        [Lvar mid], of_location ~scopes incl.incl_loc), body)
           in
-          let body, size = rebind_idents 0 fields ids in
+          let body = rebind_idents 0 fields ids in
           Llet(pure_module modl, Pgenval, mid,
-               transl_module ~scopes Tcoerce_none None modl, body),
-          size
+               transl_module ~scopes Tcoerce_none None modl, body)
 
       | Tstr_open od ->
           let pure = pure_module od.open_expr in
@@ -735,18 +728,16 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   [] -> transl_structure
                           ~scopes loc newfields cc rootpath final_env rem
                 | id :: ids ->
-                  let body, size =
+                  let body =
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
                   Llet(Alias, Pgenval, id,
                       Lprim(Pfield (pos, Pointer, Mutable), [Lvar mid],
-                            of_location ~scopes od.open_loc), body),
-                  size
+                            of_location ~scopes od.open_loc), body)
               in
-              let body, size = rebind_idents 0 fields ids in
+              let body = rebind_idents 0 fields ids in
               Llet(pure, Pgenval, mid,
-                   transl_module ~scopes Tcoerce_none None od.open_expr, body),
-              size
+                   transl_module ~scopes Tcoerce_none None od.open_expr, body)
           end
       | Tstr_modtype _
       | Tstr_class_type _
@@ -794,17 +785,27 @@ let required_globals ~flambda body =
 
 (* Compile an implementation *)
 
+let module_block_size component_names coercion =
+  match coercion with
+  | Tcoerce_none -> List.length component_names
+  | Tcoerce_structure (l, _) -> List.length l
+  | Tcoerce_functor _
+  | Tcoerce_primitive _
+  | Tcoerce_alias _ -> assert false
+
 let transl_implementation_flambda module_name (str, cc) =
   reset_labels ();
   primitive_declarations := [];
   Translprim.clear_used_primitives ();
   let module_id = Ident.create_persistent module_name in
   let scopes = enter_module_definition ~scopes:empty_scopes module_id in
-  let body, size =
+  let body =
     Translobj.transl_label_init
       (fun () -> transl_struct ~scopes Loc_unknown [] cc
                    (global_path module_id) str)
   in
+  let size =
+    module_block_size (bound_value_identifiers str.str_type) cc in
   { module_ident = module_id;
     main_module_block_size = size;
     required_globals = required_globals ~flambda:true body;
@@ -1442,7 +1443,7 @@ let toploop_setvalue id lam =
 
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
-let close_toplevel_term (lam, ()) =
+let close_toplevel_term lam =
   Ident.Set.fold (fun id l -> Llet(Strict, Pgenval, id,
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
@@ -1556,7 +1557,7 @@ let transl_toplevel_item ~scopes item =
 
 let transl_toplevel_item_and_close ~scopes itm =
   close_toplevel_term
-    (transl_label_init (fun () -> transl_toplevel_item ~scopes itm, ()))
+    (transl_label_init (fun () -> transl_toplevel_item ~scopes itm))
 
 let transl_toplevel_definition str =
   reset_labels ();
@@ -1572,15 +1573,7 @@ let get_component = function
   | Some id -> Lprim(Pgetglobal id, [], Loc_unknown)
 
 let transl_package_flambda component_names coercion =
-  let size =
-    match coercion with
-    | Tcoerce_none -> List.length component_names
-    | Tcoerce_structure (l, _) -> List.length l
-    | Tcoerce_functor _
-    | Tcoerce_primitive _
-    | Tcoerce_alias _ -> assert false
-  in
-  size,
+  module_block_size component_names coercion,
   apply_coercion Loc_unknown Strict coercion
     (Lprim(Pmakeblock(0, Immutable, None),
            List.map get_component component_names,

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -88,7 +88,7 @@ let prim_makearray =
 
 (* Also use it for required globals *)
 let transl_label_init_general f =
-  let expr, size = f () in
+  let expr = f () in
   let expr =
     Hashtbl.fold
       (fun c id expr -> Llet(Alias, Pgenval, id, Lconst c, expr))
@@ -101,7 +101,7 @@ let transl_label_init_general f =
   in
   Env.reset_required_globals ();*)
   reset_labels ();
-  expr, size
+  expr
 
 let transl_label_init_flambda f =
   assert(Config.flambda);
@@ -110,7 +110,7 @@ let transl_label_init_flambda f =
   (* Calling f (usually Translmod.transl_struct) requires the
      method_cache variable to be initialised to be able to generate
      method accesses. *)
-  let expr, size = f () in
+  let expr = f () in
   let expr =
     if !method_count = 0 then expr
     else
@@ -120,7 +120,7 @@ let transl_label_init_flambda f =
                Loc_unknown),
         expr)
   in
-  transl_label_init_general (fun () -> expr, size)
+  transl_label_init_general (fun () -> expr)
 
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
@@ -142,8 +142,7 @@ let transl_store_label_init glob size f arg =
            Loc_unknown),
      expr))
   in
-  let lam, size = transl_label_init_general (fun () -> (expr, size)) in
-  size, lam
+  size, transl_label_init_general (fun () -> expr)
 
 let transl_label_init f =
   if !Clflags.native_code then

--- a/lambda/translobj.mli
+++ b/lambda/translobj.mli
@@ -21,7 +21,7 @@ val share: structured_constant -> lambda
 val meth: lambda -> string -> lambda * lambda list
 
 val reset_labels: unit -> unit
-val transl_label_init: (unit -> lambda * 'a) -> lambda * 'a
+val transl_label_init: (unit -> lambda) -> lambda
 val transl_store_label_init:
     Ident.t -> int -> ('a -> lambda) -> 'a -> int * lambda
 


### PR DESCRIPTION
A small cleanup of the codebase.

Namely, the function `Translmod.transl_structure` currently returns the size of the block that represents the structure at runtime. This function calls itself recursively for each structure item, and computes the block size at the very end; the size is then propagated back, unmodified, through all recursive calls. This in turn needs a bit of extra plumbing in all callers of this function.

Moreover, the size in question can actually be computed independently of what is done in this function, so there is no need to compute it in this function to begin with. This is what this PR does.