### PR TITLE
faster Float.Array.fill

### DIFF
--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -271,7 +271,8 @@ module Array = struct
     else if length a2 = 0 then unsafe_sub a1 0 l1
     else append_prim a1 a2
 
-  let fill a ofs len v =
+  (* inlining exposes a float-unboxing opportunity for [v] *)
+  let[@inline] fill a ofs len v =
     check a ofs len "Float.Array.fill";
     unsafe_fill a ofs len v
 

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -185,7 +185,7 @@ module Array = struct
 
   external unsafe_fill
     : t -> (int[@untagged]) -> (int[@untagged]) -> (float[@unboxed]) -> unit
-    = "caml_floatarray_fill" "caml_floatarray_fill_unboxed"
+    = "caml_floatarray_fill" "caml_floatarray_fill_unboxed" [@@noalloc]
 
   external unsafe_blit: t -> int -> t -> int -> int -> unit =
     "caml_floatarray_blit" [@@noalloc]


### PR DESCRIPTION
Two small optimizations suggested by @alainfrisch, with convincing performance results in https://github.com/ocaml/ocaml/pull/13361#issuecomment-2711256338 :
- add a `[@@noalloc]` attribute on the external primitive, which I forgot
- add an `[@inline]` attribute on the function to expose a float-unboxing opportunity