### PR TITLE
Include camlatomic.h in platform.h

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "mlvalues.h"
 #include "sys.h"
+#include "camlatomic.h"
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif


### PR DESCRIPTION
It seems like platform.h is using `atomic_load_acquire`, but it's not including `camlatomic.h`. This leads to compilation errors when building `core_unix` from opam on arm64.

e.g.
```
# /home/stefan/.opam/5.3.0+options/lib/ocaml/caml/platform.h: In function ‘caml_plat_latch_set’:
# /home/stefan/.opam/5.3.0+options/lib/ocaml/caml/platform.h:230:3: error: implicit declaration of function ‘atomic_store_release’; did you mean ‘atomic_store_explicit’? [-Wimplicit-function-declaration]
#   230 |   atomic_store_release(&latch->value, Latch_unreleased);
# 
```