### PR TITLE
Always call `apt-get update` in CI before installing

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -77,6 +77,7 @@ jobs:
           tar xaf ocaml.tar.zst -C "$HOME"
           rm -f ocaml.tar.zst
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64-x86-64
       - name: Checkout OCaml
         uses: actions/checkout@v4
@@ -145,6 +146,7 @@ jobs:
           tar xaf ocaml.tar.zst -C "$HOME"
           rm -f ocaml.tar.zst
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          sudo apt-get update -y
           sudo apt-get install -y gcc-aarch64-linux-gnu qemu-user
       - name: Checkout OCaml
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Packages
         if: matrix.dependencies != ''
         run: |
-          sudo apt-get update -y && sudo apt-get install -y ${{ matrix.dependencies }}
+          sudo apt-get update -y
+          sudo apt-get install -y ${{ matrix.dependencies }}
       - name: Run the testsuite
         if: matrix.id == 'normal'
         run: |
@@ -216,7 +217,7 @@ jobs:
     steps:
       - name: OS Dependencies
         run: |
-          apt-get update
+          apt-get update -y
           apt-get install -y git gcc make parallel
           adduser --disabled-password --gecos '' ocaml
       - name: Checkout

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install libunwind
-        run: sudo apt install -y libunwind-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libunwind-dev
       # This temporary workaround reduces the number of random bits for the base
       # address of vma regions for mmap allocation, to avoid the
       # "FATAL: ThreadSanitizer: unexpected memory mapping" TSan error.
@@ -85,7 +87,8 @@ jobs:
       - name: Packages
         if: matrix.dependencies != ''
         run: |
-          sudo apt-get update -y && sudo apt-get install -y ${{ matrix.dependencies }}
+          sudo apt-get update -y
+          sudo apt-get install -y ${{ matrix.dependencies }}
       - name: Run the testsuite
         if: matrix.id == 'normal'
         # Run testsuite with 30-minute timeout per test


### PR DESCRIPTION
Spotted this morning - the cross-arm-linux job is failing for a test run of mine:

```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.42-4ubuntu2.3_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
Fetched 41.4 MB in 2s (17.2 MB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user_8.2.2%2bds-0ubuntu1.5_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-binfmt_8.2.2%2bds-0ubuntu1.5_amd64.deb  [40](https://github.com/dra27/ocaml/actions/runs/13587463098/job/37986133224?pr=162#step:3:41)4  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

Change here just ensures that `apt-get update` is always called - the main workflow already did this.