### PR TITLE
manual: clarify documentation of C macros on integers

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -701,25 +701,21 @@ type) corresponds to the "Some" constructor.
 
 \subsection{ss:c-int-ops}{Operations on integers}
 
+The header "<caml/config.h>" defines a C integer type "intnat" of signed 64-bit
+integers (32-bit integers on 32-bit architectures). This type is used to
+represent the integer encoded by a "value" corresponding to an unboxed integer.
+
 \begin{itemize}
-\item "Val_long("\var{n}")" returns the value encoding the C integer \var{n} of
-type "intnat". Despite its name, note that "intnat" is not necessarily the same
-size as a C "long" (e.g., on Windows, "long" is always 32-bit wide, while
-"intnat" has the size of a pointer). This operation can be applied to other C
-integer types, with the argument casted to "intnat" before conversion.
-\item "Long_val("\var{v}")" returns the C integer of type "intnat" encoded in a
-value \var{v}.
-\item "Val_int("\var{i}")" returns the value encoding of the C integer \var{i}
-of type "int".  It coincides with "Val_long("\var{i}")".
-\item "Int_val("\var{v}")" returns the C "int" encoded in a value \var{v}. It
-coincides with "(int)Val_long("\var{v}")".
-\item "Val_bool("\var{x}")" returns the OCaml boolean representing the truth
-value of the C integer \var{x} (where 0 is interpreted as "false" and any other
-value as "true").
+\item "Val_long("\var{n}")" returns the value encoding the "intnat" \var{n}.
+\item "Long_val("\var{v}")" returns the "intnat" encoded in value \var{v}.
+\item "Val_int("\var{i}")" returns the value encoding the "int" \var{i}.
+\item "Int_val("\var{v}")" returns the "int" encoded in value \var{v}.
+\item "Val_bool("\var{x}")" returns the OCaml boolean representing the
+truth value of the C integer \var{x}.
 \item "Bool_val("\var{v}")" returns 0 if \var{v} is the OCaml boolean
 "false", 1 if \var{v} is "true".
 \item "Val_true", "Val_false" represent the OCaml booleans "true" and "false".
-\item "Val_emptylist", "Val_emptylist" represents the empty list.
+\item "Val_emptylist" represents the empty list.
 \item "Val_none" represents the OCaml value "None".
 \end{itemize}
 

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -702,12 +702,20 @@ type) corresponds to the "Some" constructor.
 \subsection{ss:c-int-ops}{Operations on integers}
 
 \begin{itemize}
-\item "Val_long("\var{l}")" returns the value encoding the "long int" \var{l}.
-\item "Long_val("\var{v}")" returns the "long int" encoded in value \var{v}.
-\item "Val_int("\var{i}")" returns the value encoding the "int" \var{i}.
-\item "Int_val("\var{v}")" returns the "int" encoded in value \var{v}.
-\item "Val_bool("\var{x}")" returns the OCaml boolean representing the
-truth value of the C integer \var{x}.
+\item "Val_long("\var{n}")" returns the value encoding the C integer \var{n} of
+type "intnat". Despite its name, note that "intnat" is not necessarily the same
+size as a C "long" (e.g., on Windows, "long" is always 32-bit wide, while
+"intnat" has the size of a pointer). This operation can be applied to other C
+integer types, with the argument casted to "intnat" before conversion.
+\item "Long_val("\var{v}")" returns the C integer of type "intnat" encoded in a
+value \var{v}.
+\item "Val_int("\var{i}")" returns the value encoding of the C integer \var{i}
+of type "int".  It coincides with "Val_long("\var{i}")".
+\item "Int_val("\var{v}")" returns the C "int" encoded in a value \var{v}. It
+coincides with "(int)Val_long("\var{v}")".
+\item "Val_bool("\var{x}")" returns the OCaml boolean representing the truth
+value of the C integer \var{x} (where 0 is interpreted as "false" and any other
+value as "true").
 \item "Bool_val("\var{v}")" returns 0 if \var{v} is the OCaml boolean
 "false", 1 if \var{v} is "true".
 \item "Val_true", "Val_false" represent the OCaml booleans "true" and "false".

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -703,13 +703,16 @@ type) corresponds to the "Some" constructor.
 
 The header "<caml/config.h>" defines a C integer type "intnat" of signed 64-bit
 integers (32-bit integers on 32-bit architectures). This type is used to
-represent the integer encoded by a "value" corresponding to an unboxed integer.
+represent the integer encoded by a "value" corresponding to an unboxed integer
+without truncation.
 
 \begin{itemize}
 \item "Val_long("\var{n}")" returns the value encoding the "intnat" \var{n}.
 \item "Long_val("\var{v}")" returns the "intnat" encoded in value \var{v}.
 \item "Val_int("\var{i}")" returns the value encoding the "int" \var{i}.
-\item "Int_val("\var{v}")" returns the "int" encoded in value \var{v}.
+\item "Int_val("\var{v}")" returns the "int" encoded in value \var{v}. Note that
+this operation may result in a truncated value since "int" is 32-bit wide on
+64-bit architectures.
 \item "Val_bool("\var{x}")" returns the OCaml boolean representing the
 truth value of the C integer \var{x}.
 \item "Bool_val("\var{v}")" returns 0 if \var{v} is the OCaml boolean


### PR DESCRIPTION
It was pointed out in #13844 that the documentation of the C macros on integers (`Val_long`, `Long_val`, etc) could be clarified. This is the purpose of this PR.

Comments welcome.

Fixes #13844 