### PR TITLE
Add pointer to ocamltest docs from testsuite/HACKING.md

### DIFF
--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -11,7 +11,8 @@ a specific sub-directory.
 == Writing new tests
 
 There are many kind of tests already, so the easiest way to start is
-to extend or copy an existing test.
+to extend or copy an existing test. To learn how to write new tests
+using ocamltest, read [OCAMLTEST.org](../ocamltest/OCAMLTEST.org).
 
 Note: in april 2023, the test scripting language has changed: the
 org-mode-based syntax was replaced by at C-like syntax. ocamltest


### PR DESCRIPTION
I would have found this useful, since the special treatment of the
`(* TEST *)` comment in new test was not apparent.

(no-change-entry-needed)

Signed-off-by: Josh Berdine <josh@berdine.net>