### PR TITLE
error messages: align spellchecking hints

### DIFF
--- a/Changes
+++ b/Changes
@@ -336,6 +336,11 @@ Working version
   occurences of `'a`
   (Samuel Vivien, review by Florian Angeletti)
 
+- #13817: align spellchecking hints with the possibly misspelled identifier/
+              Error: Unbound type constructor "aray"
+              Hint:              Did you mean "array"?
+  (Florian Angeletti, suggestion by Daniel Bünzli, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #13314: Comment the code of Translclass

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -9,5 +9,5 @@ Line 1, characters 10-13:
 1 | 		let x = abc
     		        ^^^
 Error: Unbound value "abc"
-Hint: Did you mean "abs"?
+Hint:   Did you mean "abs"?
 |}];;

--- a/testsuite/tests/messages/spellcheck.ml
+++ b/testsuite/tests/messages/spellcheck.ml
@@ -9,8 +9,8 @@
 
 #directery "foo/";;
 [%%expect {|
-Unknown directive "directery".
-Hint:Did you mean "directory"?
+ Unknown directive "directery".
+Hint: Did you mean "directory"?
 |}];;
 
 

--- a/testsuite/tests/messages/spellcheck.ml
+++ b/testsuite/tests/messages/spellcheck.ml
@@ -10,7 +10,7 @@
 #directery "foo/";;
 [%%expect {|
 Unknown directive "directery".
-Hint: Did you mean "directory"?
+Hint:Did you mean "directory"?
 |}];;
 
 
@@ -22,7 +22,7 @@ Line 1, characters 8-19:
 1 | let _ = Fun.pratect
             ^^^^^^^^^^^
 Error: Unbound value "Fun.pratect"
-Hint: Did you mean "Fun.protect"?
+Hint:   Did you mean "Fun.protect"?
 |}];;
 
 type 'a t = 'a aray
@@ -31,7 +31,7 @@ Line 1, characters 15-19:
 1 | type 'a t = 'a aray
                    ^^^^
 Error: Unbound type constructor "aray"
-Hint: Did you mean "array"?
+Hint:              Did you mean "array"?
 |}];;
 
 module _ = Stdlib.Aray
@@ -40,7 +40,7 @@ Line 1, characters 11-22:
 1 | module _ = Stdlib.Aray
                ^^^^^^^^^^^
 Error: Unbound module "Stdlib.Aray"
-Hint: Did you mean "Stdlib.Array"?
+Hint:    Did you mean "Stdlib.Array"?
 |}];;
 
 let x = Same 42
@@ -49,7 +49,7 @@ Line 1, characters 8-12:
 1 | let x = Same 42
             ^^^^
 Error: Unbound constructor "Same"
-Hint: Did you mean "Some"?
+Hint:         Did you mean "Some"?
 |}];;
 
 let x : int option = Same 42
@@ -59,7 +59,7 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This variant expression is expected to have type "int option"
        There is no constructor "Same" within type "option"
-Hint: Did you mean "Some"?
+Hint:             Did you mean "Some"?
 |}];;
 
 let x = { content = 42 }
@@ -68,7 +68,7 @@ Line 1, characters 10-17:
 1 | let x = { content = 42 }
               ^^^^^^^
 Error: Unbound record field "content"
-Hint: Did you mean "contents"?
+Hint:          Did you mean "contents"?
 |}];;
 
 let x : int ref = { content = 42 }
@@ -78,7 +78,7 @@ Line 1, characters 20-27:
                         ^^^^^^^
 Error: This record expression is expected to have type "int ref"
        There is no field "content" within type "ref"
-Hint: Did you mean "contents"?
+Hint:       Did you mean "contents"?
 |}];;
 
 class foobar = object end
@@ -89,7 +89,7 @@ Line 2, characters 23-29:
 2 | let _ = object inherit foobaz end
                            ^^^^^^
 Error: Unbound class "foobaz"
-Hint: Did you mean "foobar"?
+Hint:   Did you mean "foobar"?
 |}];;
 
 module type Foobar = sig end
@@ -100,7 +100,7 @@ Line 2, characters 13-19:
 2 | module Foo : Foobaz = struct end
                  ^^^^^^
 Error: Unbound module type "Foobaz"
-Hint: Did you mean "Foobar"?
+Hint:         Did you mean "Foobar"?
 |}];;
 
 class type foobar = object end
@@ -111,7 +111,7 @@ Line 2, characters 9-15:
 2 | let _ : #foobaz = object end
              ^^^^^^
 Error: Unbound class type "foobaz"
-Hint: Did you mean "foobar"?
+Hint:        Did you mean "foobar"?
 |}];;
 
 let _ =
@@ -124,7 +124,7 @@ let _ =
 Line 5, characters 22-33:
 5 |     method update n = foobaz <- n
                           ^^^^^^^^^^^
-Error: The value "foobaz" is not an instance variable
+Error:   The value "foobaz" is not an instance variable
 Hint: Did you mean "foobar"?
 |}];;
 
@@ -136,7 +136,7 @@ let _ = function (foobar | foobaz) -> ()
 Line 1, characters 17-34:
 1 | let _ = function (foobar | foobaz) -> ()
                      ^^^^^^^^^^^^^^^^^
-Error: Variable "foobar" must occur on both sides of this "|" pattern
+Error:    Variable "foobar" must occur on both sides of this "|" pattern
 Hint: Did you mean "foobaz"?
 |}];;
 
@@ -148,7 +148,7 @@ Line 2, characters 13-19:
 2 | let _ = fun {foobaz} -> ()
                  ^^^^^^
 Error: Unbound record field "foobaz"
-Hint: Did you mean "foobar"?
+Hint:          Did you mean "foobar"?
 |}];;
 let _ = { foobaz = 42 }
 [%%expect {|
@@ -156,7 +156,7 @@ Line 1, characters 10-16:
 1 | let _ = { foobaz = 42 }
               ^^^^^^
 Error: Unbound record field "foobaz"
-Hint: Did you mean "foobar"?
+Hint:          Did you mean "foobar"?
 |}];;
 let _ = fun x -> x.foobaz
 [%%expect {|
@@ -164,7 +164,7 @@ Line 1, characters 19-25:
 1 | let _ = fun x -> x.foobaz
                        ^^^^^^
 Error: Unbound record field "foobaz"
-Hint: Did you mean "foobar"?
+Hint:          Did you mean "foobar"?
 |}];;
 
 type bar = Foobar of int
@@ -175,7 +175,7 @@ Line 2, characters 8-14:
 2 | let _ = Foobaz 42
             ^^^^^^
 Error: Unbound constructor "Foobaz"
-Hint: Did you mean "Foobar"?
+Hint:         Did you mean "Foobar"?
 |}];;
 
 type baz = K of { foobar : int }
@@ -185,7 +185,7 @@ type baz = K of { foobar : int; }
 Line 2, characters 12-18:
 2 | let _ = K { foobaz = 42 }
                 ^^^^^^
-Error: The field "foobaz" is not part of the record argument for the "baz.K" constructor
+Error:   The field "foobaz" is not part of the record argument for the "baz.K" constructor
 Hint: Did you mean "foobar"?
 |}];;
 
@@ -198,7 +198,7 @@ Line 3, characters 17-21:
 3 |   method other = self#foobaz
                      ^^^^
 Error: This expression has no method "foobaz"
-Hint: Did you mean "foobar"?
+Hint:                   Did you mean "foobar"?
 |}];;
 
 
@@ -211,7 +211,7 @@ Line 3, characters 18-35:
 3 |   method myself = {< foobaz = 42 >}
                       ^^^^^^^^^^^^^^^^^
 Error: Unbound instance variable "foobaz"
-Hint: Did you mean "foobar"?
+Hint:               Did you mean "foobar"?
 |}];;
 
 let closely = ()
@@ -226,5 +226,5 @@ Line 5, characters 9-17:
 5 | let () = M.closer
              ^^^^^^^^
 Error: Unbound value "M.closer"
-Hint: Did you mean "M.close"?
+Hint:   Did you mean "M.close"?
 |}]

--- a/testsuite/tests/typing-core-bugs/missing_rec_hint.ml
+++ b/testsuite/tests/typing-core-bugs/missing_rec_hint.ml
@@ -49,7 +49,7 @@ Line 2, characters 13-19:
 2 | let value2 = value2 (* typo: should be value1 *) + 1 in
                  ^^^^^^
 Error: Unbound value "value2"
-Hint: Did you mean "value1"?
+Hint:   Did you mean "value1"?
 |}];;
 
 let foobar1 () = () in
@@ -61,7 +61,7 @@ Line 2, characters 17-24:
 2 | let foobar2 () = foobar2 () (* typo? or missing "rec"? *) in
                      ^^^^^^^
 Error: Unbound value "foobar2"
-Hint: Did you mean "foobar1"?
+Hint:   Did you mean "foobar1"?
 Hint: If this is a recursive definition,
 you should add the "rec" keyword on line 2
 |}];;

--- a/testsuite/tests/typing-core-bugs/repeated_did_you_mean.ml
+++ b/testsuite/tests/typing-core-bugs/repeated_did_you_mean.ml
@@ -18,5 +18,5 @@ Line 7, characters 8-11:
 7 | let _ = fox;;
             ^^^
 Error: Unbound value "fox"
-Hint: Did you mean "foo"?
+Hint:   Did you mean "foo"?
 |}]

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -30,7 +30,7 @@ Line 1, characters 11-15:
                ^^^^
 Error: This variant expression is expected to have type "t"
        There is no constructor "Alph" within type "t"
-Hint: Did you mean "Aleph" or "Alpha"?
+Hint:             Did you mean "Aleph" or "Alpha"?
 |}]
 
 open M;;
@@ -41,7 +41,7 @@ Line 2, characters 12-16:
                 ^^^^
 Error: This variant expression is expected to have type "M.w"
        There is no constructor "Alha" within type "M.w"
-Hint: Did you mean "Alpha"?
+Hint:             Did you mean "Alpha"?
 |}]
 
 let z: t = Bet;;
@@ -51,7 +51,7 @@ Line 1, characters 11-14:
                ^^^
 Error: This variant expression is expected to have type "t"
        There is no constructor "Bet" within type "t"
-Hint: Did you mean "Beth"?
+Hint:             Did you mean "Beth"?
 |}]
 
 
@@ -65,7 +65,7 @@ Line 3, characters 9-13:
              ^^^^
 Error: This variant expression is expected to have type "t"
        There is no constructor "Gamm" within type "t"
-Hint: Did you mean "Gamma"?
+Hint:             Did you mean "Gamma"?
 |}];;
 
 raise Not_Found;;
@@ -75,7 +75,7 @@ Line 1, characters 6-15:
           ^^^^^^^^^
 Error: This variant expression is expected to have type "exn"
        There is no constructor "Not_Found" within type "exn"
-Hint: Did you mean "Not_found"?
+Hint:             Did you mean "Not_found"?
 |}]
 
 (** Aliasing *)
@@ -156,7 +156,7 @@ Line 7, characters 13-17:
                  ^^^^
 Error: This variant expression is expected to have type "P.p"
        There is no constructor "Alha" within type "x"
-Hint: Did you mean "Alpha"?
+Hint:             Did you mean "Alpha"?
 |}]
 
 module M = struct type t = .. type t += T end
@@ -197,7 +197,7 @@ Line 3, characters 8-12:
             ^^^^
 Error: This variant expression is expected to have type "exn"
        There is no constructor "Locl" within type "exn"
-Hint: Did you mean "Local"?
+Hint:             Did you mean "Local"?
 |}]
 
 let x =

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
@@ -296,7 +296,7 @@ Line 1, characters 22-30:
 1 | type bad_t = {x : lbl:bad_type * int}
                           ^^^^^^^^
 Error: Unbound type constructor "bad_type"
-Hint: Did you mean "bad_t"?
+Hint:              Did you mean "bad_t"?
 |}]
 
 type tx = { x : foo:int * bar:int }

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -124,7 +124,7 @@ let f (x : [`A | `B] as 'a) (y : [> 'a]) = ();;
 Line 1, characters 61-63:
 1 | let f : ([`A | `B ] as 'a) -> [> 'a] -> unit = fun x (y : [> 'a]) -> ();;
                                                                  ^^
-Error: The type "'a" does not expand to a polymorphic variant type
+Error:    The type "'a" does not expand to a polymorphic variant type
 Hint: Did you mean "`a"?
 |}]
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -9,7 +9,7 @@ type t = [ 'A_name | `Hi ];;
 Line 1, characters 11-18:
 1 | type t = [ 'A_name | `Hi ];;
                ^^^^^^^
-Error: The type "'A_name" does not expand to a polymorphic variant type
+Error:    The type "'A_name" does not expand to a polymorphic variant type
 Hint: Did you mean "`A_name"?
 |}];;
 

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -298,5 +298,5 @@ Line 6, characters 13-20:
 6 |            ; Coq__10.f2 = 0
                  ^^^^^^^
 Error: Unbound module "Coq__10"
-Hint: Did you mean "Coq__11"?
+Hint:    Did you mean "Coq__11"?
 |}]

--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -8,7 +8,7 @@ Line 1, characters 32-35:
 1 | type ('a,'at,'any,'en) t = A of 'an
                                     ^^^
 Error: The type variable "'an" is unbound in this type declaration.
-Hint: Did you mean "'a", "'any", "'at" or "'en"?
+Hint:       Did you mean "'a", "'any", "'at" or "'en"?
 |}
 ]
 

--- a/testsuite/tests/typing-modules/pr6633.ml
+++ b/testsuite/tests/typing-modules/pr6633.ml
@@ -26,7 +26,7 @@ Line 2, characters 26-32:
 2 | module Foo = functor (E : EqualF) -> struct end;;
                               ^^^^^^
 Error: Unbound module type "EqualF"
-Hint: Did you mean "Equals"?
+Hint:         Did you mean "Equals"?
 |}]
 
 (* If a module is used as a module type it should trigger the hint

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -50,7 +50,7 @@ Line 2, characters 14-22:
 2 |   module M := Funct(M)
                   ^^^^^^^^
 Error: Unbound module "Funct"
-Hint: Did you mean "Fun"?
+Hint:    Did you mean "Fun"?
 |}]
 
 module type Reject2 = sig

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -523,7 +523,7 @@ Line 3, characters 19-22:
                        ^^^
 Error: This record expression is expected to have type "t"
        There is no field "yyz" within type "t"
-Hint: Did you mean "yyy"?
+Hint:       Did you mean "yyy"?
 |}]
 
 (* PR#6004 *)

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -360,7 +360,7 @@ let try_run_directive ppf dir_name pdir_arg =
   | None ->
       let print ppf () =
         let directives = all_directive_names () in
-        Misc.with_aligned_hint ~prefix:"" ppf
+        Misc.aligned_hint ~prefix:"" ppf
           "@{<ralign>Unknown directive @}%a."
           Style.inline_code dir_name
           (Misc.did_you_mean (Misc.spellcheck directives dir_name))

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -358,11 +358,15 @@ let inline_code = Format_doc.compat Style.inline_code
 let try_run_directive ppf dir_name pdir_arg =
   begin match get_directive dir_name with
   | None ->
-      fprintf ppf "Unknown directive %a." inline_code dir_name;
-      let directives = all_directive_names () in
-      Format_doc.compat Misc.pp_hint ppf
-      (Misc.did_you_mean ~align:0 (Misc.spellcheck directives dir_name));
-      fprintf ppf "@.";
+      let print ppf () =
+        Misc.with_aligned_hint ~prefix:"" ppf
+          (Format_doc.doc_printf "@{<ralign>Unknown directive @}%a."
+             Style.inline_code dir_name)
+          (Misc.did_you_mean
+             (Misc.spellcheck (all_directive_names ()) dir_name)
+          )
+      in
+      fprintf ppf "%a@." (Format_doc.compat print) ();
       false
   | Some d ->
       match d, pdir_arg with

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -360,8 +360,10 @@ let try_run_directive ppf dir_name pdir_arg =
   | None ->
       fprintf ppf "Unknown directive %a." inline_code dir_name;
       let directives = all_directive_names () in
-      Format_doc.compat Misc.did_you_mean ppf
-        (fun () -> Misc.spellcheck directives dir_name);
+      Format_doc.compat Misc.pp_hint ppf
+      (Misc.did_you_mean ~align:0
+         (fun () -> Misc.spellcheck directives dir_name)
+      );
       fprintf ppf "@.";
       false
   | Some d ->

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -359,12 +359,11 @@ let try_run_directive ppf dir_name pdir_arg =
   begin match get_directive dir_name with
   | None ->
       let print ppf () =
+        let directives = all_directive_names () in
         Misc.with_aligned_hint ~prefix:"" ppf
-          (Format_doc.doc_printf "@{<ralign>Unknown directive @}%a."
-             Style.inline_code dir_name)
-          (Misc.did_you_mean
-             (Misc.spellcheck (all_directive_names ()) dir_name)
-          )
+          "@{<ralign>Unknown directive @}%a."
+          Style.inline_code dir_name
+          (Misc.did_you_mean (Misc.spellcheck directives dir_name))
       in
       fprintf ppf "%a@." (Format_doc.compat print) ();
       false

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -361,9 +361,7 @@ let try_run_directive ppf dir_name pdir_arg =
       fprintf ppf "Unknown directive %a." inline_code dir_name;
       let directives = all_directive_names () in
       Format_doc.compat Misc.pp_hint ppf
-      (Misc.did_you_mean ~align:0
-         (fun () -> Misc.spellcheck directives dir_name)
-      );
+      (Misc.did_you_mean ~align:0 (Misc.spellcheck directives dir_name));
       fprintf ppf "@.";
       false
   | Some d ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3585,7 +3585,7 @@ let extract_instance_variables env =
 
 let report_lookup_error_doc _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
-      Misc.with_aligned_hint ppf
+      Misc.aligned_error_hint ppf
         "@{<ralign>Unbound value @}%a" quoted_longident lid
         (spellcheck extract_values env lid);
       match hint with
@@ -3601,7 +3601,7 @@ let report_lookup_error_doc _loc env ppf = function
             line
     end
   | Unbound_type lid ->
-     Misc.with_aligned_hint ppf
+     Misc.aligned_error_hint ppf
        "@{<ralign>Unbound type constructor @}%a"
        quoted_longident lid
        (spellcheck extract_types env lid)
@@ -3610,7 +3610,7 @@ let report_lookup_error_doc _loc env ppf = function
         fprintf ppf "@{<ralign>Unbound module @}%a" quoted_longident lid in
        match find_modtype_by_name lid env with
       | exception Not_found ->
-         Misc.with_aligned_hint ppf "%t" main
+         Misc.aligned_error_hint ppf "%t" main
            (spellcheck extract_modules env lid)
       | _ ->
          fprintf ppf
@@ -3620,12 +3620,12 @@ let report_lookup_error_doc _loc env ppf = function
            "but module types are not modules"
     end
   | Unbound_constructor lid ->
-     Misc.with_aligned_hint ppf
+     Misc.aligned_error_hint ppf
        "@{<ralign>Unbound constructor @}%a"
        quoted_constr lid
        (spellcheck extract_constructors env lid)
   | Unbound_label lid ->
-     Misc.with_aligned_hint ppf
+     Misc.aligned_error_hint ppf
        "@{<ralign>Unbound record field @}%a"
        quoted_longident lid
        (spellcheck extract_labels env lid)
@@ -3635,7 +3635,7 @@ let report_lookup_error_doc _loc env ppf = function
       in
       match find_cltype_by_name lid env with
       | exception Not_found ->
-         Misc.with_aligned_hint ppf "%t" main
+         Misc.aligned_error_hint ppf "%t" main
            (spellcheck extract_classes env lid)
       | _ ->
          fprintf ppf
@@ -3650,7 +3650,7 @@ let report_lookup_error_doc _loc env ppf = function
           quoted_longident lid in
       match find_module_by_name lid env with
       | exception Not_found ->
-         Misc.with_aligned_hint ppf "%t" main
+         Misc.aligned_error_hint ppf "%t" main
            (spellcheck extract_modtypes env lid)
       | _ ->
          fprintf ppf
@@ -3660,16 +3660,16 @@ let report_lookup_error_doc _loc env ppf = function
            "but modules are not module types"
     end
   | Unbound_cltype lid ->
-     Misc.with_aligned_hint ppf
+     Misc.aligned_error_hint ppf
        "@{<ralign>Unbound class type @}%a" quoted_longident lid
       (spellcheck extract_cltypes env lid)
   | Unbound_instance_variable s ->
-        Misc.with_aligned_hint ppf
+        Misc.aligned_error_hint ppf
           "@{<ralign>Unbound instance variable @}%a"
           Style.inline_code s
           (spellcheck_name extract_instance_variables env s)
   | Not_an_instance_variable s ->
-     Misc.with_aligned_hint ppf
+     Misc.aligned_error_hint ppf
         "@{<ralign>The value @}%a is not an instance variable"
         Style.inline_code s
         (spellcheck_name extract_instance_variables env s)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3586,7 +3586,7 @@ let extract_instance_variables env =
 let report_lookup_error_doc _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
       Misc.with_aligned_hint ppf
-        (doc_printf "@{<ralign>Unbound value @}%a" quoted_longident lid)
+        "@{<ralign>Unbound value @}%a" quoted_longident lid
         (spellcheck extract_values env lid);
       match hint with
       | No_hint -> ()
@@ -3602,74 +3602,76 @@ let report_lookup_error_doc _loc env ppf = function
     end
   | Unbound_type lid ->
      Misc.with_aligned_hint ppf
-       (doc_printf "@{<ralign>Unbound type constructor @}%a"
-          quoted_longident lid)
+       "@{<ralign>Unbound type constructor @}%a"
+       quoted_longident lid
        (spellcheck extract_types env lid)
   | Unbound_module lid -> begin
-      let main =
-        doc_printf "@{<ralign>Unbound module @}%a" quoted_longident lid in
+      let main ppf =
+        fprintf ppf "@{<ralign>Unbound module @}%a" quoted_longident lid in
        match find_modtype_by_name lid env with
       | exception Not_found ->
-         Misc.with_aligned_hint ppf main (spellcheck extract_modules env lid);
+         Misc.with_aligned_hint ppf "%t" main
+           (spellcheck extract_modules env lid)
       | _ ->
          fprintf ppf
-           "%a@.@[@{<hint>Hint@}: There is a module type named %a, %s@]"
-           pp_doc main
+           "%t@.@[@{<hint>Hint@}: There is a module type named %a, %s@]"
+           main
            quoted_longident lid
            "but module types are not modules"
     end
   | Unbound_constructor lid ->
-      Misc.with_aligned_hint ppf
-        (doc_printf "@{<ralign>Unbound constructor @}%a" quoted_constr lid)
-        (spellcheck extract_constructors env lid)
+     Misc.with_aligned_hint ppf
+       "@{<ralign>Unbound constructor @}%a"
+       quoted_constr lid
+       (spellcheck extract_constructors env lid)
   | Unbound_label lid ->
      Misc.with_aligned_hint ppf
-        (doc_printf "@{<ralign>Unbound record field @}%a"
-        quoted_longident lid)
-        (spellcheck extract_labels env lid)
+       "@{<ralign>Unbound record field @}%a"
+       quoted_longident lid
+       (spellcheck extract_labels env lid)
   | Unbound_class lid -> begin
-      let main =
-        doc_printf "@{<ralign>Unbound class @}%a" quoted_longident lid
+      let main ppf =
+        fprintf ppf "@{<ralign>Unbound class @}%a" quoted_longident lid
       in
       match find_cltype_by_name lid env with
       | exception Not_found ->
-         Misc.with_aligned_hint ppf main (spellcheck extract_classes env lid)
+         Misc.with_aligned_hint ppf "%t" main
+           (spellcheck extract_classes env lid)
       | _ ->
          fprintf ppf
-           "%a@.@[@{<hint>Hint@}: There is a class type named %a, %s@]"
-           pp_doc main
+           "%t@.@[@{<hint>Hint@}: There is a class type named %a, %s@]"
+           main
            quoted_longident lid
            "but classes are not class types"
     end
   | Unbound_modtype lid -> begin
-      let main =
-        doc_printf "@{<ralign>Unbound module type @}%a"
+      let main ppf  =
+        fprintf ppf "@{<ralign>Unbound module type @}%a"
           quoted_longident lid in
       match find_module_by_name lid env with
       | exception Not_found ->
-         Misc.with_aligned_hint ppf main (spellcheck extract_modtypes env lid)
+         Misc.with_aligned_hint ppf "%t" main
+           (spellcheck extract_modtypes env lid)
       | _ ->
          fprintf ppf
-           "%a@.@[@{<hint>Hint@}: There is a module named %a, %s@]"
-           pp_doc main
+           "%t@.@[@{<hint>Hint@}: There is a module named %a, %s@]"
+           main
            quoted_longident lid
            "but modules are not module types"
     end
   | Unbound_cltype lid ->
      Misc.with_aligned_hint ppf
-       (doc_printf "@{<ralign>Unbound class type @}%a"
-          quoted_longident lid)
+       "@{<ralign>Unbound class type @}%a" quoted_longident lid
       (spellcheck extract_cltypes env lid)
   | Unbound_instance_variable s ->
         Misc.with_aligned_hint ppf
-          (doc_printf "@{<ralign>Unbound instance variable @}%a"
-             Style.inline_code s
-          )
+          "@{<ralign>Unbound instance variable @}%a"
+          Style.inline_code s
           (spellcheck_name extract_instance_variables env s)
   | Not_an_instance_variable s ->
      Misc.with_aligned_hint ppf
-        (doc_printf "@{<ralign>The value @}%a is not an instance variable"
-           Style.inline_code s)
+        "@{<ralign>The value @}%a is not an instance variable"
+        Style.inline_code s
         (spellcheck_name extract_instance_variables env s)
   | Masked_instance_variable lid ->
       fprintf ppf

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3547,22 +3547,19 @@ let quoted_constr = Style.as_inline_code Pprintast.Doc.constr
 
 let spellcheck ?(align=0) ppf extract env lid =
   let choices ~path name = Misc.spellcheck (extract path env) name in
-  let sub =
+  Misc.pp_hint ppf @@
     match lid with
     | Longident.Lapply _ -> None
     | Longident.Lident s ->
-       Misc.did_you_mean ~align (fun () -> choices ~path:None s)
+       Misc.did_you_mean ~align (choices ~path:None s)
     | Longident.Ldot (r, s) ->
        let pp ppf s =
          quoted_longident ppf (Longident.Ldot(r, Location.mknoloc s))
        in
-       Misc.did_you_mean ~align ~pp (fun () -> choices ~path:(Some r.txt) s.txt)
-  in
-  Option.iter (fprintf ppf "@.%a" pp_doc) sub
+       Misc.did_you_mean ~align ~pp (choices ~path:(Some r.txt) s.txt)
 
 let spellcheck_name ~align extract env name =
-  Misc.did_you_mean ~align
-    (fun () -> Misc.spellcheck (extract env) name)
+  Misc.did_you_mean ~align (Misc.spellcheck (extract env) name)
 
 let extract_values path env =
   fold_values (fun name _ _ acc -> name :: acc) path env []

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6756,7 +6756,7 @@ open Format_doc
 module Fmt = Format_doc
 
 let spellcheck ~align unbound_name valid_names =
-  Misc.did_you_mean ~align (fun () -> Misc.spellcheck valid_names unbound_name)
+  Misc.did_you_mean ~align (Misc.spellcheck valid_names unbound_name)
 
 let pp_spellcheck ~align ppf unbound_name valid_names =
   Misc.pp_hint ppf (spellcheck ~align unbound_name valid_names)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7009,7 +7009,7 @@ let report_error ~loc env = function
         Style.inline_code name
   | Orpat_vars (id, valid_idents) ->
      Location.error_of_printer ~loc (fun ppf () ->
-         Misc.with_aligned_hint ppf
+         Misc.aligned_error_hint ppf
            "@{<ralign>Variable @}%a must occur on both sides of this %a pattern"
            Style.inline_code (Ident.name id)
            Style.inline_code "|"
@@ -7114,7 +7114,7 @@ let report_error ~loc env = function
         Printtyp.wrap_printing_env ~error:true env (fun () ->
           let { ty; explanation } = ty_expected in
           if Path.is_constructor_typath type_path then
-            Misc.with_aligned_hint ppf
+            Misc.aligned_error_hint ppf
               "@{<ralign>The field @}%a is not part of the record argument \
                for the %a constructor"
               Style.inline_code name.txt
@@ -7125,7 +7125,7 @@ let report_error ~loc env = function
               "@[<2>%s type@ %a%a@]@\n"
               eorp (Style.as_inline_code Printtyp.type_expr) ty
               pp_doc (report_type_expected_explanation_opt explanation);
-            Misc.with_aligned_hint ppf
+            Misc.aligned_error_hint ppf
               "@{<ralign>There is no %s @}%a within type %a"
               (Datatype_kind.label_name kind)
               Style.inline_code name.txt
@@ -7164,7 +7164,7 @@ let report_error ~loc env = function
           fprintf ppf
             "@[<v>@[This expression has type@;<1 2>%a@]@,@]"
             (Style.as_inline_code Printtyp.type_expr) ty;
-          Misc.with_aligned_hint ppf
+          Misc.aligned_error_hint ppf
             "@{<ralign>It has no method @}%a" Style.inline_code me
             (match valid_methods with
              | None -> None
@@ -7173,7 +7173,7 @@ let report_error ~loc env = function
       )) ()
   | Undefined_self_method (me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Misc.with_aligned_hint ppf
+        Misc.aligned_error_hint ppf
           "@{<ralign>This expression has no method @}%a"
           Style.inline_code me
           (spellcheck me valid_methods)
@@ -7183,7 +7183,7 @@ let report_error ~loc env = function
         quoted_longident cl
   | Unbound_instance_variable (var, valid_vars) ->
      Location.error_of_printer ~loc (fun ppf () ->
-         Misc.with_aligned_hint ppf
+         Misc.aligned_error_hint ppf
            "@{<ralign>Unbound instance variable @}%a" Style.inline_code var
            (spellcheck var valid_vars)
        ) ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7010,12 +7010,9 @@ let report_error ~loc env = function
   | Orpat_vars (id, valid_idents) ->
      Location.error_of_printer ~loc (fun ppf () ->
          Misc.with_aligned_hint ppf
-           (doc_printf
-              "@{<ralign>Variable @}%a must occur on both sides of \
-               this %a pattern"
-              Style.inline_code (Ident.name id)
-              Style.inline_code "|"
-           )
+           "@{<ralign>Variable @}%a must occur on both sides of this %a pattern"
+           Style.inline_code (Ident.name id)
+           Style.inline_code "|"
            (spellcheck_idents id valid_idents)
        ) ()
   | Expr_type_clash (err, explanation, exp) ->
@@ -7117,25 +7114,22 @@ let report_error ~loc env = function
         Printtyp.wrap_printing_env ~error:true env (fun () ->
           let { ty; explanation } = ty_expected in
           if Path.is_constructor_typath type_path then
-              Misc.with_aligned_hint ppf
-                (doc_printf
-                   "@{<ralign>The field @}%a is not part of the record \
-                    argument for the %a constructor"
-                   Style.inline_code name.txt
-                   (Style.as_inline_code Printtyp.type_path) type_path
-                )
-                (spellcheck name.txt valid_names)
+            Misc.with_aligned_hint ppf
+              "@{<ralign>The field @}%a is not part of the record argument \
+               for the %a constructor"
+              Style.inline_code name.txt
+              (Style.as_inline_code Printtyp.type_path) type_path
+              (spellcheck name.txt valid_names)
           else begin
             fprintf ppf
               "@[<2>%s type@ %a%a@]@\n"
               eorp (Style.as_inline_code Printtyp.type_expr) ty
               pp_doc (report_type_expected_explanation_opt explanation);
             Misc.with_aligned_hint ppf
-              (doc_printf "@{<ralign>There is no %s @}%a within type %a"
-                 (Datatype_kind.label_name kind)
-                 Style.inline_code name.txt
-                 (Style.as_inline_code Printtyp.type_path) type_path
-              )
+              "@{<ralign>There is no %s @}%a within type %a"
+              (Datatype_kind.label_name kind)
+              Style.inline_code name.txt
+              (Style.as_inline_code Printtyp.type_path) type_path
               (spellcheck name.txt valid_names)
           end;
       )) ()
@@ -7171,17 +7165,17 @@ let report_error ~loc env = function
             "@[<v>@[This expression has type@;<1 2>%a@]@,@]"
             (Style.as_inline_code Printtyp.type_expr) ty;
           Misc.with_aligned_hint ppf
-            (doc_printf "@{<ralign>It has no method @}%a" Style.inline_code me)
-          begin match valid_methods with
-            | None -> None
-            | Some valid_methods -> spellcheck me valid_methods
-          end
+            "@{<ralign>It has no method @}%a" Style.inline_code me
+            (match valid_methods with
+             | None -> None
+             | Some valid_methods -> spellcheck me valid_methods
+            )
       )) ()
   | Undefined_self_method (me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
         Misc.with_aligned_hint ppf
-          (doc_printf "@{<ralign>This expression has no method @}%a"
-             Style.inline_code me)
+          "@{<ralign>This expression has no method @}%a"
+          Style.inline_code me
           (spellcheck me valid_methods)
       ) ()
   | Virtual_class cl ->
@@ -7190,8 +7184,7 @@ let report_error ~loc env = function
   | Unbound_instance_variable (var, valid_vars) ->
      Location.error_of_printer ~loc (fun ppf () ->
          Misc.with_aligned_hint ppf
-           (doc_printf "@{<ralign>Unbound instance variable @}%a"
-              Style.inline_code var)
+           "@{<ralign>Unbound instance variable @}%a" Style.inline_code var
            (spellcheck var valid_vars)
        ) ()
   | Instance_variable_not_mutable v ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -893,7 +893,7 @@ let pp_type ppf ty = Style.as_inline_code Printtyp.Doc.type_expr ppf ty
 
 let report_error_doc env ppf = function
   | Unbound_type_variable (name, in_scope_names) ->
-    Misc.with_aligned_hint ppf
+    Misc.aligned_error_hint ppf
       "@{<ralign>The type variable @}%a is unbound in this type declaration."
         Style.inline_code name
         (did_you_mean (Misc.spellcheck in_scope_names name))
@@ -947,15 +947,15 @@ let report_error_doc env ppf = function
           "which should be"
           pp_out_type (Out_type.tree_of_typexp Type ty'))
   | Not_a_variant ty ->
-      Misc.with_aligned_hint ppf
+      Misc.aligned_error_hint ppf
         "@{<ralign>The type @}%a@ does not expand to a polymorphic variant type"
         pp_type ty
-        (match get_desc ty with
+        begin match get_desc ty with
         | Tvar (Some s) ->
            (* PR#7012: help the user that wrote 'Foo instead of `Foo *)
            Misc.did_you_mean  ["`" ^ s]
         | _ -> None
-        )
+        end
   | Variant_tags (lab1, lab2) ->
       fprintf ppf
         "@[Variant tags %a@ and %a have the same hash value.@ %s@]"

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -894,8 +894,8 @@ let pp_type ppf ty = Style.as_inline_code Printtyp.Doc.type_expr ppf ty
 let report_error_doc env ppf = function
   | Unbound_type_variable (name, in_scope_names) ->
     let sub ppf =
-      Misc.pp_hint ppf @@
-        did_you_mean ~align:7  (fun () -> Misc.spellcheck in_scope_names name)
+      Misc.pp_hint ppf
+      @@ did_you_mean ~align:7 (Misc.spellcheck in_scope_names name)
     in
     fprintf ppf "The type variable %a is unbound in this type declaration.%t"
       Style.inline_code name
@@ -954,7 +954,7 @@ let report_error_doc env ppf = function
         match get_desc ty with
         | Tvar (Some s) ->
            (* PR#7012: help the user that wrote 'Foo instead of `Foo *)
-           Misc.did_you_mean ~align:1 (fun () -> ["`" ^ s])
+           Misc.did_you_mean ~align:1 ["`" ^ s]
         | _ -> None
       in
       fprintf ppf

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -894,11 +894,9 @@ let pp_type ppf ty = Style.as_inline_code Printtyp.Doc.type_expr ppf ty
 let report_error_doc env ppf = function
   | Unbound_type_variable (name, in_scope_names) ->
     Misc.with_aligned_hint ppf
-      (doc_printf
-        "@{<ralign>The type variable @}%a is unbound in this type declaration."
+      "@{<ralign>The type variable @}%a is unbound in this type declaration."
         Style.inline_code name
-      )
-     (did_you_mean (Misc.spellcheck in_scope_names name))
+        (did_you_mean (Misc.spellcheck in_scope_names name))
   | No_type_wildcards ->
       fprintf ppf "A type wildcard %a is not allowed in this type declaration."
         Style.inline_code "_"
@@ -950,11 +948,8 @@ let report_error_doc env ppf = function
           pp_out_type (Out_type.tree_of_typexp Type ty'))
   | Not_a_variant ty ->
       Misc.with_aligned_hint ppf
-        (doc_printf
-           "@{<ralign>The type @}%a@ does not expand to \
-            a polymorphic variant type"
-           pp_type ty
-        )
+        "@{<ralign>The type @}%a@ does not expand to a polymorphic variant type"
+        pp_type ty
         (match get_desc ty with
         | Tvar (Some s) ->
            (* PR#7012: help the user that wrote 'Foo instead of `Foo *)

--- a/utils/format_doc.mli
+++ b/utils/format_doc.mli
@@ -140,6 +140,14 @@ module Doc: sig
   val result: ok:'a printer -> error:'e printer -> ('a,'e) result printer
   val either: left:'a printer -> right:'b printer -> ('a,'b) Either.t printer
 
+  (** {1 Alignment functions } *)
+
+  (** Align the right side of one ["@{<ralign>...@}"] tag box by inserting
+      spaces at the beginning of boxes. Those function do nothing if the tag box
+      appears after a break hint. *)
+  val align_prefix: (t * int) list -> t list
+  val align_prefix2: (t * int) -> (t * int) -> t * t
+
 end
 
 (** {1 Compatibility API} *)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1014,7 +1014,7 @@ let spellcheck env name =
   let env = List.sort_uniq (fun s1 s2 -> String.compare s2 s1) env in
   fst (List.fold_left (compare name) ([], max_int) env)
 
-let with_aligned_hint ?(prefix="Error: ") ppf main_fmt  =
+let aligned_hint ~prefix ppf main_fmt  =
   let open Format_doc in
   kdoc_printf (fun main hint ->
       match hint with
@@ -1024,6 +1024,9 @@ let with_aligned_hint ?(prefix="Error: ") ppf main_fmt  =
         let h, main = Format_doc.Doc.align_prefix2 (h,0) (main,error_shift) in
         fprintf ppf "%a@.%a" pp_doc main pp_doc h
     ) main_fmt
+
+let aligned_error_hint ppf main_fmt =
+  aligned_hint ~prefix:"Error: " ppf main_fmt
 
 let did_you_mean ?(pp=Style.inline_code) choices =
   let open Format_doc in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1018,9 +1018,9 @@ let pp_spaces ppf a = for _i = 1 to a do Format_doc.pp_print_string ppf " " done
 let pp_hint ppf d = Option.iter Format_doc.(fprintf ppf "@.%a" pp_doc) d
 let pp_align d ppf n = Option.iter (fun _ -> pp_spaces ppf n) d
 
-let did_you_mean ~align ?(pp=Style.inline_code) get_choices =
+let did_you_mean ~align ?(pp=Style.inline_code) choices =
   let open Format_doc in
-  match get_choices () with
+  match choices with
   | [] -> None
   | choices ->
     let rest, last = split_last choices in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1014,14 +1014,16 @@ let spellcheck env name =
   let env = List.sort_uniq (fun s1 s2 -> String.compare s2 s1) env in
   fst (List.fold_left (compare name) ([], max_int) env)
 
-let with_aligned_hint ?(prefix="Error: ") ppf main hint =
+let with_aligned_hint ?(prefix="Error: ") ppf main_fmt  =
   let open Format_doc in
-  match hint with
-  | None -> pp_doc ppf main
-  | Some h ->
-    let error_shift = String.length prefix in
-    let h, main = Format_doc.Doc.align_prefix2 (h,0) (main,error_shift) in
-    fprintf ppf "%a@.%a" pp_doc main pp_doc h
+  kdoc_printf (fun main hint ->
+      match hint with
+      | None -> pp_doc ppf main
+      | Some h ->
+        let error_shift = String.length prefix in
+        let h, main = Format_doc.Doc.align_prefix2 (h,0) (main,error_shift) in
+        fprintf ppf "%a@.%a" pp_doc main pp_doc h
+    ) main_fmt
 
 let did_you_mean ?(pp=Style.inline_code) choices =
   let open Format_doc in

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -452,10 +452,32 @@ val spellcheck : string list -> string -> string list
 val aligned_hint:
   prefix:string -> Format_doc.formatter ->
   ('a, Format_doc.formatter, unit, Format_doc.t option -> unit) format4 -> 'a
-(** [aligned_hint ppf fmt ... hint] align the right end of
-    [@{<ralign>...@}] box in the main error message and the hint under the
-    assumption that there is an implicit [prefix] before the main
-    error message. *)
+(** [aligned_hint ~prefix ppf fmt ... hint] vertically aligns a main message
+    (described by the [fmt] format string) and a possible hint message. The
+    vertical alignment is controlled by the use of [@{<ralign> ... @}] boxes:
+    the start of one box, in either the hint or the main message, will be
+    shifted on the left to ensure that the end of the two boxes are vertically
+    aligned, taking in account a pre-existing [prefix] before the main message.
+    For instance, if you have already printed ["Error: "] at the beginning of
+    the current line
+
+{[aligned_hint
+    ~prefix:"Error: " "@{<ralign>The value @}%a is not an instance variable"
+      Style.inline_code "foobar"
+    (Some(doc_printf
+      "@{<ralign>Did you mean @}%a" Style.inline_code "foobaz"
+    ))]}
+
+  produces the following text:
+
+{[
+Error:   The value "foobaz" is not an instance variable
+Hint: Did you mean "foobar"?
+]}
+
+  where the main message has been shifted to the left to align ["foobaz"] and
+  ["foobar"].
+*)
 
 val aligned_error_hint:
   Format_doc.formatter ->
@@ -463,10 +485,9 @@ val aligned_error_hint:
 (** Same as [aligned_hint ~prefix:"Error: "] *)
 
 val did_you_mean :
-    ?pp:string Format_doc.printer ->
-    string list -> Format_doc.t option
-(** [did_you_mean ~align ~pp choices] hints that the user may have meant one of
-  the option in [choices].
+    ?pp:string Format_doc.printer -> string list -> Format_doc.t option
+(** [did_you_mean ~pp choices] hints that the user may have meant one of the
+  option in [choices].
 
   Each choice is printed with the [pp] function, or [Style.inline_code] if
   [pp]=[None].

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -451,7 +451,7 @@ val spellcheck : string list -> string -> string list
 
 val with_aligned_hint:
   ?prefix:string -> Format_doc.formatter ->
-  Format_doc.t -> Format_doc.t option -> unit
+  ('a, Format_doc.formatter, unit, Format_doc.t option -> unit) format4 -> 'a
 
 val did_you_mean :
     ?pp:string Format_doc.printer ->

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -449,9 +449,12 @@ val spellcheck : string list -> string -> string list
     list of suggestions taken from [env], that are close enough to
     [name] that it may be a typo for one of them. *)
 
+val pp_spaces: int Format_doc.printer
+val pp_hint: Format_doc.t option Format_doc.printer
+val pp_align: Format_doc.t option -> int Format_doc.printer
 val did_you_mean :
-    ?pp:string Format_doc.printer -> Format_doc.formatter ->
-    (unit -> string list) -> unit
+    align:int -> ?pp:string Format_doc.printer ->
+    (unit -> string list) -> Format_doc.t option
 (** [did_you_mean ppf get_choices] hints that the user may have meant
     one of the option returned by calling [get_choices]. It does nothing
     if the returned list is empty.

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -454,17 +454,15 @@ val pp_hint: Format_doc.t option Format_doc.printer
 val pp_align: Format_doc.t option -> int Format_doc.printer
 val did_you_mean :
     align:int -> ?pp:string Format_doc.printer ->
-    (unit -> string list) -> Format_doc.t option
-(** [did_you_mean ppf get_choices] hints that the user may have meant
-    one of the option returned by calling [get_choices]. It does nothing
-    if the returned list is empty.
+    string list -> Format_doc.t option
+(** [did_you_mean ~align ~pp choices] hints that the user may have meant one of
+  the option in [choices].
 
-    The [unit -> ...] thunking is meant to delay any potentially-slow
-    computation (typically computing edit-distance with many things
-    from the current environment) to when the hint message is to be
-    printed. You should print an understandable error message before
-    calling [did_you_mean], so that users get a clear notification of
-    the failure even if producing the hint is slow.
+  The [align] parameter can be used to align the first suggestion with the
+  original.
+
+  Each choice is printed with the [pp] function, or [Style.inline_code] if
+  [pp]=[None].
 *)
 
 (** {1 Color support detection }*)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -449,17 +449,15 @@ val spellcheck : string list -> string -> string list
     list of suggestions taken from [env], that are close enough to
     [name] that it may be a typo for one of them. *)
 
-val pp_spaces: int Format_doc.printer
-val pp_hint: Format_doc.t option Format_doc.printer
-val pp_align: Format_doc.t option -> int Format_doc.printer
+val with_aligned_hint:
+  ?prefix:string -> Format_doc.formatter ->
+  Format_doc.t -> Format_doc.t option -> unit
+
 val did_you_mean :
-    align:int -> ?pp:string Format_doc.printer ->
+    ?pp:string Format_doc.printer ->
     string list -> Format_doc.t option
 (** [did_you_mean ~align ~pp choices] hints that the user may have meant one of
   the option in [choices].
-
-  The [align] parameter can be used to align the first suggestion with the
-  original.
 
   Each choice is printed with the [pp] function, or [Style.inline_code] if
   [pp]=[None].

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -449,9 +449,18 @@ val spellcheck : string list -> string -> string list
     list of suggestions taken from [env], that are close enough to
     [name] that it may be a typo for one of them. *)
 
-val with_aligned_hint:
-  ?prefix:string -> Format_doc.formatter ->
+val aligned_hint:
+  prefix:string -> Format_doc.formatter ->
   ('a, Format_doc.formatter, unit, Format_doc.t option -> unit) format4 -> 'a
+(** [aligned_hint ppf fmt ... hint] align the right end of
+    [@{<ralign>...@}] box in the main error message and the hint under the
+    assumption that there is an implicit [prefix] before the main
+    error message. *)
+
+val aligned_error_hint:
+  Format_doc.formatter ->
+  ('a, Format_doc.formatter, unit, Format_doc.t option -> unit) format4 -> 'a
+(** Same as [aligned_hint ~prefix:"Error: "] *)
 
 val did_you_mean :
     ?pp:string Format_doc.printer ->


### PR DESCRIPTION
This PR aligns the first suggestion of the spellchecking hint with the potentially misspelled identifier in every error messages.

The implementation is quite manual, and has the drawback of removing the lazy evaluation of suggestions, but it works without requiring new features in either `Format` or `Format_doc`.
