### PR TITLE
Export Int.of_string and Int.of_string_opt

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,6 +150,10 @@ Working version
 
 ### Standard library:
 
+- #13894: Export Int.{of_string, of_string_opt} and explcitly document functions
+  that raise exceptions in Int32 and Int64 modules.
+  (Tim McGilchrist, review by ???)
+
 - #13885: Add Dynarray.{exists2, for_all2}.
   (T. Kinsart, review by Daniel Bünzli, Gabriel Scherer, and Nicolás Ojeda Bär)
 

--- a/stdlib/int.ml
+++ b/stdlib/int.ml
@@ -43,10 +43,11 @@ let max x y : t = if x >= y then x else y
 external to_float : int -> float = "%floatofint"
 external of_float : float -> int = "%intoffloat"
 
-(*
-external int_of_string : string -> int = "caml_int_of_string"
-let of_string s = try Some (int_of_string s) with Failure _ -> None
-*)
+external of_string : string -> int = "caml_int_of_string"
+
+let of_string_opt s =
+  try Some (of_string s)
+  with Failure _ -> None
 
 external format_int : string -> int -> string = "caml_format_int"
 let to_string x = format_int "%d" x

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -128,11 +128,10 @@ external of_float : float -> int = "%intoffloat"
     unspecified if the argument is [nan] or falls outside the range of
     representable integers. *)
 
-(*
-val of_string : string -> int option
-(** [of_string s] is [Some s] if [s] can be parsed to an integer
+external of_string : string -> int = "caml_int_of_string"
+(** Convert the given string to an integer
     in the range representable by the type [int] (note that this
-    depends on {!Sys.int_size}) and [None] otherwise.
+    depends on {!Sys.int_size}).
 
     The string may start with an optional ['-'] or ['+'] sign, and may
     be followed by an optional prefix that specifies the base in which
@@ -147,8 +146,14 @@ val of_string : string -> int option
     modulo 2{^[Sys.int_size]} like arithmetic operations do.
 
     The ['_'] (underscore) character can appear anywhere between two
-    digits of the number. *)
-*)
+    digits of the number.
+
+    @since 5.4 *)
+
+val of_string_opt : string -> int option
+(** Same as [of_string], but return [None] instead of raising.
+
+    @since 5.4 *)
 
 val to_string : int -> string
 (** [to_string x] is the written representation of [x] in decimal. *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -58,25 +58,29 @@ external mul : int32 -> int32 -> int32 = "%int32_mul"
 external div : int32 -> int32 -> int32 = "%int32_div"
 (** Integer division. This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}.
-   @raise Division_by_zero if the second
-   argument is zero.  *)
+
+   @raise Division_by_zero if the second argument is zero. *)
 
 val unsigned_div : int32 -> int32 -> int32
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} 32-bit integers.
 
+    @raise Division_by_zero if the second argument is zero.
     @since 4.08 *)
 
 external rem : int32 -> int32 -> int32 = "%int32_mod"
 (** Integer remainder.  If [y] is not zero, the result
    of [Int32.rem x y] satisfies the following property:
    [x = Int32.add (Int32.mul (Int32.div x y) y) (Int32.rem x y)].
-   If [y = 0], [Int32.rem x y] raises [Division_by_zero]. *)
+   If [y = 0], [Int32.rem x y] raises [Division_by_zero].
+
+   @raise Division_by_zero if y is zero. *)
 
 val unsigned_rem : int32 -> int32 -> int32
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} 32-bit integers.
 
+    @raise Division_by_zero if the second argument is zero.
     @since 4.08 *)
 
 val succ : int32 -> int32
@@ -94,7 +98,6 @@ val max_int : int32
 
 val min_int : int32
 (** The smallest representable 32-bit integer, -2{^31}. *)
-
 
 external logand : int32 -> int32 -> int32 = "%int32_and"
 (** Bitwise logical and. *)
@@ -177,7 +180,6 @@ external of_string : string -> int32 = "caml_int32_of_string"
 val of_string_opt: string -> int32 option
 (** Same as [of_string], but return [None] instead of raising.
     @since 4.05 *)
-
 
 val to_string : int32 -> string
 (** Return the string representation of its argument, in signed decimal. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -56,27 +56,31 @@ external mul : int64 -> int64 -> int64 = "%int64_mul"
 (** Multiplication. *)
 
 external div : int64 -> int64 -> int64 = "%int64_div"
-(** Integer division.
-   @raise Division_by_zero if the second
-   argument is zero.  This division rounds the real quotient of
-   its arguments towards zero, as specified for {!Stdlib.(/)}. *)
+(** Integer division. This division rounds the real quotient of
+   its arguments towards zero, as specified for {!Stdlib.(/)}.
+
+   @raise Division_by_zero if the second argument is zero. *)
 
 val unsigned_div : int64 -> int64 -> int64
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} 64-bit integers.
 
+    @raise Division_by_zero if the second argument is zero.
     @since 4.08 *)
 
 external rem : int64 -> int64 -> int64 = "%int64_mod"
 (** Integer remainder.  If [y] is not zero, the result
    of [Int64.rem x y] satisfies the following property:
    [x = Int64.add (Int64.mul (Int64.div x y) y) (Int64.rem x y)].
-   If [y = 0], [Int64.rem x y] raises [Division_by_zero]. *)
+   If [y = 0], [Int64.rem x y] raises [Division_by_zero].
+
+   @raise Division_by_zero if y is zero. *)
 
 val unsigned_rem : int64 -> int64 -> int64
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} 64-bit integers.
 
+    @raise Division_by_zero if the second argument is zero.
     @since 4.08 *)
 
 val succ : int64 -> int64

--- a/testsuite/tests/basic/opt_variants.ml
+++ b/testsuite/tests/basic/opt_variants.ml
@@ -9,6 +9,10 @@ let () =
   assert(int_of_string_opt "42" = Some 42);
   assert(int_of_string_opt (String.make 100 '9') = None);
 
+  assert(Int.of_string_opt "foo" = None);
+  assert(Int.of_string_opt "42" = Some 42);
+  assert(Int.of_string_opt (String.make 100 '9') = None);
+
   assert(Nativeint.of_string_opt "foo" = None);
   assert(Nativeint.of_string_opt "42" = Some 42n);
   assert(Nativeint.of_string_opt (String.make 100 '9') = None);

--- a/testsuite/tests/lib-int/test.ml
+++ b/testsuite/tests/lib-int/test.ml
@@ -52,8 +52,18 @@ let test_float_conv () =
 
 let test_string_conv () =
   assert (Int.to_string 50 = "50");
-(*  assert (Int.of_string "50" = Some 50);
-  assert (Int.of_string "" = None); *)
+  assert (Int.to_string 0 = "0");
+  assert (Int.to_string (-50) = "-50");
+
+  (* Convert strings to ints *)
+  assert (Int.of_string "50" = 50);
+  assert (Int.of_string "50_000" = 50000);
+  assert (Int.of_string "0x00" = 0);
+  assert (Int.of_string "0x11" = 17);
+  assert (Int.of_string "0u11" = 11);
+  assert (Int.of_string "0b1110111" = 119);
+  assert (Int.of_string "0b1_110_111" = 119);
+  assert (Int.of_string "0O10" = 8);
   ()
 
 let test_min_max () =

--- a/testsuite/tests/lib-int64/test.ml
+++ b/testsuite/tests/lib-int64/test.ml
@@ -51,8 +51,16 @@ let test_float_conv () =
 
 let test_string_conv () =
   assert (Int64.to_string 50L = "50");
-(*  assert (Int64.of_string "50" = Some 50);
-  assert (Int64.of_string "" = None); *)
+
+(* Convert strings to ints *)
+  assert (Int64.of_string "50" = 50L);
+  assert (Int64.of_string "50_000" = 50000L);
+  assert (Int64.of_string "0x00" = 0L);
+  assert (Int64.of_string "0x11" = 17L);
+  assert (Int64.of_string "0u11" = 11L);
+  assert (Int64.of_string "0b1110111" = 119L);
+  assert (Int64.of_string "0b1_110_111" = 119L);
+  assert (Int64.of_string "0O10" = 8L);
   ()
 
 let test_min_max () =


### PR DESCRIPTION
I needed this somewhere and since it's already exported via Int32.of_string Int64.of_string and int_of_string, this feels like a natural change. Plus consistency in naming is nice :-)

- 0d3dacb496852eb2a53bed913ec399124eb5654a does the real work
- fe8eb9862eb2d0a1f87a486fc43995b846ef76f4 modifies the generated documentation for functions that raise exceptions to be more explicit and use the `@raise` attribute.