### PR TITLE
Fix a minor overlook in Stdlib.Repr docs

### DIFF
--- a/stdlib/repr.mli
+++ b/stdlib/repr.mli
@@ -36,8 +36,7 @@ external equal : 'a -> 'a -> bool = "%equal"
     if and only if their current contents are structurally equal,
     even if the two mutable objects are not the same physical object.
     Equality between functional values raises [Invalid_argument].
-    Equality between cyclic data structures may not terminate.
-    Left-associative operator, see {!Ocaml_operators} for more information. *)
+    Equality between cyclic data structures may not terminate. *)
 
 external compare : 'a -> 'a -> int = "%compare"
 (** [compare x y] returns [0] if [x] is equal to [y],

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -119,7 +119,9 @@ exception Undefined_recursive_module of (string * int * int)
 (** {1 Comparisons} *)
 
 external ( = ) : 'a -> 'a -> bool = "%equal"
-(** Alias of {!Repr.equal} *)
+(** Alias of {!Repr.equal}
+    Left-associative operator, see {!Ocaml_operators} for more information.
+*)
 
 external ( <> ) : 'a -> 'a -> bool = "%notequal"
 (** Negation of {!Repr.equal}.
@@ -163,8 +165,8 @@ val max : 'a -> 'a -> 'a
 (** Alias of {!Repr.max}. *)
 
 external ( == ) : 'a -> 'a -> bool = "%eq"
-(** Operator alias to {!Repr.phys_equal}.
-   Left-associative operator,  see {!Ocaml_operators} for more information.
+(** Alias of {!Repr.phys_equal}.
+    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
 external ( != ) : 'a -> 'a -> bool = "%noteq"


### PR DESCRIPTION
A paste error was introduced in #13755 where `Repr.equal` was documented as a left-associative operator. This is fixed.
Additionally, the wording on `Stdlib.( == )` was made consistent with `Stdlib.( = )`