### PR TITLE
Fix bug in untypeast/pprintast for value bindings with polymorphic type annotations

### DIFF
--- a/Changes
+++ b/Changes
@@ -452,6 +452,10 @@ Working version
   the right-hand side of `_ as _`.
   (Samuel Vivien, review by Gabriel Scherer)
 
+- #13845: Fix bug in untypeast/pprintast for value bindings with polymorphic
+  type annotations.
+  (Chris Casinghino, review by Florian Angeletti and Gabriel Scherer)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -44,5 +44,5 @@ run {| fun x y z -> (function w -> x y z w) |};;
 run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |};;
 
 [%%expect{|
-- : string = "let (foo : 'a . 'a -> 'a) = fun x -> x in foo"
+- : string = "let foo : 'a . 'a -> 'a = fun x -> x in foo"
 |}]

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -41,8 +41,15 @@ run {| fun x y z -> (function w -> x y z w) |};;
 (***********************************)
 (* Untypeast/pprintast correctly handle value binding type annotations. *)
 
-run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |};;
+run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |}
 
 [%%expect{|
 - : string = "let foo : 'a . 'a -> 'a = fun x -> x in foo"
+|}];;
+
+run {| let foo : type a . a -> a = fun x -> x in foo |}
+
+[%%expect{|
+- : string =
+"let foo : 'a . 'a -> 'a = fun (type a) -> (fun x -> x : a -> a) in foo"
 |}]

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -37,3 +37,12 @@ run {| fun x y z -> (function w -> x y z w) |};;
 [%%expect{|
 - : string = "fun x y z -> (function | w -> x y z w)"
 |}];;
+
+(***********************************)
+(* Untypeast/pprintast correctly handle value binding type annotations. *)
+
+run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |};;
+
+[%%expect{|
+- : string = "let (foo : 'a . 'a -> 'a) = fun x -> x in foo"
+|}]

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -387,9 +387,17 @@ let case : type k . mapper -> k case -> _ = fun sub {c_lhs; c_guard; c_rhs} ->
 let value_binding sub vb =
   let loc = sub.location sub vb.vb_loc in
   let attrs = sub.attributes sub vb.vb_attributes in
-  Vb.mk ~loc ~attrs
-    (sub.pat sub vb.vb_pat)
-    (sub.expr sub vb.vb_expr)
+  let pat = sub.pat sub vb.vb_pat in
+  let pat, value_constraint =
+    match pat.ppat_desc with
+    | Ppat_constraint (pat, cty) ->
+      let constr =
+        Pvc_constraint { locally_abstract_univars = []; typ = cty }
+      in
+      pat, Some constr
+    | _ -> pat, None
+  in
+  Vb.mk ~loc ~attrs ?value_constraint pat (sub.expr sub vb.vb_expr)
 
 let expression sub exp =
   let loc = sub.location sub exp.exp_loc in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -390,7 +390,7 @@ let value_binding sub vb =
   let pat = sub.pat sub vb.vb_pat in
   let pat, value_constraint =
     match pat.ppat_desc with
-    | Ppat_constraint (pat, cty) ->
+    | Ppat_constraint (pat, ({ ptyp_desc = Ptyp_poly _; _ } as cty)) ->
       let constr =
         Pvc_constraint { locally_abstract_univars = []; typ = cty }
       in


### PR DESCRIPTION
It is expected that you can get back a valid source program if you typecheck a program, then run `untypeast` on the resulting typedtree, then print it with `pprintast` (see tests of this in `testsuite/tests/compiler-libs/test_untypeast.ml`). However, this does not work for the following expression:
```ocaml
let foo : 'a. 'a -> 'a = fun x -> x in foo
```
The issue is that `untypeast` turns the pattern in the let binding into a `Ppat_constraint` node, rather than putting the type annotation in the `pvb_constraint` field.  As a result, this invalid syntax is printed:
```ocaml
let (foo : 'a . 'a -> 'a) = fun x -> x in foo
```

This PR has two commits. The first demonstrates this issue by adding this testcase to `test_untypeast.ml`. The second fixes it, by simply having `untypeast` check whether the pattern in a value binding is a `Ppat_constraint`, and moving the type annotation to the `pvb_constraint` field in that case.