### PR TITLE
Fix Weak.get_copy not darkening custom blocks

### DIFF
--- a/Changes
+++ b/Changes
@@ -230,7 +230,7 @@ Working version
   (Antonin Décimo, review by Miod Vallat, Nicolás Ojeda Bär, and Xavier Leroy)
 
 - #13859: Fix Weak.get_copy not darkening custom blocks
-  (Josh Berdine, review by ?)
+  (Josh Berdine, review by Stephen Dolan)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -229,6 +229,9 @@ Working version
 - #13578: On Windows, use the OS CSPRNG to seed the Stdlib.Random generator.
   (Antonin Décimo, review by Miod Vallat, Nicolás Ojeda Bär, and Xavier Leroy)
 
+- #13859: Fix Weak.get_copy not darkening custom blocks
+  (Josh Berdine, review by ?)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -330,8 +330,15 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
     }
     infix_offs = 0;
 
-    /* Don't copy immediates or custom blocks #7279 */
-    if (!Is_block(val) || Tag_val(val) == Custom_tag) {
+    /* Don't copy immediates */
+    if (!Is_block(val)) {
+      copy = val;
+      goto some;
+    }
+
+    /* Don't copy, but do darken, custom blocks #7279 */
+    if (Tag_val(val) == Custom_tag) {
+      caml_darken (Caml_state, val, 0);
       copy = val;
       goto some;
     }

--- a/testsuite/tests/weak-ephe-final/ephe_custom.ml
+++ b/testsuite/tests/weak-ephe-final/ephe_custom.ml
@@ -1,0 +1,21 @@
+(* TEST *)
+
+let w = Weak.create 1
+
+let major_obj () =
+  let n = Sys.opaque_identity 42 in
+  let v = Int64.of_int n in
+  Gc.minor ();
+  v
+
+let () =
+  Weak.set w 0 (Some (major_obj ()));
+  Gc.major ();
+  let x = Option.get (Weak.get_copy w 0) in
+  Gc.major ();
+  Printf.printf "value: %Ld\n%!" x;
+  let junk = List.init 1_000_000 Fun.id in
+  Gc.minor ();
+  ignore (Sys.opaque_identity junk);
+  (* check that the memory representing x did not get reused in junk *)
+  Printf.printf "value: %Ld\n%!" x

--- a/testsuite/tests/weak-ephe-final/ephe_custom.reference
+++ b/testsuite/tests/weak-ephe-final/ephe_custom.reference
@@ -1,0 +1,2 @@
+value: 42
+value: 42


### PR DESCRIPTION
This PR changes `ephe_get_field_copy` to darken the value it returns if it is a custom block.

While looking at PRs related to ephemerons I noticed a suspicious code path in `ephe_get_field_copy`. So far I have not managed to trigger a crash, but figured I would send this PR for feedback anyhow.

The scenario that worries me is if `ephe_get_field_copy` is called with a value that is not `caml_ephe_none` and is a custom block. In this case, a `Some` block will be allocated to wrap it, and returned. So the argument custom block value will be returned without being copied nor darkened. If `ephe_get_field` were called, it would be darkened. It makes sense that custom blocks are not copied, to avoid issues with calling finalizers multiple times. But I can not see how it is safe to not darken the returned value.

Looking at the history, when custom blocks stopped being copied, they were darkened: https://github.com/ocaml/ocaml/pull/710

Unrelated but in the same code, `ephe_get_field_copy` has a retry loop to protect against an allocation changing the tag or size of the value it is being asked to copy. Isn't changing tags or sizes no longer possible with the ocaml 5 runtime? But I'm unsure about `Forward_tag` values.

Signed-off-by: Josh Berdine <josh@berdine.net>