### PR TITLE
refactoring: merge Matching.get_mod_field and Lambda.transl_prim

### DIFF
--- a/.depend
+++ b/.depend
@@ -4434,7 +4434,6 @@ lambda/lambda.cmo : \
     typing/path.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
-    parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
@@ -4448,7 +4447,6 @@ lambda/lambda.cmx : \
     typing/path.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
-    parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -727,23 +727,9 @@ let transl_extension_path loc env path =
 let transl_class_path loc env path =
   transl_path Env.find_class_address loc env path
 
-let transl_prim mod_name name =
-  let pers = Ident.create_persistent mod_name in
-  let env = Env.add_persistent_structure pers Env.empty in
-  let lid =
-    Longident.Ldot (Location.mknoloc (Longident.Lident mod_name),
-                    Location.mknoloc name)
-  in
-  match Env.find_value_by_name lid env with
-  | path, _ -> transl_value_path Loc_unknown env path
-  | exception Not_found ->
-      fatal_error ("Primitive " ^ name ^ " not found.")
-
-let transl_mod_field modname field =
+let transl_prim modname field =
   let mod_ident = Ident.create_persistent modname in
-  let env =
-    Env.add_persistent_structure mod_ident Env.initial
-  in
+  let env = Env.add_persistent_structure mod_ident Env.initial in
   match Env.open_pers_signature modname env with
   | Error `Not_found ->
       fatal_errorf "Module %s unavailable." modname

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -739,6 +739,22 @@ let transl_prim mod_name name =
   | exception Not_found ->
       fatal_error ("Primitive " ^ name ^ " not found.")
 
+let transl_mod_field modname field =
+  lazy
+    (let mod_ident = Ident.create_persistent modname in
+     let env =
+       Env.add_persistent_structure mod_ident Env.initial
+     in
+     match Env.open_pers_signature modname env with
+     | Error `Not_found ->
+         fatal_errorf "Module %s unavailable." modname
+     | Ok env -> (
+         match Env.find_value_by_name (Longident.Lident field) env with
+         | exception Not_found ->
+             fatal_errorf "Primitive %s.%s not found." modname field
+         | path, _ -> transl_value_path Loc_unknown env path
+       ))
+
 (* Compile a sequence of expressions *)
 
 let rec make_sequence fn = function

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -740,20 +740,19 @@ let transl_prim mod_name name =
       fatal_error ("Primitive " ^ name ^ " not found.")
 
 let transl_mod_field modname field =
-  lazy
-    (let mod_ident = Ident.create_persistent modname in
-     let env =
-       Env.add_persistent_structure mod_ident Env.initial
-     in
-     match Env.open_pers_signature modname env with
-     | Error `Not_found ->
-         fatal_errorf "Module %s unavailable." modname
-     | Ok env -> (
-         match Env.find_value_by_name (Longident.Lident field) env with
-         | exception Not_found ->
-             fatal_errorf "Primitive %s.%s not found." modname field
-         | path, _ -> transl_value_path Loc_unknown env path
-       ))
+  let mod_ident = Ident.create_persistent modname in
+  let env =
+    Env.add_persistent_structure mod_ident Env.initial
+  in
+  match Env.open_pers_signature modname env with
+  | Error `Not_found ->
+      fatal_errorf "Module %s unavailable." modname
+  | Ok env -> (
+      match Env.find_value_by_name (Longident.Lident field) env with
+      | exception Not_found ->
+          fatal_errorf "Primitive %s.%s not found." modname field
+      | path, _ -> transl_value_path Loc_unknown env path
+    )
 
 (* Compile a sequence of expressions *)
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -428,12 +428,9 @@ val transl_prim: string -> string -> lambda
 (** Translate a value from a persistent module. For instance:
 
     {[
-      transl_internal_value "CamlinternalLazy" "force"
+      transl_prim "CamlinternalLazy" "force"
     ]}
 *)
-
-val transl_mod_field: string -> string -> lambda
-(** Similar to {!transl_prim}, to be removed by refactoring. *)
 
 val is_evaluated : lambda -> bool
 (** [is_evaluated lam] returns [true] if [lam] is either a constant, a variable

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -432,7 +432,7 @@ val transl_prim: string -> string -> lambda
     ]}
 *)
 
-val transl_mod_field: string -> string -> lambda Lazy.t
+val transl_mod_field: string -> string -> lambda
 (** Similar to {!transl_prim}, to be removed by refactoring. *)
 
 val is_evaluated : lambda -> bool

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -432,6 +432,9 @@ val transl_prim: string -> string -> lambda
     ]}
 *)
 
+val transl_mod_field: string -> string -> lambda Lazy.t
+(** Similar to {!transl_prim}, to be removed by refactoring. *)
+
 val is_evaluated : lambda -> bool
 (** [is_evaluated lam] returns [true] if [lam] is either a constant, a variable
     or a function abstract. *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2142,9 +2142,11 @@ let get_pat_args_lazy p rem =
 
 let prim_obj_tag = Primitive.simple ~name:"caml_obj_tag" ~arity:1 ~alloc:false
 
-let code_force_lazy_block = lazy (transl_mod_field "CamlinternalLazy" "force_lazy_block")
+let code_force_lazy_block =
+  lazy (transl_prim "CamlinternalLazy" "force_lazy_block")
 
-let code_force_lazy = lazy (transl_mod_field "CamlinternalLazy" "force_gen")
+let code_force_lazy =
+  lazy (transl_prim "CamlinternalLazy" "force_gen")
 
 (* inline_lazy_force inlines the beginning of the code of Lazy.force. When
    the value argument is tagged as:

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2142,25 +2142,9 @@ let get_pat_args_lazy p rem =
 
 let prim_obj_tag = Primitive.simple ~name:"caml_obj_tag" ~arity:1 ~alloc:false
 
-let get_mod_field modname field =
-  lazy
-    (let mod_ident = Ident.create_persistent modname in
-     let env =
-       Env.add_persistent_structure mod_ident Env.initial
-     in
-     match Env.open_pers_signature modname env with
-     | Error `Not_found ->
-         fatal_errorf "Module %s unavailable." modname
-     | Ok env -> (
-         match Env.find_value_by_name (Longident.Lident field) env with
-         | exception Not_found ->
-             fatal_errorf "Primitive %s.%s not found." modname field
-         | path, _ -> transl_value_path Loc_unknown env path
-       ))
+let code_force_lazy_block = transl_mod_field "CamlinternalLazy" "force_lazy_block"
 
-let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
-
-let code_force_lazy = get_mod_field "CamlinternalLazy" "force_gen"
+let code_force_lazy = transl_mod_field "CamlinternalLazy" "force_gen"
 
 (* inline_lazy_force inlines the beginning of the code of Lazy.force. When
    the value argument is tagged as:

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2142,9 +2142,9 @@ let get_pat_args_lazy p rem =
 
 let prim_obj_tag = Primitive.simple ~name:"caml_obj_tag" ~arity:1 ~alloc:false
 
-let code_force_lazy_block = transl_mod_field "CamlinternalLazy" "force_lazy_block"
+let code_force_lazy_block = lazy (transl_mod_field "CamlinternalLazy" "force_lazy_block")
 
-let code_force_lazy = transl_mod_field "CamlinternalLazy" "force_gen"
+let code_force_lazy = lazy (transl_mod_field "CamlinternalLazy" "force_gen")
 
 (* inline_lazy_force inlines the beginning of the code of Lazy.force. When
    the value argument is tagged as:


### PR DESCRIPTION
There were two functions in the compiler codebase doing essentially the same thing, which is to produce code to access `camlinternalFoo.bar` functions: `Matching.get_mod_field` and `Lambda.transl_prim`. This PR merges them; I kept the implementation of `Matching.get_mod_field` which is slightly better, and the interface of `Lambda.transl_prim` which is public.

I was tempted to also rename `Lambda.transl_prim` to `Lambda.transl_internal_value` as a stray comment suggests, and maybe add `mod:string -> name:string -> lambda` labels, but I decided to stop here to maximize compatibility. (I didn't find any usage of this via compiler-libs on github or sherlocode, though.)