### PR TITLE
Fix the @since attribute for the Uchar.hash function

### DIFF
--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -106,8 +106,9 @@ val hash : t -> int
 (** An unseeded hash function with the same output value as {!Hashtbl.hash}.
     This function allows this module to be passed as an argument to the functor
     {!Hashtbl.Make}.
-
-    @since 5.3 *)
+    @before 5.3 The hashing algorithm was different.
+    Use [Hashtbl.rebuild] for stored tables which used this hashing
+    function *)
 
 (** {1:utf UTF codecs tools}
 


### PR DESCRIPTION
This function was documented as having been introduced in OCaml 5.3
whereas it is present since the initial implementation of the
Uchar module in 940144f30487ead603d51ad4783542fe5410b821, which was part
of OCaml 4.03 released in April 2016.

(Should be backported where appropriate)