### PR TITLE
gitignore: ignore macOS executable debug symbols directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 *.exe.manifest
 .DS_Store
 *.out
-*.out.dSYM
+*.dSYM/
 *.swp
 _ocamltest
 _ocamltestd


### PR DESCRIPTION
When an executable is linked using the -g flag, a directory for debug symbols is created under macOS. It's only appearing for `sak`, and creates noise with git status. Ignore it.