### PR TITLE
Restore lib-unix/common/cloexec.ml test on Windows

### DIFF
--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -127,7 +127,15 @@ let not_msvc = make
     "not using MSVC / clang-cl"
     "using MSVC / clang-cl")
 
-(* not_windows _skips_ on Cygwin; not_target_windows _passes_ for Cygwin *)
+(* windows _passes_ on Cygwin; target_windows _skips_ for Cygwin *)
+
+let target_windows = make
+  ~name:"target-windows"
+  ~description:"Pass if the compiler does targets native Windows"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.target_os_type = "Win32")
+    "targetting native Windows"
+    "not targetting native Windows")
+
 let not_target_windows = make
   ~name:"not-target-windows"
   ~description:"Pass if the compiler does not target native Windows"
@@ -389,6 +397,7 @@ let _ =
     windows;
     not_windows;
     not_msvc;
+    target_windows;
     not_target_windows;
     bsd;
     not_bsd;

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -127,6 +127,14 @@ let not_msvc = make
     "not using MSVC / clang-cl"
     "using MSVC / clang-cl")
 
+(* not_windows _skips_ on Cygwin; not_target_windows _passes_ for Cygwin *)
+let not_target_windows = make
+  ~name:"not-target-windows"
+  ~description:"Pass if the compiler does not target native Windows"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.target_os_type <> "Win32")
+    "not targetting native Windows"
+    "targetting native Windows")
+
 let is_bsd_system s =
   match s with
   | "bsd_elf" | "netbsd" | "freebsd" | "openbsd" -> true
@@ -381,6 +389,7 @@ let _ =
     windows;
     not_windows;
     not_msvc;
+    not_target_windows;
     bsd;
     not_bsd;
     linux;

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -33,6 +33,8 @@ let cflags = {@QS@|@common_cflags@|@QS@}
 
 let ccomptype = {@QS@|@ccomptype@|@QS@}
 
+let target_os_type = {@QS@|@target_os_type@|@QS@}
+
 let diff = {@QS@|@DIFF@|@QS@}
 let diff_flags = {@QS@|@DIFF_FLAGS@|@QS@}
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -39,6 +39,9 @@ val cflags : string
 val ccomptype : string
 (** Type of C compiler (msvc, cc, etc.) *)
 
+val target_os_type : string
+(** The value of Sys.os_type for the target (cf. Config.target_os_type) *)
+
 val diff : string
 (** Path to the diff tool *)
 

--- a/testsuite/tests/callback/signals_alloc.ml
+++ b/testsuite/tests/callback/signals_alloc.ml
@@ -1,7 +1,8 @@
 (* TEST
  include unix;
  modules = "callbackprim.c";
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/callback/test_signalhandler.ml
+++ b/testsuite/tests/callback/test_signalhandler.ml
@@ -1,7 +1,8 @@
 (* TEST
  include unix;
  modules = "test_signalhandler_.c";
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/hidden_includes/test.ml
+++ b/testsuite/tests/hidden_includes/test.ml
@@ -93,7 +93,7 @@ ocamlc.byte;
   ocamlc.byte;
 }
 {
-  not-windows;
+  not-target-windows;
   flags = "-H liba -I liba_alt -I libb -nocwd";
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
@@ -104,7 +104,7 @@ ocamlc.byte;
   check-ocamlc.byte-output;
 }
 {
-  not-windows;
+  not-target-windows;
   flags = "-I liba_alt -H liba -I libb -nocwd";
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
@@ -117,7 +117,7 @@ ocamlc.byte;
 
 (* The next two tests show that earlier -Hs take priority over later -Hs *)
 {
-  not-windows;
+  not-target-windows;
   flags = "-H liba_alt -H liba -I libb -nocwd";
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;

--- a/testsuite/tests/lib-runtime-events/test_corrupted.ml
+++ b/testsuite/tests/lib-runtime-events/test_corrupted.ml
@@ -2,7 +2,8 @@
  include runtime_events;
  include unix;
  set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_external.ml
+++ b/testsuite/tests/lib-runtime-events/test_external.ml
@@ -1,7 +1,8 @@
 (* TEST
  include runtime_events;
  include unix;
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_external_preserve.ml
+++ b/testsuite/tests/lib-runtime-events/test_external_preserve.ml
@@ -2,7 +2,8 @@
  include runtime_events;
  include unix;
  set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_fork.ml
+++ b/testsuite/tests/lib-runtime-events/test_fork.ml
@@ -1,7 +1,8 @@
 (* TEST
  include runtime_events;
  include unix;
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_user_event_signal.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_signal.ml
@@ -2,7 +2,7 @@
  include runtime_events;
  include unix;
  hasunix;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }

--- a/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
@@ -2,7 +2,8 @@
  include runtime_events;
  include unix;
  set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/eintr.ml
+++ b/testsuite/tests/lib-systhreads/eintr.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testfork.ml
+++ b/testsuite/tests/lib-systhreads/testfork.ml
@@ -2,7 +2,8 @@
  include systhreads;
  hassysthreads;
  not-bsd;
- libunix;
+ hasunix;
+ not-target-windows;
  no-tsan; (* tsan limitation: starting new threads after fork is not supported *)
  {
    bytecode;

--- a/testsuite/tests/lib-systhreads/testfork2.ml
+++ b/testsuite/tests/lib-systhreads/testfork2.ml
@@ -2,7 +2,8 @@
  include systhreads;
  hassysthreads;
  not-bsd;
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testpreempt.ml
+++ b/testsuite/tests/lib-systhreads/testpreempt.ml
@@ -6,7 +6,7 @@
      However, this does not seem very reliable, so that this test fails
      on some Windows configurations. See GPR #1533.
    *)
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testyield.ml
+++ b/testsuite/tests/lib-systhreads/testyield.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/threadsigmask.ml
+++ b/testsuite/tests/lib-systhreads/threadsigmask.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-threads/delayintr.ml
+++ b/testsuite/tests/lib-threads/delayintr.ml
@@ -2,7 +2,7 @@
  include systhreads;
  readonly_files = "sigint.c";
  hassysthreads;
- libunix; (* excludes mingw32/64 and msvc32/64 *)
+ not-target-windows; (* excludes mingw32/64 and msvc32/64 *)
  {
    program = "${test_build_directory}/delayintr.byte";
    setup-ocamlc.byte-build-env;

--- a/testsuite/tests/lib-threads/signal.ml
+++ b/testsuite/tests/lib-threads/signal.ml
@@ -2,7 +2,7 @@
  include systhreads;
  readonly_files = "sigint.c";
  hassysthreads;
- libunix; (* excludes mingw32/64 and msvc32/64 *)
+ not-target-windows; (* excludes mingw32/64 and msvc32/64 *)
  {
    program = "${test_build_directory}/signal.byte";
    setup-ocamlc.byte-build-env;

--- a/testsuite/tests/lib-threads/sockets.ml
+++ b/testsuite/tests/lib-threads/sockets.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- libunix; (* Broken on Windows (missing join?), needs to be fixed *)
+ not-target-windows; (* Broken on Windows (missing join?), needs to be fixed *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -82,16 +82,9 @@ let _ =
   let s0 = Unix.(socket PF_INET SOCK_STREAM 0) in
   let s1 = Unix.(socket ~cloexec:false PF_INET SOCK_STREAM 0) in
   let s2 = Unix.(socket ~cloexec:true PF_INET SOCK_STREAM 0) in
-  let (x0, x0') =
-    try Unix.(socketpair PF_UNIX SOCK_STREAM 0)
-    with Invalid_argument _ -> (p0, p0') in
-    (* socketpair not available under Win32; keep the same output *)
-  let (x1, x1') =
-    try Unix.(socketpair ~cloexec:false PF_UNIX SOCK_STREAM 0)
-    with Invalid_argument _ -> (p1, p1') in
-  let (x2, x2') =
-    try Unix.(socketpair ~cloexec:true PF_UNIX SOCK_STREAM 0)
-    with Invalid_argument _ -> (p2, p2') in
+  let (x0, x0') = Unix.(socketpair PF_UNIX SOCK_STREAM 0) in
+  let (x1, x1') = Unix.(socketpair ~cloexec:false PF_UNIX SOCK_STREAM 0) in
+  let (x2, x2') = Unix.(socketpair ~cloexec:true PF_UNIX SOCK_STREAM 0) in
 
   let fds = [| f0;f1;f2; d0;d1;d2;
                p0;p0';p1;p1';p2;p2';

--- a/testsuite/tests/lib-unix/common/fdstatus_aux.c
+++ b/testsuite/tests/lib-unix/common/fdstatus_aux.c
@@ -2,42 +2,17 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-
-#ifdef _WIN32
-
-#define WIN32_LEAN_AND_MEAN
-#include <wtypes.h>
-#include <winbase.h>
-#include <winerror.h>
-
-void process_fd(const char * s)
-{
-  int fd;
-  HANDLE h;
-  DWORD flags;
-
-#ifdef _WIN64
-  h = (HANDLE) _atoi64(s);
-#else
-  h = (HANDLE) atoi(s);
-#endif
-  if (GetHandleInformation(h, &flags)) {
-    printf("open\n");
-  } else if (GetLastError() == ERROR_INVALID_HANDLE) {
-    printf("closed\n");
-  } else {
-    printf("error %lu\n", (unsigned long)(GetLastError()));
-  }
-}
-
-#else
-
 #include <limits.h>
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <io.h>
+#define close _close
+#else
 #include <unistd.h>
+#endif
 
 void process_fd(const char * s)
 {
@@ -53,6 +28,7 @@ void process_fd(const char * s)
   fd = (int) n;
   if (fstat(fd, &st) != -1) {
     printf("open\n");
+    close(fd);
   } else if (errno == EBADF) {
     printf("closed\n");
   } else {
@@ -60,10 +36,9 @@ void process_fd(const char * s)
   }
 }
 
-#endif
-
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
+#include <caml/unixsupport.h>
 
 CAMLprim value caml_process_fd(value CAMLnum, value CAMLfd)
 {
@@ -71,4 +46,17 @@ CAMLprim value caml_process_fd(value CAMLnum, value CAMLfd)
   printf("#%d: ", Int_val(CAMLnum));
   process_fd(String_val(CAMLfd));
   CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_fd_of_filedescr(value v)
+{
+  CAMLparam1(v);
+
+#ifdef _WIN32
+  int fd = caml_win32_CRT_fd_of_filedescr(v);
+#else
+  int fd = Int_val(v);
+#endif
+
+  CAMLreturn(Val_int(fd));
 }

--- a/testsuite/tests/lib-unix/common/fdstatus_main.ml
+++ b/testsuite/tests/lib-unix/common/fdstatus_main.ml
@@ -1,8 +1,11 @@
 external process_and_close_fd : int -> string -> unit = "caml_process_fd"
 
 let () =
-  for i = 1 to (Array.length Sys.argv) -1
+  for i = 2 to (Array.length Sys.argv) -1
   do
-    process_and_close_fd i Sys.argv.(i);
+    process_and_close_fd (i - 1) Sys.argv.(i);
   done;
-  Sys.remove "tmp.txt"
+  (* For the execv version of the test, clean-up tmp.txt - for the
+     Unix.create_process version, this is done by cloexec.ml *)
+  if Sys.argv.(1) = "execv" then
+    Sys.remove "tmp.txt"

--- a/testsuite/tests/lib-unix/common/fdstatus_main.ml
+++ b/testsuite/tests/lib-unix/common/fdstatus_main.ml
@@ -1,7 +1,8 @@
-external process_fd : int -> string -> unit = "caml_process_fd"
+external process_and_close_fd : int -> string -> unit = "caml_process_fd"
 
 let () =
   for i = 1 to (Array.length Sys.argv) -1
   do
-    process_fd i Sys.argv.(i);
-  done
+    process_and_close_fd i Sys.argv.(i);
+  done;
+  Sys.remove "tmp.txt"

--- a/testsuite/tests/lib-unix/common/fork_cleanup.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-windows;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/sigwait.ml
+++ b/testsuite/tests/lib-unix/common/sigwait.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libunix;
+ hasunix;
+ not-target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/isatty/isatty_tty.ml
+++ b/testsuite/tests/lib-unix/isatty/isatty_tty.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libwin32unix;
+ hasunix;
+ target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/kill/unix_kill.ml
+++ b/testsuite/tests/lib-unix/kill/unix_kill.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libunix;
+ hasunix;
+ not-target-windows;
  (*
    Disabled on MacOS amd64 with TSan due to a
    possible infinite signal loop with TSan under MacOS

--- a/testsuite/tests/lib-unix/win-channel-of/parallel_channel_of.ml
+++ b/testsuite/tests/lib-unix/win-channel-of/parallel_channel_of.ml
@@ -1,7 +1,8 @@
 (* TEST
  modules = "fd_of_channel.c";
  include unix;
- libwin32unix;
+ hasunix;
+ target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/win-createprocess/test.ml
+++ b/testsuite/tests/lib-unix/win-createprocess/test.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libwin32unix;
+ hasunix;
+ target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/win-env/test_env.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env.ml
@@ -4,7 +4,8 @@
  include unix;
  flags += "-strict-sequence -w +A-70 -warn-error +A";
  modules = "stubs.c";
- libwin32unix;
+ hasunix;
+ target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/win-socketpair/test.ml
+++ b/testsuite/tests/lib-unix/win-socketpair/test.ml
@@ -1,8 +1,8 @@
 (* TEST
  script = "sh ${test_source_directory}/has-afunix.sh";
- libwin32unix;
  include systhreads;
  hassysthreads;
+ target-windows;
  script;
  {
    output = "${test_build_directory}/program-output";

--- a/testsuite/tests/lib-unix/win-stat/test.ml
+++ b/testsuite/tests/lib-unix/win-stat/test.ml
@@ -1,7 +1,8 @@
 (* TEST
  modules = "fakeclock.c";
  include unix;
- libwin32unix;
+ hasunix;
+ target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/win-symlink/parallel_symlink.ml
+++ b/testsuite/tests/lib-unix/win-symlink/parallel_symlink.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libwin32unix;
+ hasunix;
+ target-windows;
  has_symlink;
  {
    bytecode;

--- a/testsuite/tests/lib-unix/win-symlink/test.ml
+++ b/testsuite/tests/lib-unix/win-symlink/test.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
- libwin32unix;
+ hasunix;
+ target-windows;
  has_symlink;
  {
    bytecode;

--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -1,7 +1,7 @@
 (* TEST
 hassysthreads;
 include systhreads;
-not-windows;
+not-target-windows;
 no-tsan;
 {
   bytecode;

--- a/testsuite/tests/runtime-errors/syserror.ml
+++ b/testsuite/tests/runtime-errors/syserror.ml
@@ -5,12 +5,13 @@
    ocamlc.byte;
    exit_status = "2";
    run;
+   hasunix;
    {
-     libunix;
+     not-target-windows;
      reference = "${test_source_directory}/syserror.unix.reference";
      check-program-output;
    }{
-     libwin32unix;
+     target-windows;
      reference = "${test_source_directory}/syserror.win32.reference";
      check-program-output;
    }
@@ -19,12 +20,13 @@
    ocamlopt.byte;
    exit_status = "2";
    run;
+   hasunix;
    {
-     libunix;
+     not-target-windows;
      reference = "${test_source_directory}/syserror.unix.reference";
      check-program-output;
    }{
-     libwin32unix;
+     target-windows;
      reference = "${test_source_directory}/syserror.win32.reference";
      check-program-output;
    }


### PR DESCRIPTION
This test was added in #650, and tests the inheritance of `Unix.file_descr`s across process creation. This is done in the main test by setting up various different "kinds" of `file_descr` and then exec'ing a small auxiliary program which tests the state of each fd.

As part of the switch to ocamltest, this test was disabled on Windows, for reasons covered in https://github.com/ocaml/ocaml/commit/fd05a7572bef667397c7f704da2ae6fc5682b8e2.

The issue at play is that while the OCaml runtime doesn't leave any CRT fds open at the end of startup, the namespace for `HANDLE` values on Windows is shared with more than just files, so there was a strong chance that a `HANDLE` which was marked as not inheritable (i.e. a close-on-exec fd) would end up being opened in the exec'd checker.

I wish to use a further-tweaked version of this test for a second purpose as a regression test for fixing a different bug (which - as may not be a surprise by now - is a fix related to Relocatable OCaml).

The first commit removes special-cases for Windows which haven't been necessary since #10192 (though the test was of course disabled at that point).

The second commit is the major part of the change. On Windows, rather than manipulating `HANDLE` values, we actually manipulate CRT fd values instead. This has the benefit of removing most of the Windows-specific code from the C portion of the test - we simply use the required C primitive. However, at this point the test on Windows would hit a technical deficiency of the implementation of `Unix.create_process`, as it's implemented over the Windows API, rather than the CRT, so the test is switched to use `Unix.execv` instead.

Partly as a todo item, and partly because testing both `posix_spawn` and `execv` w.r.t. `cloexec` is valuable, the next two commits then run the test using the original `Unix.create_process` mechanism - but this will fail on the mingw-w64 and MSVC ports so a new `not-target-windows` primitive is added to ocamltest. At some point, it would be worth re-implementing `Unix.create_process` on Windows in terms of the CRT's `spawn`, but this will need care w.r.t. all the `cloexec` work, but it's not urgent.

Having added this `not-target-windows` primitive, I was reminded of #12844 - and the remaining commits use this `not-target-windows` and then the dual `target-windows` finally to clarify and tidy up `libunix` / `libwin32unix` which are now no longer used.