### PR TITLE
`lazy v`: optimize structured constants

### DIFF
--- a/.depend
+++ b/.depend
@@ -2187,7 +2187,6 @@ typing/typeopt.cmo : \
     typing/ctype.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
-    parsing/asttypes.cmi \
     typing/typeopt.cmi
 typing/typeopt.cmx : \
     typing/types.cmx \
@@ -2202,7 +2201,6 @@ typing/typeopt.cmx : \
     typing/ctype.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
-    parsing/asttypes.cmx \
     typing/typeopt.cmi
 typing/typeopt.cmi : \
     typing/types.cmi \

--- a/Changes
+++ b/Changes
@@ -183,6 +183,10 @@ OCaml 5.5.0
 
 ### Code generation and optimizations:
 
+- #13919: optimize `lazy v` when `v` is a structured constant, so that
+  `Lazy.from_val v` should not be necessary anymore in most cases.
+  (Gabriel Scherer, review by ???)
+
 ### Standard library:
 
 - #14437: Add String.split_{first,last,all} and String.rsplit_all

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -246,7 +246,9 @@ let classify_lazy_argument e =
         List.for_all (fun (_lbl, arg) -> small_and_commutative arg) args
     | Texp_record { fields; extended_expression } ->
         Array.for_all (fun (_lbl, def) ->
-          match def with Overridden (_, e) -> small_and_commutative e | Kept _ -> true
+          match def with
+          | Overridden (_, e) -> small_and_commutative e
+          | Kept _ -> incr size; true
         ) fields
         && Option.for_all small_and_commutative extended_expression
     | Texp_extension_constructor _ -> true

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -17,7 +17,6 @@
 
 open Path
 open Types
-open Asttypes
 open Typedtree
 open Lambda
 
@@ -201,39 +200,98 @@ let value_kind env ty =
         Pgenval
   end
 
-(** Whether a forward block is needed for a lazy thunk on a value, i.e.
-    if the value can be represented as a float/forward/lazy *)
-let lazy_val_requires_forward env ty =
-  match classify env ty with
-  | Any | Lazy -> true
-  | Float -> Config.flat_float_array
-  | Addr | Int -> false
-
 (** The compilation of the expression [lazy e] depends on the form of e:
-    constants, floats and identifiers are optimized.  The optimization must be
-    taken into account when determining whether a recursive binding is safe. *)
-let classify_lazy_argument : Typedtree.expression ->
-                             [`Constant_or_function
-                             |`Float_that_cannot_be_shortcut
-                             |`Identifier of [`Forward_value|`Other]
-                             |`Other] =
-  fun e -> match e.exp_desc with
-    | Texp_constant
-        ( Const_int _ | Const_char _ | Const_string _
-        | Const_int32 _ | Const_int64 _ | Const_nativeint _ )
-    | Texp_function _
-    | Texp_construct (_, {cstr_arity = 0}, _) ->
-       `Constant_or_function
-    | Texp_constant(Const_float _) ->
-       if Config.flat_float_array
-       then `Float_that_cannot_be_shortcut
-       else `Constant_or_function
-    | Texp_ident _ when lazy_val_requires_forward e.exp_env e.exp_type ->
-       `Identifier `Forward_value
-    | Texp_ident _ ->
-       `Identifier `Other
-    | _ ->
-       `Other
+    in some cases we optimize it into [let x = e in lazy x], evaluating
+    [e] right now (if it is equivalent) and avoiding creating a thunk.
+
+    We can also avoid creating a forward block completely in some
+    cases, depending on the value type.
+
+    This optimization must be taken into account when determining
+    whether a recursive binding is safe.
+*)
+
+type lazy_summary =
+  | Lazy_thunk
+  | Eager of forward_repr
+and forward_repr =
+  | Forward
+  | Shortcut
+
+let classify_lazy_argument e =
+  (* We can compile [lazy e] into [let x = e in lazy x] whenever [e]
+     is what we call "commutative", when we can safely evaluate it
+     earlier. In terms of [middle_end/semantics_of_primitive], this is
+     valid when [e] has no coeffects (so it does not depend on the
+     evaluation of other expressions) and only generative effects
+     (so it does not influence the evaluation of other expressions).
+
+     If a commutative expression is very large, it may be
+     a performance pessimization to force its evaluation earlier in
+     the program -- maybe the user put it under a [lazy] because it is
+     not needed most of the time. We implement a cutoff based on
+     expression size.
+  *)
+  let size_cutoff = 42 in
+  let size = ref 0 in
+  let rec small_and_commutative e =
+    incr size;
+    !size <= size_cutoff && match e.exp_desc with
+    | Texp_ident _ | Texp_constant _ | Texp_function _ | Texp_lazy _ -> true
+    | Texp_variant (_, args) ->
+        Option.for_all small_and_commutative args
+    | Texp_construct (_, _, args) | Texp_array (_, args) ->
+        List.for_all small_and_commutative args
+    | Texp_tuple args ->
+        List.for_all (fun (_lbl, arg) -> small_and_commutative arg) args
+    | Texp_record { fields; extended_expression } ->
+        Array.for_all (fun (_lbl, def) ->
+          match def with Overridden (_, e) -> small_and_commutative e | Kept _ -> true
+        ) fields
+        && Option.for_all small_and_commutative extended_expression
+    | Texp_extension_constructor _ -> true
+    (* under-approximations: these could be refined
+       -- below we write [c] for any commutative expression. *)
+    | Texp_let _ (* [let x = c in c] would be ok *)
+    | Texp_pack _ (* commutative modules would be ok *)
+    | Texp_field _ (* [v.x] for immutable fields would be ok *)
+    | Texp_atomic_loc _ (* [%atomic.loc c.x] would be ok *)
+    | Texp_object _ (* commutative objects would be ok *)
+    | Texp_struct_item _ (* [let <structure item> in c] would be ok *)
+      -> false
+    (* (typically) not commutative *)
+    | Texp_apply _
+    | Texp_match _
+    | Texp_try _
+    | Texp_setfield _
+    | Texp_ifthenelse _
+    | Texp_sequence _
+    | Texp_while _
+    | Texp_for _
+    | Texp_send _
+    | Texp_new _
+    | Texp_instvar _
+    | Texp_setinstvar _
+    | Texp_override _
+    | Texp_assert _
+    | Texp_letop _
+    | Texp_unreachable
+      -> false
+  in
+  (* In [let x = e in lazy x], [lazy x] sometimes need to be
+     a [Forward] block, but this block can typically be shortcut into
+     just [x]. The forward block is required for expressions that may
+     have a lazy type themselves, or float when flat-float-array is
+     enabled. *)
+  if not (small_and_commutative e) then Lazy_thunk
+  else Eager (match classify e.exp_env e.exp_type with
+    | Addr | Int -> Shortcut
+    | Any | Lazy -> Forward
+    | Float ->
+        if Config.flat_float_array
+        then Forward
+        else Shortcut
+  )
 
 let value_kind_union k1 k2 =
   if k1 = k2 then k1

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -30,11 +30,19 @@ val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
 
-val classify_lazy_argument : Typedtree.expression ->
-                             [ `Constant_or_function
-                             | `Float_that_cannot_be_shortcut
-                             | `Identifier of [`Forward_value | `Other]
-                             | `Other]
+(** [lazy_summary] describes how the expression [lazy e] must be compiled. *)
+type lazy_summary =
+  | Lazy_thunk
+    (** Evaluation of [e] must be delayed inside a thunk. *)
+  | Eager of forward_repr
+    (** Evaluation of [e] can be done eagerly. *)
+and forward_repr =
+  | Forward
+    (** The value must be placed inside a [Forward] block. *)
+  | Shortcut
+    (** The value can be injected directly without wrapping. *)
+
+val classify_lazy_argument : Typedtree.expression -> lazy_summary
 
 val value_kind_union :
       Lambda.value_kind -> Lambda.value_kind -> Lambda.value_kind


### PR DESCRIPTION
Sometimes we want to build values at a lazy type, but we are not interested in delaying evaluation. A typical example is the function `rev_append_list li s`, which adds the reverse of a strict list `li` to the beginning of a lazy list `s`.

```ocaml
type 'a stream = 'a cell Lazy.t
and 'a cell = Nil | Cons of 'a * 'a stream

let rec rev_append_list li s =
  match li with
  | [] -> s
  | x :: xs -> rev_append_list xs (lazy (Cons (x, s)))
```

The representation of lazy values in OCaml would let us optimize the expression `lazy (Cons (x, s))` by computing `Cons (x, s)` right now, and returning it directly (without using a forward block; there is no risk of confusion here). The compiler optimizes related expressions, such as `lazy Nil`, but it currently does not optimize `lazy (Cons (x, s))`, because we didn't bother detecting structured constants.

The present PR changes the optimization of lazy values to also support structured constants. The program above gets optimized at compile-time to not include any laziness-related indirection.

### Lazy.from_val

The `Lazy` module offers a `Lazy.from_val` helper, which performs a dynamic check to avoid the Forward block when possible. `Lazy.from_val` can be used manually by experts to avoid indirections, for example for structured constants, when the compiler optimizations are not good enough. For example the [BatLazyList module](https://github.com/ocaml-batteries-team/batteries-included/blob/7d2c4f20b28f61450a129aeb886aa28ad5dd7ee7/src/batLazyList.ml#L284) of `batteries` uses it to implement `rev_append_list`. 

The compiler checks for the possibility to avoid the Forward block statically, so it can generate better code than `Lazy.from_val` (for flat values in trunk, and for flat and structured values in this PR).

In my eyes the value of the change is not to be faster than `Lazy.from_val`, but rather to be at least as fast in many cases without requiring users to know about this manual optimization. (and as compact in terms of memory representation, without having to reason about GC-time shortcutting)

Note that not all use-cases of `Lazy.from_val e` are covered here, as users could decide to use it when `e` is not a value and performs effect (then it is equivalent to `let x = e in lazy x`, with dynamic shortcutting of forward blocks), or when `e` is a constant but its type is not statically known. (One could refine the code generator to insert a call to `Lazy.from_val` in cases where the static check fails because the types are unknown at compile-time, but the compiler typically does not know about the standard library.)

### Obligatory micro-benchmark

```ocaml
let () =
  let input = List.init 10_000 Fun.id in
  for i = 0 to 10_000 do
    ignore (Sys.opaque_identity (rev_append_list input (lazy Nil)))
  done
```

I measured 4 versions of this benchmark, along two axes:
- version: 5.3.0 or the current branch
- `lazy` or `Lazy.from_val`: the latter uses a variant of the function above with `Lazy.from_val (Cons (x, s))`

```
  ./test.branch.opt ran
    1.46 ± 0.02 times faster than ./test_from_val.branch.opt
    1.47 ± 0.02 times faster than ./test_from_val.530.opt
    2.67 ± 0.03 times faster than ./test.530.opt
```

The results suggest that `lazy (Cons (x, xs))` with this PR is 2.7x faster than without this PR, and 1.5x faster than `Lazy.from_val`.
