### PR TITLE
Harden the C primitives type against `-Wcast-function-type`

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,10 @@ Working version
   and RISC-V.  This reduces minor GC work in the presence of deep call stacks.
   (Xavier Leroy, review by Miod Vallat, Gabriel Scherer and Olivier Nicole)
 
+- #13841: Prevent cast-function-type compiler warnings on primitives
+  by using a generic function pointer type from the future.
+  (Antonin Décimo, review by ???)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -179,18 +179,27 @@ let output_primitive_table outchan =
     fprintf outchan "extern value %s(void);\n" prim.(i)
   done;
   fprintf outchan {|
-typedef value (*c_primitive)(void);
+struct caml_incomplete;
+typedef void (*caml_function_ptr_t)(struct caml_incomplete);
 
 #if defined __cplusplus
 extern
 #endif
-const c_primitive caml_builtin_cprim[] = {
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+const caml_function_ptr_t caml_builtin_cprim[] = {
 |};
   for i = 0 to Array.length prim - 1 do
-    fprintf outchan "  %s,\n" prim.(i)
+    fprintf outchan "  (caml_function_ptr_t) %s,\n" prim.(i)
   done;
   fprintf outchan
 {|  0 };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #if defined __cplusplus
 extern

--- a/configure
+++ b/configure
@@ -15113,8 +15113,7 @@ case $ocaml_cc_vendor in #(
   msvc-*) :
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
--Wno-cast-function-type-mismatch"
+    cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
          warn_error_flag='-WX' ;; #(
   *) :
     cc_warnings='-W2'
@@ -15211,6 +15210,48 @@ else $as_nop
 fi
 
 done
+
+# Use -Wcast-function-type if supported
+as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-Wcast-function-type" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -Wcast-function-type" >&5
+printf %s "checking whether the C compiler accepts -Wcast-function-type... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag -Wcast-function-type"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  cc_warnings="$cc_warnings -Wcast-function-type"
+else $as_nop
+  :
+fi
+
 
 case $enable_warn_error,true in #(
   yes,*|,true) :

--- a/configure.ac
+++ b/configure.ac
@@ -921,8 +921,7 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [AS_CASE([$ocaml_cc_vendor],
       [msvc-*-clang-*],
-        [cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
--Wno-cast-function-type-mismatch"
+        [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
          warn_error_flag='-WX'],
       [cc_warnings='-W2'
        warn_error_flag='-WX -options:strict'])],
@@ -940,6 +939,11 @@ for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
   AX_CHECK_COMPILE_FLAG([$flag],
     [cc_warnings="$cc_warnings $flag"; break], [], [$warn_error_flag])
 done
+
+# Use -Wcast-function-type if supported
+AX_CHECK_COMPILE_FLAG([-Wcast-function-type],
+  [cc_warnings="$cc_warnings -Wcast-function-type"], [],
+  [$warn_error_flag])
 
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],

--- a/runtime/caml/prims.h
+++ b/runtime/caml/prims.h
@@ -20,9 +20,10 @@
 
 #ifdef CAML_INTERNALS
 
-typedef value (*c_primitive)(void);
+struct caml_incomplete;
+typedef void (*caml_function_ptr_t)(struct caml_incomplete);
 
-extern const c_primitive caml_builtin_cprim[];
+extern const caml_function_ptr_t caml_builtin_cprim[];
 extern const char * const caml_names_of_builtin_cprim[];
 
 extern struct ext_table caml_prim_table;

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -63,7 +63,7 @@ struct ext_table caml_shared_libs_path;
 
 /* Look up the given primitive name in the built-in primitive table,
    then in the opened shared libraries (shared_libs) */
-static c_primitive lookup_primitive(const char * name)
+static caml_function_ptr_t lookup_primitive(const char * name)
 {
   void * res;
 
@@ -73,7 +73,7 @@ static c_primitive lookup_primitive(const char * name)
   }
   for (int i = 0; i < shared_libs.size; i++) {
     res = caml_dlsym(shared_libs.contents[i], name);
-    if (res != NULL) return (c_primitive) res;
+    if (res != NULL) return (caml_function_ptr_t) res;
   }
   return NULL;
 }
@@ -195,10 +195,10 @@ void caml_build_primitive_table(char_os * lib_path,
   caml_ext_table_init(&caml_prim_name_table, 0x180);
   if (req_prims != NULL)
     for (char *q = req_prims; *q != 0; q += strlen(q) + 1) {
-      c_primitive prim = lookup_primitive(q);
+      caml_function_ptr_t prim = lookup_primitive(q);
       if (prim == NULL)
             caml_fatal_error("unknown C primitive `%s'", q);
-      caml_ext_table_add(&caml_prim_table, (void *) prim);
+      caml_ext_table_add(&caml_prim_table, prim);
       caml_ext_table_add(&caml_prim_name_table, caml_stat_strdup(q));
     }
 }

--- a/runtime/gen_primsc.sh
+++ b/runtime/gen_primsc.sh
@@ -51,13 +51,24 @@ sed \
   -e 's/).*$/);/'
 
 # Generate the table of primitives
-echo
-echo 'const c_primitive caml_builtin_cprim[] = {'
-sed -e 's/.*/  (c_primitive) &,/' "$primitives"
-echo '  0 };'
+cat <<'EOF'
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+const caml_function_ptr_t caml_builtin_cprim[] = {
+EOF
+sed -e 's/.*/  (caml_function_ptr_t) &,/' "$primitives"
+cat <<'EOF'
+  0 };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+EOF
 
 # Generate the table of primitive names
-echo
 echo 'const char * const caml_names_of_builtin_cprim[] = {'
 sed -e 's/.*/  "&",/' "$primitives"
 echo '  0 };'


### PR DESCRIPTION
[GCC] and [clang] both have a `-Wcast-function-type` warning under `-Wextra`, that complains about casts in our list of primitives. This warning is also (sometimes?) enabled by clang-cl `-W4` option.

    runtime/prims.c:920:3: error: cast between incompatible function types from ‘value (*)(value)’
    {aka ‘long int (*)(long int)’} to ‘value (*)(void)’ {aka ‘long int (*)(void)’}
    [-Werror=cast-function-type]
      920 |   (c_primitive) caml_zstd_initialize,
          |   ^

[GCC]: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcast-function-type
[clang]: https://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type

I'm trying to silence this warning, but without disabling it globally with `-Wno-cast-function-type`, as it could still catch problems.

1. GCC has a workaround that's unsupported by clang.

   > The function type `void (*) (void)` is special and matches everything, which can be used to suppress this warning.

   It's not ideal as it could be the prototype of an existing function.

2. We can instead store the function pointers as `void *`, a la `dlsym(3)`, in the primitive array. Recent POSIX guarantees that function pointers returned by `dlsym` may be stored in object pointers, but no longer that _any_ function pointer may be stored in an object pointer (see POSIX 2008 § 2.12.3 Pointer Types, removed in later versions).

   In practice, (I think) storing function pointers in object pointers should be fine on any modern, non-segmented architectures. This is also common practice on Windows.

3. Define a generic function pointer type that any function pointer can be cast to and from, but that is not callable. This allows using the `-Wcast-function-type` warning for catching possible future mistakes.

   - C⁠+⁠+26 has a proposal for a generic function pointer: [P2986R0 Generic Function Pointer](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2986r0.html)
   - There was one for C23, not retained at the time: [N2230 Generic Function Pointer](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2230.htm)

   We can use the work-around described in the draft, but without a dedicated compiler attribute, we have to resort to using compiler-specific pragmas to disable the `-Wcast-function-type` warning around casts to `caml_function_ptr_t`. Using the pragmas is arguably tedious, but manageable as they only appear in the _generated_ C files. I assume that all compilers that have this warning also have ways of disabling it locally.

Here, I'm going with option 3, inspired by the N2230 draft, using compiler pragmas.