### PR TITLE
Add `Option.value_or`

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,6 +150,9 @@ Working version
 
 ### Standard library:
 
+- #13937: Add Option.value_or
+ (T. Kinsart, review by ???)
+
 - #13720: Add Result.{get_ok',error_to_failure}
  (Daniel Bünzli, review by wikku, Gabriel Scherer, Nicolás Ojeda Bär,
   Vincent Laviron and hirrolot)

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -18,6 +18,7 @@ type 'a t = 'a option = None | Some of 'a
 let none = None
 let some v = Some v
 let value o ~default = match o with Some v -> v | None -> default
+let value_or o ~f = match o with Some v -> v | None -> f ()
 let get = function Some v -> v | None -> invalid_arg "option is None"
 let bind o f = match o with None -> None | Some v -> f v
 let join = function Some o -> o | None -> None

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -33,6 +33,11 @@ val some : 'a -> 'a option
 val value : 'a option -> default:'a -> 'a
 (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
 
+val value_or : 'a option -> f:(unit -> 'a) -> 'a
+(** [value_or o ~f] is [v] if [o] is [Some v] and [f ()] otherwise.
+
+    @since 5.4 *)
+
 val get : 'a option -> 'a
 (** [get o] is [v] if [o] is [Some v] and raise otherwise.
 

--- a/testsuite/tests/lib-option/test.ml
+++ b/testsuite/tests/lib-option/test.ml
@@ -15,6 +15,11 @@ let test_value () =
   assert (Option.value (Some 3) ~default:5 = 3);
   ()
 
+let test_value_or () =
+  assert (Option.value_or None ~f:(fun () -> 5) = 5);
+  assert (Option.value_or (Some 3) ~f:(fun () -> failwith "bomb") = 3);
+  ()
+
 let test_get () =
   assert_raise_invalid_argument Option.get None;
   assert (Option.get (Some 2) = 2);


### PR DESCRIPTION
Frequently I need to write code like [this one]:

[this one]: https://gist.github.com/hirrolot/35e3c40e49e01cfb11d67b6bcc67b23e#file-supercomp-ml-L31-L33

```ocaml
match my_option with
| Some value -> value
| None -> (* do something... *)
```

This PR adds a function `Option.value_or o ~f` that returns `value` if `o` is `Some value` _or_ calls `f ()`.

## On naming

We already have (eager) `Option.value o ~default`. Therefore, it makes sense to have something that starts with the `value` prefix rather than inventing new terminology. Since (1) the semantics of the function `Option.value_or` is naturally described with English _or_ and (2) the `~f` parameter clearly indicates that this is a function, I believe that `value_or` is an appropriate name.
