### PR TITLE
Refactor merge constraint

### DIFF
--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -422,3 +422,44 @@ Error: In this "with" constraint, the new definition of "M.N"
          type t = M.r
        The type "X.t" is not equal to the type "M.r" = "M.N.s"
 |}]
+
+
+(** Aliases and substitutions **)
+
+(* Non destructive type and module type substitutions inside an alias should
+   preserve the alias signature. By contrast, destructive type and module type
+   substitutions force inlining and lose the alias information (could be fixed
+   with transparent ascription) *)
+
+type base = A | B
+module X = struct
+  type t = base = A | B
+  module type T = sig end
+end
+
+module type S = sig module Y = X end
+module type S1  = S with type Y.t = base
+module type S2  = S with module type Y.T = sig end
+[%%expect {|
+type base = A | B
+module X : sig type t = base = A | B module type T = sig end end
+module type S = sig module Y = X end
+module type S1 = sig module Y = X end
+module type S2 = sig module Y = X end
+|}]
+module type S1' = S with type Y.t := base
+[%%expect {|
+Line 1, characters 18-41:
+1 | module type S1' = S with type Y.t := base
+                      ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This deep destructive "with" substitution inside of "Y" would
+       loose the aliasing to "X" .
+|}]
+module type S2' = S with module type Y.T := sig end
+[%%expect {|
+Line 1, characters 18-51:
+1 | module type S2' = S with module type Y.T := sig end
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This deep destructive "with" substitution inside of "Y" would
+       loose the aliasing to "X" .
+|}]

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -368,9 +368,9 @@ Error: The module type "t" is not a valid type for a packed module:
        for an anonymous module type. (see manual section 12.7.3)
 |}]
 
-(* Having cyclic constraints should throw an error *)
+(* Having cyclic constraints should throw an error  *)
 module rec X : (sig module type A end with module type A = X.A)
-= struct module type A end
+= struct end (* should fail before typechecking the body *)
 [%%expect {|
 Line 1, characters 59-62:
 1 | module rec X : (sig module type A end with module type A = X.A)
@@ -382,7 +382,7 @@ Error: This module type is recursive. This use of the recursive module "X"
 
 (* Having cyclic constraints should throw an error (destructive) *)
 module rec X : (sig module type A end with module type A := X.A)
-= struct module type A end
+= struct end (* should fail before typechecking the body *)
 [%%expect {|
 Line 1, characters 60-63:
 1 | module rec X : (sig module type A end with module type A := X.A)
@@ -392,29 +392,275 @@ Error: This module type is recursive. This use of the recursive module "X"
        Such recursive definitions of module types are not allowed.
 |}]
 
-(* The approximated module types should have the merged constraints (non
-   destructive case) *)
-module rec X : (sig module type A module X' : A end)
-               with module type A = sig type t end =
-struct
-  module type A = sig type t end
-  module X' = struct type t = int end
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (abstract, non destructive case) *)
+module type Test = sig
+  module type S := sig
+    module type A
+    module X' : A
+  end
+
+  module rec X : (S with module type A = sig type t end)
+  and Y : sig type u = X.X'.t end
 end
-and Y : sig type u = X.X'.t end = struct type u = X.X'.t end
 [%%expect {|
-module rec X : sig module type A = sig type t end module X' : A end
-and Y : sig type u = X.X'.t end
+module type Test =
+  sig
+    module rec X : sig module type A = sig type t end module X' : A end
+    and Y : sig type u = X.X'.t end
+  end
 |}]
 
-(* The approximated module types should have the merged constraints
-   (destructive case) *)
-module rec X : (sig module type A module X' : A end)
-               with module type A := sig type t end =
-struct
-  module X' = struct type t = int end
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (abstract, destructive case) *)
+module type Test = sig
+  module type S := sig
+    module type A
+    module X' : A
+  end
+
+  module rec X : (S with module type A := sig type t end)
+  and Y : sig type u = X.X'.t end
 end
-and Y : sig type u = X.X'.t end = struct type u = X.X'.t end
 [%%expect {|
-module rec X : sig module X' : sig type t end end
-and Y : sig type u = X.X'.t end
+module type Test =
+  sig
+    module rec X : sig module X' : sig type t end end
+    and Y : sig type u = X.X'.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (concrete, non destructive case) *)
+module type Test = sig
+  module type S := sig
+    module type A = sig type t type u end
+    module X' : A
+  end
+
+  module rec X : (S with module type A = sig type u type t end)
+  and Y : sig type v = X.X'.t end
+end
+[%%expect {|
+module type Test =
+  sig
+    module rec X :
+      sig module type A = sig type u type t end module X' : A end
+    and Y : sig type v = X.X'.t end
+  end
+|}]
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (concrete, destructive case) *)
+module type Test = sig
+  module type S := sig
+    module type A = sig type t type u end
+    module X' : A
+  end
+
+  module rec X : (S with module type A := sig type u type t end)
+  and Y : sig type v = X.X'.t end
+end
+[%%expect {|
+module type Test =
+  sig
+    module rec X : sig module X' : sig type u type t end end
+    and Y : sig type v = X.X'.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, abstract, non destructive case) *)
+module type Test = sig
+  module type S := sig
+    module M : sig
+      module type A
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A = sig type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test =
+  sig
+    module rec X :
+      sig
+        module M : sig module type A = sig type t end module X1 : A end
+        module X2 : M.A
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, abstract, destructive case) *)
+module type Test = sig
+  module type S := sig
+    module M : sig
+      module type A
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A := sig type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test =
+  sig
+    module rec X :
+      sig
+        module M : sig module X1 : sig type t end end
+        module X2 : sig type t end
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, concrete, non destructive case) *)
+module type Test = sig
+  module type S := sig
+    module M : sig
+      module type A = sig type t type u end
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A = sig type u type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test =
+  sig
+    module rec X :
+      sig
+        module M :
+          sig module type A = sig type u type t end module X1 : A end
+        module X2 : M.A
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, concrete, destructive case) *)
+module type Test = sig
+  module type S := sig
+    module M : sig
+      module type A = sig type t type u end
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A := sig type u type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test =
+  sig
+    module rec X :
+      sig
+        module M : sig module X1 : sig type u type t end end
+        module X2 : sig type u type t end
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Invalid substitutions might be accepted during the approximation phase, but
+   should be rejected during typechecking *)
+module type Test = sig
+  module rec X : (sig
+      module type A = sig type t = bool end
+      module X' : A
+    end with module type A = sig type t = int end)
+  and Y : sig type u = X.X'.t end
+end
+[%%expect {|
+Lines 2-5, characters 18-49:
+2 | ..................sig
+3 |       module type A = sig type t = bool end
+4 |       module X' : A
+5 |     end with module type A = sig type t = int end.
+Error: In this "with" constraint, the new definition of "A"
+       does not match its original definition in the constrained signature:
+       At position "module type A = <here>"
+       Module types do not match:
+         sig type t = bool end
+       is not equal to
+         sig type t = int end
+       At position "module type A = <here>"
+       Type declarations do not match:
+         type t = bool
+       is not included in
+         type t = int
+       The type "bool" is not equal to the type "int"
+|}]
+
+(* Invalid substitutions might be accepted during the approximation phase, but
+   should be rejected during typechecking of signatures (before typechecking of
+   module bodies) *)
+module type Test = sig
+  module rec X : (sig
+      module type A = sig type t = bool end
+      module X' : A
+    end with module type A = sig type t = int end)
+  and Y : sig type u = X.X'.t end
+end
+[%%expect {|
+Lines 2-5, characters 18-49:
+2 | ..................sig
+3 |       module type A = sig type t = bool end
+4 |       module X' : A
+5 |     end with module type A = sig type t = int end.
+Error: In this "with" constraint, the new definition of "A"
+       does not match its original definition in the constrained signature:
+       At position "module type A = <here>"
+       Module types do not match:
+         sig type t = bool end
+       is not equal to
+         sig type t = int end
+       At position "module type A = <here>"
+       Type declarations do not match:
+         type t = bool
+       is not included in
+         type t = int
+       The type "bool" is not equal to the type "int"
+|}]
+
+
+(* Defining module types before the recursive module prevents them from being
+   approximated and can (erroneously) make the constraint ill-formed *)
+module type Test = sig
+  module type S = sig module type A = sig type t = int end end
+  module rec X : S with module type A = sig type t = int end
+end
+[%%expect {|
+Line 3, characters 40-60:
+3 |   module rec X : S with module type A = sig type t = int end
+                                            ^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "A"
+       does not match its original definition in the constrained signature:
+       At position "module type A = <here>"
+       Module types do not match:
+         sig type t end
+       is not equal to
+         sig type t = int end
+       At position "module type A = <here>"
+       Type declarations do not match: type t is not included in type t = int
+       The type "t" is not equal to the type "int"
 |}]

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -650,17 +650,9 @@ module type Test = sig
   module rec X : S with module type A = sig type t = int end
 end
 [%%expect {|
-Line 3, characters 40-60:
-3 |   module rec X : S with module type A = sig type t = int end
-                                            ^^^^^^^^^^^^^^^^^^^^
-Error: In this "with" constraint, the new definition of "A"
-       does not match its original definition in the constrained signature:
-       At position "module type A = <here>"
-       Module types do not match:
-         sig type t end
-       is not equal to
-         sig type t = int end
-       At position "module type A = <here>"
-       Type declarations do not match: type t is not included in type t = int
-       The type "t" is not equal to the type "int"
+module type Test =
+  sig
+    module type S = sig module type A = sig type t = int end end
+    module rec X : sig module type A = sig type t = int end end
+  end
 |}]

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -375,7 +375,9 @@ module rec X : (sig module type A end with module type A = X.A)
 Line 1, characters 59-62:
 1 | module rec X : (sig module type A end with module type A = X.A)
                                                                ^^^
-Error: Illegal recursive module reference
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
 |}]
 
 (* Having cyclic constraints should throw an error (destructive) *)
@@ -385,7 +387,9 @@ module rec X : (sig module type A end with module type A := X.A)
 Line 1, characters 60-63:
 1 | module rec X : (sig module type A end with module type A := X.A)
                                                                 ^^^
-Error: Illegal recursive module reference
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
 |}]
 
 (* The approximated module types should have the merged constraints (non

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -375,10 +375,10 @@ Line 1, characters 59-62:
 1 | module rec X : (sig module type A end with module type A = X.A)
                                                                ^^^
 Error: Illegal recursive module reference
-|}] 
+|}]
 
 module rec X : (sig module type A = X.A end)
-  = struct module type A end 
+  = struct module type A end
 [%%expect {|
 Line 1, characters 36-39:
 1 | module rec X : (sig module type A = X.A end)
@@ -393,14 +393,13 @@ Line 1, characters 60-63:
 1 | module rec X : (sig module type A end with module type A := X.A)
                                                                 ^^^
 Error: Illegal recursive module reference
-|}] 
+|}]
 
 module rec X : (sig module type A := X.A end)
-  = struct module type A end 
+  = struct module type A end
 [%%expect {|
 Line 1, characters 37-40:
 1 | module rec X : (sig module type A := X.A end)
                                          ^^^
 Error: Illegal recursive module reference
-|}] 
-
+|}]

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -368,6 +368,7 @@ Error: The module type "t" is not a valid type for a packed module:
        for an anonymous module type. (see manual section 12.7.3)
 |}]
 
+(* Having cyclic constraints should throw an error *)
 module rec X : (sig module type A end with module type A = X.A)
 = struct module type A end
 [%%expect {|
@@ -377,15 +378,7 @@ Line 1, characters 59-62:
 Error: Illegal recursive module reference
 |}]
 
-module rec X : (sig module type A = X.A end)
-  = struct module type A end
-[%%expect {|
-Line 1, characters 36-39:
-1 | module rec X : (sig module type A = X.A end)
-                                        ^^^
-Error: Illegal recursive module reference
-|}]
-
+(* Having cyclic constraints should throw an error (destructive) *)
 module rec X : (sig module type A end with module type A := X.A)
 = struct module type A end
 [%%expect {|
@@ -395,11 +388,29 @@ Line 1, characters 60-63:
 Error: Illegal recursive module reference
 |}]
 
-module rec X : (sig module type A := X.A end)
-  = struct module type A end
+(* The approximated module types should have the merged constraints (non
+   destructive case) *)
+module rec X : (sig module type A module X' : A end)
+               with module type A = sig type t end =
+struct
+  module type A = sig type t end
+  module X' = struct type t = int end
+end
+and Y : sig type u = X.X'.t end = struct type u = X.X'.t end
 [%%expect {|
-Line 1, characters 37-40:
-1 | module rec X : (sig module type A := X.A end)
-                                         ^^^
-Error: Illegal recursive module reference
+module rec X : sig module type A = sig type t end module X' : A end
+and Y : sig type u = X.X'.t end
+|}]
+
+(* The approximated module types should have the merged constraints
+   (destructive case) *)
+module rec X : (sig module type A module X' : A end)
+               with module type A := sig type t end =
+struct
+  module X' = struct type t = int end
+end
+and Y : sig type u = X.X'.t end = struct type u = X.X'.t end
+[%%expect {|
+module rec X : sig module X' : sig type t end end
+and Y : sig type u = X.X'.t end
 |}]

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -367,3 +367,40 @@ Error: The module type "t" is not a valid type for a packed module:
        it is defined as a local substitution (temporary name)
        for an anonymous module type. (see manual section 12.7.3)
 |}]
+
+module rec X : (sig module type A end with module type A = X.A)
+= struct module type A end
+[%%expect {|
+Line 1, characters 59-62:
+1 | module rec X : (sig module type A end with module type A = X.A)
+                                                               ^^^
+Error: Illegal recursive module reference
+|}] 
+
+module rec X : (sig module type A = X.A end)
+  = struct module type A end 
+[%%expect {|
+Line 1, characters 36-39:
+1 | module rec X : (sig module type A = X.A end)
+                                        ^^^
+Error: Illegal recursive module reference
+|}]
+
+module rec X : (sig module type A end with module type A := X.A)
+= struct module type A end
+[%%expect {|
+Line 1, characters 60-63:
+1 | module rec X : (sig module type A end with module type A := X.A)
+                                                                ^^^
+Error: Illegal recursive module reference
+|}] 
+
+module rec X : (sig module type A := X.A end)
+  = struct module type A end 
+[%%expect {|
+Line 1, characters 37-40:
+1 | module rec X : (sig module type A := X.A end)
+                                         ^^^
+Error: Illegal recursive module reference
+|}] 
+

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -368,29 +368,7 @@ Error: The module type "t" is not a valid type for a packed module:
        for an anonymous module type. (see manual section 12.7.3)
 |}]
 
-(* Having cyclic constraints should throw an error  *)
-module rec X : (sig module type A end with module type A = X.A)
-= struct end (* should fail before typechecking the body *)
-[%%expect {|
-Line 1, characters 59-62:
-1 | module rec X : (sig module type A end with module type A = X.A)
-                                                               ^^^
-Error: This module type is recursive. This use of the recursive module "X"
-       within its own definition makes the module type of "X" depend on itself.
-       Such recursive definitions of module types are not allowed.
-|}]
-
-(* Having cyclic constraints should throw an error (destructive) *)
-module rec X : (sig module type A end with module type A := X.A)
-= struct end (* should fail before typechecking the body *)
-[%%expect {|
-Line 1, characters 60-63:
-1 | module rec X : (sig module type A end with module type A := X.A)
-                                                                ^^^
-Error: This module type is recursive. This use of the recursive module "X"
-       within its own definition makes the module type of "X" depend on itself.
-       Such recursive definitions of module types are not allowed.
-|}]
+(** Approximation and substitutions **)
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (abstract, non destructive case) *)

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -372,7 +372,7 @@ Error: The module type "t" is not a valid type for a packed module:
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (abstract, non destructive case) *)
-module type Test = sig
+module type Test_Abstract = sig
   module type S := sig
     module type A
     module X' : A
@@ -382,7 +382,7 @@ module type Test = sig
   and Y : sig type u = X.X'.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Abstract =
   sig
     module rec X : sig module type A = sig type t end module X' : A end
     and Y : sig type u = X.X'.t end
@@ -392,7 +392,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (abstract, destructive case) *)
-module type Test = sig
+module type Test_Abstract_Destructive = sig
   module type S := sig
     module type A
     module X' : A
@@ -402,7 +402,7 @@ module type Test = sig
   and Y : sig type u = X.X'.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Abstract_Destructive =
   sig
     module rec X : sig module X' : sig type t end end
     and Y : sig type u = X.X'.t end
@@ -412,7 +412,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (concrete, non destructive case) *)
-module type Test = sig
+module type Test_Concrete = sig
   module type S := sig
     module type A = sig type t type u end
     module X' : A
@@ -422,7 +422,7 @@ module type Test = sig
   and Y : sig type v = X.X'.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Concrete =
   sig
     module rec X :
       sig module type A = sig type u type t end module X' : A end
@@ -432,7 +432,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (concrete, destructive case) *)
-module type Test = sig
+module type Test_Concrete_Destructive = sig
   module type S := sig
     module type A = sig type t type u end
     module X' : A
@@ -442,7 +442,7 @@ module type Test = sig
   and Y : sig type v = X.X'.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Concrete_Destructive =
   sig
     module rec X : sig module X' : sig type u type t end end
     and Y : sig type v = X.X'.t end
@@ -452,7 +452,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (deep, abstract, non destructive case) *)
-module type Test = sig
+module type Test_Deep_Abstract = sig
   module type S := sig
     module M : sig
       module type A
@@ -465,7 +465,7 @@ module type Test = sig
   and Y : sig type u = X.X2.t * X.M.X1.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Deep_Abstract =
   sig
     module rec X :
       sig
@@ -479,7 +479,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (deep, abstract, destructive case) *)
-module type Test = sig
+module type Test_Deep_Abstract_Destructive = sig
   module type S := sig
     module M : sig
       module type A
@@ -492,7 +492,7 @@ module type Test = sig
   and Y : sig type u = X.X2.t * X.M.X1.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Deep_Abstract_Destructive =
   sig
     module rec X :
       sig
@@ -506,7 +506,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (deep, concrete, non destructive case) *)
-module type Test = sig
+module type Test_Deep_Concrete = sig
   module type S := sig
     module M : sig
       module type A = sig type t type u end
@@ -519,7 +519,7 @@ module type Test = sig
   and Y : sig type u = X.X2.t * X.M.X1.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Deep_Concrete =
   sig
     module rec X :
       sig
@@ -534,7 +534,7 @@ module type Test =
 
 (* Approximating a signature with a constraint should merge the approximated
    constraint (deep, concrete, destructive case) *)
-module type Test = sig
+module type Test_Deep_Concrete_Destructive = sig
   module type S := sig
     module M : sig
       module type A = sig type t type u end
@@ -547,7 +547,7 @@ module type Test = sig
   and Y : sig type u = X.X2.t * X.M.X1.t end
 end
 [%%expect {|
-module type Test =
+module type Test_Deep_Concrete_Destructive =
   sig
     module rec X :
       sig
@@ -558,36 +558,6 @@ module type Test =
   end
 |}]
 
-
-(* Invalid substitutions might be accepted during the approximation phase, but
-   should be rejected during typechecking *)
-module type Test = sig
-  module rec X : (sig
-      module type A = sig type t = bool end
-      module X' : A
-    end with module type A = sig type t = int end)
-  and Y : sig type u = X.X'.t end
-end
-[%%expect {|
-Lines 2-5, characters 18-49:
-2 | ..................sig
-3 |       module type A = sig type t = bool end
-4 |       module X' : A
-5 |     end with module type A = sig type t = int end.
-Error: In this "with" constraint, the new definition of "A"
-       does not match its original definition in the constrained signature:
-       At position "module type A = <here>"
-       Module types do not match:
-         sig type t = bool end
-       is not equal to
-         sig type t = int end
-       At position "module type A = <here>"
-       Type declarations do not match:
-         type t = bool
-       is not included in
-         type t = int
-       The type "bool" is not equal to the type "int"
-|}]
 
 (* Invalid substitutions might be accepted during the approximation phase, but
    should be rejected during typechecking of signatures (before typechecking of
@@ -618,37 +588,4 @@ Error: In this "with" constraint, the new definition of "A"
        is not included in
          type t = int
        The type "bool" is not equal to the type "int"
-|}]
-
-
-(* Equivalence checks of module type constraints are ignored during
-   approximation. Therefore, the approximation accepts the ill-formed constraint
-   of replacing A by B. During the typechecking phase, the functor call
-   F(X2.X).u is accepted, as X2.X has the signature B. The typechecking fails at
-   the constraint verification. *)
-module type Test = sig
-  module F (_: sig type t = bool end) : sig type u end
-  module type S = sig
-    module type A = sig type t = int end
-    module X : A
-  end
-  module type B = sig type t = bool end
-
-  module rec X1 : sig type t = F(X2.X).u end
-  and X2 : S with module type A = B
-end
-[%%expect {|
-Line 10, characters 11-35:
-10 |   and X2 : S with module type A = B
-                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this "with" constraint, the new definition of "A"
-       does not match its original definition in the constrained signature:
-       At position "module type A = <here>"
-       Module types do not match: sig type t = int end is not equal to B
-       At position "module type A = <here>"
-       Type declarations do not match:
-         type t = int
-       is not included in
-         type t = bool
-       The type "int" is not equal to the type "bool"
 |}]

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -643,16 +643,34 @@ Error: In this "with" constraint, the new definition of "A"
 |}]
 
 
-(* Defining module types before the recursive module prevents them from being
-   approximated and can (erroneously) make the constraint ill-formed *)
+(* Equivalence checks of module type constraints are ignored during
+   approximation. Therefore, the approximation accepts the ill-formed constraint
+   of replacing A by B. During the typechecking phase, the functor call
+   F(X2.X).u is accepted, as X2.X has the signature B. The typechecking fails at
+   the constraint verification. *)
 module type Test = sig
-  module type S = sig module type A = sig type t = int end end
-  module rec X : S with module type A = sig type t = int end
+  module F (_: sig type t = bool end) : sig type u end
+  module type S = sig
+    module type A = sig type t = int end
+    module X : A
+  end
+  module type B = sig type t = bool end
+
+  module rec X1 : sig type t = F(X2.X).u end
+  and X2 : S with module type A = B
 end
 [%%expect {|
-module type Test =
-  sig
-    module type S = sig module type A = sig type t = int end end
-    module rec X : sig module type A = sig type t = int end end
-  end
+Line 10, characters 11-35:
+10 |   and X2 : S with module type A = B
+                ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "A"
+       does not match its original definition in the constrained signature:
+       At position "module type A = <here>"
+       Module types do not match: sig type t = int end is not equal to B
+       At position "module type A = <here>"
+       Type declarations do not match:
+         type t = int
+       is not included in
+         type t = bool
+       The type "int" is not equal to the type "bool"
 |}]

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -20,7 +20,9 @@ module rec X : (sig module type A = X.A end)
 Line 1, characters 36-39:
 1 | module rec X : (sig module type A = X.A end)
                                         ^^^
-Error: Illegal recursive module reference
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
 |}]
 
 (* Cyclic module type definitions should throw an error *)
@@ -30,5 +32,7 @@ module rec X : (sig module type A := X.A end)
 Line 1, characters 37-40:
 1 | module rec X : (sig module type A := X.A end)
                                          ^^^
-Error: Illegal recursive module reference
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
 |}]

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -12,3 +12,23 @@ Line 1, characters 0-39:
 Error: The type abbreviation "T.t" is cyclic:
          "T.t" = "T.t"
 |}]
+
+(* Cyclic module type definitions should throw an error *)
+module rec X : (sig module type A = X.A end)
+  = struct module type A end
+[%%expect {|
+Line 1, characters 36-39:
+1 | module rec X : (sig module type A = X.A end)
+                                        ^^^
+Error: Illegal recursive module reference
+|}]
+
+(* Cyclic module type definitions should throw an error *)
+module rec X : (sig module type A := X.A end)
+  = struct end
+[%%expect {|
+Line 1, characters 37-40:
+1 | module rec X : (sig module type A := X.A end)
+                                         ^^^
+Error: Illegal recursive module reference
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -598,7 +598,11 @@ let merge_constraint initial_env loc sg lid constr =
         in
         let typedtree_extra_opt = match mty with
           | Check_only _ -> None
-          | Build_TypedTree mty_tree -> Some (Twith_modtype mty_tree)
+          | Build_TypedTree mty_tree ->
+              if not destructive_substitution then
+                Some (Twith_modtype mty_tree)
+              else
+                Some (Twith_modtypesubst mty_tree)
         in
         if not destructive_substitution then
           let mtd': modtype_declaration =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -477,6 +477,11 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
     | With_typesubst _ | With_modsubst _ | With_modtypesubst _
     | Approx_with_modtypesubst _ -> true
   in
+  let approx_substitution =
+    match constr with
+    | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
+    | _ -> false
+  in
   let real_ids = ref [] in
   let split_row_id s ghosts =
     let srow = s ^ "#row" in
@@ -503,17 +508,18 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
     let return ?(ghosts=ghosts) ~replace_by info =
       Some (info, {Signature_group.ghosts; replace_by})
     in
-    let patch_modtype_item ~destructive
+    let patch_modtype_item
         id (mtd: Types.modtype_declaration) priv mty  =
       let sig_env = Env.add_signature sg_for_env outer_sig_env in
-      (* Check for equivalence if the previous module type was not empty *)
-      let () = match mtd.mtd_type with
-        | None -> ()
-        | Some previous_mty ->
+      (* Check for equivalence if the previous module type was not empty. During
+         approximation, the equivalence check is ignored. *)
+      let () = match approx_substitution, mtd.mtd_type with
+        | false, Some previous_mty ->
             Includemod.check_modtype_equiv ~loc sig_env
               id previous_mty mty
+        | _ -> ()
       in
-      if not destructive then
+      if not destructive_substitution then
         let mtd': modtype_declaration =
           {
             mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
@@ -624,8 +630,7 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
     | Sig_modtype(id, mtd, priv), [s],
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
-        let new_item = patch_modtype_item id mtd priv mty.mty_type
-            ~destructive:destructive_substitution in
+        let new_item = patch_modtype_item id mtd priv mty.mty_type in
         let constr_tt =
           if not destructive_substitution then
             (Twith_modtype mty)
@@ -637,8 +642,7 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
     | Sig_modtype(id, mtd, priv), [s],
       (Approx_with_modtype mty | Approx_with_modtypesubst mty)
       when Ident.name id = s ->
-        let new_item = patch_modtype_item id mtd priv mty
-            ~destructive:destructive_substitution in
+        let new_item = patch_modtype_item id mtd priv mty in
         return ~replace_by:new_item (Pident id, No_TypedTree)
     | Sig_module(id, pres, md, rs, priv), [s],
       With_module {lid=lid'; md=md'; path; remove_aliases}
@@ -1019,13 +1023,17 @@ and approx_constraint env body constr =
   | Pwith_type _
   | Pwith_typesubst _ -> body
   (* module type substitutions are approximated then merged *)
-  | Pwith_modtype (id, smty) ->
-      let approx_smty = approx_modtype env smty in
-      merge_constraint_approx ~destructive:false
-          env smty.pmty_loc body id approx_smty
+  | Pwith_modtype (id, smty)
   | Pwith_modtypesubst (id, smty) ->
+      let destructive =
+        (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      merge_constraint_approx ~destructive:true
+      (* The equivalence check for merging non abstract module types is ignored
+         during merging. Indeed, approximation only tries to build a skeleton of
+         non-recursive module types that can be used as an under-approximation
+         of the name-spaces for the typechecking phase, where invalid
+         constraints are going to be caught. *)
+      merge_constraint_approx ~destructive
         env smty.pmty_loc body id approx_smty
   (* module substitutions are ignored, but checked for cyclicity *)
   | Pwith_module (_, lid') ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -680,7 +680,6 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
             return ~replace_by:(Some current_item)
               (path, Built_TypedTree { lid; constr=tcstr} )
         | _, Built_TypedTree { lid; constr } ->
-            (* Why we do not reuse the presence of the current_item ? *)
             let new_md = {md with md_type = Mty_signature newsg} in
             let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
             return ~replace_by:(Some new_item)
@@ -759,13 +758,13 @@ let merge_constraint env loc sg lid cty =
   match merge_constraint_aux env loc sg lid cty with
   | path, Built_TypedTree { lid; constr }, newsg ->
       (path, lid, constr, newsg)
-  | _, No_TypedTree, _ -> fatal_error "Incorrect merge result"
+  | _, No_TypedTree, _ -> assert false
 
 (* Specialized merge function for package types *)
 let merge_package_constraint env loc sg lid cty =
   match merge_constraint_aux env loc sg lid (With_type_package cty) with
   | _, No_TypedTree, newsg -> newsg
-  | _, Built_TypedTree _, _ -> fatal_error "Incorrect merge result"
+  | _, Built_TypedTree _, _ -> assert false
 
 let check_package_with_type_constraints loc env mty constraints =
   let sg = extract_sig env loc mty in
@@ -792,7 +791,7 @@ let merge_constraint_approx env loc sg lid mty ~destructive =
   in
   match merge_constraint_aux env loc sg lid constr with
   | _, No_TypedTree, newsg -> newsg
-  | _, Built_TypedTree _, _ -> fatal_error "Incorrect merge result"
+  | _, Built_TypedTree _, _ -> assert false
 
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -456,6 +456,20 @@ and modtype_info =
   | Check_only      of Types.module_type
   | Build_TypedTree of Typedtree.module_type
 
+let modtype_info_extract_modtype mty =
+  match mty with
+  | Check_only mty_type -> mty_type
+  | Build_TypedTree mty_tree -> mty_tree.mty_type
+
+let modtype_info_build_typedtree mty destructive =
+  match mty with
+  | Check_only _ -> None
+  | Build_TypedTree mty_tree ->
+      if not destructive then
+        Some (Twith_modtype mty_tree)
+      else
+        Some (Twith_modtypesubst mty_tree)
+
 let merge_constraint initial_env loc sg lid constr =
   let destructive_substitution =
     match constr with
@@ -585,25 +599,15 @@ let merge_constraint initial_env loc sg lid constr =
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let mty_type =
-          match mty with
-          | Check_only mty_type -> mty_type
-          | Build_TypedTree mty_tree -> mty_tree.mty_type
-        in
+        let mty_type = modtype_info_extract_modtype mty in
         let () = match mtd.mtd_type with
           | None -> ()
           | Some previous_mty ->
               Includemod.check_modtype_equiv ~loc sig_env
                 id previous_mty mty_type
         in
-        let typedtree_extra_opt = match mty with
-          | Check_only _ -> None
-          | Build_TypedTree mty_tree ->
-              if not destructive_substitution then
-                Some (Twith_modtype mty_tree)
-              else
-                Some (Twith_modtypesubst mty_tree)
-        in
+        let typedtree_extra_opt =
+          modtype_info_build_typedtree mty destructive_substitution in
         if not destructive_substitution then
           let mtd': modtype_declaration =
             {
@@ -822,33 +826,9 @@ let rec approx_modtype env smty =
       (* the module type body is approximated and resolved to a signature *)
       let approx_body = approx_modtype env sbody in
       let initial_sig = extract_sig env sbody.pmty_loc approx_body in
+      (* then, the constraints are approximated and merged *)
       Mty_signature (List.fold_left
-          (fun body sdecl ->
-             match sdecl with
-             (* type substitutions are ignored *)
-             | Pwith_type _
-             | Pwith_typesubst _ -> body
-             (* module type substitutions are approximated then merged *)
-             | Pwith_modtype (id, smty) ->
-                 let approx_smty = approx_modtype env smty in
-                 let _, res_body = merge_constraint env smty.pmty_loc body
-                     id (With_modtype (Check_only approx_smty)) in
-                 res_body
-             | Pwith_modtypesubst (id, smty) ->
-                 let approx_smty = approx_modtype env smty in
-                 let _, res_body = merge_constraint env smty.pmty_loc body
-                     id (With_modtypesubst (Check_only approx_smty)) in
-                 res_body
-               (* module substitutions are ignored, but checked for cyclicity *)
-             | Pwith_module (_, lid') ->
-                 (* Lookup the module to make sure that it is not recursive.
-                    (GPR#1626) *)
-                 ignore (Env.lookup_module_path ~use:false ~load:false
-                           ~loc:lid'.loc lid'.txt env) ; body
-             | Pwith_modsubst (_, lid') ->
-                 ignore (Env.lookup_module_path ~use:false ~load:false
-                           ~loc:lid'.loc lid'.txt env) ; body)
-          initial_sig constraints)
+                       (approx_constraint env) initial_sig constraints)
   | Pmty_typeof smod ->
       let (_, mty) = !type_module_type_of_fwd env smod in
       mty
@@ -970,7 +950,33 @@ and approx_modtype_info env sinfo =
    mtd_attributes = sinfo.pmtd_attributes;
    mtd_loc = sinfo.pmtd_loc;
    mtd_uid = Uid.internal_not_actually_unique;
-  }
+ }
+
+and approx_constraint env body constr =
+  match constr with
+  (* type substitutions are ignored *)
+  | Pwith_type _
+  | Pwith_typesubst _ -> body
+  (* module type substitutions are approximated then merged *)
+  | Pwith_modtype (id, smty) ->
+      let approx_smty = approx_modtype env smty in
+      let _, res_body = merge_constraint env smty.pmty_loc body
+          id (With_modtype (Check_only approx_smty)) in
+      res_body
+  | Pwith_modtypesubst (id, smty) ->
+      let approx_smty = approx_modtype env smty in
+      let _, res_body = merge_constraint env smty.pmty_loc body
+          id (With_modtypesubst (Check_only approx_smty)) in
+      res_body
+  (* module substitutions are ignored, but checked for cyclicity *)
+  | Pwith_module (_, lid') ->
+      (* Lookup the module to make sure that it is not recursive.
+         (GPR#1626) *)
+      ignore (Env.lookup_module_path ~use:false ~load:false
+                ~loc:lid'.loc lid'.txt env) ; body
+  | Pwith_modsubst (_, lid') ->
+      ignore (Env.lookup_module_path ~use:false ~load:false
+                ~loc:lid'.loc lid'.txt env) ; body
 
 let approx_modtype env smty =
   Warnings.without_warnings

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -451,7 +451,7 @@ type with_info =
   | With_type_package of Typedtree.core_type
     (* Package with type constraints only use this last case.  Normal module
        with constraints never use it. *)
- (* used in merge_constraint to toggle the build of the typed tree when needed *)
+ (* used in merge_constraint to toggle the build of the typed tree *)
 and modtype_info =
   | Check_only      of Types.module_type
   | Build_TypedTree of Typedtree.module_type
@@ -843,7 +843,7 @@ let rec approx_modtype env smty =
                            ~loc:lid'.loc lid'.txt env) ; body
              | Pwith_modsubst (_, lid') ->
                  ignore (Env.lookup_module_path ~use:false ~load:false
-                           ~loc:lid'.loc lid'.txt env) ; body) 
+                           ~loc:lid'.loc lid'.txt env) ; body)
           initial_sig constraints)
   | Pmty_typeof smod ->
       let (_, mty) = !type_module_type_of_fwd env smod in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -503,6 +503,31 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
     let return ?(ghosts=ghosts) ~replace_by info =
       Some (info, {Signature_group.ghosts; replace_by})
     in
+    let patch_modtype_item ~destructive
+        id (mtd: Types.modtype_declaration) priv mty  =
+      let sig_env = Env.add_signature sg_for_env outer_sig_env in
+      (* Check for equivalence if the previous module type was not empty *)
+      let () = match mtd.mtd_type with
+        | None -> ()
+        | Some previous_mty ->
+            Includemod.check_modtype_equiv ~loc sig_env
+              id previous_mty mty
+      in
+      if not destructive then
+        let mtd': modtype_declaration =
+          {
+            mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+            mtd_type = Some mty;
+            mtd_attributes = [];
+            mtd_loc = loc;
+          }
+        in Some(Sig_modtype(id, mtd', priv))
+      else begin
+        let path = Pident id in
+        real_ids := [path];
+        None
+      end
+    in
     match item, namelist, constr with
     | Sig_type(id, decl, rs, priv), [s],
        With_type ({ptype_kind = Ptype_abstract} as sdecl)
@@ -582,8 +607,7 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
             (Pident id, Built_TypedTree {
                   lid=lid; constr=(Twith_typesubst tdecl)})
         end
-    | Sig_type(id, sig_decl, rs, priv), [s],
-      With_type_package cty
+    | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
       when Ident.name id = s ->
         begin match sig_decl.type_manifest with
         | None -> ()
@@ -595,65 +619,27 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
         in
         check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
         let tdecl = { tdecl with type_manifest = None } in
-        return ~ghosts ~replace_by: (Some(Sig_type(id, tdecl, rs, priv)))
+        return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
           (Pident id, No_TypedTree)
     | Sig_modtype(id, mtd, priv), [s],
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let () = match mtd.mtd_type with
-          | None -> ()
-          | Some previous_mty ->
-              Includemod.check_modtype_equiv ~loc sig_env
-                id previous_mty mty.mty_type
+        let new_item = patch_modtype_item id mtd priv mty.mty_type
+            ~destructive:destructive_substitution in
+        let constr_tt =
+          if not destructive_substitution then
+            (Twith_modtype mty)
+          else
+            (Twith_modtypesubst mty)
         in
-        if not destructive_substitution then
-          let mtd': modtype_declaration =
-            {
-              mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-              mtd_type = Some mty.mty_type;
-              mtd_attributes = [];
-              mtd_loc = loc;
-            }
-          in
-          return
-            ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
-            (Pident id, Built_TypedTree {lid; constr=Twith_modtype mty})
-        else begin
-          let path = Pident id in
-          real_ids := [path];
-          return ~replace_by:None
-            (Pident id, Built_TypedTree {
-                lid=lid; constr=Twith_modtypesubst mty})
-        end
+        return ~replace_by:new_item
+          (Pident id, Built_TypedTree {lid; constr=constr_tt})
     | Sig_modtype(id, mtd, priv), [s],
       (Approx_with_modtype mty | Approx_with_modtypesubst mty)
       when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let () = match mtd.mtd_type with
-          | None -> ()
-          | Some previous_mty ->
-              Includemod.check_modtype_equiv ~loc sig_env
-                id previous_mty mty
-        in
-        if not destructive_substitution then
-          let mtd': modtype_declaration =
-            {
-              mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-              mtd_type = Some mty;
-              mtd_attributes = [];
-              mtd_loc = loc;
-            }
-          in
-          return
-            ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
-            (Pident id, No_TypedTree )
-        else begin
-          let path = Pident id in
-          real_ids := [path];
-          return ~replace_by:None
-            (Pident id, No_TypedTree)
-        end
+        let new_item = patch_modtype_item id mtd priv mty
+            ~destructive:destructive_substitution in
+        return ~replace_by:new_item (Pident id, No_TypedTree)
     | Sig_module(id, pres, md, rs, priv), [s],
       With_module {lid=lid'; md=md'; path; remove_aliases}
       when Ident.name id = s ->
@@ -705,8 +691,7 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
             return ~replace_by:(Some new_item) (path, No_TypedTree)
         end
     | _ -> None
-
-  and merge_signature env sg namelist : merge_result =
+  and merge_signature env sg namelist =
     match
       Signature_group.replace_in_place (patch_item constr namelist env sg) sg
     with
@@ -808,8 +793,6 @@ let merge_constraint_approx env loc sg lid mty ~destructive =
   match merge_constraint_aux env loc sg lid constr with
   | _, No_TypedTree, newsg -> newsg
   | _, Built_TypedTree _, _ -> fatal_error "Incorrect merge result"
-
-
 
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -436,7 +436,8 @@ let params_are_constrained =
   in
   loop
 
-type with_info =
+type merge_constraint =
+  (* Normal merging cases that returns a typed tree *)
   | With_type of Parsetree.type_declaration
   | With_typesubst of Parsetree.type_declaration
   | With_module of {
@@ -446,36 +447,35 @@ type with_info =
         remove_aliases:bool
       }
   | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
-  | With_modtype of modtype_info
-  | With_modtypesubst of modtype_info
+  | With_modtype of Typedtree.module_type
+  | With_modtypesubst of Typedtree.module_type
+
+  (* Package with type constraints only use this last case. *)
   | With_type_package of Typedtree.core_type
-    (* Package with type constraints only use this last case.  Normal module
-       with constraints never use it. *)
- (* used in merge_constraint to toggle the build of the typed tree *)
-and modtype_info =
-  | Check_only      of Types.module_type
-  | Build_TypedTree of Typedtree.module_type
 
-let modtype_info_extract_modtype mty =
-  match mty with
-  | Check_only mty_type -> mty_type
-  | Build_TypedTree mty_tree -> mty_tree.mty_type
+  (* Merging of module types during signature approximation *)
+  | Approx_with_modtype      of Types.module_type
+  | Approx_with_modtypesubst of Types.module_type
 
-let modtype_info_build_typedtree mty destructive =
-  match mty with
-  | Check_only _ -> None
-  | Build_TypedTree mty_tree ->
-      if not destructive then
-        Some (Twith_modtype mty_tree)
-      else
-        Some (Twith_modtypesubst mty_tree)
+type merge_result = Path.t * merge_info * Types.signature
+and merge_info =
+  (* Result of normal merging *)
+  | Built_TypedTree of {
+      lid: Longident.t Asttypes.loc ;
+      constr : Typedtree.with_constraint
+    }
+  (* Result of merging a package_type or merging approximated module types
+     (without typedtree) *)
+  | No_TypedTree
 
-let merge_constraint initial_env loc sg lid constr =
+let merge_constraint_aux initial_env loc sg lid constr : merge_result =
   let destructive_substitution =
     match constr with
     | With_type _ | With_module _ | With_modtype _
+    | Approx_with_modtype _
     | With_type_package _ -> false
-    | With_typesubst _ | With_modsubst _ | With_modtypesubst _  -> true
+    | With_typesubst _ | With_modsubst _ | With_modtypesubst _
+    | Approx_with_modtypesubst _ -> true
   in
   let real_ids = ref [] in
   let split_row_id s ghosts =
@@ -558,9 +558,9 @@ let merge_constraint initial_env loc sg lid constr =
         in
         return ~ghosts
           ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-          (Pident id, lid, Some (Twith_type tdecl))
+          (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
     | Sig_type(id, sig_decl, rs, priv) , [s],
-       (With_type sdecl | With_typesubst sdecl as constr)
+       (With_type sdecl | With_typesubst sdecl)
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         let tdecl =
@@ -571,17 +571,19 @@ let merge_constraint initial_env loc sg lid constr =
         let ghosts = List.rev_append before_ghosts after_ghosts in
         check_type_decl outer_sig_env sg_for_env loc
           id row_id newdecl sig_decl;
-        begin match constr with
-          With_type _ ->
-            return ~ghosts
-              ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-              (Pident id, lid, Some (Twith_type tdecl))
-        | (* With_typesubst *) _ ->
-            real_ids := [Pident id];
-            return ~ghosts ~replace_by:None
-              (Pident id, lid, Some (Twith_typesubst tdecl))
+        if not destructive_substitution then
+          return ~ghosts
+            ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
+            (Pident id, Built_TypedTree {
+                  lid=lid; constr=(Twith_type tdecl)})
+        else begin
+          real_ids := [Pident id];
+          return ~ghosts ~replace_by:None
+            (Pident id, Built_TypedTree {
+                  lid=lid; constr=(Twith_typesubst tdecl)})
         end
-    | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
+    | Sig_type(id, sig_decl, rs, priv), [s],
+      With_type_package cty
       when Ident.name id = s ->
         begin match sig_decl.type_manifest with
         | None -> ()
@@ -593,38 +595,64 @@ let merge_constraint initial_env loc sg lid constr =
         in
         check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
         let tdecl = { tdecl with type_manifest = None } in
-        return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-          (Pident id, lid, None)
+        return ~ghosts ~replace_by: (Some(Sig_type(id, tdecl, rs, priv)))
+          (Pident id, No_TypedTree)
     | Sig_modtype(id, mtd, priv), [s],
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let mty_type = modtype_info_extract_modtype mty in
         let () = match mtd.mtd_type with
           | None -> ()
           | Some previous_mty ->
               Includemod.check_modtype_equiv ~loc sig_env
-                id previous_mty mty_type
+                id previous_mty mty.mty_type
         in
-        let typedtree_extra_opt =
-          modtype_info_build_typedtree mty destructive_substitution in
         if not destructive_substitution then
           let mtd': modtype_declaration =
             {
               mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-              mtd_type = Some mty_type;
+              mtd_type = Some mty.mty_type;
               mtd_attributes = [];
               mtd_loc = loc;
             }
           in
           return
             ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
-            (Pident id, lid, typedtree_extra_opt)
+            (Pident id, Built_TypedTree {lid; constr=Twith_modtype mty})
         else begin
           let path = Pident id in
           real_ids := [path];
           return ~replace_by:None
-            (Pident id, lid, typedtree_extra_opt)
+            (Pident id, Built_TypedTree {
+                lid=lid; constr=Twith_modtypesubst mty})
+        end
+    | Sig_modtype(id, mtd, priv), [s],
+      (Approx_with_modtype mty | Approx_with_modtypesubst mty)
+      when Ident.name id = s ->
+        let sig_env = Env.add_signature sg_for_env outer_sig_env in
+        let () = match mtd.mtd_type with
+          | None -> ()
+          | Some previous_mty ->
+              Includemod.check_modtype_equiv ~loc sig_env
+                id previous_mty mty
+        in
+        if not destructive_substitution then
+          let mtd': modtype_declaration =
+            {
+              mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+              mtd_type = Some mty;
+              mtd_attributes = [];
+              mtd_loc = loc;
+            }
+          in
+          return
+            ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
+            (Pident id, No_TypedTree )
+        else begin
+          let path = Pident id in
+          real_ids := [path];
+          return ~replace_by:None
+            (Pident id, No_TypedTree)
         end
     | Sig_module(id, pres, md, rs, priv), [s],
       With_module {lid=lid'; md=md'; path; remove_aliases}
@@ -638,7 +666,8 @@ let merge_constraint initial_env loc sg lid constr =
                  newmd.md_type md.md_type);
         return
           ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-          (Pident id, lid, Some (Twith_module (path, lid')))
+          (Pident id, Built_TypedTree {
+              lid=lid; constr=(Twith_module (path, lid'))})
     | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
@@ -648,41 +677,50 @@ let merge_constraint initial_env loc sg lid constr =
              ~aliasable sig_env md' path md);
         real_ids := [Pident id];
         return ~replace_by:None
-          (Pident id, lid, Some (Twith_modsubst (path, lid')))
-    | Sig_module(id, _, md, rs, priv) as item, s :: namelist, constr
+          (Pident id, Built_TypedTree {
+               lid=lid; constr=(Twith_modsubst (path, lid'))})
+
+    (* When the constraint affects a component of a submodule *)
+    | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         let sg = extract_sig sig_env loc md.md_type in
-        let ((path, _, tcstr), newsg) = merge_signature sig_env sg namelist in
-        let path = path_concat id path in
-        real_ids := path :: !real_ids;
-        let item =
-          match md.md_type, constr with
-            Mty_alias _, (With_module _ | With_type _) ->
-              (* A module alias cannot be refined, so keep it
-                 and just check that the constraint is correct *)
-              item
-          | _ ->
-              let newmd = {md with md_type = Mty_signature newsg} in
-              Sig_module(id, Mp_present, newmd, rs, priv)
-        in
-        return ~replace_by:(Some item) (path, lid, tcstr)
+        let subpath, merge_info, newsg = merge_signature sig_env sg namelist in
+        let path = path_concat id subpath in
+        real_ids := path :: !real_ids ;
+        begin match md.md_type, merge_info with
+        | Mty_alias _, Built_TypedTree
+            { lid; constr = (Twith_module _ | Twith_type _ ) as tcstr } ->
+            return ~replace_by:(Some current_item)
+              (path, Built_TypedTree { lid; constr=tcstr} )
+        | _, Built_TypedTree { lid; constr } ->
+            (* Why we do not reuse the presence of the current_item ? *)
+            let new_md = {md with md_type = Mty_signature newsg} in
+            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+            return ~replace_by:(Some new_item)
+              (path, Built_TypedTree {lid; constr})
+        | _, No_TypedTree ->
+            let new_md = {md with md_type = Mty_signature newsg} in
+            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+            return ~replace_by:(Some new_item) (path, No_TypedTree)
+        end
     | _ -> None
-  and merge_signature env sg namelist =
+
+  and merge_signature env sg namelist : merge_result =
     match
       Signature_group.replace_in_place (patch_item constr namelist env sg) sg
     with
-    | Some (x,sg) -> x, sg
+    | Some ((path, res), sg) -> path, res, sg
     | None -> raise(Error(loc, env, With_no_component lid.txt))
   in
   try
     let names = Longident.flatten lid.txt in
-    let (tcstr, sg) = merge_signature initial_env sg names in
+    let (path, merge_info, sg) = merge_signature initial_env sg names in
     if destructive_substitution then
       check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
     let sg =
-    match tcstr with
-    | (_, _, Some (Twith_typesubst tdecl)) ->
+    match merge_info, constr with
+      | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
        let how_to_extend_subst =
          let sdecl =
            match constr with
@@ -707,7 +745,7 @@ let merge_constraint initial_env loc sg lid constr =
        let sub = Subst.change_locs Subst.identity loc in
        let sub = List.fold_left how_to_extend_subst sub !real_ids in
        unsafe_signature_subst sub sg
-    | (_, _, Some (Twith_modsubst (real_path, _))) ->
+    | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
        let sub = Subst.change_locs Subst.identity loc in
        let sub =
          List.fold_left
@@ -716,8 +754,9 @@ let merge_constraint initial_env loc sg lid constr =
            !real_ids
        in
        unsafe_signature_subst sub sg
-    | (_, _, Some (Twith_modtypesubst tmty)) ->
-        let add s p = Subst.Unsafe.add_modtype_path p tmty.mty_type s in
+    | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
+    | _, Approx_with_modtypesubst mty ->
+        let add s p = Subst.Unsafe.add_modtype_path p mty s in
         let sub = Subst.change_locs Subst.identity loc in
         let sub = List.fold_left add sub !real_ids in
         unsafe_signature_subst sub sg
@@ -726,13 +765,22 @@ let merge_constraint initial_env loc sg lid constr =
     in
     check_well_formed_module initial_env loc "this instantiated signature"
       (Mty_signature sg);
-    (tcstr, sg)
+    (path, merge_info, sg)
   with Includemod.Error explanation ->
     raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-let merge_package_constraint initial_env loc sg lid cty =
-  let _, s = merge_constraint initial_env loc sg lid (With_type_package cty) in
-  s
+(* Normal merge function - build the typed tree *)
+let merge_constraint env loc sg lid cty =
+  match merge_constraint_aux env loc sg lid cty with
+  | path, Built_TypedTree { lid; constr }, newsg ->
+      (path, lid, constr, newsg)
+  | _, No_TypedTree, _ -> fatal_error "Incorrect merge result"
+
+(* Specialized merge function for package types *)
+let merge_package_constraint env loc sg lid cty =
+  match merge_constraint_aux env loc sg lid (With_type_package cty) with
+  | _, No_TypedTree, newsg -> newsg
+  | _, Built_TypedTree _, _ -> fatal_error "Incorrect merge result"
 
 let check_package_with_type_constraints loc env mty constraints =
   let sg = extract_sig env loc mty in
@@ -748,6 +796,20 @@ let check_package_with_type_constraints loc env mty constraints =
 let () =
   Typetexp.check_package_with_type_constraints :=
     check_package_with_type_constraints
+
+(* Specialized merge function for merging during signature approximation *)
+let merge_constraint_approx env loc sg lid mty ~destructive =
+  let constr =
+    if not destructive then
+      Approx_with_modtype mty
+    else
+      Approx_with_modtypesubst mty
+  in
+  match merge_constraint_aux env loc sg lid constr with
+  | _, No_TypedTree, newsg -> newsg
+  | _, Built_TypedTree _, _ -> fatal_error "Incorrect merge result"
+
+
 
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)
@@ -960,14 +1022,12 @@ and approx_constraint env body constr =
   (* module type substitutions are approximated then merged *)
   | Pwith_modtype (id, smty) ->
       let approx_smty = approx_modtype env smty in
-      let _, res_body = merge_constraint env smty.pmty_loc body
-          id (With_modtype (Check_only approx_smty)) in
-      res_body
+      merge_constraint_approx ~destructive:false
+          env smty.pmty_loc body id approx_smty
   | Pwith_modtypesubst (id, smty) ->
       let approx_smty = approx_modtype env smty in
-      let _, res_body = merge_constraint env smty.pmty_loc body
-          id (With_modtypesubst (Check_only approx_smty)) in
-      res_body
+      merge_constraint_approx ~destructive:true
+        env smty.pmty_loc body id approx_smty
   (* module substitutions are ignored, but checked for cyclicity *)
   | Pwith_module (_, lid') ->
       (* Lookup the module to make sure that it is not recursive.
@@ -1380,16 +1440,13 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
         l , With_modsubst (l',path,md')
     | Pwith_modtype (l,smty) ->
         let mty = transl_modtype env smty in
-        l, With_modtype (Build_TypedTree mty)
+        l, With_modtype mty
     | Pwith_modtypesubst (l,smty) ->
         let mty = transl_modtype env smty in
-        l, With_modtypesubst (Build_TypedTree mty)
+        l, With_modtypesubst mty
   in
-  let ((path, lid, tcstr), sg) = merge_constraint env loc sg lid with_info in
-  (* Only package with constraints result in None here. *)
-  let tcstr = Option.get tcstr in
-  ((path, lid, tcstr) :: rev_tcstrs, sg)
-
+  let (path, lid, constr, sg) = merge_constraint env loc sg lid with_info in
+  ((path, lid, constr) :: rev_tcstrs, sg)
 
 
 and transl_signature env sg =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -867,10 +867,27 @@ let rec approx_modtype env smty =
       let res = approx_modtype newenv sres in
       Mty_functor(param, res)
   | Pmty_with(sbody, constraints) ->
-      (* the module type body is approximated and resolved to a signature *)
+      (* the module type body is approximated and resolved to a signature.*)
       let approx_body = approx_modtype env sbody in
       let initial_sig = extract_sig env sbody.pmty_loc approx_body in
-      (* then, the constraints are approximated and merged *)
+      (* then, the constraints are approximated and merged, instead of merged
+         and approximated. For (1) type constraints, (2) module constraints and
+         (3) module type constraints replacing an abstract module type, it
+         should be equivalent.
+
+         However, for module type constraints replacing a concrete module type,
+         approximating the constraint and the body before merging can interact
+         with the equivalence check that is done between the constraint and the
+         original definition:
+
+         1. It can erroneously succeed because the approximation made the module
+         types equivalent. It is believed to be harmless, because the
+         ill-formedness is caught when re-typechecking the module types (with
+         the approximation in the environment).
+
+         2. It can erroneously fail because the constraint has been approximated
+         but the body has not (named module types escape approximation).
+      *)
       Mty_signature (List.fold_left
                        (approx_constraint env) initial_sig constraints)
   | Pmty_typeof smod ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -679,8 +679,12 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
         let path = path_concat id subpath in
         real_ids := path :: !real_ids ;
         begin match md.md_type, merge_info with
+        (* A module alias cannot be refined, so keep it
+           and just check that the constraint is correct *)
         | Mty_alias _, Built_TypedTree
-            { lid; constr = (Twith_module _ | Twith_type _ ) as tcstr } ->
+            { lid; constr = (Twith_module _
+                            | Twith_type _
+                            | Twith_modtype _) as tcstr } ->
             return ~replace_by:(Some current_item)
               (path, Built_TypedTree { lid; constr=tcstr} )
         | _, Built_TypedTree { lid; constr } ->
@@ -882,15 +886,13 @@ let rec approx_modtype env smty =
          However, for module type constraints replacing a concrete module type,
          approximating the constraint and the body before merging can interact
          with the equivalence check that is done between the constraint and the
-         original definition:
-
-         1. It can erroneously succeed because the approximation made the module
-         types equivalent. It is believed to be harmless, because the
-         ill-formedness is caught when re-typechecking the module types (with
-         the approximation in the environment).
-
-         2. It can erroneously fail because the constraint has been approximated
-         but the body has not (named module types escape approximation).
+         original definition. As approximation only tries to build a skeleton of
+         non-recursive module types that can be used as an under-approximation
+         of the name-spaces for the typechecking phase, the equivalence check is
+         disabled, allowing for ill-formed constraints to be merged. It is
+         believed to be harmless, because the ill-formedness is caught when
+         re-typechecking the module types (with the approximation in the
+         environment).
       *)
       Mty_signature (List.fold_left
                        (approx_constraint env) initial_sig constraints)
@@ -1028,11 +1030,6 @@ and approx_constraint env body constr =
       let destructive =
         (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      (* The equivalence check for merging non abstract module types is ignored
-         during merging. Indeed, approximation only tries to build a skeleton of
-         non-recursive module types that can be used as an under-approximation
-         of the name-spaces for the typechecking phase, where invalid
-         constraints are going to be caught. *)
       merge_constraint_approx ~destructive
         env smty.pmty_loc body id approx_smty
   (* module substitutions are ignored, but checked for cyclicity *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -446,11 +446,15 @@ type with_info =
         remove_aliases:bool
       }
   | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
-  | With_modtype of Typedtree.module_type
-  | With_modtypesubst of Typedtree.module_type
+  | With_modtype of modtype_info
+  | With_modtypesubst of modtype_info
   | With_type_package of Typedtree.core_type
     (* Package with type constraints only use this last case.  Normal module
        with constraints never use it. *)
+ (* used in merge_constraint to toggle the build of the typed tree when needed *)
+and modtype_info =
+  | Check_only      of Types.module_type
+  | Build_TypedTree of Typedtree.module_type
 
 let merge_constraint initial_env loc sg lid constr =
   let destructive_substitution =
@@ -581,29 +585,38 @@ let merge_constraint initial_env loc sg lid constr =
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
+        let mty_type =
+          match mty with
+          | Check_only mty_type -> mty_type
+          | Build_TypedTree mty_tree -> mty_tree.mty_type
+        in
         let () = match mtd.mtd_type with
           | None -> ()
           | Some previous_mty ->
               Includemod.check_modtype_equiv ~loc sig_env
-                id previous_mty mty.mty_type
+                id previous_mty mty_type
+        in
+        let typedtree_extra_opt = match mty with
+          | Check_only _ -> None
+          | Build_TypedTree mty_tree -> Some (Twith_modtype mty_tree)
         in
         if not destructive_substitution then
           let mtd': modtype_declaration =
             {
               mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-              mtd_type = Some mty.mty_type;
+              mtd_type = Some mty_type;
               mtd_attributes = [];
               mtd_loc = loc;
             }
           in
           return
             ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
-            (Pident id, lid, Some (Twith_modtype mty))
+            (Pident id, lid, typedtree_extra_opt)
         else begin
           let path = Pident id in
           real_ids := [path];
           return ~replace_by:None
-            (Pident id, lid, Some (Twith_modtypesubst mty))
+            (Pident id, lid, typedtree_extra_opt)
         end
     | Sig_module(id, pres, md, rs, priv), [s],
       With_module {lid=lid'; md=md'; path; remove_aliases}
@@ -802,24 +815,36 @@ let rec approx_modtype env smty =
       let res = approx_modtype newenv sres in
       Mty_functor(param, res)
   | Pmty_with(sbody, constraints) ->
-      let body = approx_modtype env sbody in
-      List.iter
-        (fun sdecl ->
-          match sdecl with
-          | Pwith_type _
-          | Pwith_typesubst _
-          | Pwith_modtype _
-          | Pwith_modtypesubst _  -> ()
-          | Pwith_module (_, lid') ->
-              (* Lookup the module to make sure that it is not recursive.
-                 (GPR#1626) *)
-              ignore (Env.lookup_module_path ~use:false ~load:false
-                        ~loc:lid'.loc lid'.txt env)
-          | Pwith_modsubst (_, lid') ->
-              ignore (Env.lookup_module_path ~use:false ~load:false
-                        ~loc:lid'.loc lid'.txt env))
-        constraints;
-      body
+      (* the module type body is approximated and resolved to a signature *)
+      let approx_body = approx_modtype env sbody in
+      let initial_sig = extract_sig env sbody.pmty_loc approx_body in
+      Mty_signature (List.fold_left
+          (fun body sdecl ->
+             match sdecl with
+             (* type substitutions are ignored *)
+             | Pwith_type _
+             | Pwith_typesubst _ -> body
+             (* module type substitutions are approximated then merged *)
+             | Pwith_modtype (id, smty) ->
+                 let approx_smty = approx_modtype env smty in
+                 let _, res_body = merge_constraint env smty.pmty_loc body
+                     id (With_modtype (Check_only approx_smty)) in
+                 res_body
+             | Pwith_modtypesubst (id, smty) ->
+                 let approx_smty = approx_modtype env smty in
+                 let _, res_body = merge_constraint env smty.pmty_loc body
+                     id (With_modtypesubst (Check_only approx_smty)) in
+                 res_body
+               (* module substitutions are ignored, but checked for cyclicity *)
+             | Pwith_module (_, lid') ->
+                 (* Lookup the module to make sure that it is not recursive.
+                    (GPR#1626) *)
+                 ignore (Env.lookup_module_path ~use:false ~load:false
+                           ~loc:lid'.loc lid'.txt env) ; body
+             | Pwith_modsubst (_, lid') ->
+                 ignore (Env.lookup_module_path ~use:false ~load:false
+                           ~loc:lid'.loc lid'.txt env) ; body) 
+          initial_sig constraints)
   | Pmty_typeof smod ->
       let (_, mty) = !type_module_type_of_fwd env smod in
       mty
@@ -1345,10 +1370,10 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
         l , With_modsubst (l',path,md')
     | Pwith_modtype (l,smty) ->
         let mty = transl_modtype env smty in
-        l, With_modtype mty
+        l, With_modtype (Build_TypedTree mty)
     | Pwith_modtypesubst (l,smty) ->
         let mty = transl_modtype env smty in
-        l, With_modtypesubst mty
+        l, With_modtypesubst (Build_TypedTree mty)
   in
   let ((path, lid, tcstr), sg) = merge_constraint env loc sg lid with_info in
   (* Only package with constraints result in None here. *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -890,10 +890,9 @@ let rec approx_modtype env smty =
          non-recursive module types that can be used as an under-approximation
          of the name-spaces for the typechecking phase, the equivalence check is
          disabled, allowing for ill-formed constraints to be merged. It is
-         believed to be harmless, because the ill-formedness is caught when
+         should be harmless, because the ill-formedness is caught when
          re-typechecking the module types (with the approximation in the
-         environment).
-      *)
+         environment).  *)
       Mty_signature (List.fold_left
                        (approx_constraint env) initial_sig constraints)
   | Pmty_typeof smod ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -57,6 +57,7 @@ type error =
   | With_makes_applicative_functor_ill_typed of
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
+  | With_lost_alias of Ident.t * Path.t
   | With_cannot_remove_constrained_type
   | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string
@@ -436,64 +437,67 @@ let params_are_constrained =
   in
   loop
 
-type merge_constraint =
-  (* Normal merging cases that returns a typed tree *)
-  | With_type of Parsetree.type_declaration
-  | With_typesubst of Parsetree.type_declaration
-  | With_module of {
-        lid:Longident.t loc;
-        path:Path.t;
-        md:Types.module_declaration;
-        remove_aliases:bool
-      }
-  | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
-  | With_modtype of Typedtree.module_type
-  | With_modtypesubst of Typedtree.module_type
+module Merge = struct
+  (* This module hosts the functions dealing with signature constraints. There
+     are of three forms :
+     - type constraint [... with type t = ... ], handled by [merge_type]
+     - module constraint [... with module X = ... ], handled by [merge_module]
+     - module type constraints [... with module type T = ...] handled by
+       [merge_modtype]
 
-  (* Package with type constraints only use this last case. *)
-  | With_type_package of Typedtree.core_type
+     Each constraint can be *destructive*, (with the syntax [:=]) meaning that
+     the substituted identifier is removed from the signature. This imposes
+     additional checks to ensure wellformedness, handled by the [post_process]
+     function.
 
-  (* Merging of module types during signature approximation *)
-  | Approx_with_modtype      of Types.module_type
-  | Approx_with_modtypesubst of Types.module_type
+     Each constraint can be *deep*, meaning that the substituted identifier
+     might be inside a submodule. This is handled by the [patch_deep_item]
+     function. Deep destructive substitutions inside submodules with an alias
+     signature are disallowed.
 
-type merge_result = Path.t * merge_info * Types.signature
-and merge_info =
-  (* Result of normal merging *)
-  | Built_TypedTree of {
-      lid: Longident.t Asttypes.loc ;
-      constr : Typedtree.with_constraint
-    }
-  (* Result of merging a package_type or merging approximated module types
-     (without typedtree) *)
-  | No_TypedTree
+     Each constraint can be *instantiating*, if the substitution replaces an
+     "abstract" field (for module constraints, "abstract" means "not already an
+     alias"). If the constraint is not instantiating, equivalence checks with
+     the old definition are performed.
 
-let merge_constraint_aux initial_env loc sg lid constr : merge_result =
-  let destructive_substitution =
-    match constr with
-    | With_type _ | With_module _ | With_modtype _
-    | Approx_with_modtype _
-    | With_type_package _ -> false
-    | With_typesubst _ | With_modsubst _ | With_modtypesubst _
-    | Approx_with_modtypesubst _ -> true
-  in
-  let approx_substitution =
-    match constr with
-    | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
-    | _ -> false
-  in
-  let real_ids = ref [] in
+     Finally, merging is both used in (1) "normal" mode, to build a typed tree,
+     in (2) "approx" mode, during the signature approximation phase of
+     typechecking recursive modules, and in (3) "package" mode, for checking
+     signatures of first-class modules.
+
+     The overall structure is similar for each form:
+
+     1. A [patch] function is defined to identify the item to substitute, do the
+     equivalence checks if needed, and optionally build the new replacement item
+     (if the substitution is non-destructive)
+
+     2. The patch is applied to the module type by using the general
+     [merge_signature] function. It returns the path of the affected item (along
+     with the list of all suffixes, if the substitution was deep).
+
+     3. Some post processing is applied (actual replacement for destructive
+     substitutions, wellformedness checks)
+
+  *)
+
+  (* Helpers *)
+  let return ~ghosts ~replace_by path =
+    Some ((path, [path]), {Signature_group.ghosts; replace_by})
+
+  let return_paths ~ghosts ~replace_by path paths =
+    Some ((path, paths), {Signature_group.ghosts; replace_by})
+
   let split_row_id s ghosts =
     let srow = s ^ "#row" in
     let rec split before = function
-        | Sig_type(id,_,_,_) :: rest when Ident.name id = srow ->
-            before, Some id, rest
-        | a :: rest -> split (a::before) rest
-        | [] -> before, None, []
+      | Sig_type(id,_,_,_) :: rest when Ident.name id = srow ->
+          before, Some id, rest
+      | a :: rest -> split (a::before) rest
+      | [] -> before, None, []
     in
     split [] ghosts
-  in
-  let unsafe_signature_subst sub sg =
+
+  let unsafe_signature_subst sub sg loc initial_env =
     (* This signature will not be used directly, it will always be freshened
        by the caller. So what we do with the scope doesn't really matter. But
        making it local makes it unlikely that we will ever use the result of
@@ -503,303 +507,299 @@ let merge_constraint_aux initial_env loc sg lid constr : merge_result =
     | Error (Fcm_type_substituted_away (p,mty)) ->
         let error = With_cannot_remove_packed_modtype(p,mty) in
         raise (Error(loc,initial_env,error))
-  in
-  let rec patch_item constr namelist outer_sig_env sg_for_env ~ghosts item =
-    let return ?(ghosts=ghosts) ~replace_by info =
-      Some (info, {Signature_group.ghosts; replace_by})
-    in
-    let patch_modtype_item
-        id (mtd: Types.modtype_declaration) priv mty  =
-      let sig_env = Env.add_signature sg_for_env outer_sig_env in
-      (* Check for equivalence if the previous module type was not empty. During
-         approximation, the equivalence check is ignored. *)
-      let () = match approx_substitution, mtd.mtd_type with
-        | false, Some previous_mty ->
-            Includemod.check_modtype_equiv ~loc sig_env
-              id previous_mty mty
-        | _ -> ()
-      in
-      if not destructive_substitution then
-        let mtd': modtype_declaration =
-          {
-            mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-            mtd_type = Some mty;
-            mtd_attributes = [];
-            mtd_loc = loc;
-          }
-        in Some(Sig_modtype(id, mtd', priv))
-      else begin
-        let path = Pident id in
-        real_ids := [path];
-        None
-      end
-    in
-    match item, namelist, constr with
-    | Sig_type(id, decl, rs, priv), [s],
-       With_type ({ptype_kind = Ptype_abstract} as sdecl)
-      when Ident.name id = s && Typedecl.is_fixed_type sdecl ->
-        let decl_row =
-          let arity = List.length sdecl.ptype_params in
-          {
-            type_params =
-              List.map (fun _ -> Btype.newgenvar()) sdecl.ptype_params;
-            type_arity = arity;
-            type_kind = Type_abstract Definition;
-            type_private = Private;
-            type_manifest = None;
-            type_variance =
-              List.map
-                (fun (_, (v, i)) ->
-                   let (c, n) =
-                     match v with
-                     | Covariant -> true, false
-                     | Contravariant -> false, true
-                     | NoVariance -> false, false
-                   in
-                   make_variance (not n) (not c) (i = Injective)
-                )
-                sdecl.ptype_params;
-            type_separability =
-              Types.Separability.default_signature ~arity;
-            type_loc = sdecl.ptype_loc;
-            type_is_newtype = false;
-            type_expansion_scope = Btype.lowest_level;
-            type_attributes = [];
-            type_immediate = Unknown;
-            type_unboxed_default = false;
-            type_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-          }
-        and id_row = Ident.create_local (s^"#row") in
-        let initial_env =
-          Env.add_type ~check:false id_row decl_row initial_env
-        in
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let tdecl =
-          Typedecl.transl_with_constraint id ~fixed_row_path:(Pident id_row)
-            ~sig_env ~sig_decl:decl ~outer_env:initial_env sdecl in
-        let newdecl = tdecl.typ_type in
-        let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
-        check_type_decl outer_sig_env sg_for_env sdecl.ptype_loc
-          id row_id newdecl decl;
-        let decl_row = {decl_row with type_params = newdecl.type_params} in
-        let rs' = if rs = Trec_first then Trec_not else rs in
-        let ghosts =
-          List.rev_append before_ghosts
-            (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
-        in
-        return ~ghosts
-          ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-          (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
-    | Sig_type(id, sig_decl, rs, priv) , [s],
-       (With_type sdecl | With_typesubst sdecl)
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let tdecl =
-          Typedecl.transl_with_constraint id
-            ~sig_env ~sig_decl ~outer_env:initial_env sdecl in
-        let newdecl = tdecl.typ_type and loc = sdecl.ptype_loc in
-        let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
-        let ghosts = List.rev_append before_ghosts after_ghosts in
-        check_type_decl outer_sig_env sg_for_env loc
-          id row_id newdecl sig_decl;
-        if not destructive_substitution then
-          return ~ghosts
-            ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-            (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_type tdecl)})
-        else begin
-          real_ids := [Pident id];
-          return ~ghosts ~replace_by:None
-            (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_typesubst tdecl)})
-        end
-    | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
-      when Ident.name id = s ->
-        begin match sig_decl.type_manifest with
-        | None -> ()
-        | Some ty ->
-          raise (Error(loc, outer_sig_env, With_package_manifest (lid.txt, ty)))
-        end;
-        let tdecl =
-          Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
-        in
-        check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
-        let tdecl = { tdecl with type_manifest = None } in
-        return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-          (Pident id, No_TypedTree)
-    | Sig_modtype(id, mtd, priv), [s],
-      (With_modtype mty | With_modtypesubst mty)
-      when Ident.name id = s ->
-        let new_item = patch_modtype_item id mtd priv mty.mty_type in
-        let constr_tt =
-          if not destructive_substitution then
-            (Twith_modtype mty)
-          else
-            (Twith_modtypesubst mty)
-        in
-        return ~replace_by:new_item
-          (Pident id, Built_TypedTree {lid; constr=constr_tt})
-    | Sig_modtype(id, mtd, priv), [s],
-      (Approx_with_modtype mty | Approx_with_modtypesubst mty)
-      when Ident.name id = s ->
-        let new_item = patch_modtype_item id mtd priv mty in
-        return ~replace_by:new_item (Pident id, No_TypedTree)
-    | Sig_module(id, pres, md, rs, priv), [s],
-      With_module {lid=lid'; md=md'; path; remove_aliases}
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let mty = md'.md_type in
-        let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
-        let md'' = { md' with md_type = mty } in
-        let newmd = Mtype.strengthen_decl ~aliasable:false sig_env md'' path in
-        ignore(Includemod.modtypes  ~mark:true ~loc sig_env
-                 newmd.md_type md.md_type);
-        return
-          ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-          (Pident id, Built_TypedTree {
-              lid=lid; constr=(Twith_module (path, lid'))})
-    | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let aliasable = not (Env.is_functor_arg path sig_env) in
-        ignore
-          (Includemod.strengthened_module_decl ~loc ~mark:true
-             ~aliasable sig_env md' path md);
-        real_ids := [Pident id];
-        return ~replace_by:None
-          (Pident id, Built_TypedTree {
-               lid=lid; constr=(Twith_modsubst (path, lid'))})
 
-    (* When the constraint affects a component of a submodule *)
-    | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
+  (* After the item has been patch, post processing does the actual destructive
+     substitution and checks wellformedness of the resulting signature *)
+  let post_process ~destructive loc lid env paths sg replace =
+    let sg =
+      if destructive then
+        (* Check that the substitution will not make the signature ill-formed *)
+        let _ = check_usage_after_substitution ~loc ~lid env paths sg in
+        (* Actually remove the identifiers *)
+        let sub = Subst.change_locs Subst.identity loc in
+        let sub = List.fold_left replace sub paths in
+        unsafe_signature_subst sub sg loc env
+      else sg
+    in
+    (* check that the resulting signature is still wellformed *)
+    let _ = check_well_formed_module env loc "this instantiated signature"
+        (Mty_signature sg) in
+    sg
+
+  let rec merge_signature initial_env env sg namelist loc lid
+      ~patch ~destructive =
+    try
+      begin
+        match
+          Signature_group.replace_in_place
+            (patch_deep_item ~patch ~destructive
+               namelist initial_env env sg loc lid) sg
+        with
+        | Some ((p, paths), sg) -> p, paths, sg
+        | None -> raise(Error(loc, initial_env, With_no_component lid.txt))
+      end
+    with Includemod.Error explanation ->
+      raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
+
+  and patch_deep_item ~ghosts ~patch ~destructive
+      namelist initial_env (env: Env.t) outer_sg loc lid item =
+    match item, namelist with
+    (* Shallow constraints : call the patch function *)
+    | item, [s] -> patch item s env outer_sg ~ghosts
+
+    (* Deep constraints *)
+    | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist
       when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
+        let sig_env = Env.add_signature outer_sg env in
         let sg = extract_sig sig_env loc md.md_type in
-        let subpath, merge_info, newsg = merge_signature sig_env sg namelist in
+        let subpath, paths, newsg =
+          merge_signature ~patch initial_env sig_env sg
+            namelist loc lid ~destructive in
         let path = path_concat id subpath in
-        real_ids := path :: !real_ids ;
-        begin match md.md_type, merge_info with
-        (* A module alias cannot be refined, so keep it
-           and just check that the constraint is correct *)
-        | Mty_alias _, Built_TypedTree
-            { lid; constr = (Twith_module _
-                            | Twith_type _
-                            | Twith_modtype _) as tcstr } ->
-            return ~replace_by:(Some current_item)
-              (path, Built_TypedTree { lid; constr=tcstr} )
-        | _, Built_TypedTree { lid; constr } ->
-            let new_md = {md with md_type = Mty_signature newsg} in
-            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-            return ~replace_by:(Some new_item)
-              (path, Built_TypedTree {lid; constr})
-        | _, No_TypedTree ->
-            let new_md = {md with md_type = Mty_signature newsg} in
-            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-            return ~replace_by:(Some new_item) (path, No_TypedTree)
+        begin
+          match md.md_type, destructive with
+          | Mty_alias _, false ->
+              (* Deep substitutions inside aliases are checked, but do not
+                 change the resulting signature *)
+              return ~ghosts ~replace_by:(Some current_item) path
+          | Mty_alias lost_alias, true ->
+              (* Destructive deep substitutions inside aliases are disallowed,
+                 as they would loose the alias signature *)
+              raise (Error(loc, initial_env, With_lost_alias (id, lost_alias)))
+          | _, _ ->
+              let new_md = {md with md_type = Mty_signature newsg} in
+              let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+              return_paths ~ghosts ~replace_by:(Some new_item)
+                path (path::paths)
         end
     | _ -> None
-  and merge_signature env sg namelist =
-    match
-      Signature_group.replace_in_place (patch_item constr namelist env sg) sg
-    with
-    | Some ((path, res), sg) -> path, res, sg
-    | None -> raise(Error(loc, env, With_no_component lid.txt))
-  in
-  try
+
+  (* Entry point for merging *)
+  let merge ~patch ~destructive env sg loc lid =
+    let initial_env = env in
     let names = Longident.flatten lid.txt in
-    let (path, merge_info, sg) = merge_signature initial_env sg names in
-    if destructive_substitution then
-      check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
-    let sg =
-    match merge_info, constr with
-      | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
-       let how_to_extend_subst =
-         let sdecl =
-           match constr with
-           | With_typesubst sdecl -> sdecl
-           | _ -> assert false
-         in
-         match type_decl_is_alias sdecl with
-         | Some lid ->
-            let replacement, _ =
-              try Env.find_type_by_name lid.txt initial_env
-              with Not_found -> assert false
-            in
-            fun s path -> Subst.Unsafe.add_type_path path replacement s
-         | None ->
-            let body = Option.get tdecl.typ_type.type_manifest in
-            let params = tdecl.typ_type.type_params in
-            if params_are_constrained params
-            then raise(Error(loc, initial_env,
-                             With_cannot_remove_constrained_type));
-            fun s path -> Subst.Unsafe.add_type_function path ~params ~body s
-       in
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub = List.fold_left how_to_extend_subst sub !real_ids in
-       unsafe_signature_subst sub sg
-    | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub =
-         List.fold_left
-           (fun s path -> Subst.Unsafe.add_module_path path real_path s)
-           sub
-           !real_ids
-       in
-       unsafe_signature_subst sub sg
-    | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
-    | _, Approx_with_modtypesubst mty ->
-        let add s p = Subst.Unsafe.add_modtype_path p mty s in
-        let sub = Subst.change_locs Subst.identity loc in
-        let sub = List.fold_left add sub !real_ids in
-        unsafe_signature_subst sub sg
-    | _ ->
-       sg
+    merge_signature ~patch ~destructive initial_env env sg names loc lid
+
+  (* sg with type lid = sdecl *)
+  let merge_type ~destructive env loc sg lid sdecl =
+    (* As the constraint is still a parse tree, the actual typed declaration
+       (tdecl) will be built during patching and stored here *)
+    let payload = ref None in
+
+    let patch item s sig_env sg_for_env ~ghosts =
+      match item, sdecl.ptype_kind with
+      | Sig_type(id, decl, rs, priv), Ptype_abstract
+        when Ident.name id = s && Typedecl.is_fixed_type sdecl ->
+
+          let decl_row =
+            let arity = List.length sdecl.ptype_params in
+            {
+              type_params =
+                List.map (fun _ -> Btype.newgenvar()) sdecl.ptype_params;
+              type_arity = arity;
+              type_kind = Type_abstract Definition;
+              type_private = Private;
+              type_manifest = None;
+              type_variance =
+                List.map
+                  (fun (_, (v, i)) ->
+                     let (c, n) =
+                       match v with
+                       | Covariant -> true, false
+                       | Contravariant -> false, true
+                       | NoVariance -> false, false
+                     in
+                     make_variance (not n) (not c) (i = Injective)
+                  )
+                  sdecl.ptype_params;
+              type_separability =
+                Types.Separability.default_signature ~arity;
+              type_loc = sdecl.ptype_loc;
+              type_is_newtype = false;
+              type_expansion_scope = Btype.lowest_level;
+              type_attributes = [];
+              type_immediate = Unknown;
+              type_unboxed_default = false;
+              type_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+            }
+          and id_row = Ident.create_local (s^"#row") in
+          let initial_env =
+            Env.add_type ~check:false id_row decl_row env
+          in
+          let sig_env = Env.add_signature sg_for_env sig_env in
+          let tdecl =
+            Typedecl.transl_with_constraint id ~fixed_row_path:(Pident id_row)
+              ~sig_env ~sig_decl:decl ~outer_env:initial_env sdecl in
+          payload := Some tdecl ; (* storing the type declaration *)
+          let newdecl = tdecl.typ_type in
+          let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
+          check_type_decl sig_env sg_for_env sdecl.ptype_loc
+            id row_id newdecl decl;
+          let decl_row = {decl_row with type_params = newdecl.type_params} in
+          let rs' = if rs = Trec_first then Trec_not else rs in
+          let ghosts =
+            List.rev_append before_ghosts
+              (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
+          in
+          let path = Pident id in
+          return ~ghosts
+            ~replace_by:(Some (Sig_type(id, newdecl, rs, priv))) path
+
+      | Sig_type(id, sig_decl, rs, priv), _
+        when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env sig_env in
+          let tdecl =
+            Typedecl.transl_with_constraint id
+              ~sig_env ~sig_decl ~outer_env:env sdecl in
+          payload := Some tdecl ; (* storing the type declaration *)
+          let newdecl = tdecl.typ_type in
+          let newloc = sdecl.ptype_loc in
+          let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
+          let ghosts = List.rev_append before_ghosts after_ghosts in
+          check_type_decl sig_env sg_for_env newloc
+            id row_id newdecl sig_decl;
+          let path = Pident id in
+          if not destructive then
+            return ~ghosts
+              ~replace_by:(Some(Sig_type(id, newdecl, rs, priv))) path
+          else
+            return ~ghosts ~replace_by:None path
+
+      | _ -> None
     in
-    check_well_formed_module initial_env loc "this instantiated signature"
-      (Mty_signature sg);
-    (path, merge_info, sg)
-  with Includemod.Error explanation ->
-    raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
+    (* Merging *)
+    let path, paths, sg = merge ~patch ~destructive env sg loc lid in
+    (* Post processing *)
+    let tdecl = Option.get !payload in
+    let replace =
+      match type_decl_is_alias sdecl with
+      | Some lid ->
+          (* if the type is an alias of [lid], replace by the definition *)
+          let replacement, _ =
+            try Env.find_type_by_name lid.txt env
+            with Not_found -> assert false
+          in
+          fun s path -> Subst.Unsafe.add_type_path path replacement s
+      | None ->
+          (* if the type is not an alias, try to inline it *)
+          let body = Option.get tdecl.typ_type.type_manifest in
+          let params = tdecl.typ_type.type_params in
+          if params_are_constrained params then
+            raise(Error(loc, env, With_cannot_remove_constrained_type));
+          fun s path ->
+            Subst.Unsafe.add_type_function path ~params ~body s
+    in
+    let sg = post_process ~destructive loc lid env paths sg replace in
+    (tdecl, (path, lid, sg))
 
-(* Normal merge function - build the typed tree *)
-let merge_constraint env loc sg lid cty =
-  match merge_constraint_aux env loc sg lid cty with
-  | path, Built_TypedTree { lid; constr }, newsg ->
-      (path, lid, constr, newsg)
-  | _, No_TypedTree, _ -> assert false
 
-(* Specialized merge function for package types *)
-let merge_package_constraint env loc sg lid cty =
-  match merge_constraint_aux env loc sg lid (With_type_package cty) with
-  | _, No_TypedTree, newsg -> newsg
-  | _, Built_TypedTree _, _ -> assert false
+  (* [sg with module lid = path] *)
+  (* md' is the module type of the module at [path], used for equiv checks *)
+  let merge_module ~destructive env loc sg lid
+      (md': Types.module_declaration) path remove_aliases =
+    let patch item s sig_env sg_for_env ~ghosts =
+      match item with
+      | Sig_module(id, pres, md, rs, priv) when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env sig_env in
+          let real_path = Pident id in
+          if destructive then
+            let aliasable = not (Env.is_functor_arg path sig_env) in
+            (* Inclusion check with the strengthened definition *)
+            let _ =
+              Includemod.strengthened_module_decl ~loc ~mark:true
+                ~aliasable sig_env md' path md in
+            return ~ghosts ~replace_by:None real_path
+          else
+            let mty = md'.md_type in
+            let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
+            let md'' = { md' with md_type = mty } in
+            let newmd =
+              Mtype.strengthen_decl ~aliasable:false sig_env md'' path in
+            (* Inclusion check with the original signature *)
+            let _ = Includemod.modtypes ~mark:true ~loc sig_env
+                newmd.md_type md.md_type in
+            return ~ghosts
+              ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
+              real_path
+      | _ -> None
+    in
+    let real_path, paths, sg = merge ~patch ~destructive env sg loc lid in
+    let add s p = Subst.Unsafe.add_module_path p path s in
+    let sg = post_process ~destructive loc lid env paths sg add in
+    (real_path, lid, sg)
 
-let check_package_with_type_constraints loc env mty constraints =
-  let sg = extract_sig env loc mty in
-  let sg =
-    List.fold_left
-      (fun sg (lid, cty) ->
-         merge_package_constraint env loc sg lid cty)
-      sg constraints
-  in
-  let scope = Ctype.create_scope () in
-  Mtype.freshen ~scope (Mty_signature sg)
+  (* [sg with module type lid = mty] *)
+  let merge_modtype ?(approx=false) ~destructive env loc sg lid mty =
+    let patch item s sig_env sg_for_env ~ghosts = match item with
+      | Sig_modtype(id, mtd, priv)
+        when Ident.name id = s ->
+          (* Check for equivalence if the previous module type was not
+             abstract. In approximation mode, the check is ignored *)
+          let () = match mtd.mtd_type, approx with
+            | Some previous_mty, false ->
+                let sig_env = Env.add_signature sg_for_env sig_env in
+                Includemod.check_modtype_equiv ~loc sig_env id previous_mty mty
+            | _, _ -> ()
+          in
+          (* Create replacement item *)
+          let new_item =
+            if destructive then None
+            else
+              let mtd': modtype_declaration = {
+                mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+                mtd_type = Some mty;
+                mtd_attributes = [];
+                mtd_loc = loc; }
+              in Some(Sig_modtype(id, mtd', priv))
+          in
+          let path = Pident id in
+          return ~ghosts ~replace_by:new_item path
+      | _ -> None
+    in
+    let path, paths, sg = merge ~patch ~destructive env sg loc lid in
+    let add s p = Subst.Unsafe.add_modtype_path p mty s in
+    let sg = post_process ~destructive loc lid env paths sg add in
+    (path, lid, sg)
 
-let () =
-  Typetexp.check_package_with_type_constraints :=
-    check_package_with_type_constraints
+  (* sg with type lid = cty (inside a first class module type) *)
+  let merge_package env loc sg lid cty =
+    let patch item s sig_env sg_for_env ~ghosts = match item with
+      | Sig_type(id, sig_decl, rs, priv)
+        when Ident.name id = s ->
+          begin match sig_decl.type_manifest with
+          | None -> ()
+          | Some ty ->
+              raise (Error(loc, sig_env, With_package_manifest (lid.txt, ty)))
+          end;
+          let tdecl =
+            Typedecl.transl_package_constraint ~loc sig_env cty.ctyp_type
+          in
+          check_type_decl sig_env sg_for_env loc id None tdecl sig_decl;
+          let tdecl = { tdecl with type_manifest = None } in
+          let path = Pident id in
+          return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv))) path
+      | _ -> None
+    in
+    let _, _, sg = merge ~patch ~destructive:false env sg loc lid in
+    sg
 
-(* Specialized merge function for merging during signature approximation *)
-let merge_constraint_approx env loc sg lid mty ~destructive =
-  let constr =
-    if not destructive then
-      Approx_with_modtype mty
-    else
-      Approx_with_modtypesubst mty
-  in
-  match merge_constraint_aux env loc sg lid constr with
-  | _, No_TypedTree, newsg -> newsg
-  | _, Built_TypedTree _, _ -> assert false
+  let check_package_with_type_constraints loc env mty constraints =
+    let sg = extract_sig env loc mty in
+    let sg =
+      List.fold_left
+        (fun sg (lid, cty) ->
+           merge_package env loc sg lid cty)
+        sg constraints
+    in
+    let scope = Ctype.create_scope () in
+    Mtype.freshen ~scope (Mty_signature sg)
+
+  let () =
+    Typetexp.check_package_with_type_constraints :=
+      check_package_with_type_constraints
+
+end
+
 
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)
@@ -1029,8 +1029,14 @@ and approx_constraint env body constr =
       let destructive =
         (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      merge_constraint_approx ~destructive
-        env smty.pmty_loc body id approx_smty
+      (* The equivalence check for merging non abstract module types is ignored
+         during merging. Indeed, approximation only tries to build a skeleton of
+         non-recursive module types that can be used as an under-approximation
+         of the name-spaces for the typechecking phase, where invalid
+         constraints are going to be caught. *)
+      let _,_,sg = Merge.merge_modtype ~approx:true ~destructive
+          env smty.pmty_loc body id approx_smty in
+      sg
   (* module substitutions are ignored, but checked for cyclicity *)
   | Pwith_module (_, lid') ->
       (* Lookup the module to make sure that it is not recursive.
@@ -1431,24 +1437,46 @@ and transl_modtype_aux env smty =
   | Pmty_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
-  let lid, with_info = match constr with
-    | Pwith_type (l,decl) ->l , With_type decl
-    | Pwith_typesubst (l,decl) ->l , With_typesubst decl
-    | Pwith_module (l,l') ->
-        let path, md = Env.lookup_module ~loc l'.txt env in
-        l , With_module {lid=l';path;md; remove_aliases}
-    | Pwith_modsubst (l,l') ->
-        let path, md' = Env.lookup_module ~loc l'.txt env in
-        l , With_modsubst (l',path,md')
-    | Pwith_modtype (l,smty) ->
-        let mty = transl_modtype env smty in
-        l, With_modtype mty
-    | Pwith_modtypesubst (l,smty) ->
-        let mty = transl_modtype env smty in
-        l, With_modtypesubst mty
+and transl_with ~loc env remove_aliases (rev_tcstrs, sg) constr =
+  let destructive = match constr with
+    | Pwith_typesubst _ | Pwith_modsubst _ | Pwith_modtypesubst _ -> true
+    | _ -> false
   in
-  let (path, lid, constr, sg) = merge_constraint env loc sg lid with_info in
+  let constr, (path, lid, sg) = match constr with
+    | Pwith_type (l, decl)
+    | Pwith_typesubst (l, decl) ->
+        let tdecl, merge_res =
+          Merge.merge_type ~destructive env loc sg l decl
+        in
+        let constr = if destructive then
+            (Twith_typesubst tdecl)
+          else
+            (Twith_type tdecl)
+        in
+        (constr, merge_res)
+
+    | Pwith_module (l, l')
+    | Pwith_modsubst (l,l') ->
+        let path, md = Env.lookup_module ~loc l'.txt env in
+        let constr = if destructive then
+            (Twith_modsubst (path, l'))
+          else
+            (Twith_module (path, l'))
+        in
+        (constr,
+         Merge.merge_module ~destructive env loc sg l md path remove_aliases)
+
+    | Pwith_modtype (l,smty)
+    | Pwith_modtypesubst (l,smty) ->
+        let tmty = transl_modtype env smty in
+        let constr = if destructive then
+            (Twith_modtypesubst tmty)
+          else
+            (Twith_modtype tmty)
+        in
+        (constr, Merge.merge_modtype ~destructive env loc sg l tmty.mty_type)
+
+  in
   ((path, lid, constr) :: rev_tcstrs, sg)
 
 
@@ -3401,6 +3429,14 @@ let report_error ~loc _env = function
         (Style.as_inline_code longident) lid
         Style.inline_code (Path.name path)
         Style.inline_code (Ident.name id)
+  | With_lost_alias(mod_id, lost_alias_path) ->
+      Location.errorf ~loc
+        "@[<v>\
+           @[This deep destructive %a substitution inside of %a would @ \
+             loose the aliasing to %a @].@]"
+        Style.inline_code "with"
+        (Style.as_inline_code ident) mod_id
+        Style.inline_code (Path.name lost_alias_path)
   | With_cannot_remove_constrained_type ->
       Location.errorf ~loc
         "@[<v>Destructive substitutions are not supported for constrained @ \

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -114,6 +114,7 @@ type error =
   | With_makes_applicative_functor_ill_typed of
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
+  | With_lost_alias of Ident.t * Path.t
   | With_cannot_remove_constrained_type
   | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string


### PR DESCRIPTION
This PR proposes a refactoring of the `merge_constraint` function, which handles signatures constraints. It is meant to be merged after #13829

# Context

Constraints are modifiers that act on module types. There are of three forms of constraints :
- **type** constraint `... with type t = ...`
- **module** constraint `... with module X = ...`
- **module type** constraints `... with module type T = ...`

Each constraint can be *destructive*, (with the syntax `:=`) meaning that the substituted identifier is removed from the signature. This imposes additional checks to ensure wellformedness in the absence of the destructed item.

Each constraint can be *deep*, meaning that the substituted identifier might be inside a submodule (`... with type X.Y.t = ...`). 

Each constraint can be *instantiating*, if the substitution replaces an "*abstract*" field (for module constraints, "*abstract*" means "*not already an alias*"). If the constraint is not instantiating, equivalence or subtyping checks with the old definition are performed.

Finally, merging is used both in (1) "normal" mode, to build a typed tree, in (2) "approx" mode, during the signature approximation phase of typechecking recursive modules, and in (3) "package" mode, for checking signatures of first-class modules.

# Refactoring

The refactoring is limited to `typemod.ml`. It consists of : 
1. Creating a `Merge` module to gather the merge related functions
2. Extract the mutually recursive functions `patch_deep_item` and `merge_signature` to handle deep constraints
3. Create separated (non-recursive) functions `merge_type`, `merge_module` and `merge_modtype`.
4. Add documentation comments

Now, the structure is similar for each form of merging:
1. A `patch` function is defined to identify the item to substitute, do the equivalence checks if needed, and optionally build the new replacement item (if the substitution is non-destructive)
2. The patch is applied to the module type by using the general `merge` function. It returns the path of the affected item (along with the list of all suffixes, if the substitution was deep).
3. Some post processing is applied (actual replacement for destructive substitutions, wellformedness checks) 

# Semantic changes

The only visible change is the introduction of a new error when doing deep destructive substitutions inside aliases signatures, as in : 
```ocaml
module X = sig type t = int val x : t end 
module type T = sig module Y = X end with type Y.t := int
```
Throws a new error `With_lost_alias` : 
 ```
 Error: This deep destructive "with" substitution inside of "Y" would
       loose the aliasing to "X" .
```