### PR TITLE
Refactor merge constraints on signatures 

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,6 +44,12 @@ Working version
   (Nicolás Ojeda Bär, review by Gabriel Scherer, Samuel Vivien, Ulysse Gérard
   and Vincent Laviron)
 
+- #13911: Refactor the merging of signature constraints, by splitting the
+  monolithic merge function into separate, specialized functions (for merging
+  types, modules and module types) - sharing only the recursive part for
+  handling deep constraints.
+  (Clement Blaudeau, review by Florian Angeletti and Samuel Vivien)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -705,28 +705,6 @@ module Merge = struct
     let names = Longident.flatten lid.txt in
     merge_signature ~patch ~destructive initial_env env sg names loc lid
 
-  (* Specialized merge function for package types *)
-  let merge_package_constraint env loc sg lid cty =
-    let patch =
-      patch_all ~destructive:false env loc lid (With_type_package cty) in
-    let _, _, _, sg = merge ~patch ~destructive:false env sg loc lid in
-    sg
-
-  let check_package_with_type_constraints loc env mty constraints =
-    let sg = extract_sig env loc mty in
-    let sg =
-      List.fold_left
-        (fun sg (lid, cty) ->
-           merge_package_constraint env loc sg lid cty)
-        sg constraints
-    in
-    let scope = Ctype.create_scope () in
-    Mtype.freshen ~scope (Mty_signature sg)
-
-  let () =
-    Typetexp.check_package_with_type_constraints :=
-      check_package_with_type_constraints
-
   (* sg with type lid = sdecl *)
   let merge_type ~destructive env loc sg lid sdecl =
     let constr =
@@ -791,6 +769,27 @@ module Merge = struct
     let sg = post_process ~destructive loc lid env paths sg replace in
     path, lid, sg
 
+  (* Specialized merge function for package types *)
+  let merge_package_constraint env loc sg lid cty =
+    let patch =
+      patch_all ~destructive:false env loc lid (With_type_package cty) in
+    let _, _, _, sg = merge ~patch ~destructive:false env sg loc lid in
+    sg
+
+  let check_package_with_type_constraints loc env mty constraints =
+    let sg = extract_sig env loc mty in
+    let sg =
+      List.fold_left
+        (fun sg (lid, cty) ->
+           merge_package_constraint env loc sg lid cty)
+        sg constraints
+    in
+    let scope = Ctype.create_scope () in
+    Mtype.freshen ~scope (Mty_signature sg)
+
+  let () =
+    Typetexp.check_package_with_type_constraints :=
+      check_package_with_type_constraints
 end
 
 (* Add recursion flags on declarations arising from a mutually recursive

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -543,6 +543,8 @@ module Merge = struct
     with
     | Some ((p, paths, late_typedtree), sg) -> p, paths, late_typedtree, sg
     | None -> raise(Error(loc, initial_env, With_no_component lid.txt))
+    | exception Includemod.Error explanation ->
+      raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
   and patch_deep_item ~ghosts ~patch ~destructive
       namelist initial_env (env: Env.t) outer_sg loc lid item =
@@ -578,10 +580,7 @@ module Merge = struct
   let merge ~patch ~destructive env sg loc lid =
     let initial_env = env in
     let names = Longident.flatten lid.txt in
-    try
-      merge_signature ~patch ~destructive initial_env env sg names loc lid
-    with Includemod.Error explanation ->
-      raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
+    merge_signature ~patch ~destructive initial_env env sg names loc lid
 
   (* sg with type lid = sdecl *)
   let merge_type ~destructive env loc sg lid sdecl =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -447,28 +447,27 @@ type merge_constraint =
         remove_aliases:bool
       }
   | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
-  | With_modtype of Typedtree.module_type
-  | With_modtypesubst of Typedtree.module_type
+  | With_modtype of Types.module_type
+  | With_modtypesubst of Types.module_type
 
   (* Package with type constraints only use this last case. *)
   | With_type_package of Typedtree.core_type
 
-  (* Merging of module types during signature approximation *)
-  | Approx_with_modtype      of Types.module_type
-  | Approx_with_modtypesubst of Types.module_type
 
-type merge_result = Path.t * merge_info * Types.signature
-and merge_info =
-  (* Result of normal merging *)
-  | Built_TypedTree of {
-      lid: Longident.t Asttypes.loc ;
-      constr : Typedtree.with_constraint
-    }
-  (* Result of merging a package_type or merging approximated module types
-     (without typedtree) *)
-  | No_TypedTree
+type merge_result = Path.t * (Path.t list)
+                    * (Typedtree.type_declaration option) * Types.signature
 
 module Merge = struct
+
+  (* Helpers *)
+  let return ~ghosts ~replace_by path =
+    Some ((path, [path], None), {Signature_group.ghosts; replace_by})
+
+  let return_payload  ~payload ~ghosts ~replace_by path =
+    Some ((path, [path], payload), {Signature_group.ghosts; replace_by})
+
+  let return_paths  ~payload ~ghosts ~replace_by path paths =
+    Some ((path, paths, payload), {Signature_group.ghosts; replace_by})
 
   let split_row_id s ghosts =
     let srow = s ^ "#row" in
@@ -491,37 +490,45 @@ module Merge = struct
         let error = With_cannot_remove_packed_modtype(p,mty) in
         raise (Error(loc,initial_env,error))
 
-  let merge_constraint_aux initial_env loc sg lid constr : merge_result =
-    let destructive_substitution =
+  (* After the item has been patch, post processing does the actual destructive
+     substitution and checks wellformedness of the resulting signature *)
+  let post_process ~destructive loc lid env paths sg replace =
+    let sg =
+      if destructive then
+        (* Check that the substitution will not make the signature ill-formed *)
+        let _ = check_usage_after_substitution ~loc ~lid env paths sg in
+        (* Actually remove the identifiers *)
+        let sub = Subst.change_locs Subst.identity loc in
+        let sub = List.fold_left replace sub paths in
+        unsafe_signature_subst sub sg loc env
+      else sg
+    in
+    (* check that the resulting signature is still wellformed *)
+    let _ = check_well_formed_module env loc "this instantiated signature"
+        (Mty_signature sg) in
+    sg
+
+  let merge_constraint_aux ?(approx=false) initial_env loc sg lid constr
+    : merge_result =
+    let destructive =
       match constr with
       | With_type _ | With_module _ | With_modtype _
-      | Approx_with_modtype _
       | With_type_package _ -> false
-      | With_typesubst _ | With_modsubst _ | With_modtypesubst _
-      | Approx_with_modtypesubst _ -> true
+      | With_typesubst _ | With_modsubst _ | With_modtypesubst _ -> true
     in
-    let approx_substitution =
-      match constr with
-      | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
-      | _ -> false
-    in
-    let real_ids = ref [] in
     let rec patch_item constr namelist outer_sig_env sg_for_env ~ghosts item =
-      let return ?(ghosts=ghosts) ~replace_by info =
-        Some (info, {Signature_group.ghosts; replace_by})
-      in
       let patch_modtype_item
           id (mtd: Types.modtype_declaration) priv mty  =
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         (* Check for equivalence if the previous module type was not
            empty. During approximation, the equivalence check is ignored. *)
-        let () = match approx_substitution, mtd.mtd_type with
+        let () = match approx, mtd.mtd_type with
           | false, Some previous_mty ->
               Includemod.check_modtype_equiv ~loc sig_env
                 id previous_mty mty
           | _ -> ()
         in
-        if not destructive_substitution then
+        if not destructive then
           let mtd': modtype_declaration =
             {
               mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
@@ -530,11 +537,7 @@ module Merge = struct
               mtd_loc = loc;
             }
           in Some(Sig_modtype(id, mtd', priv))
-        else begin
-          let path = Pident id in
-          real_ids := [path];
-          None
-        end
+        else None
       in
       match item, namelist, constr with
       | Sig_type(id, decl, rs, priv), [s],
@@ -590,9 +593,9 @@ module Merge = struct
             List.rev_append before_ghosts
               (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
           in
-          return ~ghosts
-            ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-            (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
+          let path = Pident id in
+          return_payload ~ghosts ~payload:(Some tdecl)
+            ~replace_by:(Some (Sig_type(id, newdecl, rs, priv))) path
       | Sig_type(id, sig_decl, rs, priv) , [s],
         (With_type sdecl | With_typesubst sdecl)
         when Ident.name id = s ->
@@ -605,17 +608,12 @@ module Merge = struct
           let ghosts = List.rev_append before_ghosts after_ghosts in
           check_type_decl outer_sig_env sg_for_env loc
             id row_id newdecl sig_decl;
-          if not destructive_substitution then
-            return ~ghosts
-              ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-              (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_type tdecl)})
-          else begin
-            real_ids := [Pident id];
-            return ~ghosts ~replace_by:None
-              (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_typesubst tdecl)})
-          end
+          let path = Pident id in
+          let item_opt =
+            if not destructive then (Some(Sig_type(id, newdecl, rs, priv)))
+            else None
+          in
+          return_payload ~ghosts ~payload:(Some tdecl) ~replace_by:item_opt path
       | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
         when Ident.name id = s ->
           begin match sig_decl.type_manifest with
@@ -630,29 +628,19 @@ module Merge = struct
           in
           check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
           let tdecl = { tdecl with type_manifest = None } in
-          return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-            (Pident id, No_TypedTree)
+          let path = Pident id in
+          return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv))) path
       | Sig_modtype(id, mtd, priv), [s],
-        (With_modtype mty | With_modtypesubst mty)
-        when Ident.name id = s ->
-          let new_item = patch_modtype_item id mtd priv mty.mty_type in
-          let constr_tt =
-            if not destructive_substitution then
-              (Twith_modtype mty)
-            else
-              (Twith_modtypesubst mty)
-          in
-          return ~replace_by:new_item
-            (Pident id, Built_TypedTree {lid; constr=constr_tt})
-      | Sig_modtype(id, mtd, priv), [s],
-        (Approx_with_modtype mty | Approx_with_modtypesubst mty)
+        ( With_modtype mty | With_modtypesubst mty)
         when Ident.name id = s ->
           let new_item = patch_modtype_item id mtd priv mty in
-          return ~replace_by:new_item (Pident id, No_TypedTree)
+          let path = Pident id in
+          return ~ghosts ~replace_by:new_item path
       | Sig_module(id, pres, md, rs, priv), [s],
-        With_module {lid=lid'; md=md'; path; remove_aliases}
+        With_module {lid=_; md=md'; path; remove_aliases}
         when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let real_path = Pident id in
           let mty = md'.md_type in
           let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
           let md'' = { md' with md_type = mty } in
@@ -660,127 +648,59 @@ module Merge = struct
               sig_env md'' path in
           ignore(Includemod.modtypes  ~mark:true ~loc sig_env
                    newmd.md_type md.md_type);
-          return
+          return ~ghosts
             ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-            (Pident id, Built_TypedTree {
-                lid=lid; constr=(Twith_module (path, lid'))})
-      | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
+            real_path
+      | Sig_module(id, _, md, _rs, _), [s], With_modsubst (_,path,md')
         when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let real_path = Pident id in
           let aliasable = Env.is_aliasable path sig_env in
           ignore
             (Includemod.strengthened_module_decl ~loc ~mark:true
                ~aliasable sig_env md' path md);
-          real_ids := [Pident id];
-          return ~replace_by:None
-            (Pident id, Built_TypedTree {
-                lid=lid; constr=(Twith_modsubst (path, lid'))})
+          return ~ghosts ~replace_by:None real_path
 
       (* When the constraint affects a component of a submodule *)
       | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
         when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env outer_sig_env in
           let sg = extract_sig sig_env loc md.md_type in
-          let subpath, merge_info, newsg = merge_signature sig_env sg
+          let subpath, paths, payload, newsg = merge_signature sig_env sg
               namelist in
           let path = path_concat id subpath in
-          real_ids := path :: !real_ids ;
-          begin match md.md_type, merge_info with
-          (* A module alias cannot be refined, so keep it
-             and just check that the constraint is correct *)
-          | Mty_alias _, Built_TypedTree
-              { lid; constr = (Twith_module _
-                              | Twith_type _
-                              | Twith_modtype _) as tcstr } ->
-              return ~replace_by:(Some current_item)
-                (path, Built_TypedTree { lid; constr=tcstr} )
-          | _, Built_TypedTree { lid; constr } ->
+          begin match md.md_type, destructive with
+          | Mty_alias _, false ->
+              (* Deep substitutions inside aliases are checked, but do not
+                 change the resulting signature *)
+              return_payload ~ghosts
+                ~replace_by:(Some current_item) path ~payload
+          | _, _ ->
               let new_md = {md with md_type = Mty_signature newsg} in
               let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-              return ~replace_by:(Some new_item)
-                (path, Built_TypedTree {lid; constr})
-          | _, No_TypedTree ->
-              let new_md = {md with md_type = Mty_signature newsg} in
-              let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-              return ~replace_by:(Some new_item) (path, No_TypedTree)
+              return_paths ~ghosts ~replace_by:(Some new_item)
+                path (path::paths) ~payload
           end
       | _ -> None
     and merge_signature env sg namelist =
       match
         Signature_group.replace_in_place (patch_item constr namelist env sg) sg
       with
-      | Some ((path, res), sg) -> path, res, sg
+      | Some ((path, paths, payload), sg) -> path, paths, payload, sg
       | None -> raise(Error(loc, env, With_no_component lid.txt))
     in
     try
       let names = Longident.flatten lid.txt in
-      let (path, merge_info, sg) = merge_signature initial_env sg names in
-      if destructive_substitution then
-        check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
-      let sg =
-        match merge_info, constr with
-        | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
-            let how_to_extend_subst =
-              let sdecl =
-                match constr with
-                | With_typesubst sdecl -> sdecl
-                | _ -> assert false
-              in
-              match type_decl_is_alias sdecl with
-              | Some lid ->
-                  let replacement, _ =
-                    try Env.find_type_by_name lid.txt initial_env
-                    with Not_found -> assert false
-                  in
-                  fun s path -> Subst.Unsafe.add_type_path path replacement s
-              | None ->
-                  let body = Option.get tdecl.typ_type.type_manifest in
-                  let params = tdecl.typ_type.type_params in
-                  if params_are_constrained params
-                  then raise(Error(loc, initial_env,
-                                   With_cannot_remove_constrained_type));
-                  fun s path ->
-                    Subst.Unsafe.add_type_function path ~params ~body s
-            in
-            let sub = Subst.change_locs Subst.identity loc in
-            let sub = List.fold_left how_to_extend_subst sub !real_ids in
-            unsafe_signature_subst sub sg loc initial_env
-        | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
-            let sub = Subst.change_locs Subst.identity loc in
-            let sub =
-              List.fold_left
-                (fun s path -> Subst.Unsafe.add_module_path path real_path s)
-                sub
-                !real_ids
-            in
-            unsafe_signature_subst sub sg loc initial_env
-        | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
-        | _, Approx_with_modtypesubst mty ->
-            let add s p = Subst.Unsafe.add_modtype_path p mty s in
-            let sub = Subst.change_locs Subst.identity loc in
-            let sub = List.fold_left add sub !real_ids in
-            unsafe_signature_subst sub sg loc initial_env
-        | _ ->
-            sg
-      in
-      check_well_formed_module initial_env loc "this instantiated signature"
-        (Mty_signature sg);
-      (path, merge_info, sg)
+      let path, paths, payload, sg = merge_signature initial_env sg names in
+      (path, paths, payload, sg)
     with Includemod.Error explanation ->
       raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-  (* Normal merge function - build the typed tree *)
-  let merge_constraint env loc sg lid cty =
-    match merge_constraint_aux env loc sg lid cty with
-    | path, Built_TypedTree { lid; constr }, newsg ->
-        (path, lid, constr, newsg)
-    | _, No_TypedTree, _ -> assert false
-
   (* Specialized merge function for package types *)
   let merge_package_constraint env loc sg lid cty =
-    match merge_constraint_aux env loc sg lid (With_type_package cty) with
-    | _, No_TypedTree, newsg -> newsg
-    | _, Built_TypedTree _, _ -> assert false
+    let _, _, _, sg =
+      merge_constraint_aux env loc sg lid (With_type_package cty) in
+    sg
 
   let check_package_with_type_constraints loc env mty constraints =
     let sg = extract_sig env loc mty in
@@ -797,17 +717,67 @@ module Merge = struct
     Typetexp.check_package_with_type_constraints :=
       check_package_with_type_constraints
 
-  (* Specialized merge function for merging during signature approximation *)
-  let merge_constraint_approx env loc sg lid mty ~destructive =
+  (* sg with type lid = sdecl *)
+  let merge_type ~destructive env loc sg lid sdecl =
     let constr =
       if not destructive then
-        Approx_with_modtype mty
+        With_type sdecl
       else
-        Approx_with_modtypesubst mty
+        With_typesubst sdecl
     in
-    match merge_constraint_aux env loc sg lid constr with
-    | _, No_TypedTree, newsg -> newsg
-    | _, Built_TypedTree _, _ -> assert false
+    match (merge_constraint_aux env loc sg lid constr) with
+    | path, paths, Some tdecl, sg -> begin
+        let replace =
+          match type_decl_is_alias sdecl with
+          | Some lid ->
+              (* if the type is an alias of [lid], replace by the definition *)
+              let replacement, _ =
+                try Env.find_type_by_name lid.txt env
+                with Not_found -> assert false
+              in
+              fun s path -> Subst.Unsafe.add_type_path path replacement s
+          | None ->
+              (* if the type is not an alias, try to inline it *)
+              let body = Option.get tdecl.typ_type.type_manifest in
+              let params = tdecl.typ_type.type_params in
+              if params_are_constrained params then
+                raise(Error(loc, env, With_cannot_remove_constrained_type));
+              fun s path ->
+                Subst.Unsafe.add_type_function path ~params ~body s
+        in
+        let sg = post_process ~destructive loc lid env paths sg replace in
+        tdecl, (path, lid, sg)
+      end
+    | _ -> assert false
+
+  (* [sg with module lid = path] *)
+  (* md' is the module type of the module at [path], used for equiv checks *)
+  let merge_module ~destructive env loc sg lid
+      (md': Types.module_declaration) path remove_aliases =
+    let constr =
+      if not destructive then
+        With_module {lid; path; md=md'; remove_aliases}
+      else
+        With_modsubst (lid, path, md')
+    in
+    let real_path,paths,_,sg = (merge_constraint_aux env loc sg lid constr) in
+    let replace s p = Subst.Unsafe.add_module_path p path s in
+    let sg = post_process ~destructive loc lid env paths sg replace in
+    real_path, lid, sg
+
+  (* [sg with module type lid = mty] *)
+  let merge_modtype ?(approx=false) ~destructive env loc sg lid mty =
+    let constr =
+      if not destructive then
+        With_modtype mty
+      else
+        With_modtypesubst mty
+    in
+    let path,paths,_,sg =
+      (merge_constraint_aux ~approx env loc sg lid constr) in
+    let replace s p = Subst.Unsafe.add_modtype_path p mty s in
+    let sg = post_process ~destructive loc lid env paths sg replace in
+    path, lid, sg
 
 end
 
@@ -1039,8 +1009,9 @@ and approx_constraint env body constr =
       let destructive =
         (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      Merge.merge_constraint_approx ~destructive
-        env smty.pmty_loc body id approx_smty
+      let _ ,_,sg = Merge.merge_modtype ~destructive ~approx:true
+          env smty.pmty_loc body id approx_smty in
+      sg
   (* module substitutions are ignored, but checked for cyclicity *)
   | Pwith_module (_, lid') ->
       (* Lookup the module to make sure that it is not recursive.
@@ -1435,25 +1406,47 @@ and transl_modtype_aux env smty =
   | Pmty_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
-  let lid, with_info = match constr with
-    | Pwith_type (l,decl) ->l , With_type decl
-    | Pwith_typesubst (l,decl) ->l , With_typesubst decl
-    | Pwith_module (l,l') ->
-        let path, md = Env.lookup_module ~loc l'.txt env in
-        l , With_module {lid=l';path;md; remove_aliases}
-    | Pwith_modsubst (l,l') ->
-        let path, md' = Env.lookup_module ~loc l'.txt env in
-        l , With_modsubst (l',path,md')
-    | Pwith_modtype (l,smty) ->
-        let mty = transl_modtype env smty in
-        l, With_modtype mty
-    | Pwith_modtypesubst (l,smty) ->
-        let mty = transl_modtype env smty in
-        l, With_modtypesubst mty
+
+and transl_with ~loc env remove_aliases (rev_tcstrs, sg) constr =
+  let destructive = match constr with
+    | Pwith_typesubst _ | Pwith_modsubst _ | Pwith_modtypesubst _ -> true
+    | _ -> false
   in
-  let (path, lid, constr, sg) =
-    Merge.merge_constraint env loc sg lid with_info in
+  let constr, (path, lid, sg) = match constr with
+    | Pwith_type (l, decl)
+    | Pwith_typesubst (l, decl) ->
+        let tdecl, merge_res =
+          Merge.merge_type ~destructive env loc sg l decl
+        in
+        let constr = if destructive then
+            (Twith_typesubst tdecl)
+          else
+            (Twith_type tdecl)
+        in
+        (constr, merge_res)
+
+    | Pwith_module (l, l')
+    | Pwith_modsubst (l,l') ->
+        let path, md = Env.lookup_module ~loc l'.txt env in
+        let constr = if destructive then
+            (Twith_modsubst (path, l'))
+          else
+            (Twith_module (path, l'))
+        in
+        (constr,
+         Merge.merge_module ~destructive env loc sg l md path remove_aliases)
+
+    | Pwith_modtype (l,smty)
+    | Pwith_modtypesubst (l,smty) ->
+        let tmty = transl_modtype env smty in
+        let constr = if destructive then
+            (Twith_modtypesubst tmty)
+          else
+            (Twith_modtype tmty)
+        in
+        (constr, Merge.merge_modtype ~destructive env loc sg l tmty.mty_type)
+
+  in
   ((path, lid, constr) :: rev_tcstrs, sg)
 
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -480,14 +480,19 @@ module Merge = struct
   *)
 
   (* Helpers *)
-  let return ~ghosts ~replace_by path =
-    Some ((path, [path], None), {Signature_group.ghosts; replace_by})
 
-  let return_payload  ~payload ~ghosts ~replace_by path =
-    Some ((path, [path], payload), {Signature_group.ghosts; replace_by})
+  (** For the merging of type fields [S with type P.t = tdecl], the typedtree
+      for the right-hand side type declaration [tdecl] is built at the point of
+      the (possibly deep) constrained item [P.t] inside [S]. It is returned as
+      an extra payload by merge. Other cases (module, module types) don't use
+      the payload mechanism (the payload is [()]). *)
 
-  let return_paths  ~payload ~ghosts ~replace_by path paths =
-    Some ((path, paths, payload), {Signature_group.ghosts; replace_by})
+  let return_payload ~ghosts ~replace_by ?(paths=[]) path ~late_typedtree =
+    Some ((path, path::paths, late_typedtree),
+          {Signature_group.ghosts; replace_by})
+
+  let return = return_payload ~late_typedtree:()
+
 
   let split_row_id s ghosts =
     let srow = s ^ "#row" in
@@ -499,7 +504,7 @@ module Merge = struct
     in
     split [] ghosts
 
-  let unsafe_signature_subst sub sg loc initial_env =
+  let unsafe_signature_subst initial_env loc sg sub =
     (* This signature will not be used directly, it will always be freshened
        by the caller. So what we do with the scope doesn't really matter. But
        making it local makes it unlikely that we will ever use the result of
@@ -516,15 +521,15 @@ module Merge = struct
     let sg =
       if destructive then
         (* Check that the substitution will not make the signature ill-formed *)
-        let _ = check_usage_after_substitution ~loc ~lid env paths sg in
+        let () = check_usage_after_substitution ~loc ~lid env paths sg in
         (* Actually remove the identifiers *)
         let sub = Subst.change_locs Subst.identity loc in
         let sub = List.fold_left replace sub paths in
-        unsafe_signature_subst sub sg loc env
+        unsafe_signature_subst env loc sg sub
       else sg
     in
     (* check that the resulting signature is still wellformed *)
-    let _ = check_well_formed_module env loc "this instantiated signature"
+    let () = check_well_formed_module env loc "this instantiated signature"
         (Mty_signature sg) in
     sg
 
@@ -536,7 +541,7 @@ module Merge = struct
         (patch_deep_item ~patch ~destructive
            namelist initial_env env sg loc lid) sg
     with
-    | Some ((p, paths, payload), sg) -> p, paths, payload, sg
+    | Some ((p, paths, late_typedtree), sg) -> p, paths, late_typedtree, sg
     | None -> raise(Error(loc, initial_env, With_no_component lid.txt))
 
   and patch_deep_item ~ghosts ~patch ~destructive
@@ -550,7 +555,7 @@ module Merge = struct
       when Ident.name id = s ->
         let sig_env = Env.add_signature outer_sg env in
         let sg = extract_sig sig_env loc md.md_type in
-        let subpath, paths, payload, newsg =
+        let subpath, paths, late_typedtree, newsg =
           merge_signature ~patch initial_env sig_env sg
             namelist loc lid ~destructive in
         let path = path_concat id subpath in
@@ -560,12 +565,12 @@ module Merge = struct
               (* Deep substitutions inside aliases are checked, but do not
                  change the resulting signature *)
               return_payload ~ghosts
-                ~replace_by:(Some current_item) path ~payload
+                ~replace_by:(Some current_item) path ~late_typedtree
           | _, _ ->
               let new_md = {md with md_type = Mty_signature newsg} in
               let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-              return_paths ~ghosts ~replace_by:(Some new_item)
-                path (path::paths) ~payload
+              return_payload ~ghosts ~replace_by:(Some new_item)
+                path ~paths ~late_typedtree
         end
     | _ -> None
 
@@ -636,7 +641,7 @@ module Merge = struct
               (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
           in
           let path = Pident id in
-          return_payload ~ghosts ~payload:tdecl
+          return_payload ~ghosts ~late_typedtree:tdecl
             ~replace_by:(Some (Sig_type(id, newdecl, rs, priv))) path
 
       | Sig_type(id, sig_decl, rs, priv), _
@@ -656,7 +661,7 @@ module Merge = struct
             if not destructive then (Some(Sig_type(id, newdecl, rs, priv)))
             else None
           in
-          return_payload ~ghosts ~payload:tdecl ~replace_by:item_opt path
+          return_payload ~ghosts ~late_typedtree:tdecl ~replace_by:item_opt path
 
       | _ -> None
     in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -438,13 +438,6 @@ let params_are_constrained =
 
 type merge_constraint =
   (* Normal merging cases that returns a typed tree *)
-  | With_module of {
-        lid:Longident.t loc;
-        path:Path.t;
-        md:Types.module_declaration;
-        remove_aliases:bool
-      }
-  | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
   | With_modtype of Types.module_type
   | With_modtypesubst of Types.module_type
 
@@ -532,30 +525,6 @@ module Merge = struct
           let new_item = patch_modtype_item id mtd priv mty in
           let path = Pident id in
           return ~ghosts ~replace_by:new_item path
-      | Sig_module(id, pres, md, rs, priv),
-        With_module {lid=_; md=md'; path; remove_aliases}
-        when Ident.name id = s ->
-          let sig_env = Env.add_signature sg_for_env outer_sig_env in
-          let real_path = Pident id in
-          let mty = md'.md_type in
-          let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
-          let md'' = { md' with md_type = mty } in
-          let newmd = Mtype.strengthen_decl ~aliasable:false
-              sig_env md'' path in
-          ignore(Includemod.modtypes  ~mark:true ~loc sig_env
-                   newmd.md_type md.md_type);
-          return ~ghosts
-            ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-            real_path
-      | Sig_module(id, _, md, _rs, _), With_modsubst (_,path,md')
-        when Ident.name id = s ->
-          let sig_env = Env.add_signature sg_for_env outer_sig_env in
-          let real_path = Pident id in
-          let aliasable = Env.is_aliasable path sig_env in
-          ignore
-            (Includemod.strengthened_module_decl ~loc ~mark:true
-               ~aliasable sig_env md' path md);
-          return ~ghosts ~replace_by:None real_path
       | _ -> None
 
   (* Main recursive knot to handle deep merges *)
@@ -720,13 +689,32 @@ module Merge = struct
   (* md' is the module type of the module at [path], used for equiv checks *)
   let merge_module ~destructive env loc sg lid
       (md': Types.module_declaration) path remove_aliases =
-    let constr =
-      if not destructive then
-        With_module {lid; path; md=md'; remove_aliases}
-      else
-        With_modsubst (lid, path, md')
+    let patch item s sig_env sg_for_env ~ghosts =
+      match item with
+      | Sig_module(id, pres, md, rs, priv) when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env sig_env in
+          let real_path = Pident id in
+          if destructive then
+            let aliasable = Env.is_aliasable path sig_env in
+            (* Inclusion check with the strengthened definition *)
+            let _ =
+              Includemod.strengthened_module_decl ~loc ~mark:true
+                ~aliasable sig_env md' path md in
+            return ~ghosts ~replace_by:None real_path
+          else
+            let mty = md'.md_type in
+            let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
+            let md'' = { md' with md_type = mty } in
+            let newmd =
+              Mtype.strengthen_decl ~aliasable:false sig_env md'' path in
+            (* Inclusion check with the original signature *)
+            let _ = Includemod.modtypes ~mark:true ~loc sig_env
+                newmd.md_type md.md_type in
+            return ~ghosts
+              ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
+              real_path
+      | _ -> None
     in
-    let patch = patch_all ~destructive loc constr in
     let real_path,paths,_,sg = merge ~patch ~destructive env sg loc lid in
     let replace s p = Subst.Unsafe.add_module_path p path s in
     let sg = post_process ~destructive loc lid env paths sg replace in


### PR DESCRIPTION
This PR proposes a refactoring of the `merge_constraint` function, which handles signatures constraints. 

# Context

Constraints are modifiers that act on module types. There are of three forms of constraints :
- **type** constraint `... with type t = ...`
- **module** constraint `... with module X = ...`
- **module type** constraints `... with module type T = ...`

In addition, 

1. Each constraint can be *destructive*, (with the syntax `:=`) meaning that the substituted identifier is removed from the signature. This imposes additional checks to ensure wellformedness in the absence of the destructed item.
2. Each constraint can be *deep*, meaning that the substituted identifier might be inside a submodule (`... with type X.Y.t = ...`, `with module type M.N.T := sig end`, etc). 
3. Each constraint can be *instantiating*, if the substitution replaces an "*abstract*" field (for module constraints, "*abstract*" means "*not already an alias*"). If the constraint is not instantiating, equivalence or subtyping checks with the old definition are performed.
    ```ocaml 
    (sig type t end) with type t = int * int (* instantiating, as [t] was abstract *)
    (sig type t = bool end) with type t = bool (* non-instantiating, the two definitions must be equivalent *) 
    ```
4. Finally, merging is used both in (1) "normal" mode, to build a typed tree, in (2) "approx" mode, during the signature approximation phase of typechecking recursive modules (see #13829), and in (3) "package" mode, for checking signatures of first-class modules.

# Refactoring

The refactoring is limited to `typemod.ml`. It consists of : 
1. Creating a `Merge` module to gather the merge related functions
2. Extract the mutually recursive functions `patch_deep_item` and `merge_signature` to handle deep constraints
3. Create separated (non-recursive) functions `merge_type`, `merge_module` and `merge_modtype`.
4. Add documentation comments

Now, the structure is similar for each form of merging:
1. A `patch` function is defined to identify the item to substitute, do the equivalence checks if needed, and optionally build the new replacement item (if the substitution is non-destructive)
2. The patch is applied to the module type by using the general `merge` function. It returns the path of the affected item (along with the list of all suffixes, if the substitution was deep).
3. Some post processing is applied (actual replacement for destructive substitutions, wellformedness checks) 

# ~~Semantic changes~~

[Removed, moved to #13929]

The only visible change is the introduction of a new error when doing deep destructive substitutions inside aliases signatures, as in : 
```ocaml
module X = sig type t = int val x : t end 
module type T = sig module Y = X end with type Y.t := int
```
Throws a new error `With_lost_alias` : 
 ```
 Error: This deep destructive "with" substitution inside of "Y" would
       loose the aliasing to "X" .
```