### PR TITLE
Fix documentation of Array.compare regarding the ordering.

### DIFF
--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -168,8 +168,9 @@ val equal : ('a -> 'a -> bool) -> 'a array -> 'a array -> bool
     @since 5.4 *)
 
 val compare : ('a -> 'a -> int) -> 'a array -> 'a array -> int
-(** [compare cmp a b] orders [a] and [b] in lexicographic order
-    using [cmp] to compare elements.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -168,8 +168,9 @@ val equal : eq:('a -> 'a -> bool) -> 'a array -> 'a array -> bool
     @since 5.4 *)
 
 val compare : cmp:('a -> 'a -> int) -> 'a array -> 'a array -> int
-(** [compare cmp a b] orders [a] and [b] in lexicographic order
-    using [cmp] to compare elements.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -406,10 +406,9 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 *)
 
 val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
-(** Provided the function [cmp] defines a preorder on elements,
-    [compare cmp a b] compares first [a] and [b] by their length,
-    and then, if equal, by their elements according to
-    the lexicographic preorder.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     For more details on comparison functions, see {!Array.sort}.
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -611,8 +611,9 @@ module Array : sig
       @since 5.4 *)
 
   val compare : (float -> float -> int) -> t -> t -> int
-  (** [compare cmp a b] orders [a] and [b] in lexicographic order
-      using [cmp] to compare elements.
+  (** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+      that is, shorter arrays are smaller and equal-sized arrays are compared
+      in lexicographic order using [cmp] to compare elements.
 
       @since 5.4 *)
 
@@ -993,8 +994,9 @@ module ArrayLabels : sig
       @since 5.4 *)
 
   val compare : cmp:(float -> float -> int) -> t -> t -> int
-  (** [compare cmp a b] orders [a] and [b] in lexicographic order
-      using [cmp] to compare elements.
+  (** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+      that is, shorter arrays are smaller and equal-sized arrays are compared
+      in lexicographic order using [cmp] to compare elements.
 
       @since 5.4 *)
 

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -127,8 +127,9 @@ val equal : eq:(float -> float -> bool) -> t -> t -> bool
     @since 5.4 *)
 
 val compare : cmp:(float -> float -> int) -> t -> t -> int
-(** [compare cmp a b] orders [a] and [b] in lexicographic order
-    using [cmp] to compare elements.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     @since 5.4 *)
 


### PR DESCRIPTION
The documentation of `Array.compare` incorrectly states that it uses a lexicographic order, while its implementation actually uses a shortlex order. (Note how the behavior differs from all the other functions below, which are lexicographic.)

```plain
# Array.compare Stdlib.compare [|'b'|] [|'a'; 'a'|];;
- : int = -1
# List.compare Stdlib.compare ['b'] ['a'; 'a'];;
- : int = 1
# Stdlib.compare ['b'] ['a'; 'a'];;
- : int = 1
# Stdlib.compare "b" "aa";;
- : int = 1
# String.compare "b" "aa";;
- : int = 1
```

The first version of #13836 did actually implement a lexicographic order. But during the review process, it was changed to a shortlex order, and the documentation became outdated.