### PR TITLE
Regression fix: Allow to include caml/custom.h in C++ code

### DIFF
--- a/Changes
+++ b/Changes
@@ -449,9 +449,9 @@ Working version
 
 ### Bug fixes:
 
-- #13691: Make four globals underlying Gc.control atomic to avoid C data
-  races against them
-  (Jan Midtgaard, review by Miod Vallat and Sadiq Jaffer)
+- #13691 #13895: Make four globals underlying Gc.control atomic to avoid C data
+  races against them.
+  (Jan Midtgaard, review by Miod Vallat, Sadiq Jaffer and Antonin Décimo)
 
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -51,7 +51,7 @@ struct custom_operations {
 extern "C" {
 #endif
 
-CAMLextern _Atomic uintnat caml_custom_major_ratio;
+CAMLextern atomic_uintnat caml_custom_major_ratio;
 
 CAMLextern value caml_alloc_custom(const struct custom_operations * ops,
                                    uintnat size, /*size in bytes*/


### PR DESCRIPTION
This is a regression fix for trunk compared to 5.3.0.
Using trunk, including `caml/custom.h` will result in the following error when using g++:
```
# /home/kit_ty_kate/.opam/5.4/lib/ocaml/caml/custom.h:54:12: error: ‘_Atomic’ does not name a type; did you mean ‘Atom’?
#    54 | CAMLextern _Atomic uintnat caml_custom_major_ratio;
#       |            ^~~~~~~
#       |            Atom
```

Related to #13777 