### PR TITLE
`Gc.ramp_{up,down}` to avoid wasted collection work during program initialization

### DIFF
--- a/Changes
+++ b/Changes
@@ -110,6 +110,14 @@ Working version
   (Stephen Dolan, review by Nick Barnes and Josh Berdine, benchmarking by
    Nicolás Ojeda Bär)
 
+- #13300, #13861: introduce `Gc.ramp_up` to explicitly mark ramp-up
+  phases of memory consumption and avoid GC overwork. Ramp-up behaviors
+  are worse with OCaml 5 than with OCaml 4 due to higher sensitivity
+  to excessive pacing computations. Indicating ramp-up explicitly eliminates
+  the main known slowdown of OCaml 5 (relative to OCaml 4) for Coq/Rocq.
+  (Gabriel Scherer, review by Damien Doligez and Guillaume Munch-Maccagnoni,
+   report by Emilio Jesús Gallego Arias and Olivier Nicole)
+
 ### Code generation and optimizations:
 
 * #13050: Use '$' instead of '.' to separate module names in symbol names.

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -74,12 +74,24 @@ DOMAIN_STATE(uintnat, sweeping_done)
 /* Is sweeping done for the current major cycle. */
 
 DOMAIN_STATE(uintnat, allocated_words)
-/* Number of words promoted or allocated directly to the major heap since
-   latest slice. */
+/* Number of words allocated in the major heap (by promotion or
+   direct allocation) since the latest slice. */
 
 DOMAIN_STATE(uintnat, allocated_words_direct)
-/* Number of words allocated directly to the major heap since the latest
-   slice. (subset of allocated_words) */
+/* Subset of [allocated_words] that was allocated directly to the
+   major heap since the latest slice. */
+
+DOMAIN_STATE(uintnat, allocated_words_suspended)
+/* Subset of [allocated_words] that were allocated in ramp-up
+   phases since the latest slice.
+
+   The corresponding deallocation work is "suspended" for later
+   ramp-down phases, instead of being performed in the next slice. */
+
+DOMAIN_STATE(uintnat, allocated_words_resumed)
+/* A number of allocated words (disjoint from [allocated_words])
+   whose deallocation work was suspended by a previous ramp-up phase,
+   and was resumed during a ramp-down phase since the latest slice. */
 
 DOMAIN_STATE(uintnat, swept_words)
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -93,6 +93,24 @@ DOMAIN_STATE(uintnat, allocated_words_resumed)
    whose deallocation work was suspended by a previous ramp-up phase,
    and was resumed during a ramp-down phase since the latest slice. */
 
+DOMAIN_STATE(intnat, current_ramp_up_allocated_words_diff)
+/* The total number of suspended deallocation words for the current ramp-up
+   phase is [allocated_suspended + current_ramp_up_allocated_words_diff].
+
+   When [current_ramp_up_allocated_words_diff] is positive, it adds
+   allocations that happened during the current ramp-up phase but
+   before the latest slice.
+
+   When [current_ramp_up_allocated_words_diff] is negative, it
+   subtracts allocations that happened since the latest slice but
+   during a previous ramp-up phase.
+
+   (Instead of tracking a difference, we could count the total
+   number of suspended deallocation of the ramp_up phase, but
+   this would require additional work to increment this value
+   in [caml_update_major_allocated_words].)
+*/
+
 DOMAIN_STATE(uintnat, swept_words)
 
 DOMAIN_STATE(caml_gc_policy, gc_policy)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -95,6 +95,9 @@ DOMAIN_STATE(uintnat, allocated_words_resumed)
 
 DOMAIN_STATE(uintnat, swept_words)
 
+DOMAIN_STATE(caml_gc_policy, gc_policy)
+/* Domain-local GC policy setting. */
+
 DOMAIN_STATE(uintnat, major_slice_epoch)
 
 DOMAIN_STATE(struct caml__roots_block*, local_roots)

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -43,6 +43,16 @@ value caml_gc_major(value);
 void caml_heap_check (void);
 #endif
 
+/* Put the current domain in a "ramp-up" phase to run the provided
+   callback. During ramp-up, allocations do not increase the
+   collection work to be performed immediately, this collection
+.  work is suspended. */
+caml_result caml_gc_ramp_up(value callback);
+
+/* Notify the GC about some amount of collection work that was
+   suspended during a ramp-up phase, to be resumed now. */
+void caml_gc_ramp_down(uintnat ramp_up_words);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_GC_CTRL_H */

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -46,12 +46,25 @@ void caml_heap_check (void);
 /* Put the current domain in a "ramp-up" phase to run the provided
    callback. During ramp-up, allocations do not increase the
    collection work to be performed immediately, this collection
-.  work is suspended. */
-caml_result caml_gc_ramp_up(value callback);
+.  work is suspended.
+
+   The total number of suspended deallocation work, counted in
+   number of allocated words, is written to [*out_suspended_work].
+
+   If the user discards this suspended work (by doing nothing with
+   it), the GC will not try to recover the corresponding amount
+   of memory. This is appropriate if the ramp-up work allocates
+   long-lived memory that remains live until the end of the program
+   execution.
+
+   If the ramp-up memory is likely to become unused at some point,
+   then the user should call [gc_ramp_down] below with the suspended amount,
+   to resume the corresponding deallocation work. */
+caml_result caml_gc_ramp_up(value callback, uintnat *out_suspended_work);
 
 /* Notify the GC about some amount of collection work that was
    suspended during a ramp-up phase, to be resumed now. */
-void caml_gc_ramp_down(uintnat ramp_up_words);
+void caml_gc_ramp_down(uintnat suspended_ramp_up_words);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -43,27 +43,10 @@ value caml_gc_major(value);
 void caml_heap_check (void);
 #endif
 
-/* Put the current domain in a "ramp-up" phase to run the provided
-   callback. During ramp-up, allocations do not increase the
-   collection work to be performed immediately, this collection
-.  work is suspended.
-
-   The total number of suspended deallocation work, counted in
-   number of allocated words, is written to [*out_suspended_work].
-
-   If the user discards this suspended work (by doing nothing with
-   it), the GC will not try to recover the corresponding amount
-   of memory. This is appropriate if the ramp-up work allocates
-   long-lived memory that remains live until the end of the program
-   execution.
-
-   If the ramp-up memory is likely to become unused at some point,
-   then the user should call [gc_ramp_down] below with the suspended amount,
-   to resume the corresponding deallocation work. */
+/* See the documentation of [Gc.ramp_up] in the standard library. */
 caml_result caml_gc_ramp_up(value callback, uintnat *out_suspended_work);
 
-/* Notify the GC about some amount of collection work that was
-   suspended during a ramp-up phase, to be resumed now. */
+/* See the documentation of [Gc.ramp_down] in the standard library. */
 void caml_gc_ramp_down(uintnat suspended_ramp_up_words);
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -64,6 +64,9 @@ Caml_inline void caml_update_major_allocated_words(
   if (direct) {
     self->allocated_words_direct += words;
   }
+  if (self->gc_policy & CAML_GC_RAMP_UP) {
+    self->allocated_words_suspended += words;
+  }
 }
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -57,6 +57,15 @@ void caml_orphan_finalisers(caml_domain_state*);
    so it need not be atomic */
 extern uintnat caml_major_cycles_completed;
 
+Caml_inline void caml_update_major_allocated_words(
+  caml_domain_state *self, intnat words, int direct
+) {
+  self->allocated_words += words;
+  if (direct) {
+    self->allocated_words_direct += words;
+  }
+}
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_MAJOR_GC_H */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -806,6 +806,10 @@ typedef void * backtrace_slot;
 #define IO_BUFFER_SIZE 65536
 #endif
 
+/* GC policy settings */
+typedef intnat caml_gc_policy;
+#define CAML_GC_RAMP_UP             0x0001
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -734,6 +734,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   domain_state->allocated_words_direct = 0;
   domain_state->allocated_words_suspended = 0;
   domain_state->allocated_words_resumed = 0;
+  domain_state->current_ramp_up_allocated_words_diff = 0;
   domain_state->swept_words = 0;
 
   domain_state->local_roots = NULL;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -732,6 +732,8 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   domain_state->allocated_words = 0;
   domain_state->allocated_words_direct = 0;
+  domain_state->allocated_words_suspended = 0;
+  domain_state->allocated_words_resumed = 0;
   domain_state->swept_words = 0;
 
   domain_state->local_roots = NULL;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -482,6 +482,11 @@ CAMLprim value caml_ml_gc_ramp_up(value callback) {
   CAMLlocal1(v);
   uintnat deferred_words;
   caml_result res = caml_gc_ramp_up(callback, &deferred_words);
+  if (caml_result_is_exception(res)) {
+    // We will re-raise the exception below; before that,
+    // we ramp_down to avoid discarding the deferred work.
+    caml_gc_ramp_down(deferred_words);
+  }
   v = caml_get_value_or_raise(res);
   CAMLreturn (caml_alloc_2(0, v, Val_long(deferred_words)));
 }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -468,3 +468,17 @@ caml_result caml_gc_ramp_up(value callback, uintnat *out_suspended_words) {
 void caml_gc_ramp_down(uintnat ramp_up_words) {
   Caml_state->allocated_words_resumed += ramp_up_words;
 }
+
+CAMLprim value caml_ml_gc_ramp_up(value callback) {
+  CAMLparam1(callback);
+  CAMLlocal1(v);
+  uintnat deferred_words;
+  caml_result res = caml_gc_ramp_up(callback, &deferred_words);
+  v = caml_get_value_or_raise(res);
+  CAMLreturn (caml_alloc_2(0, v, Val_long(deferred_words)));
+}
+
+CAMLprim value caml_ml_gc_ramp_down(value work) {
+  caml_gc_ramp_down(Long_val(work));
+  return Val_unit;
+}

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,6 +38,7 @@
 #include "caml/signals.h"
 #include "caml/startup.h"
 #include "caml/fail.h"
+#include "caml/callback.h"
 
 atomic_uintnat caml_max_stack_wsize;
 uintnat caml_fiber_wsz;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -418,3 +418,21 @@ CAMLprim value caml_ml_runtime_warnings_enabled(value unit)
   CAMLassert (unit == Val_unit);
   return Val_bool(caml_runtime_warnings);
 }
+
+
+/* Ramp-up phase. */
+
+caml_result caml_gc_ramp_up(value callback) {
+    /* Set the GC policy to ramp-up. */
+    Caml_state->gc_policy = (Caml_state->gc_policy | CAML_GC_RAMP_UP);
+
+    caml_result res = caml_callback_res(callback, Val_unit);
+
+    Caml_state->gc_policy = (Caml_state->gc_policy & ~CAML_GC_RAMP_UP);
+
+    return res;
+}
+
+void caml_gc_ramp_down(uintnat ramp_up_words) {
+  Caml_state->allocated_words_resumed += ramp_up_words;
+}

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -438,8 +438,8 @@ static value intern_alloc_obj(struct caml_intern_state* s, caml_domain_state* d,
       intern_cleanup (s);
       caml_raise_out_of_memory();
     }
-    d->allocated_words += Whsize_wosize(wosize);
-    d->allocated_words_direct += Whsize_wosize(wosize);
+    caml_update_major_allocated_words(
+      d, Whsize_wosize(wosize), 1 /* direct */);
     Hd_hp(p) = Make_header (wosize, tag, caml_global_heap_state.MARKED);
     caml_memprof_sample_block(Val_hp(p), wosize,
                               Whsize_wosize(wosize),

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -736,6 +736,8 @@ update_major_slice_work(intnat howmuch,
   my_extra_count = dom_st->extra_heap_resources;
 
   dom_st->stat_major_words += dom_st->allocated_words;
+  dom_st->current_ramp_up_allocated_words_diff +=
+    dom_st->allocated_words_suspended;
 
   dom_st->allocated_words = 0;
   dom_st->allocated_words_direct = 0;
@@ -2155,6 +2157,8 @@ void caml_finish_marking (void)
     caml_empty_mark_stack();
     caml_shrink_mark_stack();
     Caml_state->stat_major_words += Caml_state->allocated_words;
+    Caml_state->current_ramp_up_allocated_words_diff +=
+      Caml_state->allocated_words_suspended;
     Caml_state->allocated_words = 0;
     Caml_state->allocated_words_direct = 0;
     Caml_state->allocated_words_suspended = 0;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -436,8 +436,8 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
       return (value)NULL;
   }
 
-  dom_st->allocated_words += Whsize_wosize(wosize);
-  dom_st->allocated_words_direct += Whsize_wosize(wosize);
+  caml_update_major_allocated_words(
+    dom_st, Whsize_wosize(wosize), 1 /* direct */);
   if (dom_st->allocated_words_direct > dom_st->minor_heap_wsz / 5) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice(1);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -154,7 +154,8 @@ static value alloc_shared(caml_domain_state* d,
 {
   void* mem = caml_shared_try_alloc(d->shared_heap, wosize, tag,
                                     reserved);
-  d->allocated_words += Whsize_wosize(wosize);
+  caml_update_major_allocated_words(
+    d, Whsize_wosize(wosize), 0 /* promoted, not direct */);
   if (mem == NULL) {
     caml_fatal_error("allocation failure during minor GC");
   }

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -163,3 +163,27 @@ module Memprof =
 
     external discard : t -> unit = "caml_memprof_discard"
   end
+
+
+
+type suspended_collection_work = int
+(* Note: we do not currently expose this type outside the module,
+   because it could plausibly change in the future. In particular,
+   currently the runtime only track major allocations during ramp-up
+   work, but there are other sources of GC pressure, such as custom
+   block allocation, that could be tracked as well and should probably
+   be tracked separately. This suggests that the type of suspended work
+   could become a record of integers instead of one integer.
+
+   On the other hand, it would be nice to let users, say, smooth out
+   suspended work by splitting it in N smaller parts to be ramped down
+   separately. This would be possible by exposing the type as int, or
+   possibly by defining a division/splitting function for the abstract
+   type.
+*)
+
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
+  = "caml_ml_gc_ramp_up"
+
+external ramp_down : suspended_collection_work -> unit
+  = "caml_ml_gc_ramp_down"

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -585,3 +585,53 @@ module Memprof :
        called on a profile which has not been stopped.
        *)
 end
+
+
+type suspended_collection_work
+
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
+  = "caml_ml_gc_ramp_up"
+(** In general, the OCaml GC assumes that the program runs in
+    a "steady state" where peak memory usage remains constant: for
+    each newly allocated work, it assumes that one work has become
+    unreachable and will try to collect it during the next GC slice.
+
+    This assumption is incorrect at the points during program
+    execution where the live memory increases instead of remaining
+    stable: the steady-state assumption will make the GC work harder
+    at no benefit as it will not find more memory to collect.
+
+    [ramp_up f] puts the current domain in a "ramp-up" phase for the
+    duration of the evaluation of [f ()], letting the GC know that the
+    steady-state assumption does not hold; it should be used when you
+    know that the live memory of the program will increase
+    significantly.
+
+    During a ramp-up phase, the GC will not try to work harder for new
+    allocations: the corresponding collection work is "suspended". The
+    total amount of suspended collection work is returned by [ramp_up]
+    along with the result of the function.
+
+    If the user discards this suspended work (by doing nothing
+    with it), the GC will never accelerate to recover the
+    corresponding amount of memory. This is appropriate if the ramp-up
+    work allocates long-lived memory that remains live until the end
+    of the program execution.
+
+    If the user knows that at a certain point in the program the live
+    memory consumption has been reduced by the corresponding amount --
+    typically, because the memory allocated during [ramp_up] has become
+    unused -- then they should call {!ramp_down} below to have the GC
+    "resume" this collection work.
+
+    If [f ()] raises an exception, the ramp-up phase terminates and
+    the exception is re-raised.
+
+    If [f ()] performs an effect, the effect is not handled and an
+    [Effect.Unhandled] exception is thrown instead.
+*)
+
+external ramp_down : suspended_collection_work -> unit
+  = "caml_ml_gc_ramp_down"
+(** Notify the GC about some amount of collection work that was
+    suspended during a ramp-up phase, to be resumed now. *)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -624,8 +624,9 @@ external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
     unused -- then they should call {!ramp_down} below to have the GC
     "resume" this collection work.
 
-    If [f ()] raises an exception, the ramp-up phase terminates and
-    the exception is re-raised.
+    If [f ()] raises an exception, the ramp-up phase terminates, the
+    collection work that was suspended is resumed, and the exception
+    is re-raised.
 
     If [f ()] performs an effect, the effect is not handled and an
     [Effect.Unhandled] exception is thrown instead.


### PR DESCRIPTION
This is another iteration to improve the performance of Coq/Rocq on 5.x, a proposal for fixing the GC pacing issues around unmarshalling discussed in #13300 ( the root cause was identified by @NickBarnes in https://github.com/ocaml/ocaml/issues/13300#issuecomment-2233053966 ) which is an alternative to #13320.

In short:

- #13320 uses a size-based heuristic to guess automatically whether a deserialization will be short-lived or long-lived; it gives good result on many OCaml programs (without changing their code), but it could result in (silent) memory blowup on some rarer programs.

- The current PR provides a manual control in the `Gc` module for programmers to express this knowledge explicitly. It is more robust and more expressive, but requires users to change their code so it will be rarely used.

- I have not been able to evaluate the impact of this approach on Rocq itself, but results on a synthetic benchmark suggest that it does improve program performance.


### The problem

By default, when we allocate 1Mio in the major heap (via large allocations or promotions from the minor heap), the major GC assumes that about 1Mio of memory has become dead at roughly the same time, because it assumes that the program is a steady-state of peak memory consumption. So it asks mutator to traverse the major heap to find 1Mio of dead memory to collect.

As discussed in #13300, this assumption is wrong during initialization phases where programs allocate a lot more memory than they collect -- we call this a "ramp up" behavior. In particular, Coq/Rocq typically starts proof scripts with a `Require Import` instruction, which unmarshalls a lot of files recursively, allocating a lot of memory at the start of the program that typically remains live until the end. (OCaml may have similar behaviors with the .cmi of module dependencies which are long-lived). The GC tries to collect inexistant dead memory at the same time, and slows down the progrma. As observed in https://github.com/ocaml/ocaml/pull/13320#issuecomment-2239579571, the OCaml 4 GC was more robust to this sort of situation: for some obscure technical reasons, it behaves better when the flawed heuristic demands a lot of useless work -- and so these "ramp up" situations become performance regressions of OCaml 5 compared to OCaml 4.

### Past proposal

In #13320 I tried to fix the issue by saying bluntly that unmarshalling, above a certain payload size, should be handled as part of a ramp-up phase -- it should not hasten the GC. This is heuristically true for most OCaml programs that look like type-checkers or proof-checkers or modular analyzers, which deserialize information on program/proof dependencies that remain relevant until the end of processing.

But one could also imagine program that use deserialization for message-passing, where each deserialized payload typically has a very short life: on each iteration of the event loop we deserialize input messages, do some work, and produce some output, and typically the input data is dead at this point. On such programs the heuristic of #13320 would be very bad, it could result in a blowup in memory consumption.

### Current proposal

The current PR implements a more manual approach where the programmer is in charge of being explicit about which parts of the program are "ramp up" phases, where most of the memory allocated does not replace pre-existing memory that becomes dead, and will remain live for a long time. In the Gc module:

```ocaml
type suspended_collection_work

val ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
val ramp_down : suspended_collection_work -> unit
```

During the execution of the `ramp_up` callback, allocations into the major heap do not hasten collection work. When the callback returns, the user also gets a count of the amount of collectino work that was suspended in this way. This lets them *optionally* call `ramp_down` at some later time, once they suspect that a corresponding amount of memory has become unreachable, typically when the memory allocated during ramp-up itself becomes dead.

In the case of Rocq, `ramp_up` could be called exactly around the unmarshalling of `.vo` files, or possibly at a slightly larger granularity of `Require Import` work. (Note that using this PR requires a manual change to the source code, so programs do not get magically faster or slower unlike with #13320. And using the new functions while supporting older OCaml versions will require configure-time hacks, meh.)

In the case of a message-passing event loop, it is possible to call `ramp_up` when loading input messages/events at the beginning of each turn of the event loop, and then `ramp_down` at the end of the turn. This should behave roughly like today in the case where the input messages size is approximately constant from one turn to the next, but it would behave better if the sizes are very heterogeneous: without `ramp_up`, the first round with a "very large" input could make the GC waste collection time at the beginning of the round, while with `ramp_up` and `ramp_down` the collection work would be delayed to the end of the turn where it is actually useful.

### Benchmarks

I have not yet tried to experiment with using this feature in the Rocq codebase. For I am using a [synthetic benchmark](https://github.com/gasche/ocaml/blob/gc-rampup-control-benchmark/consume_large_marshal.ml) that unmarshalls 30 lists of 50_000 integers, and then does some light work over them (`List.map succ`). On this benchmark, wrapping the unmarshalling part under a `Gc.ramp_up` call (whose deferred work is thus ignored) results in a speedup that seems to be around 15-20%. (I tried putting a `ramp_down` call later, the speedup is still there.)

The benchmark programs are available on my branch 
  https://github.com/gasche/ocaml/tree/gc-rampup-control-benchmark

### How to review

I have rewritten the history so that the PR is pleasant to read commit-by-commit, so I would recommend doing that. (The definition of `ramp_up` is a bit complex, and seeing it grow in complexity over time is better than reading it in one go.)

cc @NickBarnes which suggested this broad approach, and @damiendoligez with whom I discussed an interface yesterday. I also discussed the Rocq behavior with @OlivierNicole, @ejgallego and @gadmm.

### Implementation notes

The general idea is to add more information to the domain state:

- whether we are in a ramp-up phase or not (`gc_policy`)
- (during ramp-up) how much collection work has been suspended

Whenever we allocate in the major heap, check whether we are in a ramp-up phase and in that case "do the right thing": track the allocation in a way that will not hasten the GC, but correctly counts the amount of suspended work.

I found it more difficult than I thought to get the implementation right, for three reasons:

1. My first idea was to not increment `domain_state->allocated_words` during ramp-up phases (this is the counter that is used for GC pacing calculation), but `allocated_words` is used in a lot of *other* statistics that would become completely wrong during ramp-up. For example, the GC would gladly report that no words have been promoted to the major heap.

   Instead what I do is that I increment `allocated_words` as always, but also increment a `allocated_suspended_words` in parallel, which denotes a subset of major allocations since the last slice that should be considered "suspended". Then I need to change the GC-pacing computation in `update_major_slice_work` to use `allocated_words - allocated_suspended_words`, but all other usages of `allocated_words` can remain unchanged.

2. `allocated_words` and other such counters are reset to 0 on each new slice of the major GC. (Major collections happen incrementally, one "slice" of the memory at a time.) But to count suspended allocations I want to track something during the full ramp-up phase, which (1) could start in the middle of a GC slice and (2) could last for several slices. I tried to have `allocated_suspended_words` *not* be reset on each slice and it does not work. I ended up with two different variables, one with per-slice information and one with per-phase information. (See documentation comments in `domain_state.tbl`.)

3. Initially I thought that `ramp_down` would just subtract from the counter of `allocated_suspended_words`. (And then that counter can become negative, in which case it adds more GC collection work at the next slice instead of reducing it.) This makes it tricky and I couldn't get the behavior I expected in the corner case where someone calls `ramp_down` on a large amount of suspended work in the middle of a short `ramp_up` phase. Now I track two separate unsigned counters, `allocated_suspended_words` which grows on `ramp_up` and `allocated_resumed_words` which grows on `ramp_down`, and the GC work calculation uses `allocated_words - allocated_suspended_words + allocated_resumed_words`.
