### PR TITLE
Set `action_pending` more sparingly inside `caml_reset_young_limit`

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1796,7 +1796,13 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
               (uintnat)dom_st->young_trigger);
   /* An interrupt might have been queued in the meanwhile; this
      achieves the proper synchronisation. */
-  atomic_exchange(&dom_st->young_limit, (uintnat)trigger);
+  if (atomic_exchange(&dom_st->young_limit, (uintnat)trigger)
+      == CAML_UINTNAT_MAX) {
+    /* In case of a recently-recorded signal or forced systhread switching,
+       we need to remember that we must run signal handlers or systhread's
+       yield. */
+    caml_set_action_pending(dom_st);
+  }
 
   /* For non-delayable asynchronous actions, we immediately interrupt
      the domain again. */
@@ -1807,14 +1813,6 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
       || dom_st->major_slice_epoch < atomic_load (&caml_major_slice_epoch)) {
     interrupt_domain_local(dom_st);
   }
-  /* We might be here due to a recently-recorded signal or forced
-     systhread switching, so we need to remember that we must run
-     signal handlers or systhread's yield. In addition, in the case of
-     long-running C code (that may regularly poll with
-     caml_process_pending_actions), we want to force a query of all
-     callbacks at every minor collection or major slice (similarly to
-     the OCaml behaviour). */
-  caml_set_action_pending(dom_st);
 }
 
 void caml_update_young_limit_after_c_call(caml_domain_state * dom_st)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -909,6 +909,11 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
       /* In the case of allocations performed from C, only perform
          non-delayable actions. */
       caml_handle_gc_interrupt();
+      /* In the case of long-running C code that regularly polls with
+         caml_process_pending_actions, we want to force a query of all
+         callbacks at every minor collection or major slice (similarly
+         to OCaml behaviour). */
+      caml_set_action_pending(dom_st);
     }
 
     /* Now, there might be enough room in the minor heap to do our


### PR DESCRIPTION
In [#12923 (comment)](https://github.com/ocaml/ocaml/pull/12923#issuecomment-1937543967) @NickBarnes reported a possible impact of always setting `action_pending` inside `caml_reset_young_limit` with the intention of going back to it later, for which I proposed the patch attached. I have not got any news since so I do not know if this is still important for them, but I think this is a good patch to have anyway.

This patch treats `CAML_UINTNAT_MAX` as a special value for the young limit denoting that an external pending action has been notified. Then thanks to the `atomic_exchange` we are certain not to miss any. We must also be careful to preserve the property of forcing examination of all callbacks after every minor collection or major slice.

(@NickBarnes or @stedolan might be interested in reviewing this patch.)