### PR TITLE
Document Printexc gotchas

### DIFF
--- a/Changes
+++ b/Changes
@@ -364,6 +364,10 @@ Working version
 - #13818: better delimited hints in error message
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13876: When stack traces are printed in code compiled or run without the
+  -g option, the stack trace suggests adding that option
+  (Zachary Vance)
+
 ### Internal/compiler-libs changes:
 
 - #13314: Comment the code of Translclass

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -118,7 +118,8 @@ The following environment variables are also consulted:
 \fi
   \begin{options}
   \item[b] (backtrace) Trigger the printing of a stack backtrace
-        when an uncaught exception aborts the program. An optional argument can
+        when an uncaught exception aborts the program (or
+        \stdmoduleref{Printexc} functions are called). An optional argument can
         be provided: "b=0" turns backtrace printing off; "b=1" is equivalent to
         "b" and turns backtrace printing on; "b=2" turns backtrace printing on
         and forces the runtime system to load debugging information at program

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -50,7 +50,8 @@ The following command-line options are recognized by "ocamlrun".
 \begin{options}
 
 \item["-b"]
-When the program aborts due to an uncaught exception, print a detailed
+When the program aborts due to an uncaught exception (or
+\stdmoduleref{Printexc} functions are called), print a detailed
 ``back trace'' of the execution, showing where the exception was
 raised and which function calls were outstanding at this point.  The
 back trace is printed only if the bytecode executable contains

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -87,7 +87,7 @@ static void print_location(const struct caml_loc_info * li, int index)
     inlined = "";
   }
   if (! li->loc_valid) {
-    fprintf(stderr, "%s unknown location%s\n", info, inlined);
+    fprintf(stderr, "%s unknown location%s -- did you use ocamlrun/ocamlc -g ?\n", info, inlined);
   } else if (li->loc_start_lnum == li->loc_end_lnum) {
     fprintf(stderr, "%s %s in file \"%s\"%s, line %d, characters %d-%d\n",
             info, li->loc_defname, li->loc_filename, inlined,

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -87,7 +87,8 @@ static void print_location(const struct caml_loc_info * li, int index)
     inlined = "";
   }
   if (! li->loc_valid) {
-    fprintf(stderr, "%s unknown location%s -- did you use ocamlrun/ocamlc -g ?\n", info, inlined);
+    fprintf(stderr, "%s unknown location%s "
+            "-- did you use ocamlrun/ocamlc -g ?\n", info, inlined);
   } else if (li->loc_start_lnum == li->loc_end_lnum) {
     fprintf(stderr, "%s %s in file \"%s\"%s, line %d, characters %d-%d\n",
             info, li->loc_defname, li->loc_filename, inlined,

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -150,7 +150,7 @@ let format_backtrace_slot pos slot =
       if l.is_raise then
         (* compiler-inserted re-raise, skipped *) None
       else
-        Some (sprintf "%s unknown location" (info false))
+        Some (sprintf "%s unknown location -- did you use ocamlrun/ocamlc -g ?" (info false))
   | Known_location l ->
       let lines =
         if l.start_lnum = l.end_lnum then

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -150,7 +150,9 @@ let format_backtrace_slot pos slot =
       if l.is_raise then
         (* compiler-inserted re-raise, skipped *) None
       else
-        Some (sprintf "%s unknown location -- did you use ocamlrun/ocamlc -g ?" (info false))
+        Some (sprintf 
+             "%s unknown location -- did you use ocamlrun/ocamlc -g ?" 
+             (info false))
   | Known_location l ->
       let lines =
         if l.start_lnum = l.end_lnum then

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Facilities for printing exceptions and inspecting current call stack. *)
+(** Facilities for printing exceptions and inspecting current call stack.
+
+Note that the facilities in this module rely on recording the call stack
+which must be explicitly enabled. See {!record_backtrace}.
+*)
 
 type t = exn = ..
 (** The type of exception values. *)
@@ -70,10 +74,12 @@ val get_backtrace: unit -> string
 *)
 
 val record_backtrace: bool -> unit
-(** [Printexc.record_backtrace b] turns recording of exception backtraces
-    on (if [b = true]) or off (if [b = false]).  Initially, backtraces
-    are not recorded, unless the [b] flag is given to the program
-    through the [OCAMLRUNPARAM] variable.
+(** [Printexc.record_backtrace b] turns on (if [b = true]) or off recording
+    of exception backtraces in the current domain.
+    Initially, backtraces are not recorded, unless the [b] flag is given to
+    the program through the [OCAMLRUNPARAM] variable.
+    Useful debugging information requires the [-g] flag to be passed
+    to [ocamlc] or [ocamlopt].
     @since 3.11
 *)
 

--- a/testsuite/tests/backtrace/pr2195-nolocs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-nolocs.byte.reference
@@ -1,6 +1,6 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at unknown location
-Called from unknown location
+Raised by primitive operation at unknown location -- did you use ocamlrun/ocamlc -g ?
+Called from unknown location -- did you use ocamlrun/ocamlc -g ?
 (Cannot print locations:
  bytecode executable program file cannot be opened;
  -- too many open files. Try running with OCAMLRUNPARAM=b=2)


### PR DESCRIPTION
Fixes #13822

This documents:

- Recording backtraces is off by default and pointer to `-g`, bigger note at top of `Printexc` docs.
- `Printexc.record_backtrace true` is per-domain, in `Printexc` docs
- OCAMLRUNPARAM is cross-domain, implicitly in `Printexc` docs
- `-g` flag affects Printexc, in `ocamlc` docs

Note that (e.g.) `ocamlc`, when run without `-g`, compiles code that prints `Called from unknown location`. I think this message should be expanded include a hint to compile using `ocamlc -g`. But, I am not sure how to make this change correctly in this commit. `git grep "unknown location"` shows several bits of code.

I have not yet learned how to generate the docs and look at them, so this code is untested.