### PR TITLE
Add `List.singleton` and `Seq.singleton`

### DIFF
--- a/Changes
+++ b/Changes
@@ -246,6 +246,9 @@ Working version
 - #13859: Fix Weak.get_copy not darkening custom blocks
   (Josh Berdine, review by Stephen Dolan)
 
+- #13932: Add List.singleton and Seq.singleton
+  (David Allsopp, tariffs applied by Nicolás Ojeda Bär and Gabriel Scherer)
+
 ### Other libraries:
 
 * #13376: Allow Dynlink.loadfile_private to load bytecode libraries with

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -26,6 +26,8 @@ let length l = length_aux 0 l
 
 let cons a l = a::l
 
+let singleton a = [a]
+
 let hd = function
     [] -> failwith "hd"
   | a::_ -> a

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -68,6 +68,11 @@ val cons : 'a -> 'a list -> 'a list
     @since 4.03 (4.05 in ListLabels)
  *)
 
+val singleton: 'a -> 'a list
+(** [singleton x] returns the one-element list [[x]].
+
+    @since 5.4 *)
+
 val hd : 'a list -> 'a
 (** Return the first element of the given list.
    @raise Failure if the list is empty.

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -68,6 +68,11 @@ val cons : 'a -> 'a list -> 'a list
     @since 4.03 (4.05 in ListLabels)
  *)
 
+val singleton: 'a -> 'a list
+(** [singleton x] returns the one-element list [[x]].
+
+    @since 5.4 *)
+
 val hd : 'a list -> 'a
 (** Return the first element of the given list.
    @raise Failure if the list is empty.

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -27,6 +27,8 @@ let return x () = Cons (x, empty)
 
 let cons x next () = Cons (x, next)
 
+let singleton x () = Cons (x, empty)
+
 let rec append seq1 seq2 () =
   match seq1() with
   | Nil -> seq2()

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -362,6 +362,11 @@ val cons : 'a -> 'a t -> 'a t
 
     @since 4.11 *)
 
+val singleton: 'a -> 'a t
+(** [singleton x] returns the one-element sequence containing only [x].
+
+    @since 5.4 *)
+
 val init : int -> (int -> 'a) -> 'a t
 (** [init n f] is the sequence [f 0; f 1; ...; f (n-1)].
 

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,9 +1,9 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
 Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", lines 84-90, characters 4-47
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), lines 352-361, characters 6-13
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 34, characters 8-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-362, characters 4-7
@@ -12,10 +12,10 @@ Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, character
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 87-89, characters 10-43
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
 Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", lines 84-90, characters 4-47
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), lines 352-361, characters 6-13
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 34, characters 8-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-362, characters 4-7

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,17 +1,17 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 87-89, characters 10-43
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -6,7 +6,7 @@ Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 167, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 169-171, characters 6-39
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
 Called from Test10_main in file "test10_main.ml", lines 51-53, characters 13-7

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,9 +1,9 @@
 Error: Failure("Plugin error")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 87-89, characters 10-43
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -159,7 +159,7 @@
                 (apply f (field_imm 0 param) (field_imm 1 param)))
             map =
               (function f l
-                (apply (field_imm 19 (global Stdlib__List!))
+                (apply (field_imm 20 (global Stdlib__List!))
                   (apply uncurry f) l)))
            (makeblock 0
              (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
@@ -198,7 +198,7 @@
                     (apply f (field_imm 0 param) (field_imm 1 param)))
                 map =
                   (function f l
-                    (apply (field_imm 19 (global Stdlib__List!))
+                    (apply (field_imm 20 (global Stdlib__List!))
                       (apply uncurry f) l)))
                (makeblock 0
                  (makeblock 0 (apply map eta_gen_cmp vec)


### PR DESCRIPTION
A profound, and hopefully tariff-free, addition to the Standard Library to mark the end of the UK tax year.

I occasionally reach for `Set.S.singleton`, and have on other previous occasions missed `List.singleton` (in patterns like `|> List.map List.singleton`). Here it is, therefore - along with the very similar `Seq.singleton` (although I've never actually missed that one).

In addition to already having `Set.S.singleton`, we have the equivalent functions in other modules - `{Array,Bytes,String}.make 1` and `Option.some`, for example.