### PR TITLE
Mark tests that actually require multicore

### DIFF
--- a/Changes
+++ b/Changes
@@ -298,6 +298,10 @@ Working version
   odoc behaviour).
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13906: Add support for a `multicore` tag in ocamltest and use it for
+  tests that fail on mono-core systems.
+  (Stéphane Glondu)
+
 ### Manual and documentation:
 
 - #13694: Fix name for caml_hash_variant in the C interface.

--- a/Changes
+++ b/Changes
@@ -300,7 +300,7 @@ Working version
 
 - #13906: Add support for a `multicore` tag in ocamltest and use it for
   tests that fail on mono-core systems.
-  (Stéphane Glondu)
+  (Stéphane Glondu, review by Nicolás Ojeda Bär)
 
 ### Manual and documentation:
 

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -102,6 +102,13 @@ let hasstr = make
     "str library available"
     "str library not available")
 
+let multicore = make
+  ~name:"multicore"
+  ~description:"Pass if running on multicore"
+  (Actions_helpers.pass_or_skip (Domain.recommended_domain_count () >= 2)
+    "running on multicore"
+    "not running on multicore")
+
 let windows_OS = "Windows_NT"
 
 let get_OS () = Sys.safe_getenv "OS"
@@ -392,6 +399,7 @@ let _ =
     hasunix;
     hassysthreads;
     hasstr;
+    multicore;
     libunix;
     libwin32unix;
     windows;

--- a/testsuite/tests/memory-model/forbidden.ml
+++ b/testsuite/tests/memory-model/forbidden.ml
@@ -1,5 +1,6 @@
 (* TEST
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
+ multicore;
  not-bsd;
  no-tsan; (* tsan detects the intentional data races and fails *)
  {

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -1,5 +1,6 @@
 (* TEST
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
+ multicore;
  no-tsan; (* tsan detects data races and fails *)
  not-bsd;
  {

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -1,5 +1,6 @@
 (* TEST
  include unix;
+ multicore;
  hasunix;
  {
    bytecode;

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -1,4 +1,5 @@
 (* TEST
+ multicore;
  no-tsan; (* TSan detects the intentional data race *)
  {
    bytecode;


### PR DESCRIPTION
Some tests fail or hang on mono-core systems. In this commit, we introduce the "multicore" predicate in ocamltest, and mark the affected tests.

Bug-Debian: https://bugs.debian.org/1101353