### PR TITLE
Format: place hint white spaces after the break hint

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,9 @@ Working version
 
 ### Bug fixes:
 
+- #13853: Format breaks some line too early when there
+  is a break hint at the end.
+  (Florian Angeletti, review by Gabriel Scherer)
 
 OCaml 5.4.0
 ---------------

--- a/testsuite/tests/lib-format/breaks.ml
+++ b/testsuite/tests/lib-format/breaks.ml
@@ -1,0 +1,27 @@
+(* TEST
+  expect;
+*)
+
+let test fmt =
+  let open Format in
+  let ppf = std_formatter in
+  set_geometry ~margin:16 ~max_indent:15;
+  pp_open_hovbox ppf 0;
+  kfprintf (fun ppf -> pp_close_box ppf (); pp_print_newline ppf ()) ppf fmt
+let newline ppf = Format.(pp_print_break ppf pp_infinity 0)
+[%%expect {|
+val test : ('a, Format.formatter, unit, unit) format4 -> 'a = <fun>
+val newline : Format.formatter -> unit = <fun>
+|}]
+
+let () = test "0.@ 3.5@ 7..A@;<10 0>N"
+[%%expect {|
+0. 3.5 7..A
+N
+|}]
+
+let () = test "0....5@ 7..A%tN" newline
+[%%expect {|
+0....5 7..A
+N
+|}]


### PR DESCRIPTION
When formatting the following format string with margin > 9

    "@[aaaa@ bbbb@;<∞ 0>cccc@]"

Format currently renders it as

    aaaa
    bbbb
    cccc

This behavior is not in line with the specification of the `b` or `hov` box which are supposed to fit as much contents on the line as possible while not overflowing the margin.
In particular, since the  `a` and `b` blocks fits inside the margin, this text ought to be formatted as

    aaaa bbbb
    cccc

according to the specification. This PR makes `Format` follows this specification.

------------------

More precisely, this issue stems from the fact that  `Format` processes a break hint in four steps:
1. add the break to the printing queue
2. adds the length of the horizontal contents to the pending contents counter
3. resolve the size of the potential pending break hint in the hint queue
4. add the break hint to the hint queue.

which has the effects of attributing the size of horizontal contents of the new break to the previous pending
break.

This PR fixes this misattribution by swapping step 2 and 3:

1. add the break to the printing queue
2. resolve the size of the potential pending break hint in the hint queue
3. adds the length of the horizontal contents to the pending contents counter
4. add the break hint to the hint queue.

--------------------

Arguably, the main advantage of this PR is that it makes possible to define a newline printer
```ocaml
let newline ppf () = Format.(pp_print_break ppf pp_infinity 0)
```
with a far simpler semantics than `@\n` (and I am planning to send a subsequent PR with this new function).
