### PR TITLE
Fix ocamldoc `@since 5.0` Annotation Loss by Swapping Alert and Header in domain.mli and effect.mli

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -16,15 +16,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@alert unstable
-    "The Domain interface may change in incompatible ways in the future."
-]
-
 (** Domains.
 
     See 'Parallel programming' chapter in the manual.
 
     @since 5.0 *)
+
+[@@@alert unstable
+    "The Domain interface may change in incompatible ways in the future."
+]
 
 type !'a t
 (** A domain of type ['a t] runs independently, eventually producing a

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -12,15 +12,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@alert unstable
-    "The Effect interface may change in incompatible ways in the future."
-]
-
 (** Effects.
 
     See 'Language extensions/Effect handlers' section in the manual.
 
     @since 5.0 *)
+
+[@@@alert unstable
+    "The Effect interface may change in incompatible ways in the future."
+]
 
 type 'a t = 'a eff = ..
 (** The type of effects. *)


### PR DESCRIPTION
**Description:**
This pull request addresses the issue where the `@since 5.0` annotation is omitted in the generated documentation for `domain.mli` and `effect.mli`. By swapping the positions of the alert and the documentation header, the `@since 5.0` annotation is correctly displayed, while the alert remains visible.
This solution is suggested by @Octachron.
**Original:**
<img width="785" alt="Screenshot 2025-04-05 at 1 16 30 PM" src="https://github.com/user-attachments/assets/b7842371-d13c-47cf-b999-0112f73bbf49" />
**Suggestion:**
<img width="935" alt="Screenshot 2025-04-05 at 1 13 31 PM" src="https://github.com/user-attachments/assets/0bd8bae4-217c-46fd-bc89-8a984e481541" />
**Local Test:**
<img width="639" alt="Screenshot 2025-04-05 at 1 12 57 PM" src="https://github.com/user-attachments/assets/790ebb98-cb45-419e-bba0-45f23c66519f" />

**Changes:**
In domain.mli and effect.mli, moved the `[@@@alert unstable ...]` block to appear after the documentation header that includes the `@since 5.0` annotation.

**Testing:**
Built the documentation locally using `dune build @doc` in a minimal Dune project and confirmed that the `@since 5.0` annotation now appears in the rendered HTML for the Domain module and the Effect module.

**Related Issue:**
Closes #13907

Author:
Hanliang Xu
hxu110@jh.edu
Johns Hopkins University