### PR TITLE
`occur_rec` on a graph rather than a tree

### DIFF
--- a/Changes
+++ b/Changes
@@ -459,6 +459,11 @@ Working version
   content of a `Tpackage` node
   (Samuel Vivien, review by Florian Angeletti)
 
+- #13866: Modified occurence check that prevents recursive types for it to see
+  the checked type as a graph rather than a tree
+  (Samuel Vivien, report by Didier Remy, review by Florian Angeletti
+   and Jacques Garrigue)
+
 - #13884 Correctly index modules in constructors and labels paths
   (Ulysse Gérard, review by Florian Angeletti)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1846,33 +1846,33 @@ let is_contractive env p =
 
 exception Occur
 
-let rec occur_rec env mark allow_recursive visited ty0 ty =
-  if not_marked_node mark ty then begin
+let rec occur_rec env visited allow_recursive parents ty0 ty =
+  if not_marked_node visited ty then begin
     if eq_type ty ty0 then raise Occur;
     begin match get_desc ty with
       Tconstr(p, _tl, _abbrev) ->
         if allow_recursive && is_contractive env p then () else
         begin try
-          if TypeSet.mem ty visited then raise Occur;
-          let visited = TypeSet.add ty visited in
-          iter_type_expr (occur_rec env mark allow_recursive visited ty0) ty
+          if TypeSet.mem ty parents then raise Occur;
+          let parents = TypeSet.add ty parents in
+          iter_type_expr (occur_rec env visited allow_recursive parents ty0) ty
         with Occur -> try
           let ty' = try_expand_head try_expand_safe env ty in
           (* This call used to be inlined, but there seems no reason for it.
             Message was referring to change in rev. 1.58 of the CVS repo. *)
-          occur_rec env mark allow_recursive visited ty0 ty'
+          occur_rec env visited allow_recursive parents ty0 ty'
         with Cannot_expand ->
           raise Occur
         end
     | Tobject _ | Tvariant _ ->
         ()
     | _ ->
-        if allow_recursive ||  TypeSet.mem ty visited then () else begin
-          let visited = TypeSet.add ty visited in
-          iter_type_expr (occur_rec env mark allow_recursive visited ty0) ty
+        if allow_recursive ||  TypeSet.mem ty parents then () else begin
+          let parents = TypeSet.add ty parents in
+          iter_type_expr (occur_rec env visited allow_recursive parents ty0) ty
         end
     end;
-    ignore (try_mark_node mark ty)
+    ignore (try_mark_node visited ty)
   end
 
 let type_changed = ref false (* trace possible changes to the studied type *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1846,30 +1846,34 @@ let is_contractive env p =
 
 exception Occur
 
-let rec occur_rec env allow_recursive visited ty0 ty =
-  if eq_type ty ty0 then raise Occur;
-  match get_desc ty with
-    Tconstr(p, _tl, _abbrev) ->
-      if allow_recursive && is_contractive env p then () else
-      begin try
-        if TypeSet.mem ty visited then raise Occur;
-        let visited = TypeSet.add ty visited in
-        iter_type_expr (occur_rec env allow_recursive visited ty0) ty
-      with Occur -> try
-        let ty' = try_expand_head try_expand_safe env ty in
-        (* This call used to be inlined, but there seems no reason for it.
-           Message was referring to change in rev. 1.58 of the CVS repo. *)
-        occur_rec env allow_recursive visited ty0 ty'
-      with Cannot_expand ->
-        raise Occur
-      end
-  | Tobject _ | Tvariant _ ->
-      ()
-  | _ ->
-      if allow_recursive ||  TypeSet.mem ty visited then () else begin
-        let visited = TypeSet.add ty visited in
-        iter_type_expr (occur_rec env allow_recursive visited ty0) ty
-      end
+let rec occur_rec env mark allow_recursive visited ty0 ty =
+  if not_marked_node mark ty then begin
+    if eq_type ty ty0 then raise Occur;
+    begin match get_desc ty with
+      Tconstr(p, _tl, _abbrev) ->
+        if allow_recursive && is_contractive env p then () else
+        begin try
+          if TypeSet.mem ty visited then raise Occur;
+          let visited = TypeSet.add ty visited in
+          iter_type_expr (occur_rec env mark allow_recursive visited ty0) ty
+        with Occur -> try
+          let ty' = try_expand_head try_expand_safe env ty in
+          (* This call used to be inlined, but there seems no reason for it.
+            Message was referring to change in rev. 1.58 of the CVS repo. *)
+          occur_rec env mark allow_recursive visited ty0 ty'
+        with Cannot_expand ->
+          raise Occur
+        end
+    | Tobject _ | Tvariant _ ->
+        ()
+    | _ ->
+        if allow_recursive ||  TypeSet.mem ty visited then () else begin
+          let visited = TypeSet.add ty visited in
+          iter_type_expr (occur_rec env mark allow_recursive visited ty0) ty
+        end
+    end;
+    ignore (try_mark_node mark ty)
+  end
 
 let type_changed = ref false (* trace possible changes to the studied type *)
 
@@ -1883,7 +1887,8 @@ let occur uenv ty0 ty =
     while
       type_changed := false;
       if not (eq_type ty0 ty) then
-        occur_rec env allow_recursive TypeSet.empty ty0 ty;
+        with_type_mark (fun mark ->
+          occur_rec env mark allow_recursive TypeSet.empty ty0 ty);
       !type_changed
     do () (* prerr_endline "changed" *) done;
     merge type_changed old


### PR DESCRIPTION
When unifying two types we check that this does not create a recursive type (if `-rectypes` is not enabled).

However this test can be quite costly as reported by @diremy.

For example if we take the following example :
```ocaml
let unif x y = (fun k z -> k (z x) (z y)) (fun x y -> y) (fun z -> z)

let mairson() =
  let _ =
    let d = unif in
    let d x = d (d x) in (* repeated line *)
    d (fun z -> z) in
  () (* e *)
```
If we repeat line 6 we get a catastrophic complexity :
- 3 times : 3.7ms in typing
- 4 times : 0.6s in typing
- 5 times : did not finish after more than 10 minutes, I expect the actual time to be around 20minutes
On the other hand, with `-rectypes`, repeating this line 14 times leads to a whole compilation time below 0.1s.


A first fix for this problem is to do the occurrence check on a graph rather than on a tree. With this optimization we get the following performances on the test presented above :
- 3 times : 1.2ms in typing
- 4 times : 1.6ms in typing
- 10 times : 1.3s
- 13 times : 120s

As a side note : I checked and this does not seam to impact the time needed to compile the testsuite