### PR TITLE
infixing operators in stdlib

### DIFF
--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -76,7 +76,7 @@ let split s =
 let make_symlist prefix sep suffix l =
   match l with
   | [] -> "<none>"
-  | h::t -> (List.fold_left (fun x y -> x ^ sep ^ y) (prefix ^ h) t) ^ suffix
+  | h::t -> (List.fold_left (fun x y -> x /* string_cat */ sep /* string_cat */ y) (prefix /* string_cat */ h) t) /* string_cat */ suffix
 
 
 let print_spec buf (key, spec, doc) =
@@ -100,7 +100,7 @@ let add_help speclist =
     with Not_found ->
             ["--help", Unit help_action, " Display this list of options"]
   in
-  speclist @ (add1 @ add2)
+  speclist /* list_cat */ (add1 /* list_cat */ add2)
 
 
 let usage_b buf speclist errmsg =
@@ -200,7 +200,7 @@ let parse_and_expand_argv_dynamic_aux allow_expand current argv speclist anonfun
               consume_arg ();
             end else begin
               raise (Stop (Wrong (s, arg, "one of: "
-                                          ^ (make_symlist "" " " "" symb))))
+                                          /* string_cat */ (make_symlist "" " " "" symb))))
             end
         | Set_string r ->
             r := get_arg ();
@@ -344,7 +344,7 @@ let add_padding len ksd =
   | (kwd, (Symbol _ as spec), msg) ->
       let cutcol = second_word msg in
       let spaces = String.make ((Int.max 0 (len - cutcol)) + 3) ' ' in
-      (kwd, spec, "\n" ^ spaces ^ replace_leading_tab msg)
+      (kwd, spec, "\n" /* string_cat */ spaces /* string_cat */ replace_leading_tab msg)
   | (kwd, spec, msg) ->
       let cutcol = second_word msg in
       let kwd_len = String.length kwd in
@@ -355,7 +355,7 @@ let add_padding len ksd =
         let spaces = String.make diff ' ' in
         let prefix = String.sub (replace_leading_tab msg) 0 cutcol in
         let suffix = String.sub msg cutcol (String.length msg - cutcol) in
-        (kwd, spec, prefix ^ spaces ^ suffix)
+        (kwd, spec, prefix /* string_cat */ spaces /* string_cat */ suffix)
 
 
 let align ?(limit=max_int) speclist =

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -459,9 +459,9 @@ let fast_sort = stable_sort
 let shuffle_contract_violation i j =
   let int = string_of_int in
   invalid_arg
-    ("Array.shuffle: 'rand " ^ int (i + 1) ^
-     "' returned " ^ int j ^
-     ", out of expected range [0; " ^ int i ^ "]")
+    ("Array.shuffle: 'rand " /* string_cat */ int (i + 1) /* string_cat */
+     "' returned " /* string_cat */ int j /* string_cat */
+     ", out of expected range [0; " /* string_cat */ int i /* string_cat */ "]")
 
 let shuffle ~rand a = (* Fisher-Yates *)
   for i = length a - 1 downto 1 do

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -472,7 +472,7 @@ let string_of_formatting_lit formatting_lit = match formatting_lit with
   | Magic_size (str, _)  -> str
   | Escaped_at           -> "@@"
   | Escaped_percent      -> "@%"
-  | Scan_indic c -> "@" ^ (String.make 1 c)
+  | Scan_indic c -> "@" /* string_cat */ (String.make 1 c)
 
 (***)
 
@@ -1473,7 +1473,7 @@ let convert_float fconv prec x =
         match str.[i] with
         | '.' | 'e' | 'E' -> true
         | _ -> is_valid (i + 1) in
-    if is_valid 0 then str else str ^ "." in
+    if is_valid 0 then str else str /* string_cat */ "." in
   let caml_special_val str = match classify_float x with
     | FP_normal | FP_subnormal | FP_zero -> str
     | FP_infinite -> if x < 0.0 then "neg_infinity" else "infinity"

--- a/stdlib/char.ml
+++ b/stdlib/char.ml
@@ -91,7 +91,7 @@ module Ascii = struct
   let is_digit = function '0' .. '9' -> true | _ -> false
   let digit_to_int = function
     | '0' .. '9' as c -> code c - 0x30
-    | c -> invalid_arg (escaped c ^ ": not a decimal digit")
+    | c -> invalid_arg (escaped c /* string_cat */ ": not a decimal digit")
 
   let digit_of_int n = unsafe_chr (0x30 + abs (n mod 10))
 
@@ -105,7 +105,7 @@ module Ascii = struct
     | '0' .. '9' as c -> code c - 0x30
     | 'A' .. 'F' as c -> 10 + code c - 0x41
     | 'a' .. 'f' as c -> 10 + code c - 0x61
-    | c -> invalid_arg (escaped c ^ ": not a hexadecimal digit")
+    | c -> invalid_arg (escaped c /* string_cat */ ": not a hexadecimal digit")
 
   let lower_hex_digit_of_int n =
     let d = abs (n mod 16) in

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -118,11 +118,11 @@ module Unix : SYSDEPS = struct
   let quote = generic_quote "'\\''"
   let quote_command cmd ?stdin ?stdout ?stderr args =
     String.concat " " (List.map quote (cmd :: args))
-    ^ (match stdin  with None -> "" | Some f -> " <" ^ quote f)
-    ^ (match stdout with None -> "" | Some f -> " >" ^ quote f)
-    ^ (match stderr with None -> "" | Some f -> if stderr = stdout
+    /* string_cat */ (match stdin  with None -> "" | Some f -> " <" /* string_cat */ quote f)
+    /* string_cat */ (match stdout with None -> "" | Some f -> " >" /* string_cat */ quote f)
+    /* string_cat */ (match stderr with None -> "" | Some f -> if stderr = stdout
                                                 then " 2>&1"
-                                                else " 2>" ^ quote f)
+                                                else " 2>" /* string_cat */ quote f)
   let basename = generic_basename is_dir_sep current_dir_name
   let dirname = generic_dirname is_dir_sep current_dir_name
 end
@@ -227,7 +227,7 @@ Quoting commands for execution by cmd.exe is difficult.
       else f
     in
     if String.exists (function '\"' | '%' -> true | _ -> false) f then
-      failwith ("Filename.quote_command: bad file name " ^ f)
+      failwith ("Filename.quote_command: bad file name " /* string_cat */ f)
     else if String.contains f ' ' then
       String.concat "" ["\""; f; "\""]
     else
@@ -241,12 +241,12 @@ Quoting commands for execution by cmd.exe is difficult.
       quote_cmd_filename cmd;
       " ";
       quote_cmd (String.concat " " (List.map quote args));
-      (match stdin  with None -> "" | Some f -> " <" ^ quote_cmd_filename f);
-      (match stdout with None -> "" | Some f -> " >" ^ quote_cmd_filename f);
+      (match stdin  with None -> "" | Some f -> " <" /* string_cat */ quote_cmd_filename f);
+      (match stdout with None -> "" | Some f -> " >" /* string_cat */ quote_cmd_filename f);
       (match stderr with None -> "" | Some f ->
                                         if stderr = stdout
                                         then " 2>&1"
-                                        else " 2>" ^ quote_cmd_filename f);
+                                        else " 2>" /* string_cat */ quote_cmd_filename f);
       "\""
     ]
   let has_drive s =
@@ -262,7 +262,7 @@ Quoting commands for execution by cmd.exe is difficult.
   let dirname s =
     let (drive, path) = drive_and_path s in
     let dir = generic_dirname is_dir_sep current_dir_name path in
-    drive ^ dir
+    drive /* string_cat */ dir
   let basename s =
     let (_drive, path) = drive_and_path s in
     generic_basename is_dir_sep current_dir_name path
@@ -296,8 +296,8 @@ include Sysdeps
 let concat dirname filename =
   let l = String.length dirname in
   if l = 0 || is_dir_sep dirname (l-1)
-  then dirname ^ filename
-  else dirname ^ dir_sep ^ filename
+  then dirname /* string_cat */ filename
+  else dirname /* string_cat */ dir_sep /* string_cat */ filename
 
 let chop_suffix name suff =
   if check_suffix name suff

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -875,7 +875,7 @@ let pp_set_geometry state ~max_indent ~margin =
   let geometry = { max_indent; margin } in
   match validate_geometry geometry with
   | Error msg ->
-    raise (Invalid_argument ("Format.pp_set_geometry: " ^ msg))
+    raise (Invalid_argument ("Format.pp_set_geometry: " /* string_cat */ msg))
   | Ok () ->
     pp_set_full_geometry state geometry
 
@@ -961,10 +961,10 @@ let pp_set_formatter_out_channel state oc =
 *)
 
 let default_pp_mark_open_tag = function
-  | String_tag s -> "<" ^ s ^ ">"
+  | String_tag s -> "<" /* string_cat */ s /* string_cat */ ">"
   | _ -> ""
 let default_pp_mark_close_tag = function
-  | String_tag s -> "</" ^ s ^ ">"
+  | String_tag s -> "</" /* string_cat */ s /* string_cat */ ">"
   | _ -> ""
 
 let default_pp_print_open_tag = ignore

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -22,7 +22,7 @@ let negate p v = not (p v)
 exception Finally_raised of exn
 
 let () = Printexc.register_printer @@ function
-| Finally_raised exn -> Some ("Fun.Finally_raised: " ^ Printexc.to_string exn)
+| Finally_raised exn -> Some ("Fun.Finally_raised: " /* string_cat */ Printexc.to_string exn)
 | _ -> None
 
 let protect ~(finally : unit -> unit) work =

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -50,7 +50,7 @@ let nth_opt l n =
     | a::l -> if n = 0 then Some a else nth_aux l (n-1)
   in nth_aux l n
 
-let append = (@)
+let append = list_cat
 
 let rec rev_append l1 l2 =
   match l1 with
@@ -73,7 +73,7 @@ let init len f =
 
 let rec flatten = function
     [] -> []
-  | l::r -> l @ flatten r
+  | l::r -> l /* append */ flatten r
 
 let concat = flatten
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -64,7 +64,7 @@ let string_of_extension_constructor t =
   let constructor, fields_opt = destruct_ext_constructor t in
   match fields_opt with
   | None -> constructor
-  | Some f -> constructor ^ f
+  | Some f -> constructor /* string_cat */ f
 
 let to_string_default = function
   | Out_of_memory -> "Out of memory"

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -75,7 +75,7 @@ module State = struct
     then
       failwith
         ("Random.State.of_binary_string: expected a format \
-          compatible with OCaml " ^ Sys.ocaml_version);
+          compatible with OCaml " /* string_cat */ Sys.ocaml_version);
     let i1 = String.get_int64_le buf (preflen + 0 * 8) in
     let i2 = String.get_int64_le buf (preflen + 1 * 8) in
     let i3 = String.get_int64_le buf (preflen + 2 * 8) in

--- a/stdlib/scanf.ml
+++ b/stdlib/scanf.ml
@@ -523,10 +523,10 @@ let token_int_literal conv ib =
   let tok =
     match conv with
     | D_conversion | I_conversion -> Scanning.token ib
-    | U_conversion -> "0u" ^ Scanning.token ib
-    | O_conversion -> "0o" ^ Scanning.token ib
-    | X_conversion -> "0x" ^ Scanning.token ib
-    | B_conversion -> "0b" ^ Scanning.token ib in
+    | U_conversion -> "0u" /* string_cat */ Scanning.token ib
+    | O_conversion -> "0o" /* string_cat */ Scanning.token ib
+    | X_conversion -> "0x" /* string_cat */ Scanning.token ib
+    | B_conversion -> "0b" /* string_cat */ Scanning.token ib in
   let l = String.length tok in
   if l = 0 || tok.[0] <> '+' then tok else String.sub tok 1 (l - 1)
 
@@ -1467,7 +1467,7 @@ let kscanf_gen ib ef af (Format (fmt, str)) =
     | exception (Scan_failure _ | Failure _ | End_of_file as exc) ->
         ef ib exc
     | exception Invalid_argument msg ->
-        invalid_arg (msg ^ " in format \"" ^ String.escaped str ^ "\"")
+        invalid_arg (msg /* string_cat */ " in format \"" /* string_cat */ String.escaped str /* string_cat */ "\"")
     | args ->
         af (apply f args)
   in
@@ -1514,8 +1514,8 @@ let sscanf_format :
 
 
 let format_from_string s fmt =
-  sscanf_format ("\"" ^ String.escaped s ^ "\"") fmt (fun x -> x)
+  sscanf_format ("\"" /* string_cat */ String.escaped s /* string_cat */ "\"") fmt (fun x -> x)
 
 
 let unescaped s =
-  sscanf ("\"" ^ s ^ "\"") "%S%!" (fun x -> x)
+  sscanf ("\"" /* string_cat */ s /* string_cat */ "\"") "%S%!" (fun x -> x)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -48,6 +48,10 @@ exception Undefined_recursive_module = Undefined_recursive_module
 external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
 external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
 
+(* Infixing operators *)
+external ( /* ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
+external ( */ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+
 (* Debugging *)
 
 external __LOC__ : string = "%loc_LOC"
@@ -209,12 +213,13 @@ external bytes_blit : bytes -> int -> bytes -> int -> int -> unit
                         = "caml_blit_bytes" [@@noalloc]
 external bytes_unsafe_to_string : bytes -> string = "%bytes_to_string"
 
-let ( ^ ) s1 s2 =
+let string_cat s1 s2 =
   let l1 = string_length s1 and l2 = string_length s2 in
   let s = bytes_create (l1 + l2) in
   string_blit s1 0 s 0 l1;
   string_blit s2 0 s l1 l2;
   bytes_unsafe_to_string s
+let ( ^ ) = string_cat
 
 (* Character operations -- more in module Char *)
 
@@ -295,12 +300,14 @@ let float_of_string_opt s =
 
 (* List operations -- more in module List *)
 
-let[@tail_mod_cons] rec ( @ ) l1 l2 =
+let[@tail_mod_cons] rec list_cat l1 l2 =
   match l1 with
   | [] -> l2
   | h1 :: [] -> h1 :: l2
   | h1 :: h2 :: [] -> h1 :: h2 :: l2
-  | h1 :: h2 :: h3 :: tl -> h1 :: h2 :: h3 :: (tl @ l2)
+  | h1 :: h2 :: h3 :: tl -> h1 :: h2 :: h3 :: (list_cat tl l2)
+
+let ( @ ) = list_cat
 
 (* I/O operations *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -275,6 +275,20 @@ external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
  @since 4.01
 *)
 
+(** {1 Infixing operators} *)
+
+external ( /* ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
+(** See [( */ )]
+  @since 6.0
+*)
+
+external ( */ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+(** The infixing operators [( /* )] and [( */ )] allow the use of any function
+  as an infix operator. E.g., ["OC" /* String.cat */ "aml"] or
+  [0L /* Int64.add */ 0L].
+ @since 6.0
+*)
+
 (** {1 Integer arithmetic} *)
 
 (** Integers are [Sys.int_size] bits wide.
@@ -654,13 +668,10 @@ external classify_float : (float [@unboxed]) -> fpclass =
    More string operations are provided in module {!String}.
 *)
 
-val ( ^ ) : string -> string -> string
-(** String concatenation.
-    Right-associative operator, see {!Ocaml_operators} for more information.
+val string_cat : string -> string -> string
 
-    @raise Invalid_argument if the result is longer then
-    than {!Sys.max_string_length} bytes.
-*)
+val ( ^ ) : string -> string -> string
+[@@ocaml.deprecated "Use /* String.cat */ instead"]
 
 (** {1 Character operations}
 
@@ -781,11 +792,10 @@ external snd : 'a * 'b -> 'b = "%field1"
    More list operations are provided in module {!List}.
 *)
 
+val list_cat : 'a list -> 'a list -> 'a list
+
 val ( @ ) : 'a list -> 'a list -> 'a list
-(** [l0 @ l1] appends [l1] to [l0]. Same function as {!List.append}.
-  Right-associative operator, see {!Ocaml_operators} for more information.
-  @since 5.1 this function is tail-recursive.
-*)
+[@@ocaml.deprecated "Use /* List.append */ instead"]
 
 (** {1 Input/output}
     Note: all input/output functions can raise [Sys_error] when the system

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -69,7 +69,7 @@ let concat sep = function
             (B.create (sum_lengths 0 seplen l))
             0 sep seplen l
 
-let cat = ( ^ )
+let cat = string_cat
 
 (* duplicated in bytes.ml *)
 let iter f s =

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -17,8 +17,8 @@ external format_int : string -> int -> string = "caml_format_int"
 
 let err_no_pred = "U+0000 has no predecessor"
 let err_no_succ = "U+10FFFF has no successor"
-let err_not_sv i = format_int "%X" i ^ " is not a Unicode scalar value"
-let err_not_latin1 u = "U+" ^ format_int "%04X" u ^ " is not a latin1 character"
+let err_not_sv i = format_int "%X" i /* string_cat */ " is not a Unicode scalar value"
+let err_not_latin1 u = "U+" /* string_cat */ format_int "%04X" u /* string_cat */ " is not a latin1 character"
 
 type t = int
 


### PR DESCRIPTION
## Summary

This PR proposes to add infixing operators *à la* Haskell's backticks, but instead of making it a parser thing, it is instead in the Stdlib.

```
val ( /* ) : 'a -> ('a -> 'b) -> 'b
val ( */ ) : ('a -> 'b) -> 'a -> 'b
```

Equipped with these operators, a programmer can turn any function, or any expression really, into an infix function.

```
let () = print_endline ("hello" /* String.cat */ " " /* String.cat */ "world");;
```


## Advantages

Beyond being one step closer to parity with Haskell, this addition brigns the following advantages:

**No need to export symbols as both infix and prefix and binding operators.** For example, the following signature is sufficient for monads:

```
module type M = sig
  type 'a t
  val return : 'a -> 'a t
  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
end
```

and the user of the module can decide to use the `let*` in prefix form (`( let* ) x f`) or infix form (`x /* ( let* ) */ fun x -> …`).

## Potential criticism

One might criticise this PR for introducing infixing operators as infix operators. In a way this PR encourages the use of infix operators as a way to avoid using infix operators.

This is entirely unfounded, anyone who wants to use the infixing operators in a prefix form (`( /* )` and `( */ )`) is able to do so:

```
4 /* ( /* ) */ ( + ) /* ( */ ) */ 1 ;;
```

## Future works

In this PR I decided to deprecate the infix operators `@` and `^`. These are not needed anymore because we can simply wrap the prefix versions of these operators in the newly introduced infixing operators. After the publication of a `legacy-stdlib-infixing-operator` package on opam, I will make an additional PR to simply remove the deprecated operators from the OCaml stdlib.

In this PR I have introduced only one set of infixing operators. Because of precendence rules, they cannot be nested (without `(`-`)`). In a future PR I will introduce additional sets of infixing operators (`|+`, `+|` or some such) such that it is possible to nest infixing expressions. If this work is considered too urgent, I can add it to this PR instead of waiting.

In this PR I have only introduced parameters-order-preserving infixing operators. In a future PR I will be adding parameter-swapping infixing operators. Operators such that `"left" /** String.cat **/ "right"` evaluates to "rightleft". This will allow for much more compact version of `/* Fun.flip f */`, saving precious characters in the process. Once again, if this work is considered too urgent, I can add it to this PR instead of waiting.

---------------------

EDIT: fixed some formatting issue in the description