### PR TITLE
document what Location.loc_ghost is

### DIFF
--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -26,7 +26,31 @@ type t = Warnings.loc = {
   loc_start: Lexing.position;
   loc_end: Lexing.position;
   loc_ghost: bool;
-}
+  }
+(** [t] represents a range of characters in the source code.
+
+    loc_ghost=false whenever the AST described by the location can be parsed
+    from the location. In all other cases, loc_ghost must be true. Most
+    locations produced by the parser have loc_ghost=false.
+    When loc_ghost=true, the location is usually a best effort approximation.
+
+    This info is used by tools like merlin that want to relate source code with
+    parsetrees or later asts. ocamlprof skips instrumentation of ghost nodes.
+
+    Example: in `let f x = x`, we have:
+    - a structure item at location "let f x = x"
+    - a pattern "f" at location "f"
+    - an expression "fun x -> x" at location "x = x" with loc_ghost=true
+    - a pattern "x" at location "x"
+    - an expression "x" at location "x"
+    In this case, every node has loc_ghost=false, except the node "fun x -> x",
+    since [Parser.expression (Lexing.from_string "x = x")] would fail to parse.
+    By contrast, in `let f = fun x -> x`, every node has loc_ghost=false.
+
+    Line directives can modify the filenames and line numbers arbitrarily,
+    which is orthogonal to loc_ghost, which describes the range of characters
+    from loc_start.pos_cnum to loc_end.pos_cnum in the parsed string.
+ *)
 
 (** Note on the use of Lexing.position in this module.
    If [pos_fname = ""], then use [!input_name] instead.

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -122,21 +122,10 @@ let mkpatvar ~loc name =
   mkpat ~loc (Ppat_var (mkrhs name loc))
 
 (*
-  Ghost expressions and patterns:
-  expressions and patterns that do not appear explicitly in the
-  source file they have the loc_ghost flag set to true.
-  Then the profiler will not try to instrument them and the
-  -annot option will not try to display their type.
+  See ./location.mli for when to use a ghost location or not.
 
   Every grammar rule that generates an element with a location must
   make at most one non-ghost element, the topmost one.
-
-  How to tell whether your location must be ghost:
-  A location corresponds to a range of characters in the source file.
-  If the location contains a piece of code that is syntactically
-  valid (according to the documentation), and corresponds to the
-  AST node, then the location must be real; in all other cases,
-  it must be ghost.
 *)
 let ghexp ~loc d = Exp.mk ~loc:(ghost_loc loc) d
 let ghpat ~loc d = Pat.mk ~loc:(ghost_loc loc) d


### PR DESCRIPTION
The general idea of "it's for stuff added by the parser" is simple, but it's also not particularly precise, as it doesn't clearly explain why `let f x = x` creates a ghost node for `fun x -> x`.