### PR TITLE
ocamdoc and manual: underscores are a normal part of identifiers

### DIFF
--- a/Changes
+++ b/Changes
@@ -290,6 +290,11 @@ Working version
 - #13764, #13779: add missing "-keywords" flag to ocamldep and ocamlprof
   (Florian Angeletti, report by Prashanth Mundkur, review by Gabriel Scherer)
 
+- #13877: ocamldoc, add a `-latex-escape-underscore` flag to control the
+  escaping of `_` underscore in latex references (in order to be able to match
+  odoc behaviour).
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #13694: Fix name for caml_hash_variant in the C interface.

--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -89,6 +89,7 @@ build/latex/Stdlib.tex: $(ALL_COMPILED_DOC) | build/latex
 	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -latex -o build/latex/all.tex \
 	-hide Stdlib -lib Stdlib $(DOC_ALL_INCLUDES) \
 	-sepfiles \
+	-latex-escape-underscore "false" \
 	-latextitle "1,subsection*" \
 	-latextitle "2,subsubsection*" \
 	-latex-type-prefix "TYP" \

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -643,7 +643,7 @@ After parsing, pipe the abstract syntax tree through the preprocessor
 \ifouthtml
 chapter~\ref{c:parsinglib}:
 \ahref{compilerlibref/Ast\_mapper.html}{ \texttt{Ast_mapper} }
-\else section~\ref{Ast-underscoremapper}\fi,
+\else section~\ref{Ast_mapper}\fi,
 implements the external interface of a preprocessor.
 
 \item["-principal"]
@@ -702,7 +702,7 @@ compiler's intermediate representation of the program
 using "compiler-libs" library (see
 \ifouthtml chapter~\ref{c:parsinglib} and
 \ahref{compilerlibref/Compiler\_libs.html}{ \texttt{Compiler_libs} }
-\else section~\ref{Compiler-underscorelibs}\fi
+\else section~\ref{Compiler_libs}\fi
 ).
 }%nat
 

--- a/manual/src/library/compilerlibs.etex
+++ b/manual/src/library/compilerlibs.etex
@@ -1,5 +1,5 @@
 \chapter{The compiler front-end} \label{c:parsinglib}\cutname{parsing.html}
-\label{Compiler-underscorelibs} % redirect references to compiler_libs.mld here
+\label{Compiler_libs} % redirect references to compiler_libs.mld here
 
 This chapter describes the OCaml front-end, which declares the abstract
 syntax tree used by the compiler, provides a way to parse, print

--- a/manual/src/library/stdlib-blurb.etex
+++ b/manual/src/library/stdlib-blurb.etex
@@ -82,8 +82,8 @@ integers
 \end{tabular}
 \subsubsection*{sss:stdlib-io}{input/output:}
 \begin{tabular}{lll}
-"In_channel" & p.~\stdpageref{In-underscorechannel} & input channels \\
-"Out_channel" & p.~\stdpageref{Out-underscorechannel} & output channels \\
+"In_channel" & p.~\stdpageref{In_channel} & input channels \\
+"Out_channel" & p.~\stdpageref{Out_channel} & output channels \\
 "Format" & p.~\stdpageref{Format} & pretty printing with automatic
 indentation and line breaking \\
 "Marshal" & p.~\stdpageref{Marshal} & marshaling of data structures \\

--- a/manual/tests/check-stdlib-modules
+++ b/manual/tests/check-stdlib-modules
@@ -10,7 +10,7 @@ cut -c 2- $TMPDIR/stdlib-$$-files \
 exitcode=0
 for i in `cat $TMPDIR/stdlib-$$-modules`; do
   case $i in
-    Stdlib | Camlinternal* | *Labels | Obj | In_channel | Out_channel) continue;;
+    Stdlib | Camlinternal* | *Labels | Obj ) continue;;
     Std_exit*) continue;;
   esac
   grep -q -e '"'$i'" & p\.~\\stdpageref{'$i'} &' $1/manual/src/library/stdlib-blurb.etex || {

--- a/ocamldoc/odoc_args.ml
+++ b/ocamldoc/odoc_args.ml
@@ -297,6 +297,9 @@ let default_options = Options.list @
     Arg.String (fun s -> Odoc_latex.latex_class_prefix := s), M.latex_class_prefix ;
   "-latex-class-type-prefix",
     Arg.String (fun s -> Odoc_latex.latex_class_type_prefix := s), M.latex_class_type_prefix ;
+  "-latex-escape-underscore", Arg.Bool ((:=) Odoc_latex.latex_escape_underscore),
+    "escape underscore in references";
+
   "-notoc", Arg.Unit (fun () -> Odoc_global.with_toc := false), M.no_toc ^
   "\n\n *** texinfo options ***\n";
 

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -47,6 +47,7 @@ let latex_class_prefix = ref Odoc_messages.default_latex_class_prefix
 let latex_class_type_prefix = ref Odoc_messages.default_latex_class_type_prefix
 let latex_attribute_prefix = ref Odoc_messages.default_latex_attribute_prefix
 let latex_method_prefix = ref Odoc_messages.default_latex_method_prefix
+let latex_escape_underscore = ref true
 
 let new_buf () = Buffer.create 1024
 let new_fmt () =
@@ -186,7 +187,10 @@ class text =
       for i = 0 to len - 1 do
         let (s_no_, s) =
           match name.[i] with
-          '_' -> ("-underscore", "_")
+        |  '_' ->
+              if !latex_escape_underscore then
+                ("-underscore", "_")
+              else ("_","_")
         | '~' -> ("-tilde", "~")
         | '%' -> ("-percent", "%")
         | '@' -> ("-at", "\"@")

--- a/ocamldoc/odoc_latex.mli
+++ b/ocamldoc/odoc_latex.mli
@@ -41,6 +41,8 @@ val latex_attribute_prefix : string ref
 
 val latex_method_prefix : string ref
 
+val latex_escape_underscore: bool ref
+
 module Generator :
   sig
     class latex :


### PR DESCRIPTION
Over the years, the OCaml manual latex preamble and macros have been updated to consider that `_` underscore are normal part of an `OCaml` identifier rather than a typographic operator for indices, at least in non-mathematical contexts.

One of the last remnant of the special handling of `_` was `ocamldoc` which unconditionally escapes  `_` to `-underscore` in references and labels.

This PR proposes to add a flag to `ocamldoc` to stop this escaping of `_` underscore.

With this change, the `In_channel` and `Out_channel` modules (or any future modules with `_` in their name) do not require any special handling anymore in the manual and its test suite.