### PR TITLE
Signals

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,6 +255,13 @@ Working version
 - #13932: Add List.singleton and Seq.singleton
   (David Allsopp, tariffs applied by Nicolás Ojeda Bär and Gabriel Scherer)
 
+* #13843: Add signal definitions for SIGIO and SIGWINCH. Introduces a
+  type alias for signal int, signal_to_string to convert OCaml signal numbers
+  to their POSIX equivalent names, and signal_of_int/signal_to_int for
+  converting between OCaml and platform signal numbers. (Reported in #13825)
+  (Tim McGilchrist, review by David Allsopp, Nicolás Ojeda Bär, Daniel Bünzli
+   Jan Midtgaard and Miod Vallat)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -190,15 +190,14 @@ type process_status =
     WEXITED of int
         (** The process terminated normally by [exit];
            the argument is the return code. *)
-  | WSIGNALED of int
+  | WSIGNALED of Sys.signal
         (** The process was killed by a signal;
            the argument is the signal number. *)
-  | WSTOPPED of int
+  | WSTOPPED of Sys.signal
         (** The process was stopped by a signal; the argument is the
            signal number. *)
-(** The termination status of a process.  See module {!Sys} for the
-    definitions of the standard signal numbers.  Note that they are
-    not the numbers used by the OS.
+(** The termination status of a process. See {!Sys.signal} for the
+    definitions of the standard signal numbers.
 
     On Windows: only [WEXITED] is used (as there are no inter-process signals)
     but with specific return codes to indicate special termination causes.
@@ -1152,7 +1151,7 @@ val lockf : file_descr -> lock_command -> int -> unit
    the functions {!Sys.signal} and {!Sys.set_signal}.
 *)
 
-val kill : int -> int -> unit
+val kill : int -> Sys.signal -> unit
 (** [kill pid signal] sends signal number [signal] to the process
    with id [pid].
 
@@ -1163,7 +1162,7 @@ type sigprocmask_command =
   | SIG_BLOCK
   | SIG_UNBLOCK
 
-val sigprocmask : sigprocmask_command -> int list -> int list
+val sigprocmask : sigprocmask_command -> Sys.signal list -> Sys.signal list
 (** [sigprocmask mode sigs] changes the set of blocked signals.
    If [mode] is [SIG_SETMASK], blocked signals are set to those in
    the list [sigs].
@@ -1180,13 +1179,13 @@ val sigprocmask : sigprocmask_command -> int list -> int list
    @raise Invalid_argument on Windows (no inter-process signals on
    Windows) *)
 
-val sigpending : unit -> int list
+val sigpending : unit -> Sys.signal list
 (** Return the set of blocked signals that are currently pending.
 
    @raise Invalid_argument on Windows (no inter-process
    signals on Windows) *)
 
-val sigsuspend : int list -> unit
+val sigsuspend : Sys.signal list -> unit
 (** [sigsuspend sigs] atomically sets the blocked signals to [sigs]
    and waits for a non-ignored, non-blocked signal to be delivered.
    On return, the blocked signals are reset to their initial value.
@@ -1200,7 +1199,7 @@ val pause : unit -> unit
    @raise Invalid_argument on Windows (no inter-process signals on
    Windows) *)
 
-val sigwait : int list -> int
+val sigwait : Sys.signal list -> Sys.signal
 (** [sigwait sigs] waits until one of the signals in the list [sigs]
    becomes pending.  It then removes this signal from the set of pending
    signals, and returns the number of this signal.

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -190,15 +190,14 @@ type process_status = Unix.process_status =
     WEXITED of int
         (** The process terminated normally by [exit];
            the argument is the return code. *)
-  | WSIGNALED of int
+  | WSIGNALED of Sys.signal
         (** The process was killed by a signal;
            the argument is the signal number. *)
-  | WSTOPPED of int
+  | WSTOPPED of Sys.signal
         (** The process was stopped by a signal; the argument is the
            signal number. *)
-(** The termination status of a process.  See module {!Sys} for the
-    definitions of the standard signal numbers.  Note that they are
-    not the numbers used by the OS.
+(** The termination status of a process. See {!Sys.signal} for the
+    definitions of the standard signal numbers.
 
     On Windows: only [WEXITED] is used (as there are no inter-process signals)
     but with specific return codes to indicate special termination causes.
@@ -1152,7 +1151,7 @@ val lockf : file_descr -> mode:lock_command -> len:int -> unit
    the functions {!Sys.signal} and {!Sys.set_signal}.
 *)
 
-val kill : pid:int -> signal:int -> unit
+val kill : pid:int -> signal:Sys.signal -> unit
 (** [kill ~pid ~signal] sends signal number [signal] to the process
    with id [pid].
 
@@ -1163,7 +1162,7 @@ type sigprocmask_command = Unix.sigprocmask_command =
   | SIG_BLOCK
   | SIG_UNBLOCK
 
-val sigprocmask : mode:sigprocmask_command -> int list -> int list
+val sigprocmask : mode:sigprocmask_command -> Sys.signal list -> Sys.signal list
 (** [sigprocmask ~mode sigs] changes the set of blocked signals.
    If [mode] is [SIG_SETMASK], blocked signals are set to those in
    the list [sigs].
@@ -1180,13 +1179,13 @@ val sigprocmask : mode:sigprocmask_command -> int list -> int list
    @raise Invalid_argument on Windows (no inter-process signals on
    Windows) *)
 
-val sigpending : unit -> int list
+val sigpending : unit -> Sys.signal list
 (** Return the set of blocked signals that are currently pending.
 
    @raise Invalid_argument on Windows (no inter-process
    signals on Windows) *)
 
-val sigsuspend : int list -> unit
+val sigsuspend : Sys.signal list -> unit
 (** [sigsuspend sigs] atomically sets the blocked signals to [sigs]
    and waits for a non-ignored, non-blocked signal to be delivered.
    On return, the blocked signals are reset to their initial value.
@@ -1200,7 +1199,7 @@ val pause : unit -> unit
    @raise Invalid_argument on Windows (no inter-process signals on
    Windows) *)
 
-val sigwait : int list -> int
+val sigwait : Sys.signal list -> Sys.signal
 (** [sigwait sigs] waits until one of the signals in the list [sigs]
    becomes pending.  It then removes this signal from the set of pending
    signals, and returns the number of this signal.

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -499,12 +499,18 @@ CAMLexport value caml_process_pending_actions_exn(void)
 #ifndef SIGXFSZ
 #define SIGXFSZ -1
 #endif
+#ifndef SIGIO
+#define SIGIO -1
+#endif
+#ifndef SIGWINCH
+#define SIGWINCH -1
+#endif
 
 static const int posix_signals[] = {
   SIGABRT, SIGALRM, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE,
   SIGQUIT, SIGSEGV, SIGTERM, SIGUSR1, SIGUSR2, SIGCHLD, SIGCONT,
   SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU, SIGVTALRM, SIGPROF, SIGBUS,
-  SIGPOLL, SIGSYS, SIGTRAP, SIGURG, SIGXCPU, SIGXFSZ
+  SIGPOLL, SIGSYS, SIGTRAP, SIGURG, SIGXCPU, SIGXFSZ, SIGIO, SIGWINCH
 };
 
 CAMLexport int caml_convert_signal_number(int signo)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -521,11 +521,21 @@ CAMLexport int caml_convert_signal_number(int signo)
     return signo;
 }
 
+CAMLprim value caml_sys_convert_signal_number(value signo)
+{
+  return Val_int(caml_convert_signal_number(Int_val(signo)));
+}
+
 CAMLexport int caml_rev_convert_signal_number(int signo)
 {
   for (int i = 0; i < (int)(sizeof(posix_signals) / sizeof(int)); i++)
     if (signo == posix_signals[i]) return -i - 1;
   return signo;
+}
+
+CAMLprim value caml_sys_rev_convert_signal_number(value signo)
+{
+  return Val_int(caml_rev_convert_signal_number(Int_val(signo)));
 }
 
 void * caml_init_signal_stack(void)

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -71,12 +71,14 @@ let io_buffer_size = io_buffer_size ()
 
 let interactive = ref false
 
+type signal = int
+
 type signal_behavior =
     Signal_default
   | Signal_ignore
-  | Signal_handle of (int -> unit)
+  | Signal_handle of (signal -> unit)
 
-external signal : int -> signal_behavior -> signal_behavior
+external signal : signal -> signal_behavior -> signal_behavior
                 = "caml_install_signal_handler"
 
 let set_signal sig_num sig_beh = ignore(signal sig_num sig_beh)
@@ -113,38 +115,37 @@ let sigio = -29
 let sigwinch = -30
 
 let signal_to_string s =
-  match s with
-  | s' when s' == sigabrt -> "SIGABRT"
-  | s' when s' == sigalrm -> "SIGALRM"
-  | s' when s' == sigfpe -> "SIGFPE"
-  | s' when s' == sighup -> "SIGHUP"
-  | s' when s' == sigill -> "SIGILL"
-  | s' when s' == sigint -> "SIGINT"
-  | s' when s' == sigkill -> "SIGKILL"
-  | s' when s' == sigpipe -> "SIGPIPE"
-  | s' when s' == sigquit -> "SIGQUIT"
-  | s' when s' == sigsegv -> "SIGSEGV"
-  | s' when s' == sigterm -> "SIGTERM"
-  | s' when s' == sigusr1 -> "SIGUSR1"
-  | s' when s' == sigusr2 -> "SIGUSR2"
-  | s' when s' == sigchld -> "SIGCHLD"
-  | s' when s' == sigcont -> "SIGCONT"
-  | s' when s' == sigstop -> "SIGSTOP"
-  | s' when s' == sigtstp -> "SIGTSTP"
-  | s' when s' == sigttin -> "SIGTTIN"
-  | s' when s' == sigttou -> "SIGTTOU"
-  | s' when s' == sigvtalrm -> "SIGVTALRM"
-  | s' when s' == sigprof -> "SIGPROF"
-  | s' when s' == sigbus -> "SIGBUS"
-  | s' when s' == sigpoll -> "SIGPOLL"
-  | s' when s' == sigsys -> "SIGSYS"
-  | s' when s' == sigtrap -> "SIGTRAP"
-  | s' when s' == sigurg -> "SIGURG"
-  | s' when s' == sigxcpu -> "SIGXCPU"
-  | s' when s' == sigxfsz -> "SIGXFSZ"
-  | s' when s' == sigio -> "SIGIO"
-  | s' when s' == sigwinch -> "SIGWINCH"
-  | s' -> "SIG(" ^ string_of_int s' ^ ")"
+  if s = sigabrt then "SIGABRT"
+  else if s = sigalrm then "SIGALRM"
+  else if s = sigfpe then "SIGFPE"
+  else if s = sighup then "SIGHUP"
+  else if s = sigill then "SIGILL"
+  else if s = sigint then "SIGINT"
+  else if s = sigkill then "SIGKILL"
+  else if s = sigpipe then "SIGPIPE"
+  else if s = sigquit then "SIGQUIT"
+  else if s = sigsegv then "SIGSEGV"
+  else if s = sigterm then "SIGTERM"
+  else if s = sigusr1 then "SIGUSR1"
+  else if s = sigusr2 then "SIGUSR2"
+  else if s = sigchld then "SIGCHLD"
+  else if s = sigcont then "SIGCONT"
+  else if s = sigstop then "SIGSTOP"
+  else if s = sigtstp then "SIGTSTP"
+  else if s = sigttin then "SIGTTIN"
+  else if s = sigttou then "SIGTTOU"
+  else if s = sigvtalrm then "SIGVTALRM"
+  else if s = sigprof then "SIGPROF"
+  else if s = sigbus then "SIGBUS"
+  else if s = sigpoll then "SIGPOLL"
+  else if s = sigsys then "SIGSYS"
+  else if s = sigtrap then "SIGTRAP"
+  else if s = sigurg then "SIGURG"
+  else if s = sigxcpu then "SIGXCPU"
+  else if s = sigxfsz then "SIGXFSZ"
+  else if s = sigio then "SIGIO"
+  else if s = sigwinch then "SIGWINCH"
+  else "SIG(" ^ string_of_int s ^ ")"
 
 exception Break
 

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -109,6 +109,8 @@ let sigtrap = -25
 let sigurg = -26
 let sigxcpu = -27
 let sigxfsz = -28
+let sigio = -29
+let sigwinch = -30
 
 exception Break
 

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -145,6 +145,7 @@ let signal_to_string s =
   else if s = sigxfsz then "SIGXFSZ"
   else if s = sigio then "SIGIO"
   else if s = sigwinch then "SIGWINCH"
+  else if s < sigwinch then invalid_arg "Sys.signal_to_string"
   else "SIG(" ^ string_of_int s ^ ")"
 
 external rev_convert_signal_number: int -> int =
@@ -152,9 +153,13 @@ external rev_convert_signal_number: int -> int =
 external convert_signal_number: int -> int =
   "caml_sys_convert_signal_number"
 
-let signal_of_int i = rev_convert_signal_number i
+let signal_of_int i =
+  if i < 0 then invalid_arg "Sys.signal_of_int"
+  else rev_convert_signal_number i
 
-let signal_to_int i = convert_signal_number i
+let signal_to_int i =
+  if i < sigwinch then invalid_arg "Sys.signal_to_int"
+  else convert_signal_number i
 
 exception Break
 

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -147,6 +147,15 @@ let signal_to_string s =
   else if s = sigwinch then "SIGWINCH"
   else "SIG(" ^ string_of_int s ^ ")"
 
+external rev_convert_signal_number: int -> int =
+  "caml_sys_rev_convert_signal_number"
+external convert_signal_number: int -> int =
+  "caml_sys_convert_signal_number"
+
+let signal_of_int i = rev_convert_signal_number i
+
+let signal_to_int i = convert_signal_number i
+
 exception Break
 
 let catch_break on =

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -112,6 +112,40 @@ let sigxfsz = -28
 let sigio = -29
 let sigwinch = -30
 
+let signal_to_string s =
+  match s with
+  | s' when s' == sigabrt -> "SIGABRT"
+  | s' when s' == sigalrm -> "SIGALRM"
+  | s' when s' == sigfpe -> "SIGFPE"
+  | s' when s' == sighup -> "SIGHUP"
+  | s' when s' == sigill -> "SIGILL"
+  | s' when s' == sigint -> "SIGINT"
+  | s' when s' == sigkill -> "SIGKILL"
+  | s' when s' == sigpipe -> "SIGPIPE"
+  | s' when s' == sigquit -> "SIGQUIT"
+  | s' when s' == sigsegv -> "SIGSEGV"
+  | s' when s' == sigterm -> "SIGTERM"
+  | s' when s' == sigusr1 -> "SIGUSR1"
+  | s' when s' == sigusr2 -> "SIGUSR2"
+  | s' when s' == sigchld -> "SIGCHLD"
+  | s' when s' == sigcont -> "SIGCONT"
+  | s' when s' == sigstop -> "SIGSTOP"
+  | s' when s' == sigtstp -> "SIGTSTP"
+  | s' when s' == sigttin -> "SIGTTIN"
+  | s' when s' == sigttou -> "SIGTTOU"
+  | s' when s' == sigvtalrm -> "SIGVTALRM"
+  | s' when s' == sigprof -> "SIGPROF"
+  | s' when s' == sigbus -> "SIGBUS"
+  | s' when s' == sigpoll -> "SIGPOLL"
+  | s' when s' == sigsys -> "SIGSYS"
+  | s' when s' == sigtrap -> "SIGTRAP"
+  | s' when s' == sigurg -> "SIGURG"
+  | s' when s' == sigxcpu -> "SIGXCPU"
+  | s' when s' == sigxfsz -> "SIGXFSZ"
+  | s' when s' == sigio -> "SIGIO"
+  | s' when s' == sigwinch -> "SIGWINCH"
+  | s' -> "SIG(" ^ string_of_int s' ^ ")"
+
 exception Break
 
 let catch_break on =

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -228,6 +228,13 @@ external poll_actions : unit -> unit = "%poll"
 (** {1 Signal handling} *)
 
 type signal = int
+(** The type for signal numbers.
+
+  This is either a platform independent negative number for those signals
+  that OCaml recognizes or a positive number for a platform dependent
+  signal number. The function {!signal_of_int} converts known platform dependent
+  numbers to independent ones, and {!signal_to_int} does the reverse converting
+  known platform independent numbers to dependent ones. *)
 
 type signal_behavior =
     Signal_default
@@ -354,7 +361,21 @@ val sigwinch : signal
     @since 5.4 *)
 
 val signal_to_string : signal -> string
-(** Signal name as a string, based on POSIX names.
+(** [signal_to_string] formats an OCaml [signal] as a C POSIX
+    {{:http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html}
+    constant} or ["SIG(%d)"] for an unrecognised signal number.
+    @since 5.4 *)
+
+val signal_of_int : int -> signal
+(** [signal_of_int n] converts a platform dependent signal number [n] to
+    an OCaml signal number.
+    This is [n] itself if the number is unknown.
+    @since 5.4 *)
+
+val signal_to_int : signal -> int
+(** [signal_to_int n] converts an OCaml signal number [n] to
+    a platform dependent signal number.
+    This is [n] itself if the number is unknown.
     @since 5.4 *)
 
 exception Break

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -299,7 +299,7 @@ val sigcont : int
 (** Continue *)
 
 val sigstop : int
-(** Stop *)
+(** Stop (cannot be caught or ignored) *)
 
 val sigtstp : int
 (** Interactive stop *)
@@ -344,11 +344,17 @@ val sigxfsz : int
 (** File size limit exceeded
     @since 4.03 *)
 
+val sigio : int
+(** I/O is possible on a descriptor
+    @since 5.4 *)
+
+val sigwinch : int
+(** Window size change
+    @since 5.4 *)
 
 exception Break
 (** Exception raised on interactive interrupt if {!Sys.catch_break}
    is enabled. *)
-
 
 val catch_break : bool -> unit
 (** [catch_break] governs whether interactive interrupt (ctrl-C)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -227,11 +227,12 @@ external poll_actions : unit -> unit = "%poll"
 
 (** {1 Signal handling} *)
 
+type signal = int
 
 type signal_behavior =
     Signal_default
   | Signal_ignore
-  | Signal_handle of (int -> unit)   (** *)
+  | Signal_handle of (signal -> unit)   (** *)
 (** What to do when receiving a signal:
    - [Signal_default]: take the default behavior
      (usually: abort the program)
@@ -240,119 +241,119 @@ type signal_behavior =
    number as argument. *)
 
 external signal :
-  int -> signal_behavior -> signal_behavior = "caml_install_signal_handler"
+  signal -> signal_behavior -> signal_behavior = "caml_install_signal_handler"
 (** Set the behavior of the system on receipt of a given signal.  The
    first argument is the signal number.  Return the behavior
    previously associated with the signal. If the signal number is
    invalid (or not available on your system), an [Invalid_argument]
    exception is raised. *)
 
-val set_signal : int -> signal_behavior -> unit
+val set_signal : signal -> signal_behavior -> unit
 (** Same as {!Sys.signal} but return value is ignored. *)
 
 
 (** {2 Signal numbers for the standard POSIX signals.} *)
 
-val sigabrt : int
+val sigabrt : signal
 (** Abnormal termination *)
 
-val sigalrm : int
+val sigalrm : signal
 (** Timeout *)
 
-val sigfpe : int
+val sigfpe : signal
 (** Arithmetic exception *)
 
-val sighup : int
+val sighup : signal
 (** Hangup on controlling terminal *)
 
-val sigill : int
+val sigill : signal
 (** Invalid hardware instruction *)
 
-val sigint : int
+val sigint : signal
 (** Interactive interrupt (ctrl-C) *)
 
-val sigkill : int
+val sigkill : signal
 (** Termination (cannot be ignored) *)
 
-val sigpipe : int
+val sigpipe : signal
 (** Broken pipe *)
 
-val sigquit : int
+val sigquit : signal
 (** Interactive termination *)
 
-val sigsegv : int
+val sigsegv : signal
 (** Invalid memory reference *)
 
-val sigterm : int
+val sigterm : signal
 (** Termination *)
 
-val sigusr1 : int
+val sigusr1 : signal
 (** Application-defined signal 1 *)
 
-val sigusr2 : int
+val sigusr2 : signal
 (** Application-defined signal 2 *)
 
-val sigchld : int
+val sigchld : signal
 (** Child process terminated *)
 
-val sigcont : int
+val sigcont : signal
 (** Continue *)
 
-val sigstop : int
+val sigstop : signal
 (** Stop (cannot be caught or ignored) *)
 
-val sigtstp : int
+val sigtstp : signal
 (** Interactive stop *)
 
-val sigttin : int
+val sigttin : signal
 (** Terminal read from background process *)
 
-val sigttou : int
+val sigttou : signal
 (** Terminal write from background process *)
 
-val sigvtalrm : int
+val sigvtalrm : signal
 (** Timeout in virtual time *)
 
-val sigprof : int
+val sigprof : signal
 (** Profiling interrupt *)
 
-val sigbus : int
+val sigbus : signal
 (** Bus error
     @since 4.03 *)
 
-val sigpoll : int
+val sigpoll : signal
 (** Pollable event
     @since 4.03 *)
 
-val sigsys : int
+val sigsys : signal
 (** Bad argument to routine
     @since 4.03 *)
 
-val sigtrap : int
+val sigtrap : signal
 (** Trace/breakpoint trap
     @since 4.03 *)
 
-val sigurg : int
+val sigurg : signal
 (** Urgent condition on socket
     @since 4.03 *)
 
-val sigxcpu : int
+val sigxcpu : signal
 (** Timeout in cpu time
     @since 4.03 *)
 
-val sigxfsz : int
+val sigxfsz : signal
 (** File size limit exceeded
     @since 4.03 *)
 
-val sigio : int
+val sigio : signal
 (** I/O is possible on a descriptor
     @since 5.4 *)
 
-val sigwinch : int
+val sigwinch : signal
 (** Window size change
     @since 5.4 *)
 
-val signal_to_string : int -> string
+val signal_to_string : signal -> string
 (** Signal name as a string, based on POSIX names.
     @since 5.4 *)
 

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -230,11 +230,12 @@ external poll_actions : unit -> unit = "%poll"
 type signal = int
 (** The type for signal numbers.
 
-  This is either a platform independent negative number for those signals
-  that OCaml recognizes or a positive number for a platform dependent
-  signal number. The function {!signal_of_int} converts known platform dependent
-  numbers to independent ones, and {!signal_to_int} does the reverse converting
-  known platform independent numbers to dependent ones. *)
+  Negative numbers are used by OCaml to provide a platform-independent
+  number for signals recognised by OCaml. Positive numbers are always the
+  platform-dependent value for a given signal.
+  The function {!signal_of_int} converts known platform-dependent numbers
+  to independent ones, and {!signal_to_int} does the reverse.
+  @since 5.4 *)
 
 type signal_behavior =
     Signal_default
@@ -253,11 +254,15 @@ external signal :
    first argument is the signal number.  Return the behavior
    previously associated with the signal. If the signal number is
    invalid (or not available on your system), an [Invalid_argument]
-   exception is raised. *)
+   exception is raised.
+
+   If a platform-dependent signal number is used, it will be converted
+   to a platform-independent signal using {!signal_of_int} before
+   calling the handler.
+*)
 
 val set_signal : signal -> signal_behavior -> unit
-(** Same as {!Sys.signal} but return value is ignored. *)
-
+(** Same as {!Sys.signal} but the return value is ignored. *)
 
 (** {2 Signal numbers for the standard POSIX signals.} *)
 
@@ -362,20 +367,22 @@ val sigwinch : signal
 
 val signal_to_string : signal -> string
 (** [signal_to_string] formats an OCaml [signal] as a C POSIX
-    {{:http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html}
+    {{:http://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html}
     constant} or ["SIG(%d)"] for an unrecognised signal number.
     @since 5.4 *)
 
 val signal_of_int : int -> signal
-(** [signal_of_int n] converts a platform dependent signal number [n] to
+(** [signal_of_int n] converts a platform-dependent signal number [n] to
     an OCaml signal number.
-    This is [n] itself if the number is unknown.
+    This is [n] itself if OCaml does not have a platform-independent signal
+    number for [n].
     @since 5.4 *)
 
 val signal_to_int : signal -> int
 (** [signal_to_int n] converts an OCaml signal number [n] to
-    a platform dependent signal number.
-    This is [n] itself if the number is unknown.
+    a platform-dependent signal number.
+    This is [n] itself if OCaml does not have a platform-dependent signal
+    number for [n].
     @since 5.4 *)
 
 exception Break

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -352,6 +352,10 @@ val sigwinch : int
 (** Window size change
     @since 5.4 *)
 
+val signal_to_string : int -> string
+(** Signal name as a string, based on POSIX names.
+    @since 5.4 *)
+
 exception Break
 (** Exception raised on interactive interrupt if {!Sys.catch_break}
    is enabled. *)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -246,7 +246,7 @@ type signal_behavior =
      (usually: abort the program)
    - [Signal_ignore]: ignore the signal
    - [Signal_handle f]: call function [f], giving it the signal
-   number as argument. *)
+   number as an argument. *)
 
 external signal :
   signal -> signal_behavior -> signal_behavior = "caml_install_signal_handler"
@@ -368,21 +368,28 @@ val sigwinch : signal
 val signal_to_string : signal -> string
 (** [signal_to_string] formats an OCaml [signal] as a C POSIX
     {{:http://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html}
-    constant} or ["SIG(%d)"] for an unrecognised signal number.
+    constant} or ["SIG(%d)"] for platform-dependent signal numbers.
+
+    @raise Invalid_argument for unrecognised negative numbers.
     @since 5.4 *)
 
 val signal_of_int : int -> signal
 (** [signal_of_int n] converts a platform-dependent signal number [n] to
     an OCaml signal number.
-    This is [n] itself if OCaml does not have a platform-independent signal
-    number for [n].
+
+    For positive [n] this is [n] itself if OCaml does not have a
+    platform-independent signal number for [n].
+
+    @raise Invalid_argument if [n] is negative.
     @since 5.4 *)
 
 val signal_to_int : signal -> int
 (** [signal_to_int n] converts an OCaml signal number [n] to
     a platform-dependent signal number.
-    This is [n] itself if OCaml does not have a platform-dependent signal
-    number for [n].
+
+    For positive [n] this is [n] itself.
+
+    @raise Invalid_argument for unrecognised negative numbers.
     @since 5.4 *)
 
 exception Break

--- a/testsuite/tests/lib-sys/signal.ml
+++ b/testsuite/tests/lib-sys/signal.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libunix;
+ hasunix;
+ not-windows;
  native;
 *)
 open Sys
@@ -71,5 +72,15 @@ let () =
   let x = !r in
   (* Should trigger signal_handle for signal corresponding to 1 SIGHUP? *)
   assert (x == true);
+
+  (* Should convert known signals between OCaml numbering and
+     platform numbering. *)
+  let platform_sighup = 1 (* SIGHUP on Linux and various BSDs *) in
+  let platform_signal = Sys.signal_to_int sighup in
+  let ocaml_signal = Sys.signal_of_int platform_sighup in
+  Printf.printf "SIGHUP platform_no: %d ocaml_no: %d\n"
+    platform_signal ocaml_signal;
+  assert (ocaml_signal == sighup &&
+          platform_signal == platform_sighup);
 
   print_endline "Sys.set_signal works!"

--- a/testsuite/tests/lib-sys/signal.ml
+++ b/testsuite/tests/lib-sys/signal.ml
@@ -1,0 +1,75 @@
+(* TEST
+ include unix;
+ libunix;
+ native;
+*)
+open Sys
+
+let () =
+  let r = ref false in
+  Sys.set_signal Sys.sigcont (Signal_handle (fun _ -> r := true));
+  Unix.kill (Unix.getpid ()) Sys.sigcont;
+  let x = !r in
+  assert (x == true); (* Should trigger signal_handle for sigcont *)
+  r := false;
+
+  Sys.set_signal Sys.sigcont (Signal_handle (fun _ -> r := true));
+  Unix.kill (Unix.getpid ()) Sys.sigwinch;
+  let x = !r in
+  (* Sending sigwinch shouldn't trigger signal_handle for sigcont *)
+  assert (x == false);
+  r := false;
+
+  Sys.set_signal Sys.sigwinch (Signal_handle (fun _ -> r := true));
+  Unix.kill (Unix.getpid ()) Sys.sigwinch;
+  let x = !r in
+  assert (x == true); (* Should trigger signal_handle for sigwinch *)
+  r := false;
+
+  Sys.set_signal Sys.sigio (Signal_handle (fun _ -> r := true));
+  Unix.kill (Unix.getpid ()) Sys.sigio;
+  let x = !r in
+  assert (x == true); (* Should trigger signal_handle for sigio *)
+
+  (* Signals should map to POSIX standard names *)
+  let signals = [(sighup, "SIGHUP");
+                 (sigint, "SIGINT");
+                 (sigquit, "SIGQUIT");
+                 (sigill, "SIGILL");
+                 (sigtrap, "SIGTRAP");
+                 (sigabrt, "SIGABRT");
+                 (sigfpe, "SIGFPE");
+                 (sigkill, "SIGKILL");
+                 (sigbus, "SIGBUS");
+                 (sigsegv, "SIGSEGV");
+                 (sigsys, "SIGSYS");
+                 (sigpipe, "SIGPIPE");
+                 (sigalrm, "SIGALRM");
+                 (sigterm, "SIGTERM");
+                 (sigurg, "SIGURG");
+                 (sigstop, "SIGSTOP");
+                 (sigtstp, "SIGTSTP");
+                 (sigcont, "SIGCONT");
+                 (sigchld, "SIGCHLD");
+                 (sigttin, "SIGTTIN");
+                 (sigttou, "SIGTTOU");
+                 (sigio, "SIGIO");
+                 (sigxcpu, "SIGXCPU");
+                 (sigxfsz, "SIGXFSZ");
+                 (sigvtalrm, "SIGVTALRM");
+                 (sigprof, "SIGPROF");
+                 (sigwinch, "SIGWINCH");
+                 (sigusr1, "SIGUSR1");
+                 (sigusr2, "SIGUSR2");
+                 (-33, "SIG(-33)");] in
+  List.iter (fun (s,str) -> assert (String.equal (Sys.signal_to_string s) str)) signals;
+
+  r := false;
+
+  Sys.set_signal 1 (Signal_handle (fun _ -> r := true));
+  Unix.kill (Unix.getpid ()) 1;
+  let x = !r in
+  (* Should trigger signal_handle for signal corresponding to 1 SIGHUP? *)
+  assert (x == true);
+
+  print_endline "Sys.set_signal works!"

--- a/testsuite/tests/lib-sys/signal.ml
+++ b/testsuite/tests/lib-sys/signal.ml
@@ -62,7 +62,7 @@ let () =
                  (sigwinch, "SIGWINCH");
                  (sigusr1, "SIGUSR1");
                  (sigusr2, "SIGUSR2");
-                 (-33, "SIG(-33)");] in
+                 (33, "SIG(33)");] in
   List.iter (fun (s,str) -> assert (String.equal (Sys.signal_to_string s) str)) signals;
 
   r := false;

--- a/testsuite/tests/lib-sys/signal.reference
+++ b/testsuite/tests/lib-sys/signal.reference
@@ -1,0 +1,1 @@
+Sys.set_signal works!

--- a/testsuite/tests/lib-sys/signal.reference
+++ b/testsuite/tests/lib-sys/signal.reference
@@ -1,1 +1,2 @@
+SIGHUP platform_no: 1 ocaml_no: -4
 Sys.set_signal works!

--- a/tools/sync_stdlib_docs
+++ b/tools/sync_stdlib_docs
@@ -25,7 +25,7 @@ fi
 #Removes a label, i.e a space, a variable name, followed by a colon followed by
 #an alphabetic character or ( or '. This should avoid altering the contents of
 #comments.
-LABREGEX="s/ [a-z_]+:([a-z\('])/ \1/g"
+LABREGEX="s/ [a-z_]+:([A-Za-z\('])/ \1/g"
 
 #A second, slightly different round sometimes required to deal with f:(key:key
 LABLABREGEX="s/\([a-z_]+:([a-z\('])/\(\1/g"


### PR DESCRIPTION
Solution for Stdlib - missing signals #13825

* 1faf314 does the minimal change adding the missing signals
* 46308d8 adds `signal_to_string` to give POSIX names for the signals
* 3a81250 introduces a type alias for signal plus some sanity check tests.

What do you think @nojb @dbuenzli ? This keeps the escape option of supplying your own signal numbers and the type alias documents the intent of the API (without providing much type safety).