### PR TITLE
stdlib: Option.{for_all, exists}

### DIFF
--- a/Changes
+++ b/Changes
@@ -49,6 +49,10 @@ Working version
 - #14086: Add Domain.running_domain_count.
   (Nicolás Ojeda Bär, review by David Allsopp and Gabriel Scherer)
 
+- #13920: add Option.{for_all, exists}
+  (Gabriel Scherer, review by Kate Deplaix, Nicolás Ojeda Bär, Richard Eisenberg
+  and Jeremy Yallop)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -47,6 +47,14 @@ let compare cmp o0 o1 = match o0, o1 with
 | None, Some _ -> -1
 | Some _, None -> 1
 
+let for_all p = function
+  | None -> true
+  | Some v -> p v
+
+let exists p = function
+  | None -> false
+  | Some v -> p v
+
 let to_result ~none = function None -> Error none | Some v -> Ok v
 let to_list = function None -> [] | Some v -> [v]
 let to_seq = function None -> Seq.empty | Some v -> Seq.return v

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -66,6 +66,24 @@ val blend : ('a -> 'a -> 'a) -> 'a option -> 'a option -> 'a option
 
     @since 5.5 *)
 
+val for_all : ('a -> bool) -> 'a option -> bool
+(** [for_all p] behaves like {!List.for_all} [p]
+    on a list of zero or one element:
+    - [for_all p None] is [true],
+    - [for_all p (Some v)] is [p v].
+
+    @since 5.5
+*)
+
+val exists : ('a -> bool) -> 'a option -> bool
+(** [exists p] behaves like {!List.exists} [p]
+    on a list of zero or one element:
+    - [exists p None] is [false],
+    - [exists p (Some v)] is [p v].
+
+    @since 5.5
+*)
+
 (** {1:preds Predicates and comparisons} *)
 
 val is_none : 'a option -> bool


### PR DESCRIPTION
I needed `Option.for_all` in the following code which is part of #13919:

```ocaml
    let rec is_open_constant e = match e.exp_desc with
    | Texp_ident _ | Texp_constant _ | Texp_function _ | Texp_lazy _ -> true
    | Texp_variant (_, args) ->
      Option.for_all is_open_constant args
    | Texp_construct (_, _, args) | Texp_array (_, args) ->
      List.for_all is_open_constant args
    | [...]
```

All other ways to express this that I can think of (the shorter would be `Option.fold ~none:true ~some:is_open_constant args`) are significantly less homogeneous with the rest of the code, so they make the code ugly.