### PR TITLE
#13702 error messages: specialized error messages for non-functors

### DIFF
--- a/Changes
+++ b/Changes
@@ -323,10 +323,10 @@ Working version
   references another recursive module type.
   (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
 
-- #13702, #????: Specialized error messages for functors appearing in contexts
+- #13702, #13865: Specialized error messages for functors appearing in contexts
   where non-functors were expected `module A: sig ... end = Set.Make`
   (and the reverse)
-  (Florian Angeletti, report by Jeremy Yallop, review by ????)
+  (Florian Angeletti, report by Jeremy Yallop, review by Gabriel Scherer)
 
 - #13788, #13813: Keep the module context in spellchecking hints.
   `Fun.protact` now prompts `Did you mean "Fun.protect?"` rather than

--- a/Changes
+++ b/Changes
@@ -323,6 +323,11 @@ Working version
   references another recursive module type.
   (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
 
+- #13702, #????: Specialized error messages for functors appearing in contexts
+  where non-functors were expected `module A: sig ... end = Set.Make`
+  (and the reverse)
+  (Florian Angeletti, report by Jeremy Yallop, review by ????)
+
 - #13788, #13813: Keep the module context in spellchecking hints.
   `Fun.protact` now prompts `Did you mean "Fun.protect?"` rather than
   `Did you mean "protect?"`.

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -2134,3 +2134,17 @@ Error: Signature mismatch:
        In module "F":
        Modules do not match: a is not included in empty -> empty
 |}]
+
+(** Incorrect hint: the compatibility check consider that [X.T] can not be equal
+    to [x] but this is false. However, anyone using abstract module types can
+    handle a slightly wrong hint. *)
+module F(G: functor(X:sig module type T module I:T end) -> X.T): x = G
+[%%expect {|
+Line 1, characters 69-70:
+1 | module F(G: functor(X:sig module type T module I:T end) -> X.T): x = G
+                                                                         ^
+Error: Signature mismatch:
+       This module should not be a functor, a structure was expected.
+       Moreover, the type of the functor body is incompatible with the
+       expected module type.
+|}]

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -2120,3 +2120,17 @@ Error: Modules do not match: (Arg : empty) -> sig end is not included in
      This module should not be a functor, a structure was expected.
      Hint: Did you forget to apply the functor?
 |}]
+
+module F(X:a): sig module F:empty -> empty end = struct module F = X end
+[%%expect {|
+Line 1, characters 49-72:
+1 | module F(X:a): sig module F:empty -> empty end = struct module F = X end
+                                                     ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module F : a end
+       is not included in
+         sig module F : empty -> empty end
+       In module "F":
+       Modules do not match: a is not included in empty -> empty
+|}]

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -14,8 +14,8 @@ module type z = sig type z end
 module type w = sig type w end
 
 module type empty = sig end
-
 module Empty = struct end
+
 module X: x = struct type x end
 module Y: y = struct type y end
 module Z: z = struct type z end
@@ -1255,9 +1255,9 @@ Error: This application of the functor "F" is ill-typed.
             F : (X : sig type witness module type t module M : t end) -> X.t
           is not included in
             $T6 = sig type witness module type t module M : t end
-          Modules do not match: (X : $S1) -> ... is not included in  -> ...
-          An extra argument is provided of module type
-              $S1 = sig type witness module type t module M : t end
+          This module should not be a functor, a signature was expected.
+          Moreover, the type of the functor body is incompatible with the
+          expected module type.
 |}]
 
 (** Divergent arities *)
@@ -2047,4 +2047,76 @@ Error: The functor application "Set.Make(Set)(A)" is ill-typed.
           The value "compare" is required but not provided
           File "set.mli", line 55, characters 4-31: Expected declaration
        2. The following extra argument is provided A : sig type a = A.a end
+|}]
+
+
+module F(X:a -> a): a = X
+[%%expect {|
+Line 1, characters 24-25:
+1 | module F(X:a -> a): a = X
+                            ^
+Error: Signature mismatch:
+       This module should not be a functor,  an abstract module type was
+       expected.
+       Hint: Did you forget to apply the functor?
+|}]
+
+module F(X:a -> a): empty = X
+[%%expect {|
+Line 1, characters 28-29:
+1 | module F(X:a -> a): empty = X
+                                ^
+Error: Signature mismatch:
+       This module should not be a functor, a signature was expected.
+       Moreover, the type of the functor body is incompatible with the
+       expected module type.
+|}]
+
+
+module F_empty(_:empty) = Empty
+module M: empty = F_empty
+[%%expect {|
+module F_empty : empty -> sig end
+Line 2, characters 18-25:
+2 | module M: empty = F_empty
+                      ^^^^^^^
+Error: Signature mismatch:
+       This module should not be a functor, a signature was expected.
+       Hint: Did you forget to apply the functor?
+|}]
+
+module M: x = F_empty
+[%%expect {|
+Line 1, characters 14-21:
+1 | module M: x = F_empty
+                  ^^^^^^^
+Error: Signature mismatch:
+       This module should not be a functor, a signature was expected.
+       Moreover, the type of the functor body is incompatible with the
+       expected module type.
+|}]
+
+
+module F(X:empty -> empty) = Empty
+module G(X:empty) = Empty
+module A = F(Empty)
+[%%expect {|
+module F : (X : empty -> empty) -> sig end
+module G : (X : empty) -> sig end
+Line 3, characters 11-19:
+3 | module A = F(Empty)
+               ^^^^^^^^
+Error: Modules do not match: sig end is not included in empty -> empty
+     This module should not be structure, a functor was expected.
+|}]
+
+module B = G(F_empty)
+[%%expect {|
+Line 1, characters 11-21:
+1 | module B = G(F_empty)
+               ^^^^^^^^^^
+Error: Modules do not match: (Arg : empty) -> sig end is not included in
+       empty
+     This module should not be a functor, a signature was expected.
+     Hint: Did you forget to apply the functor?
 |}]

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1255,7 +1255,7 @@ Error: This application of the functor "F" is ill-typed.
             F : (X : sig type witness module type t module M : t end) -> X.t
           is not included in
             $T6 = sig type witness module type t module M : t end
-          This module should not be a functor, a signature was expected.
+          This module should not be a functor, a structure was expected.
           Moreover, the type of the functor body is incompatible with the
           expected module type.
 |}]
@@ -2056,8 +2056,8 @@ Line 1, characters 24-25:
 1 | module F(X:a -> a): a = X
                             ^
 Error: Signature mismatch:
-       This module should not be a functor,  an abstract module type was
-       expected.
+       This module should not be a functor, a module with an abstract module
+       type was expected.
        Hint: Did you forget to apply the functor?
 |}]
 
@@ -2067,7 +2067,7 @@ Line 1, characters 28-29:
 1 | module F(X:a -> a): empty = X
                                 ^
 Error: Signature mismatch:
-       This module should not be a functor, a signature was expected.
+       This module should not be a functor, a structure was expected.
        Moreover, the type of the functor body is incompatible with the
        expected module type.
 |}]
@@ -2081,7 +2081,7 @@ Line 2, characters 18-25:
 2 | module M: empty = F_empty
                       ^^^^^^^
 Error: Signature mismatch:
-       This module should not be a functor, a signature was expected.
+       This module should not be a functor, a structure was expected.
        Hint: Did you forget to apply the functor?
 |}]
 
@@ -2091,7 +2091,7 @@ Line 1, characters 14-21:
 1 | module M: x = F_empty
                   ^^^^^^^
 Error: Signature mismatch:
-       This module should not be a functor, a signature was expected.
+       This module should not be a functor, a structure was expected.
        Moreover, the type of the functor body is incompatible with the
        expected module type.
 |}]
@@ -2107,7 +2107,7 @@ Line 3, characters 11-19:
 3 | module A = F(Empty)
                ^^^^^^^^
 Error: Modules do not match: sig end is not included in empty -> empty
-     This module should not be structure, a functor was expected.
+     This module should not be a structure, a functor was expected.
 |}]
 
 module B = G(F_empty)
@@ -2117,6 +2117,6 @@ Line 1, characters 11-21:
                ^^^^^^^^^^
 Error: Modules do not match: (Arg : empty) -> sig end is not included in
        empty
-     This module should not be a functor, a signature was expected.
+     This module should not be a functor, a structure was expected.
      Hint: Did you forget to apply the functor?
 |}]

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -77,7 +77,9 @@ module Error: sig
     (Types.functor_parameter, Ident.t) functor_param_symptom
 
   and functor_params_diff =
-    (Types.functor_parameter list * Types.module_type) core_diff
+    functor_params_info core_diff
+   and functor_params_info =
+     { params: functor_parameter list; res: module_type }
 
   and signature_symptom = {
     env: Env.t;

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -778,11 +778,12 @@ let functor_expected ~before ~ctx got =
     match got.Err.res with
     | Mty_ident _ ->
         Fmt.dprintf
-          "@[This module should not be an abstract@ module@ type,@ \
-           a@ functor was expected.@]"
+          "@[This module should not have an abstract@ module@ type,@ \
+           a@ functor@ was expected.@]"
     | Mty_signature _ | _ ->
         Fmt.dprintf
-          "@[This module should not be structure,@ a functor was expected.@]"
+          "@[This module should not be@ a@ structure,@ \
+           a@ functor@ was expected.@]"
   in
   dwith_context ctx main :: before
 
@@ -792,11 +793,11 @@ let unexpected_functor ~env ~before ~ctx diff =
     match diff.expected.res with
     | Mty_ident _ ->
         Fmt.dprintf
-          "@[This module should not be a functor,@ @ an@ abstract@ module@ \
-           type@ was@ expected.@]"
+          "@[This module should not be a functor,@ a@ module with an@ \
+           abstract@ module@ type@ was@ expected.@]"
     | Mty_signature _ | _ ->
         Fmt.dprintf
-          "@[This module should not be a functor,@ a@ signature was expected.@]"
+          "@[This module should not be a functor,@ a@ structure was expected.@]"
   in
   let main =
     match Includemod.modtypes_consistency ~loc:Location.none env rmty

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -773,17 +773,12 @@ let core_module_type_symptom (x:Err.core_module_type_symptom)  =
 
 (* Construct a linearized error message from the error tree *)
 
-let functor_expected ~before ~ctx got =
+let functor_expected ~before ~ctx =
   let main =
-    match got.Err.res with
-    | Mty_ident _ ->
-        Fmt.dprintf
-          "@[This module should not have an abstract@ module@ type,@ \
-           a@ functor@ was expected.@]"
-    | Mty_signature _ | _ ->
-        Fmt.dprintf
-          "@[This module should not be@ a@ structure,@ \
-           a@ functor@ was expected.@]"
+    (* The abstract module type case is detected by {!Includemod} *)
+    Fmt.dprintf
+      "@[This module should not be@ a@ structure,@ \
+       a@ functor@ was expected.@]"
   in
   dwith_context ctx main :: before
 
@@ -856,7 +851,7 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
 
 and functor_params ~expansion_token ~env ~before ~ctx diff =
   match diff.got.params, diff.expected.params with
-  | [], _ -> functor_expected ~before ~ctx diff.got
+  | [], _ -> functor_expected ~before ~ctx
   | _, [] -> unexpected_functor ~env ~before ~ctx diff
   | _ :: _, _ :: _ ->
       compare_functor_params ~expansion_token ~env ~before ~ctx diff

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -773,6 +773,45 @@ let core_module_type_symptom (x:Err.core_module_type_symptom)  =
 
 (* Construct a linearized error message from the error tree *)
 
+let functor_expected ~before ~ctx got =
+  let main =
+    match got.Err.res with
+    | Mty_ident _ ->
+        Fmt.dprintf
+          "@[This module should not be an abstract@ module@ type,@ \
+           a@ functor was expected.@]"
+    | Mty_signature _ | _ ->
+        Fmt.dprintf
+          "@[This module should not be structure,@ a functor was expected.@]"
+  in
+  dwith_context ctx main :: before
+
+let unexpected_functor ~env ~before ~ctx diff =
+  let rmty = diff.got.res in
+  let intro =
+    match diff.expected.res with
+    | Mty_ident _ ->
+        Fmt.dprintf
+          "@[This module should not be a functor,@ @ an@ abstract@ module@ \
+           type@ was@ expected.@]"
+    | Mty_signature _ | _ ->
+        Fmt.dprintf
+          "@[This module should not be a functor,@ a@ signature was expected.@]"
+  in
+  let main =
+    match Includemod.modtypes_consistency ~loc:Location.none env rmty
+            diff.expected.res with
+    | _ ->
+        Fmt.dprintf
+          "%t@ @{<hint>Hint@}: Did you forget to apply the functor?"
+          intro
+    | exception _ ->
+        Fmt.dprintf "%t@ @[Moreover,@ the type of the functor@ body@ is@ \
+                     incompatible@ with@ the@ expected@ module type.@]"
+          intro
+  in
+  dwith_context ctx main :: before
+
 let rec module_type ~expansion_token ~eqmode ~env ~before ~ctx diff =
   match diff.symptom with
   | Invalid_module_alias _ (* the difference is non-informative here *)
@@ -814,8 +853,18 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
       in
       dwith_context ctx printer :: before
 
-and functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
-  let d = Functor_suberror.Inclusion.patch env got expected in
+and functor_params ~expansion_token ~env ~before ~ctx diff =
+  match diff.got.params, diff.expected.params with
+  | [], _ -> functor_expected ~before ~ctx diff.got
+  | _, [] -> unexpected_functor ~env ~before ~ctx diff
+  | _ :: _, _ :: _ ->
+      compare_functor_params ~expansion_token ~env ~before ~ctx diff
+
+and compare_functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
+  let d = Functor_suberror.Inclusion.patch env
+      (got.params, got.res)
+      (expected.params, expected.res)
+  in
   let actual = Functor_suberror.Inclusion.got d in
   let expected = Functor_suberror.expected d in
   let main =


### PR DESCRIPTION
As reported in #13702, functors appearing in a context where non-functor where expected, for instance
```ocaml
module Int_set: sig include Set.S end = Set.Make
```
are handled by the generic functor parameters mismatch error message:
>```
>Error: Signature mismatch:
>       Modules do not match:
>         (Ord : Set.OrderedType) -> ...
>       is not included in
>          -> ...
>       An extra argument is provided of module type Set.OrderedType
>```

which is not easy to decipher.

This PR proposes to specialize the error message to reduce it to a simpler
```
Error: Signature mismatch:
       This module should not be a functor, a signature was expected.
       Hint: Did you forget to apply the functor?
```
with a variant when the expected type is incompatible with the body of the functor
```ocaml
module Int_set: sig type x end = Set.Make
```

>```Error: Signature mismatch:
>       This module should not be a functor, a signature was expected.
>       Moreover, the type of the functor body is incompatible with the
>       expected module type.
>```

The reverse situation of structure appearing where a functor was expected is handled symmetrically
```ocaml
module M: () -> sig end = Int
```

>```
>Error: Signature mismatch:
>       This module should not be structure, a functor was expected.
>```

without the symmetrical hint of suggesting adding abstractions, which does not seems likely to be correct.