### PR TITLE
Windows threads: maintain a number of threads waiting on the master lock to avoid unnecessary context switches

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,10 @@ OCaml 4.14 maintenance version
   #5115 in #11788)
   (David Allsopp, review by Nicolás Ojeda Bär)
 
+- #13847: On Windows, maintain a number of threads waiting on the master lock to
+  avoid unnecessary context switches
+  (Dmitry Bely, review by Antonin Décimo)
+
 OCaml 4.14.2 (14 March 2024)
 ----------------------------
 

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -157,40 +157,48 @@ Caml_inline intnat st_current_thread_id(void)
 
 /* The master lock.  */
 
-typedef CRITICAL_SECTION st_masterlock;
+typedef struct {
+  CRITICAL_SECTION crit;
+  volatile LONG waiters;         /* number of threads waiting on master lock */
+} st_masterlock;
 
 static void st_masterlock_init(st_masterlock * m)
 {
   TRACE("st_masterlock_init");
-  InitializeCriticalSection(m);
-  EnterCriticalSection(m);
+  InitializeCriticalSection(&m->crit);
+  EnterCriticalSection(&m->crit);
+  m->waiters = 0;
 }
 
 Caml_inline void st_masterlock_acquire(st_masterlock * m)
 {
   TRACE("st_masterlock_acquire");
-  EnterCriticalSection(m);
+  InterlockedIncrement(&m->waiters);
+  EnterCriticalSection(&m->crit);
+  InterlockedDecrement(&m->waiters);
   TRACE("st_masterlock_acquire (done)");
 }
 
 Caml_inline void st_masterlock_release(st_masterlock * m)
 {
-  LeaveCriticalSection(m);
+  LeaveCriticalSection(&m->crit);
   TRACE("st_masterlock_released");
 }
 
 Caml_inline int st_masterlock_waiters(st_masterlock * m)
 {
-  return 1;                     /* info not maintained */
+  return m->waiters;
 }
 
 /* Scheduling hints */
 
 Caml_inline void st_thread_yield(st_masterlock * m)
 {
-  LeaveCriticalSection(m);
+  LeaveCriticalSection(&m->crit);
   Sleep(0);
-  EnterCriticalSection(m);
+  InterlockedIncrement(&m->waiters);
+  EnterCriticalSection(&m->crit);
+  InterlockedDecrement(&m->waiters);
 }
 
 /* Mutexes */


### PR DESCRIPTION
In my application, several heavily loaded C threads are running concurrently with a single OCaml thread. With this setup I ran into a scheduler issue under Windows, sometimes
```C
  LeaveCriticalSection(m);
  Sleep(0);
  EnterCriticalSection(m);
```
in `st_thread_yield()` causes enormously long delays (`EnterCriticalSection` takes up to several seconds under some circumstances). This PR proposes a straightforward solution to this issue: like POSIX implementation, maintain the amount of waiting OCaml threads and yield only when it's more than zero. In my situation, this fully eliminates unpredictable delays in the OCaml thread.