### PR TITLE
add `Thread.set_extended_uncaught_exception_handler`

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,8 +150,8 @@ Working version
 
 ### Standard library:
 
-- #13870: Add `Thread.set_extended_uncaught_exception_handler` for backtrace-aware
-  error handling in threads.
+- #13870: Add `Thread.set_extended_uncaught_exception_handler`
+  for backtrace-aware error handling in threads.
   (Simon Cruanes, review by Stefan Muenzel)
 
 - #13836: Add [Float.]Array.{equal,compare}.

--- a/Changes
+++ b/Changes
@@ -150,8 +150,9 @@ Working version
 
 ### Standard library:
 
-- Add `Thread.set_extended_uncaught_exception_handler` for backtrace-aware
+- #13870: Add `Thread.set_extended_uncaught_exception_handler` for backtrace-aware
   error handling in threads.
+  (Simon Cruanes, review by Stefan Muenzel)
 
 - #13836: Add [Float.]Array.{equal,compare}.
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -150,6 +150,9 @@ Working version
 
 ### Standard library:
 
+- Add `Thread.set_extended_uncaught_exception_handler` for backtrace-aware
+  error handling in threads.
+
 - #13836: Add [Float.]Array.{equal,compare}.
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -34,12 +34,16 @@ external join : t -> unit = "caml_thread_join"
 let[@inline never] check_memprof_cb () = ref ()
 
 let default_uncaught_exception_handler = thread_uncaught_exception
-let default_uncaught_exception_handler_with_backtrace exn _bt = thread_uncaught_exception exn
+let default_uncaught_exception_handler_with_backtrace exn _bt =
+  thread_uncaught_exception exn
 
-let uncaught_exception_handler = ref default_uncaught_exception_handler_with_backtrace
+let uncaught_exception_handler =
+  ref default_uncaught_exception_handler_with_backtrace
 
-let set_uncaught_exception_handler fn = uncaught_exception_handler := (fun exn _bt -> fn exn)
-let set_uncaught_exception_handler_with_backtrace fn = uncaught_exception_handler := fn
+let set_uncaught_exception_handler fn =
+  uncaught_exception_handler := (fun exn _bt -> fn exn)
+let set_uncaught_exception_handler_with_backtrace fn =
+  uncaught_exception_handler := fn
 
 exception Exit
 

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -34,8 +34,9 @@ external join : t -> unit = "caml_thread_join"
 let[@inline never] check_memprof_cb () = ref ()
 
 let default_uncaught_exception_handler = thread_uncaught_exception
+let default_uncaught_exception_handler_with_backtrace exn _bt = thread_uncaught_exception exn
 
-let uncaught_exception_handler = ref (fun exn _bt -> default_uncaught_exception_handler exn)
+let uncaught_exception_handler = ref default_uncaught_exception_handler_with_backtrace
 
 let set_uncaught_exception_handler fn = uncaught_exception_handler := (fun exn _bt -> fn exn)
 let set_uncaught_exception_handler_with_backtrace fn = uncaught_exception_handler := fn

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -38,7 +38,7 @@ let default_uncaught_exception_handler = thread_uncaught_exception
 let uncaught_exception_handler = ref (fun exn _bt -> default_uncaught_exception_handler exn)
 
 let set_uncaught_exception_handler fn = uncaught_exception_handler := (fun exn _bt -> fn exn)
-let set_extended_uncaught_exception_handler fn = uncaught_exception_handler := fn
+let set_uncaught_exception_handler_with_backtrace fn = uncaught_exception_handler := fn
 
 exception Exit
 

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -35,9 +35,10 @@ let[@inline never] check_memprof_cb () = ref ()
 
 let default_uncaught_exception_handler = thread_uncaught_exception
 
-let uncaught_exception_handler = ref default_uncaught_exception_handler
+let uncaught_exception_handler = ref (fun exn _bt -> default_uncaught_exception_handler exn)
 
-let set_uncaught_exception_handler fn = uncaught_exception_handler := fn
+let set_uncaught_exception_handler fn = uncaught_exception_handler := (fun exn _bt -> fn exn)
+let set_extended_uncaught_exception_handler fn = uncaught_exception_handler := fn
 
 exception Exit
 
@@ -54,7 +55,7 @@ let create fn arg =
         let raw_backtrace = Printexc.get_raw_backtrace () in
         flush stdout; flush stderr;
         try
-          !uncaught_exception_handler exn
+          !uncaught_exception_handler exn raw_backtrace
         with
         | Exit -> ()
         | exn' ->

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -185,8 +185,10 @@ val set_uncaught_exception_handler : (exn -> unit) -> unit
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
 
-val set_uncaught_exception_handler_with_backtrace : (exn -> Printexc.raw_backtrace -> unit) -> unit
+val set_uncaught_exception_handler_with_backtrace :
+  (exn -> Printexc.raw_backtrace -> unit) -> unit
 (** [Thread.set_uncaught_exception_handler_with_backtrace f] registers [f]
     as the handler called when a thread fails from an uncaught exception.
-    Unlike {!set_uncaught_exception_handler} it is passed the exception and the backtrace.
+    Unlike {!set_uncaught_exception_handler} it is passed the exception
+    and the backtrace.
     @since 5.4 *)

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -184,3 +184,9 @@ val set_uncaught_exception_handler : (exn -> unit) -> unit
 
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
+
+val set_extended_uncaught_exception_handler: (exn -> Printexc.raw_backtrace -> unit) -> unit
+(** [Thread.set_extended_uncaught_exception_handler f] registers [f]
+    as the handler called when a thread fails from an uncaught exception.
+    Unlike {!set_uncaught_exception_handler} it is passed the exception and the backtrace.
+    @since 5.4 *)

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -185,8 +185,8 @@ val set_uncaught_exception_handler : (exn -> unit) -> unit
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
 
-val set_extended_uncaught_exception_handler: (exn -> Printexc.raw_backtrace -> unit) -> unit
-(** [Thread.set_extended_uncaught_exception_handler f] registers [f]
+val set_uncaught_exception_handler_with_backtrace : (exn -> Printexc.raw_backtrace -> unit) -> unit
+(** [Thread.set_uncaught_exception_handler_with_backtrace f] registers [f]
     as the handler called when a thread fails from an uncaught exception.
     Unlike {!set_uncaught_exception_handler} it is passed the exception and the backtrace.
     @since 5.4 *)

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -2,24 +2,24 @@ Thread 2 killed on uncaught exception Failure("0")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 Thread 3 killed on uncaught exception Failure("1")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 Thread 4 killed on uncaught exception Failure("2")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 Thread 5 killed on uncaught exception Failure("3")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 Thread 1 killed on uncaught exception Failure("backtrace")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
 Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -2,24 +2,24 @@ Thread 2 killed on uncaught exception Failure("0")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 Thread 3 killed on uncaught exception Failure("1")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 Thread 4 killed on uncaught exception Failure("2")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 Thread 5 killed on uncaught exception Failure("3")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 Thread 1 killed on uncaught exception Failure("backtrace")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
 Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -12,4 +12,4 @@ Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 11, c
 Called from Callstack.f1 in file "callstack.ml", line 12, characters 27-32
 Called from Callstack.f2 in file "callstack.ml", line 13, characters 27-32
 Called from Callstack.f3 in file "callstack.ml", line 14, characters 27-32
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -12,4 +12,4 @@ Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 11, c
 Called from Callstack.f1 in file "callstack.ml", line 12, characters 27-32
 Called from Callstack.f2 in file "callstack.ml", line 13, characters 27-32
 Called from Callstack.f3 in file "callstack.ml", line 14, characters 27-32
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,15 +1,15 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-17
-Called from Thread.create.(fun) in file "thread.ml", line 57, characters 10-41
+Called from Thread.create.(fun) in file "thread.ml", line 59, characters 10-55
 [thread 3] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,15 +1,15 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-17
-Called from Thread.create.(fun) in file "thread.ml", line 59, characters 10-55
+Called from Thread.create.(fun) in file "thread.ml", line 63, characters 10-55
 [thread 3] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
-Called from Thread.create.(fun) in file "thread.ml", line 50, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 54, characters 8-14


### PR DESCRIPTION
because backtraces are the oxygen I breathe, the water I swim in, the sable chaud under my feet
