### PR TITLE
Add `[Float.]Array.{equal.compare}`

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,6 +150,9 @@ Working version
 
 ### Standard library:
 
+- #13836: Add [Float.]Array.{equal,compare}.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 - #13796: Add Uchar.utf_8_decode_length_of_byte and
   Uchar.max_utf_8_decode_length.
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Florian Angeletti)

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -195,14 +195,12 @@ let equal eq a b =
 let stdlib_compare = compare
 let compare cmp a b =
   let len_a = length a and len_b = length b in
-  let imax = (if len_a < len_b then len_a else len_b) - 1 in
-  let i = ref 0 in
-  let c = ref 0 in
-  while !i <= imax && !c = 0 do
-    c := cmp (unsafe_get a !i) (unsafe_get b !i);
-    incr i
-  done;
-  if !c = 0 then (stdlib_compare : int -> int -> int) len_a len_b else !c
+  let diff = len_a - len_b in
+  if diff <> 0 then (if diff < 0 then -1 else 1) else
+  let i = ref 0 and c = ref 0 in
+  while !i < len_a && !c = 0
+  do c := cmp (unsafe_get a !i) (unsafe_get b !i); incr i done;
+  !c
 
 let fold_left f x a =
   let r = ref x in

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -185,6 +185,27 @@ let of_list = function
         | hd::tl -> unsafe_set a i hd; fill (i+1) tl in
       fill 1 tl
 
+let equal eq a b =
+  if length a <> length b then false else
+  try
+    for i = 0 to length a - 1 do
+      if eq (unsafe_get a i) (unsafe_get b i) then () else raise_notrace Exit
+    done;
+    true
+  with Exit -> false
+
+let stdlib_compare = compare
+let compare cmp a b =
+  let len_a = length a and len_b = length b in
+  let imax = (if len_a < len_b then len_a else len_b) - 1 in
+  let i = ref 0 in
+  let c = ref 0 in
+  while (!i <= imax && !c = 0) do
+    c := cmp (unsafe_get a !i) (unsafe_get b !i);
+    incr i
+  done;
+  if !c = 0 then (stdlib_compare : int -> int -> int) len_a len_b else !c
+
 let fold_left f x a =
   let r = ref x in
   for i = 0 to length a - 1 do
@@ -253,7 +274,7 @@ let mem x a =
   let n = length a in
   let rec loop i =
     if i = n then false
-    else if compare (unsafe_get a i) x = 0 then true
+    else if stdlib_compare (unsafe_get a i) x = 0 then true
     else loop (succ i) in
   loop 0
 

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -187,12 +187,10 @@ let of_list = function
 
 let equal eq a b =
   if length a <> length b then false else
-  try
-    for i = 0 to length a - 1 do
-      if eq (unsafe_get a i) (unsafe_get b i) then () else raise_notrace Exit
-    done;
-    true
-  with Exit -> false
+  let i = ref 0 in
+  let len = length a in
+  while !i < len && eq (unsafe_get a !i) (unsafe_get b !i) do incr i done;
+  !i = len
 
 let stdlib_compare = compare
 let compare cmp a b =

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -198,7 +198,7 @@ let compare cmp a b =
   let imax = (if len_a < len_b then len_a else len_b) - 1 in
   let i = ref 0 in
   let c = ref 0 in
-  while (!i <= imax && !c = 0) do
+  while !i <= imax && !c = 0 do
     c := cmp (unsafe_get a !i) (unsafe_get b !i);
     incr i
   done;

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -158,6 +158,21 @@ val of_list : 'a list -> 'a array
    @raise Invalid_argument if the length of [l] is greater than
    [Sys.max_array_length]. *)
 
+(** {1:comparison Comparison} *)
+
+val equal : ('a -> 'a -> bool) -> 'a array -> 'a array -> bool
+(** [equal eq a b] is [true] if and only if [a] and [b] have the
+    same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
+    is [true].
+
+    @since 5.4 *)
+
+val compare : ('a -> 'a -> int) -> 'a array -> 'a array -> int
+(** [compare cmp a b] orders [a] and [b] in lexicographic order
+    (see {!List.compare}) using [cmp] to compare elements.
+
+    @since 5.4 *)
+
 (** {1 Iterators} *)
 
 val iter : ('a -> unit) -> 'a array -> unit

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -169,7 +169,7 @@ val equal : ('a -> 'a -> bool) -> 'a array -> 'a array -> bool
 
 val compare : ('a -> 'a -> int) -> 'a array -> 'a array -> int
 (** [compare cmp a b] orders [a] and [b] in lexicographic order
-    (see {!List.compare}) using [cmp] to compare elements.
+    using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -158,6 +158,21 @@ val of_list : 'a list -> 'a array
    @raise Invalid_argument if the length of [l] is greater than
    [Sys.max_array_length]. *)
 
+(** {1:comparison Comparison} *)
+
+val equal : eq:('a -> 'a -> bool) -> 'a array -> 'a array -> bool
+(** [equal eq a b] is [true] if and only if [a] and [b] have the
+    same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
+    is [true].
+
+    @since 5.4 *)
+
+val compare : cmp:('a -> 'a -> int) -> 'a array -> 'a array -> int
+(** [compare cmp a b] orders [a] and [b] in lexicographic order
+    (see {!List.compare}) using [cmp] to compare elements.
+
+    @since 5.4 *)
+
 (** {1 Iterators} *)
 
 val iter : f:('a -> unit) -> 'a array -> unit

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -169,7 +169,7 @@ val equal : eq:('a -> 'a -> bool) -> 'a array -> 'a array -> bool
 
 val compare : cmp:('a -> 'a -> int) -> 'a array -> 'a array -> int
 (** [compare cmp a b] orders [a] and [b] in lexicographic order
-    (see {!List.compare}) using [cmp] to compare elements.
+    using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -304,14 +304,12 @@ module Array = struct
   (* duplicated from array.ml *)
   let compare cmp a b =
     let len_a = length a and len_b = length b in
-    let imax = (if len_a < len_b then len_a else len_b) - 1 in
-    let i = ref 0 in
-    let c = ref 0 in
-    while !i <= imax && !c = 0 do
-      c := cmp (unsafe_get a !i) (unsafe_get b !i);
-      incr i
-    done;
-    if !c = 0 then (Stdlib.compare : int -> int -> int) len_a len_b else !c
+    let diff = len_a - len_b in
+    if diff <> 0 then (if diff < 0 then -1 else 1) else
+    let i = ref 0 and c = ref 0 in
+    while !i < len_a && !c = 0
+    do c := cmp (unsafe_get a !i) (unsafe_get b !i); incr i done;
+    !c
 
   (* duplicated from array.ml *)
   let iter f a =

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -294,16 +294,14 @@ module Array = struct
 
   (* duplicated from array.ml *)
   let equal eq a b =
-  if length a <> length b then false else
-  try
-    for i = 0 to length a - 1 do
-      if eq (unsafe_get a i) (unsafe_get b i) then () else raise_notrace Exit
-    done;
-    true
-  with Exit -> false
+    if length a <> length b then false else
+    let i = ref 0 in
+    let len = length a in
+    while !i < len && eq (unsafe_get a i) (unsafe_get b i) do incr i done;
+    !i = len
 
-  (* duplicated from array.ml *)
   let float_compare = compare
+  (* duplicated from array.ml *)
   let compare cmp a b =
     let len_a = length a and len_b = length b in
     let imax = (if len_a < len_b then len_a else len_b) - 1 in

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -297,7 +297,7 @@ module Array = struct
     if length a <> length b then false else
     let i = ref 0 in
     let len = length a in
-    while !i < len && eq (unsafe_get a i) (unsafe_get b i) do incr i done;
+    while !i < len && eq (unsafe_get a !i) (unsafe_get b !i) do incr i done;
     !i = len
 
   let float_compare = compare
@@ -307,7 +307,7 @@ module Array = struct
     let imax = (if len_a < len_b then len_a else len_b) - 1 in
     let i = ref 0 in
     let c = ref 0 in
-    while (!i <= imax && !c = 0) do
+    while !i <= imax && !c = 0 do
       c := cmp (unsafe_get a !i) (unsafe_get b !i);
       incr i
     done;

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -293,6 +293,29 @@ module Array = struct
     fill 0 l
 
   (* duplicated from array.ml *)
+  let equal eq a b =
+  if length a <> length b then false else
+  try
+    for i = 0 to length a - 1 do
+      if eq (unsafe_get a i) (unsafe_get b i) then () else raise_notrace Exit
+    done;
+    true
+  with Exit -> false
+
+  (* duplicated from array.ml *)
+  let float_compare = compare
+  let compare cmp a b =
+    let len_a = length a and len_b = length b in
+    let imax = (if len_a < len_b then len_a else len_b) - 1 in
+    let i = ref 0 in
+    let c = ref 0 in
+    while (!i <= imax && !c = 0) do
+      c := cmp (unsafe_get a !i) (unsafe_get b !i);
+      incr i
+    done;
+    if !c = 0 then (Stdlib.compare : int -> int -> int) len_a len_b else !c
+
+  (* duplicated from array.ml *)
   let iter f a =
     for i = 0 to length a - 1 do f (unsafe_get a i) done
 
@@ -387,7 +410,7 @@ module Array = struct
     let n = length a in
     let rec loop i =
       if i = n then false
-      else if compare (unsafe_get a i) x = 0 then true
+      else if float_compare (unsafe_get a i) x = 0 then true
       else loop (i + 1)
     in
     loop 0

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -601,6 +601,21 @@ module Array : sig
       @raise Invalid_argument if the length of [l] is greater than
       [Sys.max_floatarray_length].*)
 
+  (** {1:comparison Comparison} *)
+
+  val equal : (float -> float -> bool) -> t -> t -> bool
+  (** [equal eq a b] is [true] if and only if [a] and [b] have the
+      same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
+      is [true].
+
+      @since 5.4 *)
+
+  val compare : (float -> float -> int) -> t -> t -> int
+  (** [compare cmp a b] orders [a] and [b] in lexicographic order
+      (see {!List.compare}) using [cmp] to compare elements.
+
+      @since 5.4 *)
+
   (** {1 Iterators} *)
 
   val iter : (float -> unit) -> t -> unit
@@ -967,6 +982,21 @@ module ArrayLabels : sig
       of [l].
       @raise Invalid_argument if the length of [l] is greater than
       [Sys.max_floatarray_length].*)
+
+  (** {1:comparison Comparison} *)
+
+  val equal : eq:(float -> float -> bool) -> t -> t -> bool
+  (** [equal eq a b] is [true] if and only if [a] and [b] have the
+      same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
+      is [true].
+
+      @since 5.4 *)
+
+  val compare : cmp:(float -> float -> int) -> t -> t -> int
+  (** [compare cmp a b] orders [a] and [b] in lexicographic order
+      (see {!List.compare}) using [cmp] to compare elements.
+
+      @since 5.4 *)
 
   (** {1 Iterators} *)
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -612,7 +612,7 @@ module Array : sig
 
   val compare : (float -> float -> int) -> t -> t -> int
   (** [compare cmp a b] orders [a] and [b] in lexicographic order
-      (see {!List.compare}) using [cmp] to compare elements.
+      using [cmp] to compare elements.
 
       @since 5.4 *)
 
@@ -994,7 +994,7 @@ module ArrayLabels : sig
 
   val compare : cmp:(float -> float -> int) -> t -> t -> int
   (** [compare cmp a b] orders [a] and [b] in lexicographic order
-      (see {!List.compare}) using [cmp] to compare elements.
+      using [cmp] to compare elements.
 
       @since 5.4 *)
 

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -128,7 +128,7 @@ val equal : eq:(float -> float -> bool) -> t -> t -> bool
 
 val compare : cmp:(float -> float -> int) -> t -> t -> int
 (** [compare cmp a b] orders [a] and [b] in lexicographic order
-    (see {!List.compare}) using [cmp] to compare elements.
+    using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -117,6 +117,21 @@ val of_list : float list -> t
     @raise Invalid_argument if the length of [l] is greater than
     [Sys.max_floatarray_length].*)
 
+(** {1:comparison Comparison} *)
+
+val equal : eq:(float -> float -> bool) -> t -> t -> bool
+(** [equal eq a b] is [true] if and only if [a] and [b] have the
+    same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
+    is [true].
+
+    @since 5.4 *)
+
+val compare : cmp:(float -> float -> int) -> t -> t -> int
+(** [compare cmp a b] orders [a] and [b] in lexicographic order
+    (see {!List.compare}) using [cmp] to compare elements.
+
+    @since 5.4 *)
+
 (** {1 Iterators} *)
 
 val iter : f:(float -> unit) -> t -> unit

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -195,3 +195,38 @@ let a = Array.init_matrix 2 3 (fun i j -> 10 * i + j);;
 [%%expect{|
 val a : int array array = [|[|0; 1; 2|]; [|10; 11; 12|]|]
 |}]
+
+let () = (* Array.equal *)
+  let test a b ~eq =
+    assert (Array.equal Int.equal a b = eq);
+    assert (Array.equal Int.equal b a = eq)
+  in
+  test [||] [||] ~eq:true;
+  test [||] [|1|] ~eq:false;
+  test [|1;2|] [|1;2|] ~eq:true;
+  test [|1;2|] [|1;2;3|] ~eq:false;
+  test [|1;2|] [|1;2;3|] ~eq:false;
+  ()
+[%%expect{|
+|}]
+
+let () = (* Array.compare *)
+  let test a b ~cmp =
+    assert (Array.compare Int.compare a b = cmp);
+    assert (Array.compare Int.compare b a = -1 * cmp);
+  in
+  test [||] [||] ~cmp:0;
+  test [||] [|0;1|] ~cmp:~-1;
+  test [|0|] [||] ~cmp:1;
+  test [|0|] [|0;1|] ~cmp:~-1;
+  test [|0;1|] [|0;1|] ~cmp:0;
+  test [|0;1|] [|0;2|] ~cmp:~-1;
+  test [|0;1|] [|0;0|] ~cmp:1;
+  test [|0;1|] [|0;1|] ~cmp:0;
+  test [|1;0|] [|0;1|] ~cmp:1;
+  test [|0;1;2|] [|0;1;2|] ~cmp:0;
+  test [|0;2;2|] [|0;1;2|] ~cmp:1;
+  test [|0;1;2|] [|0;1|] ~cmp:1;
+  ()
+[%%expect{|
+|}]

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -227,6 +227,10 @@ let () = (* Array.compare *)
   test [|0;1;2|] [|0;1;2|] ~cmp:0;
   test [|0;2;2|] [|0;1;2|] ~cmp:1;
   test [|0;1;2|] [|0;1|] ~cmp:1;
+  (* Check that the result of compare is normalized in -1,0,1 on large
+     array length differences. *)
+  test [|0;1;2;2;2|] [|0;1|] ~cmp:1;
+  test [|0;1|] [|0;1;2;2;2|] ~cmp:~-1;
   (* If the length is different it is sufficent to order arrays and
      we do not compare elements. This tests that so that
      a possible behaviour change in the future can be detected *)

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -227,6 +227,11 @@ let () = (* Array.compare *)
   test [|0;1;2|] [|0;1;2|] ~cmp:0;
   test [|0;2;2|] [|0;1;2|] ~cmp:1;
   test [|0;1;2|] [|0;1|] ~cmp:1;
+  (* If the length is different it is sufficent to order arrays and
+     we do not compare elements. This tests that so that
+     a possible behaviour change in the future can be detected *)
+  assert (Array.compare (fun _ _ -> assert false) [|0;1|] [|0;1;2|] = -1);
+  assert (Array.compare (fun _ _ -> assert false) [|0;1;2|] [|0;1|] = 1);
   ()
 [%%expect{|
 |}]


### PR DESCRIPTION
As the title says. Two notes for reviewers:

1. It seems that `test_array.ml` uses snapshot testing. I don't think it's that great for testing this kind of library code. So you may find the test structure a bit at odds (but if an assert fails the empty expectation fails).

2. There's a bit of tricky stuff around `compare` whose naked incarnation is used by `Array.mem` (and `Float.Array.mem` which uses `Float.compare`) which is bellow the `compare` addition. Since there's currently no dependency on `Stdlib` in `array.ml` I prefered not to use `Stdlib.compare` but rename it locally. If that's a dependency that is fine to introduce I can change that. Looking forward to https://github.com/ocaml/ocaml/pull/13755


P.S. Contributing functions to `Array` is painfull, between the label madness and `Float.Array` one spends most time bureaucratizing around and c&p code :-( 
