### PR TITLE
Preserve `O_CLOEXEC` when converting `Unix.file_descr` to a CRT fd on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -275,6 +275,13 @@ Working version
   is used. Cap the timeout to $2^{32}$ milliseconds.
   (Antonin Décimo, review by Gabriel Scherer and Miod Vallat)
 
+- #13921: Set cloexec correctly on CRT file descriptors created by the Unix
+  library on Windows. The inheritance on the underlying Win32 handles was
+  correctly set, but the book-keeping for the CRT was leaking the value of
+  non-inherited handles which combined with re-use of HANDLE values within
+  processes could appear to make a CRT file descriptor "re-open".
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
 ### Tools:
 
 - #12019: ocamlc: add `align_double` and `align_int64` to `ocamlc -config`

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -52,9 +52,11 @@ let string_of_fd fd = Int.to_string (fd_of_file_descr fd)
 let status_checker = "fdstatus.exe"
 
 let _ =
-  let f0 = Unix.(openfile "tmp.txt" [O_WRONLY; O_CREAT; O_TRUNC] 0o600) in
-  let f1 = Unix.(openfile "tmp.txt" [O_RDONLY; O_KEEPEXEC] 0) in
-  let f2 = Unix.(openfile "tmp.txt" [O_RDONLY; O_CLOEXEC] 0) in
+  let f0 =
+    Unix.(openfile "tmp.txt" [O_WRONLY; O_CREAT; O_TRUNC; O_SHARE_DELETE] 0o600)
+  in
+  let f1 = Unix.(openfile "tmp.txt" [O_RDONLY; O_KEEPEXEC; O_SHARE_DELETE] 0) in
+  let f2 = Unix.(openfile "tmp.txt" [O_RDONLY; O_CLOEXEC; O_SHARE_DELETE] 0) in
   let d0 = Unix.dup f0 in
   let d1 = Unix.dup ~cloexec:false f1 in
   let d2 = Unix.dup ~cloexec:true f2 in

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -78,6 +78,25 @@ let _ =
         the test step is not terminated until _all_ processes have completed, so
         we can use Unix.execv here, even on Windows. *)
   if Sys.argv.(1) = "execv" then
+    let () =
+      (* The Windows implementation of exec in the CRT uses CreateProcess and
+         then calls _exit to terminate itself. There is a race, which can be
+         seen on slower machines, where the test begins running before this
+         call has happened, and which results in tmp.txt still being locked when
+         fdstatus_main.ml tries to delete it, leading to a "Permission denied"
+         exception. To prevent this, lock.txt is created and locked for writing
+         by this process. If the checker then sees that lock.txt exists, it
+         attempts to acquire a write lock on it, which will succeed only after
+         this process has completely exited and its lock has been automatically
+         released via process termination.
+         This dance is strictly done on native on Windows only, because execv
+         hanging on to open files in this way with a Unix kernel is a very
+         serious misimplementation of execv! *)
+      if Sys.win32 then
+        let lock =
+          Unix.(openfile "lock.txt" [O_WRONLY; O_CREAT;
+                                     O_TRUNC; O_CLOEXEC] 0o600) in
+        Unix.lockf lock Unix.F_LOCK 0 in
     Unix.execv
       (Filename.concat Filename.current_dir_name status_checker)
       (Array.append [| status_checker; Sys.argv.(1) |] string_fds)

--- a/testsuite/tests/lib-unix/common/fdstatus_main.ml
+++ b/testsuite/tests/lib-unix/common/fdstatus_main.ml
@@ -1,4 +1,5 @@
 external process_and_close_fd : int -> string -> unit = "caml_process_fd"
+external delete_on_close : string -> unit = "caml_win32_delete_on_close"
 
 let () =
   if Sys.win32 then
@@ -14,11 +15,21 @@ let () =
     wait_until "lock.txt"
 
 let () =
+  (* Windows virus scanning can easily get in the way here on slower VMs. When
+     the file is closed, systems such as Windows Defender may trigger and open
+     the file, preventing its deletion. There are various mitigations - the
+     typical one is to use a retry-loop for a couple of seconds, but given that
+     this really is a temporary file and we already have a C stub for the fd
+     checking, we use a slightly different approach and instead open the file
+     using FILE_FLAG_DELETE_ON_CLOSE and let Windows take care of removing the
+     file - after Windows Defender at al have "finished" with it *)
+  if Sys.argv.(1) = "execv" && Sys.win32 then
+    delete_on_close "tmp.txt";
   for i = 2 to (Array.length Sys.argv) -1
   do
     process_and_close_fd (i - 1) Sys.argv.(i);
   done;
   (* For the execv version of the test, clean-up tmp.txt - for the
      Unix.create_process version, this is done by cloexec.ml *)
-  if Sys.argv.(1) = "execv" then
+  if Sys.argv.(1) = "execv" && not Sys.win32 then
     Sys.remove "tmp.txt"

--- a/testsuite/tests/lib-unix/common/fdstatus_main.ml
+++ b/testsuite/tests/lib-unix/common/fdstatus_main.ml
@@ -1,6 +1,19 @@
 external process_and_close_fd : int -> string -> unit = "caml_process_fd"
 
 let () =
+  if Sys.win32 then
+    (* Ensure the ancestor process has definitely terminated (and therefore
+       closed its handles to tmp.txt) *)
+    let wait_until file =
+      if Sys.file_exists file then
+        let fd = Unix.openfile file [O_RDWR] 0o600 in
+        Unix.lockf fd Unix.F_LOCK 0;
+        Unix.close fd;
+        Sys.remove file
+    in
+    wait_until "lock.txt"
+
+let () =
   for i = 2 to (Array.length Sys.argv) -1
   do
     process_and_close_fd (i - 1) Sys.argv.(i);


### PR DESCRIPTION
Follow-on from #13879, which has been sporadically failing in Jenkins.

There are two kinds of failure which have been showing up:
1. The test fails because of a `Sys_error` exception reporting `"tmp.txt: Permission denied"`
2. The test fails because an fd which was expected to be closed appears to be open

I've investigated this further (in large part, because one of the bug-fixes in Relocatable OCaml made both these issues much more reproducible than they were before) and have determined:
1. Is caused by Windows Defender (or other file system filters). The issue is that the VM is under considerable load during a testsuite run. The various open handles to `tmp.txt` are closed by L6 in:
https://github.com/ocaml/ocaml/blob/76ec239015fde345d3444b0094dce66cc20c271b/testsuite/tests/lib-unix/common/fdstatus_main.ml#L3-L11
but by the time we reach the `Sys.remove` on L11, Windows Defender has opened the file ready for "scanning", but not actually done it. As a result, the `Sys.remove` fails.
2. Amusingly, despite having switched to using CRT fds and `Unix.execv` in #13879, we still end up seeing the same issue that caused the test to be disabled previously because of some missing code in `caml_win32_CRT_fd_of_filedescr`. The various mechanisms tested in `cloexec.ml` all correctly use `SetHandleInformation` or `SECURITY_ATTRIBUTES`, but when `caml_win32_CRT_fd_of_filedescr` converts them to CRT fds, we don't pass the `O_NOINHERIT` flag for close-on-exec handles. As a result _all_ of the handles will be passed to the exec'd process - but the ones which are meant to be close-on-exec will just be invalid. However, what we are then sporadically seeing is that the Win32 handle value has been reused, so the CRT fd _appears_ to be open (but it's in fact a different handle). This is what was being seen before when we were passing the Win32 handle values directly 🤦

Finally, while debugging this, I noted and have worked around an additional quirk of the way the `exec` family are implemented on Windows. Again, on an overloaded system, it's just possible that the exec'd program runs for quite some time, or even to completion, before the process which actually exec'd it (let's call it the "ancestor" rather than "parent", as it's not supposed to exist) has reached the `_exit(0)` call in the CRT. In this race condition, the handles may still be open when the `Sys.remove` is reached. That's obviously not a situation which can happen on a POSIX system, where the ancestor still running while the exec'd image is running is a major misimplementation!

This PR is therefore three commits:
1. On Windows only, `cloexec.ml` creates a file `lock.txt` (with `O_CLOEXEC`) and locks the entire file for reading and writing. Again, on Windows only, `fdstatus_main.ml` opens this `lock.txt` and also attempts to lock the file for reading and writing. This will only succeed once the "ancestor" has completely terminated - in other words, `fdstatus_main.ml` is then able to block until `cloexec.ml` has _definitely_ terminated.
2. The second commit then deals with Windows Defender, et al. by opening `tmp.txt` with `FILE_SHARE_DELETE` and then adding an additional C stub which is used _at the start_ of `fdstatus_main.ml` to open `tmp.txt` with `FILE_FLAG_DELETE_ON_CLOSE`. The Windows handle from this is then intentionally leaked - the point is that the handle will be automatically closed by Windows when the process exits and when Windows Defender has finally scanned it, the kernel will dutifully delete the file for us. Enough processes get held open in the process group while this happens that ocamltest waits around as normal for the test to conclude. This is a well-known problem on Windows, but this a less-common solution to it. The more common approach is to spin for up to a few seconds, retrying the deletion every 100ms or so. The solution I propose here is technically neater - the file is temporary, and we're using an (old and) actual Windows technology for dealing with the removal of temporary files, but also the value of the timeout we'd need for the spin is hard to determine - in one run on precheck, the delay is 10 seconds...!
3. The final commit uses `GetHandleInformation` to determine if the Win32 handle has been marked as inheritable. If it is _not_, then we pass `O_NOINHERIT` to `_open_osf_handle`, which causes the CRT fd book-keeping to be corrected.

Note that while the fix to `caml_win32_CRT_fd_of_filedescr` is a bug-fix, it is not as critical a bug-fix as it might look on first glance. Handles marked as close-on-exec were _not_ being passed to any exec'd processes - the issue is that the Win32 handle _values_ were being passed in fds, but the descriptors fail on first use. This combined slightly unfortunately in the cloexec.ml test with the fact that Windows uses HANDLE values for multiple things and meant that the fdstatus_main.ml might re-use the value of a HANDLE with the result that an fd _appeared_ open - but it would not be a handle to the same thing as in cloexec.ml (i.e. the bug is book-keeping/correctness and not security). That said, Jenkins is relatively frequently suffering from this, so it'd be good to fix the test (again)...