### PR TITLE
GHA: small improvements for Cygwin and Linux actions

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -90,6 +90,8 @@ jobs:
           ./configure --prefix="$HOME/cross" --target=x86_64-w64-mingw32 \
               TARGET_LIBDIR="$TESTDIR" || res=$?
           if ! [ "$res" = 0 ]; then cat config.log; exit "$res"; fi
+          # The OOM-killer may be triggered if the number of parallel
+          # jobs isn't limited.
           make crossopt -j$(nproc)
           make installcross
           ln -sr "$HOME/cross/bin/flexlink.opt.exe" "$HOME/.local/bin/flexlink"

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v3
         with:
-          packages: make,bash,mingw64-x86_64-gcc-core
+          packages: make,mingw64-x86_64-gcc-core
           install-dir: 'D:\cygwin'
 
       - name: Save Cygwin cache

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -35,14 +35,6 @@ jobs:
             x86_64: false
 
     steps:
-      - name: Save pristine PATH
-        run: |
-          echo "PRISTINE_PATH=${env:Path}" >> "${env:GITHUB_ENV}"
-
-      - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Fetch OCaml
         uses: actions/checkout@v4
@@ -51,8 +43,6 @@ jobs:
 
       - name: Restore Cygwin cache
         uses: actions/cache/restore@v4
-        env:
-          PATH: ${{ env.PRISTINE_PATH }}
         with:
           path: |
             C:\cygwin-packages
@@ -66,12 +56,15 @@ jobs:
 
       - name: Save Cygwin cache
         uses: actions/cache/save@v4
-        env:
-          PATH: ${{ env.PRISTINE_PATH }}
         with:
           path: |
             C:\cygwin-packages
           key: cygwin-packages
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Compute a key to cache configure results
         shell: bash

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -87,15 +87,16 @@ jobs:
       - name: Build OCaml
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
-          CC: ${{ matrix.cc }}
         run: |
           eval $(tools/msvs-promote-path)
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC \
-               --prefix "$PROGRAMFILES/Бактріан🐫"; then
+          if ! ./configure --cache-file=config.cache --host=$HOST \
+               --prefix="$PROGRAMFILES/Бактріан🐫" \
+               CC=${{ matrix.cc }}; then
             rm -rf config.cache
             failed=0
-            ./configure --cache-file=config.cache --host=$HOST CC=$CC \
-                --prefix "$PROGRAMFILES/Бактріан🐫" \
+            ./configure --cache-file=config.cache --host=$HOST \
+                --prefix="$PROGRAMFILES/Бактріан🐫" \
+                CC=${{ matrix.cc }} \
               || failed=$?
             if ((failed)) ; then cat config.log ; exit $failed ; fi
           fi

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -16,6 +16,10 @@ on:
   # Fully print commands executed by Make
   # MAKEFLAGS: V=1
 
+defaults:
+  run:
+    shell: bash -eo pipefail -o igncr {0}
+
 jobs:
   build:
     permissions: {}
@@ -67,11 +71,10 @@ jobs:
           arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Compute a key to cache configure results
-        shell: bash
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
           CC: ${{ matrix.cc }}
-        run: >-
+        run: |
           echo "AUTOCONF_CACHE_KEY=$HOST-$CC-$({ cat configure; uname; } | sha1sum | cut -c 1-7)" >> $GITHUB_ENV
 
       - name: Restore Autoconf cache
@@ -82,27 +85,23 @@ jobs:
           key: ${{ env.AUTOCONF_CACHE_KEY }}
 
       - name: Build OCaml
-        shell: bash
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
           CC: ${{ matrix.cc }}
-        run: >-
-          eval $(tools/msvs-promote-path) ;
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC
-          --prefix "$PROGRAMFILES/Бактріан🐫"; then
-          rm -rf config.cache ;
-          failed=0 ;
-          ./configure --cache-file=config.cache --host=$HOST CC=$CC
-          --prefix "$PROGRAMFILES/Бактріан🐫"
-          || failed=$?;
-          if ((failed)) ; then cat config.log ; exit $failed ; fi ;
-          fi ;
-          make -j || failed=$? ;
-          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi ;
-          runtime/ocamlrun ocamlc -config ;
-        # Don't add indentation or comments, it breaks Bash on
-        # Windows when the yaml text block scalar is processed as a
-        # single line.
+        run: |
+          eval $(tools/msvs-promote-path)
+          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+               --prefix "$PROGRAMFILES/Бактріан🐫"; then
+            rm -rf config.cache
+            failed=0
+            ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+                --prefix "$PROGRAMFILES/Бактріан🐫" \
+              || failed=$?
+            if ((failed)) ; then cat config.log ; exit $failed ; fi
+          fi
+          make -j || failed=$?
+          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
+          runtime/ocamlrun ocamlc -config
 
       - name: Save Autoconf cache
         uses: actions/cache/save@v4
@@ -112,26 +111,23 @@ jobs:
           key: ${{ env.AUTOCONF_CACHE_KEY }}
 
       - name: Assemble backend with MinGW GASM and compare
-        shell: bash
-        run: >-
-          x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S ;
-          dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump ;
-          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64nt.dump runtime/amd64nt.dump > runtime/amd64nt.canonical ;
-          dumpbin /disasm:nobytes runtime/amd64.o > runtime/amd64.dump ;
-          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64.dump runtime/amd64.dump > runtime/amd64.canonical ;
-          git diff --no-index -- runtime/amd64*.canonical ;
-          wc -l runtime/amd64*.dump runtime/amd64*.canonical ;
+        run: |
+          x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S
+          dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump
+          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64nt.dump runtime/amd64nt.dump > runtime/amd64nt.canonical
+          dumpbin /disasm:nobytes runtime/amd64.o > runtime/amd64.dump
+          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64.dump runtime/amd64.dump > runtime/amd64.canonical
+          git diff --no-index -- runtime/amd64*.canonical
+          wc -l runtime/amd64*.dump runtime/amd64*.canonical
         # ^ The final wc is there to make sure that the canonical files are
         # reasonable cleaned-up versions of the raw dumpbins and not simply
         # empty
         if: matrix.x86_64
 
       - name: Run the test suite
-        shell: bash
-        run: >-
-          eval $(tools/msvs-promote-path) ;
-          make -j tests ;
+        run: |
+          eval $(tools/msvs-promote-path)
+          make -j tests
 
       - name: Install the compiler
-        shell: bash
         run: make install

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -98,7 +98,13 @@ jobs:
                 --prefix="$PROGRAMFILES/Бактріан🐫" \
                 CC=${{ matrix.cc }} \
               || failed=$?
-            if ((failed)) ; then cat config.log ; exit $failed ; fi
+            if ((failed)) ; then
+              echo
+              echo "::group::config.log content ($(wc -l config.log) lines)"
+              cat config.log
+              echo '::endgroup::'
+              exit $failed
+            fi
           fi
 
       - name: Save Autoconf cache

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -71,18 +71,18 @@ jobs:
           arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Compute a key to cache configure results
+        id: autoconf-cache-key
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
-          CC: ${{ matrix.cc }}
         run: |
-          echo "AUTOCONF_CACHE_KEY=$HOST-$CC-$({ cat configure; uname; } | sha1sum | cut -c 1-7)" >> $GITHUB_ENV
+          echo "key=${{ env.HOST }}-${{ matrix.cc }}-${{ hashFiles('configure') }}" >> $GITHUB_OUTPUT
 
       - name: Restore Autoconf cache
         uses: actions/cache/restore@v4
         with:
           path: |
             config.cache
-          key: ${{ env.AUTOCONF_CACHE_KEY }}
+          key: ${{ steps.autoconf-cache-key.outputs.key }}
 
       - name: Build OCaml
         env:
@@ -108,7 +108,7 @@ jobs:
         with:
           path: |
             config.cache
-          key: ${{ env.AUTOCONF_CACHE_KEY }}
+          key: ${{ steps.autoconf-cache-key.outputs.key }}
 
       - name: Assemble backend with MinGW GASM and compare
         run: |

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run the test suite
         run: |
           eval $(tools/msvs-promote-path)
-          make -j tests
+          make tests
 
       - name: Install the compiler
         run: make install

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -84,7 +84,7 @@ jobs:
             config.cache
           key: ${{ steps.autoconf-cache-key.outputs.key }}
 
-      - name: Build OCaml
+      - name: Configure tree
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
         run: |
@@ -100,9 +100,6 @@ jobs:
               || failed=$?
             if ((failed)) ; then cat config.log ; exit $failed ; fi
           fi
-          make -j || failed=$?
-          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
-          runtime/ocamlrun ocamlc -config
 
       - name: Save Autoconf cache
         uses: actions/cache/save@v4
@@ -111,7 +108,14 @@ jobs:
             config.cache
           key: ${{ steps.autoconf-cache-key.outputs.key }}
 
-      - name: Assemble backend with MinGW GASM and compare
+      - name: Build OCaml
+        run: |
+          eval $(tools/msvs-promote-path)
+          make -j || failed=$?
+          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
+          runtime/ocamlrun ocamlc -config
+
+      - name: Assemble backend with mingw-w64 GASM and compare
         run: |
           x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S
           dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump

--- a/tools/ci/actions/multicoretests.sh
+++ b/tools/ci/actions/multicoretests.sh
@@ -32,7 +32,10 @@ build_ocaml() {
   cd "$OCAMLDIR"
   if ! ./configure --disable-warn-error --disable-stdlib-manpages \
       --disable-ocamltest --disable-ocamldoc --prefix="$PREFIX" ; then
+    echo
+    echo "::group::config.log content ($(wc -l config.log) lines)"
     cat config.log
+    echo '::endgroup::'
     exit 1
   fi
 

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -63,7 +63,7 @@ Build () {
   if [ "$(uname)" = 'Darwin' ]; then
     script -q build.log $MAKE_WARN || failed=$?
     if ((failed)); then
-      script -q build.log $MAKE_WARN make -j1 V=1
+      script -q build.log $MAKE_WARN -j1 V=1
       exit $failed
     fi
   else

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -29,7 +29,12 @@ call-configure () {
   local failed
   ./configure "$@" || failed=$?
   if ((failed)); then
+    # Output seems to be a little unpredictable in GitHub Actions: ensure that
+    # the fold is definitely on a new line
+    echo
+    echo "::group::config.log content ($(wc -l config.log) lines)"
     cat config.log
+    echo '::endgroup::'
     exit $failed
   fi
 }


### PR DESCRIPTION
- [GHA: tell Cygwin's bash to ignore CR line endings](https://github.com/ocaml/ocaml/commit/a99f39569f1fc439ec883731f96f6286db24b8df) in workflow scripts.
  As [suggested by the cygwin-install action](https://github.com/cygwin/cygwin-install-action?tab=readme-ov-file#line-endings). Makes much nicer looking shell scripts! This also makes the build-msvc workflow look more like the 'regular' workflows, and Bash can report the line on which an error occurs, if any. Previously, the whole script was submitted as a single line.
- [GHA: use native Windows symlinks when installing Cygwin](https://github.com/ocaml/ocaml/commit/a583eafb7940b39ed1bcbb579768b0f003c5bf95): slightly more efficient install.
- [GHA: run all Make targets in parallel](https://github.com/ocaml/ocaml/commit/41c7e42aa2ec84fb4c130e22ad8d5ca3ada3ae76) for more efficient builds. Installation rules can also be parallelized. I've found it useful to limit the number of concurrent jobs with `nproc`. If unbounded, the out-of-memory (OOM) killer may be triggered on Linux.

(no change entry needed)