### PR TITLE
Make object stat counters atomic

### DIFF
--- a/Changes
+++ b/Changes
@@ -488,6 +488,9 @@ Working version
   Cmm to prevent bugs linked to incorrect handling of coeffects.
   (Vincent Laviron, review by Gabriel Scherer)
 
+- #13880: Make object stat counters atomic
+  (Dimitris Mostrous, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -163,6 +163,7 @@ camlinternalOO.cmo : \
     stdlib__Map.cmi \
     stdlib__List.cmi \
     stdlib__Char.cmi \
+    stdlib__Atomic.cmi \
     stdlib__Array.cmi \
     camlinternalOO.cmi
 camlinternalOO.cmx : \
@@ -172,6 +173,7 @@ camlinternalOO.cmx : \
     stdlib__Map.cmx \
     stdlib__List.cmx \
     stdlib__Char.cmx \
+    stdlib__Atomic.cmx \
     stdlib__Array.cmx \
     camlinternalOO.cmi
 camlinternalOO.cmi : \

--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -609,4 +609,5 @@ type stats =
 
 let stats () =
   { classes = Atomic.get table_count;
-    methods = Atomic.get method_count; inst_vars = Atomic.get inst_var_count; }
+    methods = Atomic.get method_count;
+    inst_vars = Atomic.get inst_var_count; }

--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -113,7 +113,7 @@ let dummy_table =
     initializers = [];
     size = 0 }
 
-let table_count = ref 0
+let table_count = Atomic.make 0
 
 (* dummy_met should be a pointer, so use an atom *)
 let dummy_met : item = Obj.obj (Obj.new_block 0 0)
@@ -125,7 +125,7 @@ let rec fit_size n =
   fit_size ((n+1)/2) * 2
 
 let new_table pub_labels =
-  incr table_count;
+  Atomic.incr table_count;
   let len = Array.length pub_labels in
   let methods = Array.make (len*2+2) dummy_met in
   methods.(0) <- Obj.magic len;
@@ -154,8 +154,8 @@ let put array label element =
 
 (**** Classes ****)
 
-let method_count = ref 0
-let inst_var_count = ref 0
+let method_count = Atomic.make 0
+let inst_var_count = Atomic.make 0
 
 (* type t *)
 type meth = item
@@ -178,7 +178,7 @@ let get_method_labels table names =
   Array.map (get_method_label table) names
 
 let set_method table label element =
-  incr method_count;
+  Atomic.incr method_count;
   if Labs.find label table.methods_by_label then
     put table label element
   else
@@ -309,7 +309,7 @@ let create_table public_methods =
   table
 
 let init_class table =
-  inst_var_count := !inst_var_count + table.size - 1;
+  ignore (Atomic.fetch_and_add inst_var_count (table.size - 1));
   table.initializers <- List.rev table.initializers;
   resize table (3 + Obj.magic table.methods.(1) * 16 / Sys.word_size)
 
@@ -608,5 +608,5 @@ type stats =
   { classes: int; methods: int; inst_vars: int; }
 
 let stats () =
-  { classes = !table_count;
-    methods = !method_count; inst_vars = !inst_var_count; }
+  { classes = (Atomic.get table_count);
+    methods = (Atomic.get method_count); inst_vars = (Atomic.get inst_var_count); }

--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -608,5 +608,5 @@ type stats =
   { classes: int; methods: int; inst_vars: int; }
 
 let stats () =
-  { classes = (Atomic.get table_count);
-    methods = (Atomic.get method_count); inst_vars = (Atomic.get inst_var_count); }
+  { classes = Atomic.get table_count;
+    methods = Atomic.get method_count; inst_vars = Atomic.get inst_var_count; }


### PR DESCRIPTION
In a codebase where a lot of objects were being created in parallel, Thread Sanitizer reported races, which seem to be from these counters. (Unfortunately on my machine the line numbers won't show in the TSan logs, but the rest was clear from code inspection.)

Unless if I'm missing something, the race is pretty obvious.

Example from some TSan logs:

```
WARNING: ThreadSanitizer: data race (pid=90398)
  Write of size 8 at 0x00010e0fbe88 by thread T6 (mutexes: write M0):
    #0 camlCamlinternalOO.new_table_808 <null>:277879472 (opengrep-core:arm64+0x1036eb358)
    #1 camlCamlinternalOO.create_table_1120 <null>:277879472 (opengrep-core:arm64+0x1036eda88)
    ....
    #39 camlStdlib__Domain.body_741 <null>:277879472 (opengrep-core:arm64+0x10366ff18)
    #40 domain_thread_func domain.c:1245 (opengrep-core:arm64+0x103d75208)

  Previous write of size 8 at 0x00010e0fbe88 by thread T4 (mutexes: write M1):
    #0 camlCamlinternalOO.new_table_808 <null>:277877008 (opengrep-core:arm64+0x1036eb358)
    #1 camlCamlinternalOO.create_table_1120 <null>:277877008 (opengrep-core:arm64+0x1036eda88)
   ...
   #36 caml_runstack <null>:277877008 (opengrep-core:arm64+0x103dba180)
   #37 camlDomainslib__Task.worker_604 <null>:277877008 (opengrep-core:arm64+0x102924580)

Thread T6 (tid=8335990, running) created by main thread at:
    #0 pthread_create <null>:277877120 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x309d8)
    #1 caml_domain_spawn domain.c:1294 (opengrep-core:arm64+0x103d74ef8)
    #2 caml_c_call <null>:277877008 (opengrep-core:arm64+0x103db9850)
    #3 camlStdlib__Domain.spawn_736 <null>:277877008 (opengrep-core:arm64+0x10366fe10)
   ...

 Thread T4 (tid=8335988, running) created by main thread at:
    #0 pthread_create <null>:277879360 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x309d8)
    #1 caml_domain_spawn domain.c:1294 (opengrep-core:arm64+0x103d74ef8)
    #2 caml_c_call <null>:277879472 (opengrep-core:arm64+0x103db9850)
    #3 camlStdlib__Domain.spawn_736 <null>:277879472 (opengrep-core:arm64+0x10366fe10)
   ...

SUMMARY: ThreadSanitizer: data race (opengrep-core:arm64+0x1036eb358) in camlCamlinternalOO.new_table_808+0x68
``` 
