### PR TITLE
Implement `Dynarray.{exists2, for_all2}`

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,6 +150,9 @@ Working version
 
 ### Standard library:
 
+- #13885: Add Dynarray.{exists2, for_all2}.
+  (T. Kinsart, review by Daniel Bünzli, Gabriel Scherer, and Nicolás Ojeda Bär)
+
 - #13836: Add [Float.]Array.{equal,compare}.
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -327,6 +327,22 @@ val for_all : ('a -> bool) -> 'a t -> bool
     [for_all f a] is [f x0 && f x1 && f x2].
 *)
 
+val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** Same as {!exists}, but for a two-argument predicate.
+
+   @raise Invalid_argument if the two arrays have different lengths.
+
+   @since 5.4
+*)
+
+val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** Same as {!for_all}, but for a two-argument predicate.
+
+   @raise Invalid_argument if the two arrays have different lengths.
+
+   @since 5.4
+*)
+
 val mem : 'a -> 'a t -> bool
 (** [mem a set] is true if and only if [a] is structurally equal
     to an element of [set] (i.e. there is an [x] in [set] such that

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -87,6 +87,36 @@ let () =
   let a = A.of_list [1; 2; 3] in
   assert (A.fold_right List.cons a [] = [1; 2; 3]);;
 
+(* exists2 *)
+let () =
+  let a = A.of_list [1; 2; 3] in
+  assert (A.exists2 (=) a a);
+  assert (not (A.exists2 (=) (A.of_list []) (A.of_list [])));
+  assert (A.exists2 (=) a (A.of_list [1; 4; 3]));
+  assert (match A.exists2 (=) a (A.of_list [1; 2]) with
+    | exception (Invalid_argument _) -> true
+    | _ -> false
+  );
+  assert (match A.exists2 (=) (A.of_list [1; 2]) a with
+    | exception (Invalid_argument _) -> true
+    | _ -> false
+  );;
+
+(* for_all2 *)
+let () =
+  let a = A.of_list [1; 2; 3] in
+  assert (A.for_all2 (=) a a);
+  assert (A.for_all2 (=) (A.of_list []) (A.of_list []));
+  assert (not (A.for_all2 (=) a (A.of_list [1; 4; 3])));
+  assert (match A.for_all2 (=) a (A.of_list [1; 2]) with
+    | exception (Invalid_argument _) -> true
+    | _ -> false
+  );
+  assert (match A.for_all2 (=) (A.of_list [1; 2]) a with
+    | exception (Invalid_argument _) -> true
+    | _ -> false
+  );;
+
 (** {1:adding Adding elements} *)
 
 (** add_last was tested above *)


### PR DESCRIPTION
This is a follow-up on PR https://github.com/ocaml/ocaml/pull/13296, where it was [suggested] to have `exists2` and `for_all2` in another PR.

[suggested]: https://github.com/ocaml/ocaml/pull/13296#issuecomment-2248702045
