### PR TITLE
Add Option.product and Option.Syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ Working version
 
 ### Standard library:
 
+- #13916: Add Option.product and Option.Syntax.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli, Gabriel Scherer and David
+  Allsopp)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -22,6 +22,10 @@ let get = function Some v -> v | None -> invalid_arg "option is None"
 let bind o f = match o with None -> None | Some v -> f v
 let join = function Some o -> o | None -> None
 let map f o = match o with None -> None | Some v -> Some (f v)
+let product o0 o1 = match o0, o1 with
+| None, _ | _, None -> None
+| Some v0, Some v1 -> Some (v0, v1)
+
 let fold ~none ~some = function Some v -> some v | None -> none
 let iter f = function Some v -> f v | None -> ()
 let is_none = function None -> true | Some _ -> false
@@ -41,3 +45,10 @@ let compare cmp o0 o1 = match o0, o1 with
 let to_result ~none = function None -> Error none | Some v -> Ok v
 let to_list = function None -> [] | Some v -> [v]
 let to_seq = function None -> Seq.empty | Some v -> Seq.return v
+
+module Syntax = struct
+  let ( let* ) = bind
+  let ( and* ) = product
+  let ( let+ ) o f = map f o
+  let ( and+ ) = product
+end

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -47,6 +47,12 @@ val join : 'a option option -> 'a option
 val map : ('a -> 'b) -> 'a option -> 'b option
 (** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v]. *)
 
+val product : 'a option -> 'b option -> ('a * 'b) option
+(** [product o0 o1] is [Some (v0, v1)] if [o0] is [Some v0] and [o1] is [Some
+    v1] and [None] otherwise.
+
+    @since 5.5 *)
+
 val fold : none:'a -> some:('b -> 'a) -> 'b option -> 'a
 (** [fold ~none ~some o] is [none] if [o] is [None] and [some v] if [o] is
     [Some v]. *)
@@ -82,3 +88,23 @@ val to_list : 'a option -> 'a list
 val to_seq : 'a option -> 'a Seq.t
 (** [to_seq o] is [o] as a sequence. [None] is the empty sequence and
     [Some v] is the singleton sequence containing [v]. *)
+
+(** {1:syntax Syntax} *)
+
+(** Binding operators. See manual section 12.23 for details.
+
+    @since 5.5 *)
+module Syntax : sig
+
+  val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option
+  (** [( let* )] is {!Option.bind}. *)
+
+  val ( and* ) : 'a option -> 'b option -> ('a * 'b) option
+  (** [( and* )] is {!Option.product}. *)
+
+  val ( let+ ) : 'a option -> ('a -> 'b) -> 'b option
+  (** [( let+ )] is {!Option.map}. *)
+
+  val ( and+ ) : 'a option -> 'b option -> ('a * 'b) option
+  (** [( and+ )] is {!Option.product}. *)
+end

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -127,7 +127,7 @@ val to_seq : ('a, 'e) result -> 'a Seq.t
 
 (** {1:syntax Syntax} *)
 
-(** Binding operators.
+(** Binding operators. See manual section 12.23 for details.
 
     @since 5.4 *)
 module Syntax : sig

--- a/testsuite/tests/lib-option/test.ml
+++ b/testsuite/tests/lib-option/test.ml
@@ -96,6 +96,13 @@ let test_to_option_list_seq () =
   assert ((Option.to_seq None) () = Seq.Nil);
   ()
 
+let test_product () =
+  assert (Option.product None None = None);
+  assert (Option.product None (Some 1) = None);
+  assert (Option.product (Some 1) None = None);
+  assert (Option.product (Some 1) (Some 2) = Some (1, 2));
+  ()
+
 let tests () =
   test_none_some ();
   test_value ();
@@ -109,6 +116,7 @@ let tests () =
   test_equal ();
   test_compare ();
   test_to_option_list_seq ();
+  test_product ();
   ()
 
 let () =


### PR DESCRIPTION
**EDIT:** contrary to what is written below, following discussion, this PR only adds `Option.product` and `Option.Syntax`.

As a follow-up to #13696, this PR adds a `Syntax` submodule to `Option`, `List` and `Seq` containing binding operators for these modules. Along the way, it also adds `Option.product` and `List.product`.

The addition of the `Syntax` submodules was discussed and approved in principle during the last dev meeting.