### PR TITLE
Enforce evaluation order for generic applications in Closure

### DIFF
--- a/Changes
+++ b/Changes
@@ -514,6 +514,10 @@ Working version
   definitions
   (Clement Blaudeau, review by Florian Angeletti)
 
+* #13874, #13882: Make evaluation order consistent for applications when using
+  the non-flambda native compiler
+  (Vincent Laviron, report by Jean-Marie Madiot, review by Gabriel Scherer)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 


### PR DESCRIPTION
Fixes #13874, by enforcing evaluation order for function calls in `Closure`.

I have an alternative branch [here](https://github.com/lthls/ocaml/tree/cmmgen-generic-application-order) which binds the arguments in `Cmmgen`  instead. It is a bit simpler because it doesn't change much existing code, but I prefer this one because it allows some factorisation with the direct application case.