### PR TITLE
dune support: iarray placeholder

### DIFF
--- a/stdlib/dune
+++ b/stdlib/dune
@@ -14,12 +14,13 @@
 
 (library
  (name stdlib)
+ (libraries dune_support)
  (stdlib
    (exit_module std_exit)
    (internal_modules Camlinternal*)
    (modules_before_stdlib
      camlinternalFormatBasics))
- (flags (:standard -w -9 -nolabels))
+ (flags (:standard -w -9 -nolabels -open New_predef_types))
  (preprocess
    (per_module
     ((action

--- a/stdlib/dune_support/dune
+++ b/stdlib/dune_support/dune
@@ -1,0 +1,6 @@
+(library
+ (name dune_support)
+ (modules_without_implementation new_predef_types)
+ (flags (:standard -nostdlib -nopervasives))
+ (wrapped false)
+)

--- a/stdlib/dune_support/new_predef_types.mli
+++ b/stdlib/dune_support/new_predef_types.mli
@@ -1,0 +1,1 @@
+type !+'a iarray


### PR DESCRIPTION
This PR adds a placeholder implementation of iarray on the dune build path which seems to be enough to restore merlin support for the trunk compiler.