### PR TITLE
Disallow deep destructive constraints in aliases

### DIFF
--- a/Changes
+++ b/Changes
@@ -659,6 +659,10 @@ OCaml 5.4.0
 - #13818: better delimited hints in error message
   (Florian Angeletti, review by Gabriel Scherer)
 
+* #13911: Added an `Lost alias` error message for deep destructive substitutions
+  inside alias signatures
+  (Clement Blaudeau, review by ??)
+
 ### Internal/compiler-libs changes:
 
 - #13539, #13776: Use nanosleep instead of usleep or select, if available.

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -617,3 +617,41 @@ Lines 4-8, characters 18-26:
 Error: In this "with" constraint, replacing "X0" by "F(X)" would
        introduce an invalid alias at "X1"
 |}]
+
+(** Aliases and substitutions **)
+
+(* Non destructive type and module type substitutions inside an alias should
+   preserve the alias signature. By contrast, destructive type and module type
+   substitutions force inlining and lose the alias information (could be fixed
+   with transparent ascription) *)
+
+type base = A | B
+module X = struct
+  type t = base = A | B
+  module type T = sig end
+end
+
+module type S = sig module Y = X end
+module type S1  = S with type Y.t = base
+module type S2  = S with module type Y.T = sig end
+[%%expect {|
+type base = A | B
+module X : sig type t = base = A | B module type T = sig end end
+module type S = sig module Y = X end
+module type S1 = sig module Y = X end
+module type S2 = sig module Y = X end
+|}]
+
+(* Losing the alias makes the subtyping fail *)
+module type Test_destructive_type = S with type Y.t := base
+[%%expect {|
+module type Test_destructive_type =
+  sig module Y : sig module type T = X.T end end
+|}]
+
+(* Losing the alias makes the subtyping fail *)
+module type Test_destructive_modtype = S with module type Y.T := sig end
+[%%expect {|
+module type Test_destructive_modtype =
+  sig module Y : sig type t = base = A | B end end
+|}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -645,13 +645,19 @@ module type S2 = sig module Y = X end
 (* Losing the alias makes the subtyping fail *)
 module type Test_destructive_type = S with type Y.t := base
 [%%expect {|
-module type Test_destructive_type =
-  sig module Y : sig module type T = X.T end end
+Line 1, characters 36-59:
+1 | module type Test_destructive_type = S with type Y.t := base
+                                        ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This deep destructive "with" substitution inside of "Y" would
+       lose the aliasing to "X" .
 |}]
 
 (* Losing the alias makes the subtyping fail *)
 module type Test_destructive_modtype = S with module type Y.T := sig end
 [%%expect {|
-module type Test_destructive_modtype =
-  sig module Y : sig type t = base = A | B end end
+Line 1, characters 39-72:
+1 | module type Test_destructive_modtype = S with module type Y.T := sig end
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This deep destructive "with" substitution inside of "Y" would
+       lose the aliasing to "X" .
 |}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -58,6 +58,7 @@ type error =
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
   | With_creates_invalid_aliases of Ident.t * Path.t * Path.t
+  | With_lost_alias of Ident.t * Path.t
   | With_cannot_remove_constrained_type
   | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string
@@ -610,6 +611,10 @@ module Merge = struct
                  but do not change the resulting signature *)
               return_payload ~ghosts
                 ~replace_by:(Some current_item) path ~late_typedtree
+          | Mty_alias lost_alias, true ->
+              (* Destructive deep substitutions inside aliases are disallowed,
+                 as they would lose the alias signature *)
+              raise (Error(loc, initial_env, With_lost_alias (id, lost_alias)))
           | _, _ ->
               let new_md = {md with md_type = Mty_signature newsg} in
               let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
@@ -3494,6 +3499,14 @@ let report_error ~loc _env = function
         Style.inline_code (Path.name path)
         Style.inline_code (Path.name invalid_path)
         Style.inline_code (Ident.name id)
+  | With_lost_alias(mod_id, lost_alias_path) ->
+      Location.errorf ~loc
+        "@[<v>\
+           @[This deep destructive %a substitution inside of %a would @ \
+             lose the aliasing to %a @].@]"
+        Style.inline_code "with"
+        (Style.as_inline_code ident) mod_id
+        Style.inline_code (Path.name lost_alias_path)
   | With_cannot_remove_constrained_type ->
       Location.errorf ~loc
         "@[<v>Destructive substitutions are not supported for constrained @ \

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -114,6 +114,7 @@ type error =
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
   | With_creates_invalid_aliases of Ident.t * Path.t * Path.t
+  | With_lost_alias of Ident.t * Path.t
   | With_cannot_remove_constrained_type
   | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string


### PR DESCRIPTION
This PR proposes to add a new form of error when doing deep destructive substitutions inside submodules that have aliases signatures. For example 
```ocaml
module X = sig type t = int val x : t end 
module type T = sig module Y = X end with type Y.t := int
```
Throws a new error `With_lost_alias` : 
 ```
 Error: This deep destructive "with" substitution inside of "Y" would
       loose the aliasing to "X" .
```

The motivation behind this choice is that, currently, the aliasing information is silently lost, the typechecker returns :
```
module type T = sig module Y : sig end
```

Another option might be to authorize the loss of the alias but emit a warning.