### PR TITLE
[shapes] Correctly index modules in constructors and labels paths

### DIFF
--- a/Changes
+++ b/Changes
@@ -424,6 +424,9 @@ Working version
   content of a `Tpackage` node
   (Samuel Vivien, review by Florian Angeletti)
 
+- #13884 Correctly index modules in constructors and labels paths
+  (Ulysse Gérard, review by Florian Angeletti)
+
 ### Build system:
 
 - #13431: Simplify github action responsible for flagging PRs with

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -153,7 +153,7 @@ let iter_on_occurrences
   let path_in_type typ name =
     match Types.get_desc typ with
     | Tconstr (type_path, _, _) ->
-      Some (Path.Pdot (type_path,  name))
+      Some (Path.Pextra_ty(type_path, Pcstr_ty name))
     | _ -> None
   in
   let add_constructor_description env lid =
@@ -379,7 +379,8 @@ let index_occurrences binary_annots =
        should make these successive reductions fast. *)
     let rec index_components namespace lid path  =
       let module_ = Shape.Sig_component_kind.Module in
-      match lid.Location.txt, path with
+      let scraped_path = Path.scrape_extra_ty path in
+      match lid.Location.txt, scraped_path with
       | Longident.Ldot (lid', _), Path.Pdot (path', _) ->
         reduce_and_store ~namespace lid path;
         index_components module_ lid' path'

--- a/testsuite/tests/shape-index/index_constrs_records.ml
+++ b/testsuite/tests/shape-index/index_constrs_records.ml
@@ -42,3 +42,11 @@ let e = Exn { l_exn = 2}
 let _ = match e with
   | Exn { l_exn } -> l_exn
   | _ -> assert false
+
+module Mod = struct
+  type t = A of { lbl : int}
+end
+let () =
+  match Mod.A { lbl = 42 } with
+  | Mod.A { lbl = 42 } -> ()
+  | Mod.A r -> ignore r.lbl

--- a/testsuite/tests/shape-index/index_constrs_records.reference
+++ b/testsuite/tests/shape-index/index_constrs_records.reference
@@ -1,4 +1,26 @@
 Indexed shapes:
+Resolved: Index_constrs_records.47:
+  r (File "index_constrs_records.ml", line 52, characters 22-23)
+Resolved: Index_constrs_records.38:
+  lbl (File "index_constrs_records.ml", line 52, characters 24-27)
+Unresolved: CU Stdlib . "ignore"[value] :
+  ignore (File "index_constrs_records.ml", line 52, characters 15-21)
+Approximated: Index_constrs_records.45:
+  Mod (File "index_constrs_records.ml", line 52, characters 4-7)
+Resolved: Index_constrs_records.39:
+  Mod.A (File "index_constrs_records.ml", line 52, characters 4-9)
+Resolved: Index_constrs_records.38:
+  lbl (File "index_constrs_records.ml", line 51, characters 12-15)
+Approximated: Index_constrs_records.45:
+  Mod (File "index_constrs_records.ml", line 51, characters 4-7)
+Resolved: Index_constrs_records.39:
+  Mod.A (File "index_constrs_records.ml", line 51, characters 4-9)
+Resolved: Index_constrs_records.38:
+  lbl (File "index_constrs_records.ml", line 50, characters 16-19)
+Approximated: Index_constrs_records.45:
+  Mod (File "index_constrs_records.ml", line 50, characters 8-11)
+Resolved: Index_constrs_records.39:
+  Mod.A (File "index_constrs_records.ml", line 50, characters 8-13)
 Resolved: Index_constrs_records.36:
   l_exn (File "index_constrs_records.ml", line 43, characters 21-26)
 Resolved: Index_constrs_records.32:
@@ -93,3 +115,11 @@ Index_constrs_records.33:
   Exn (File "index_constrs_records.ml", line 39, characters 10-13)
 Index_constrs_records.35:
   e (File "index_constrs_records.ml", line 41, characters 4-5)
+Index_constrs_records.37:
+  t (File "index_constrs_records.ml", line 47, characters 7-8)
+Index_constrs_records.38:
+  lbl (File "index_constrs_records.ml", line 47, characters 18-21)
+Index_constrs_records.39:
+  A (File "index_constrs_records.ml", line 47, characters 11-12)
+Index_constrs_records.45:
+  Mod (File "index_constrs_records.ml", line 46, characters 7-10)

--- a/testsuite/tests/shape-index/index_constrs_records.reference
+++ b/testsuite/tests/shape-index/index_constrs_records.reference
@@ -5,19 +5,19 @@ Resolved: Index_constrs_records.38:
   lbl (File "index_constrs_records.ml", line 52, characters 24-27)
 Unresolved: CU Stdlib . "ignore"[value] :
   ignore (File "index_constrs_records.ml", line 52, characters 15-21)
-Approximated: Index_constrs_records.45:
+Resolved: Index_constrs_records.45:
   Mod (File "index_constrs_records.ml", line 52, characters 4-7)
 Resolved: Index_constrs_records.39:
   Mod.A (File "index_constrs_records.ml", line 52, characters 4-9)
 Resolved: Index_constrs_records.38:
   lbl (File "index_constrs_records.ml", line 51, characters 12-15)
-Approximated: Index_constrs_records.45:
+Resolved: Index_constrs_records.45:
   Mod (File "index_constrs_records.ml", line 51, characters 4-7)
 Resolved: Index_constrs_records.39:
   Mod.A (File "index_constrs_records.ml", line 51, characters 4-9)
 Resolved: Index_constrs_records.38:
   lbl (File "index_constrs_records.ml", line 50, characters 16-19)
-Approximated: Index_constrs_records.45:
+Resolved: Index_constrs_records.45:
   Mod (File "index_constrs_records.ml", line 50, characters 8-11)
 Resolved: Index_constrs_records.39:
   Mod.A (File "index_constrs_records.ml", line 50, characters 8-13)
@@ -71,7 +71,7 @@ Resolved: Index_constrs_records.19:
   M (File "index_constrs_records.ml", line 27, characters 5-6)
 Resolved: Index_constrs_records.3:
   l_c (File "index_constrs_records.ml", line 25, characters 14-17)
-Approximated: Index_constrs_records.19:
+Resolved: Index_constrs_records.19:
   M (File "index_constrs_records.ml", line 25, characters 8-9)
 Resolved: Index_constrs_records.4:
   M.A (File "index_constrs_records.ml", line 25, characters 8-11)

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -122,6 +122,10 @@ let flatten =
   in
   fun t -> flatten [] t
 
+let rec scrape_extra_ty = function
+  | Pextra_ty (t, _) -> scrape_extra_ty t
+  | t -> t
+
 let heads p =
   let rec heads p acc = match p with
     | Pident id -> id :: acc

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -64,6 +64,9 @@ val exists_free: Ident.t list -> t -> bool
 val scope: t -> int
 val flatten : t -> [ `Contains_apply | `Ok of Ident.t * string list ]
 
+val scrape_extra_ty: t -> t
+(** Removes surrounding `Pext_ty` constructors from a path *)
+
 val name: ?paren:(string -> bool) -> t -> string
     (* [paren] tells whether a path suffix needs parentheses *)
 val head: t -> Ident.t

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -276,26 +276,22 @@ let dummy_mod =
 let of_path ~find_shape ~namespace path =
   (* We need to handle the following cases:
     Path of constructor:
-      M.t.C
+      M.t.C [Pextra_ty("M.t", "C")]
     Path of label:
-      M.t.lbl
+      M.t.lbl [Pextra_ty("M.t", "lbl")]
     Path of label of inline record:
-      M.t.C.lbl *)
+      M.t.C.lbl [Pextra_ty(Pextra_ty("M.t", "C"), "lbl")] *)
   let rec aux : Sig_component_kind.t -> Path.t -> t = fun ns -> function
     | Pident id -> find_shape ns id
-    | Pdot (path, name) ->
-        let namespace :  Sig_component_kind.t =
-          match (ns : Sig_component_kind.t) with
-          | Constructor -> Type
-          | Label -> Type
-          | _ -> Module
-        in
-        proj (aux namespace path) (name, ns)
+    | Pdot (path, name) -> proj (aux Module path) (name, ns)
     | Papply (p1, p2) -> app (aux Module p1) ~arg:(aux Module p2)
     | Pextra_ty (path, extra) -> begin
-        match extra with
-          Pcstr_ty name -> proj (aux Type path) (name, Constructor)
-        | Pext_ty -> aux Extension_constructor path
+        match extra, ns, path with
+        | Pcstr_ty name, Label, Pextra_ty _ ->
+            (* Handle the M.t.C.lbl case *)
+            proj (aux Constructor path) (name, ns)
+        | Pcstr_ty name, _, _ -> proj (aux Type path) (name, ns)
+        | Pext_ty, _, _ -> aux Extension_constructor path
       end
   in
   aux namespace path


### PR DESCRIPTION
The notion of Path used to derive shapes is slightly different than elsewhere in the compiler and allows accessing types' constructors and inline records' labels in shape structures.

This ad-hoc processing was made overly complex in `Shape.of_path` by relying on additional `Pdot` components. This PR reworks that to make better use of the `Pextra_ty` path component which is a much better fit here, reducing the need for ad-hoc processing to the "label of an inline record" case.

The function used to split paths for indexing is also reworked to handle correctly these cases. This fixes the shape reduction issues highlighted in the test cases introduced in 4f82f15a3a470dc741a3d1497839bd5870d33a8d (and in one already present in the testsuite).

cc @Octachron 