### PR TITLE
Value_rec_compiler: prevent duplication of values

### DIFF
--- a/.depend
+++ b/.depend
@@ -4874,7 +4874,6 @@ lambda/value_rec_compiler.cmo : \
     typing/value_rec_types.cmi \
     typing/primitive.cmi \
     utils/misc.cmi \
-    utils/lazy_backtrack.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
     lambda/debuginfo.cmi \
@@ -4884,7 +4883,6 @@ lambda/value_rec_compiler.cmx : \
     typing/value_rec_types.cmi \
     typing/primitive.cmx \
     utils/misc.cmx \
-    utils/lazy_backtrack.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
     lambda/debuginfo.cmx \

--- a/Changes
+++ b/Changes
@@ -104,6 +104,10 @@ Working version
   is a break hint at the end.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13938: Tweak compilation of recursive values to preserve unicity of
+  mutable structures
+  (Vincent Laviron, review by Gabriel Scherer)
+
 OCaml 5.4.0
 ---------------
 

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -102,15 +102,85 @@ type size =
       but also some more complex expressions where the block is bound to
       an intermediate variable before being returned.
   *)
-
-type binding_size = (lambda_with_env, size) Lazy_backtrack.t
-and lambda_with_env = {
-  lambda : lambda;
-  env : binding_size Ident.Map.t;
-}
+  | Variable of { id : Ident.t }
+  (** Unknown size, but looking up the definition of the variable could
+      give us the actual size. *)
 
 let dynamic_size () =
   Misc.fatal_error "letrec: No size found for Static binding"
+
+let no_loc = Debuginfo.Scoped_location.Loc_unknown
+
+(** Allocation and backpatching code *)
+
+let compile_alloc size =
+  let alloc prim size =
+    Lprim (Pccall prim,
+           [Lconst (Lambda.const_int size)],
+           no_loc)
+  in
+  (* if you add new allocation primitives below,
+     you should update {!find_size_of_alloc_prim} as well. *)
+  match size with
+  | Regular_block size ->
+      alloc alloc_prim size
+  | Float_record size ->
+      alloc alloc_float_record_prim size
+  | Lazy_block ->
+      Lprim(Pccall alloc_lazy_prim,
+            [Lambda.lambda_unit],
+            no_loc)
+
+let compile_lazy_indirect newval =
+  let indirect = Lambda.transl_prim "CamlinternalLazy" "indirect" in
+  Lapply {
+    ap_func = indirect;
+    ap_args = [newval];
+    ap_loc = no_loc;
+    ap_tailcall = Default_tailcall;
+    ap_inlined = Default_inline;
+    ap_specialised = Default_specialise;
+  }
+
+let compile_update size dummy newval =
+  let prim, newval =
+    match size with
+    | Regular_block _ | Float_record _ ->
+      update_prim, newval
+    | Lazy_block ->
+      (* Consider the following example from Vincent Laviron:
+         {[let rec v =
+             let l = lazy (expensive computation) in
+             let () = maybe_force_in_another_domain l in
+             l
+         ]}
+
+         The naive/simple compilation scheme would do
+         a [caml_update_dummy_lazy(v, l)], and the dummy-update code
+         could run concurrently with another domain forcing [l].
+
+         To avoid this issue, lazy blocks get updated via
+         [caml_update_dummy_lazy(dummy, CamlinternalLazy.indirect newval)],
+         where [CamlinternalLazy.indirect] returns a fresh/local thunk
+         that is not getting forced concurrently (whereas [newval]
+         might be).
+      *)
+      update_lazy_prim,
+      begin match newval with
+        | Lprim(Pmakelazyblock _, _, _) ->
+          (* No need to wrap the thunk if was just constructed.
+             This removes indirections on terms defined as lazy thunks
+             at the toplevel: [let rec x = lazy ...] *)
+          newval
+        | _ -> compile_lazy_indirect newval
+      end
+  in
+  Lprim (Pccall prim, [dummy; newval],
+         no_loc)
+
+let add_update_dummy id size lam =
+  let update = compile_update size (Lvar id) lam in
+  Lsequence (update, Lvar id)
 
 (* [join_sizes] is used to compute the size of an expression with multiple
    branches. Such expressions are normally classified as [Dynamic] by
@@ -159,80 +229,152 @@ let find_size_of_alloc_prim prim args =
     Some Lazy_block
   else None
 
-let compute_static_size lam =
-  let rec compute_expression_size env lam =
+let compute_static_size bound_id lam =
+  let rec compute_expression_size lam =
     match lam with
-    | Lvar v ->
-      begin match Ident.Map.find_opt v env with
-      | None ->
-        dynamic_size ()
-      | Some binding_size ->
-        Lazy_backtrack.force
-          (fun { lambda; env } -> compute_expression_size env lambda)
-          binding_size
-      end
+    | Lvar id -> lam, Variable { id }
     | Lmutvar _ -> dynamic_size ()
-    | Lconst _ -> Constant
+    | Lconst _ -> lam, Constant
     | Lapply _ -> dynamic_size ()
-    | Lfunction _ -> Function
-    | Llet (_, _, id, def, body) ->
-      let env =
-        Ident.Map.add id (Lazy_backtrack.create { lambda = def; env }) env
-      in
-      compute_expression_size env body
-    | Lmutlet(_, _, _, body) ->
-      compute_expression_size env body
+    | Lfunction _ -> lam, Function
+    | Llet (kind, vk, id, def, body) ->
+      let body, size = compute_expression_size body in
+      begin match size with
+      | Variable { id = id' } when Ident.same id id' ->
+        let new_def, size = compute_expression_size def in
+        Llet(kind, vk, id, new_def, body), size
+      | _ ->
+        Llet(kind, vk, id, def, body), size
+      end
+    | Lmutlet(vk, id, def, body) ->
+      let body, size = compute_expression_size body in
+      Lmutlet(vk, id, def, body), size
     | Lletrec (bindings, body) ->
-      let env =
-        List.fold_left (fun env_acc { id; def = _ } ->
-            Ident.Map.add id (Lazy_backtrack.create_forced Function) env_acc)
-          env bindings
-      in
-      compute_expression_size env body
+      let body, size = compute_expression_size body in
+      begin match size with
+      | Variable { id = id' }
+        when List.exists (fun { id; _ } -> Ident.same id id') bindings ->
+        Lletrec (bindings, body), Function
+      | _ ->
+        Lletrec (bindings, body), size
+      end
     | Lprim (p, args, _) ->
-      size_of_primitive env p args
-    | Lswitch (_, sw, _) ->
+      begin match size_of_primitive p args with
+      | (Constant | Function | Unreachable) as size ->
+        lam, size
+      | Block block_size as size ->
+        add_update_dummy bound_id block_size lam, size
+      | Variable { id = _ } ->
+        (* This case cannot be handled well.
+           Currently it can only happen if the primitive is [Pduparray],
+           and the argument is something that ends with a variable.
+           This is never generated directly by Translcore, and the
+           rewritings done during this pass should also guarantee
+           that we do not end up in this case. *)
+        dynamic_size ()
+      end
+    | Lswitch (arg, sw, loc) ->
       let fail_case =
         match sw.sw_failaction with
         | None -> []
         | Some fail -> [0 (* ignored *), fail]
       in
-      compute_and_join_sizes_switch env [sw.sw_consts; sw.sw_blocks; fail_case]
-    | Lstringswitch (_, cases, fail, _) ->
+      let all_cases = [sw.sw_consts; sw.sw_blocks; fail_case] in
+      begin match compute_and_join_sizes_switch all_cases with
+      | [sw_consts; sw_blocks; maybe_fail], size ->
+        let sw_failaction =
+          match maybe_fail with
+          | [] -> None
+          | [ _, fail ] -> Some fail
+          | _ ->
+            Misc.fatal_error
+              "Unexpected result from compute_and_join_sizes_switch"
+        in
+        Lswitch (arg, { sw with sw_consts; sw_blocks; sw_failaction }, loc),
+        size
+      | _ ->
+          Misc.fatal_error
+            "Unexpected result from compute_and_join_sizes_switch"
+      end
+    | Lstringswitch (arg, cases, fail, loc) ->
       let fail_case =
         match fail with
         | None -> []
         | Some fail -> ["" (* ignored *), fail]
       in
-      compute_and_join_sizes_switch env [cases; fail_case]
-    | Lstaticraise _ -> Unreachable
-    | Lstaticcatch (body, _, handler)
-    | Ltrywith (body, _, handler) ->
-      compute_and_join_sizes env [body; handler]
-    | Lifthenelse (_cond, ifso, ifnot) ->
-      compute_and_join_sizes env [ifso; ifnot]
-    | Lsequence (_, e) ->
-      compute_expression_size env e
+      let all_cases = [cases; fail_case] in
+      begin match compute_and_join_sizes_switch all_cases with
+      | [cases; maybe_fail], size ->
+        let fail =
+          match maybe_fail with
+          | [] -> None
+          | [ _, fail ] -> Some fail
+          | _ ->
+            Misc.fatal_error
+              "Unexpected result from compute_and_join_sizes_switch"
+        in
+        Lstringswitch (arg, cases, fail, loc), size
+      | _ ->
+          Misc.fatal_error
+            "Unexpected result from compute_and_join_sizes_switch"
+      end
+    | Lstaticraise _ -> lam, Unreachable
+    | Lstaticcatch (body, params, handler) ->
+      (* Note: we don't follow aliases through handler parameters *)
+      begin match compute_and_join_sizes [body; handler] with
+      | [body; handler], size ->
+        Lstaticcatch (body, params, handler), size
+      | ([] | [_] | _::_::_::_), _ ->
+          Misc.fatal_error
+            "Unexpected result from compute_and_join_sizes"
+      end
+    | Ltrywith (body, id, handler) ->
+      begin match compute_and_join_sizes [body; handler] with
+      | [body; handler], size ->
+        Ltrywith (body, id, handler), size
+      | ([] | [_] | _::_::_::_), _ ->
+          Misc.fatal_error
+            "Unexpected result from compute_and_join_sizes"
+      end
+    | Lifthenelse (cond, ifso, ifnot) ->
+      begin match compute_and_join_sizes [ifso; ifnot] with
+      | [ifso; ifnot], size ->
+        Lifthenelse (cond, ifso, ifnot), size
+      | ([] | [_] | _::_::_::_), _ ->
+          Misc.fatal_error
+            "Unexpected result from compute_and_join_sizes"
+      end
+    | Lsequence (e1, e2) ->
+      let e2, size = compute_expression_size e2 in
+      Lsequence (e1, e2), size
     | Lwhile _
     | Lfor _
-    | Lassign _ -> Constant
+    | Lassign _ -> lam, Constant
     | Lsend _ -> dynamic_size ()
-    | Levent (e, _) ->
-      compute_expression_size env e
-    | Lifused _ -> Constant
-  and compute_and_join_sizes env branches =
-    List.fold_left (fun size branch ->
-        join_sizes size (compute_expression_size env branch))
-      Unreachable branches
+    | Levent (e, ev) ->
+      let e, size = compute_expression_size e in
+      Levent (e, ev), size
+    | Lifused _ -> lam, Constant
+  and compute_and_join_sizes branches =
+    List.fold_right (fun branch (branches, size) ->
+        let branch, size_branch = compute_expression_size branch in
+        let size = join_sizes size size_branch in
+        branch :: branches, size)
+      branches ([], Unreachable)
   and compute_and_join_sizes_switch :
-    type a. binding_size Ident.Map.t -> (a * lambda) list list -> size =
-    fun env all_cases ->
-      List.fold_left (fun size cases ->
-          List.fold_left (fun size (_key, action) ->
-              join_sizes size (compute_expression_size env action))
-            size cases)
-        Unreachable all_cases
-  and size_of_primitive env p args =
+    type a. (a * lambda) list list -> (a * lambda) list list * size =
+    fun all_cases ->
+      List.fold_right (fun cases (all_cases, size) ->
+          let cases, size =
+            List.fold_right (fun (key, action) (cases, size) ->
+                let action, size_action = compute_expression_size action in
+                let size = join_sizes size size_action in
+                (key, action) :: cases, size)
+              cases ([], size)
+          in
+          cases :: all_cases, size)
+        all_cases ([], Unreachable)
+  and size_of_primitive p args =
     match p with
     | Pignore
     | Psetfield _
@@ -286,7 +428,11 @@ let compute_static_size lam =
         (* The size has to be recovered from the size of the argument *)
         begin match args with
         | [arg] ->
-            compute_expression_size env arg
+            (* Note: We're ignoring the rewritten expression, because in this
+               case we want to push the rewriting outwards, around the
+               [Pduparray] primitive. *)
+            let _, size = compute_expression_size arg in
+            size
         | [] | _ :: _ :: _ ->
             Misc.fatal_error "size_of_primitive"
         end
@@ -369,7 +515,12 @@ let compute_static_size lam =
     | Pdls_get ->
         dynamic_size ()
   in
-  compute_expression_size Ident.Map.empty lam
+  match compute_expression_size lam with
+  | _, (Constant | Function | Unreachable | Variable _ as size) ->
+    (* See comment in the Lprim case: we drop the rewritten term because
+       it may contain calls to [caml_update_dummy] added preventively *)
+    lam, size
+  | (_rewritten, Block _) as result -> result
 
 let lfunction_with_body { kind; params; return; body = _; attr; loc } body =
   lfunction' ~kind ~params ~return ~body ~attr ~loc
@@ -450,7 +601,10 @@ let ( let+ ) res f =
    would cause errors later.) *)
 let lifted_block_mut : Asttypes.mutable_flag = Immutable
 
-let no_loc = Debuginfo.Scoped_location.Loc_unknown
+let build_closure_block block_var args =
+  let lam = Lprim (Pmakeblock (0, lifted_block_mut, None), args, no_loc) in
+  let block_size = Regular_block (List.length args) in
+  add_update_dummy block_var block_size lam
 
 let rec split_static_function block_var local_idents lam :
   Lambda.lambda split_result =
@@ -482,8 +636,7 @@ let rec split_static_function block_var local_idents lam :
         ~loc:no_loc
     in
     let lifted = { lfun = wrapper; free_vars_block_size = 1 } in
-    Reachable (lifted,
-               Lprim (Pmakeblock (0, lifted_block_mut, None), [Lvar v], no_loc))
+    Reachable (lifted, build_closure_block block_var [Lvar v])
   | Lfunction lfun ->
     let free_vars = Lambda.free_variables lfun.body in
     let local_free_vars = Ident.Set.inter free_vars local_idents in
@@ -507,11 +660,7 @@ let rec split_static_function block_var local_idents lam :
         (Lambda.subst (fun _ _ env -> env) subst lfun.body)
     in
     let lifted = { lfun = new_fun; free_vars_block_size } in
-    let block =
-      Lprim (Pmakeblock (0, lifted_block_mut, None),
-             List.rev block_fields_rev,
-             no_loc)
-    in
+    let block = build_closure_block block_var (List.rev block_fields_rev) in
     Reachable (lifted, block)
   | Llet (lkind, vkind, var, def, body) ->
     let+ body =
@@ -745,73 +894,6 @@ let empty_bindings =
     dynamic = [];
   }
 
-(** Allocation and backpatching code *)
-
-let compile_indirect newval =
-  let indirect = Lambda.transl_prim "CamlinternalLazy" "indirect" in
-  Lapply {
-    ap_func = indirect;
-    ap_args = [newval];
-    ap_loc = no_loc;
-    ap_tailcall = Default_tailcall;
-    ap_inlined = Default_inline;
-    ap_specialised = Default_specialise;
-  }
-
-let compile_alloc size =
-  let alloc prim size =
-    Lprim (Pccall prim,
-           [Lconst (Lambda.const_int size)],
-           no_loc)
-  in
-  (* if you add new allocation primitives below,
-     you should update {!find_size_of_alloc_prim} as well. *)
-  match size with
-  | Regular_block size ->
-      alloc alloc_prim size
-  | Float_record size ->
-      alloc alloc_float_record_prim size
-  | Lazy_block ->
-      Lprim(Pccall alloc_lazy_prim,
-            [Lambda.lambda_unit],
-            no_loc)
-
-let compile_update size dummy newval =
-  let prim, newval =
-    match size with
-    | Regular_block _ | Float_record _ ->
-      update_prim, newval
-    | Lazy_block ->
-      (* Consider the following example from Vincent Laviron:
-         {[let rec v =
-             let l = lazy (expensive computation) in
-             let () = maybe_force_in_another_domain l in
-             l
-         ]}
-
-         The naive/simple compilation scheme would do
-         a [caml_update_dummy_lazy(v, l)], and the dummy-update code
-         could run concurrently with another domain forcing [l].
-
-         To avoid this issue, lazy blocks get updated via
-         [caml_update_dummy_lazy(dummy, CamlinternalLazy.indirect newval)],
-         where [CamlinternalLazy.indirect] returns a fresh/local thunk
-         that is not getting forced concurrently (whereas [newval]
-         might be).
-      *)
-      update_lazy_prim,
-      begin match newval with
-        | Lprim(Pmakelazyblock _, _, _) ->
-          (* No need to wrap the thunk if was just constructed.
-             This removes indirections on terms defined as lazy thunks
-             at the toplevel: [let rec x = lazy ...] *)
-          newval
-        | _ -> compile_indirect newval
-      end
-  in
-  Lprim (Pccall prim, [dummy; newval],
-         no_loc)
-
 (** Compilation function *)
 
 let compile_letrec input_bindings body =
@@ -826,7 +908,7 @@ let compile_letrec input_bindings body =
         | Dynamic ->
           { rev_bindings with dynamic = (id, def) :: rev_bindings.dynamic }
         | Static ->
-          let size = compute_static_size def in
+          let def, size = compute_static_size id def in
           begin match size with
           | Constant | Unreachable ->
             (* The result never escapes any recursive variables, so as we know
@@ -860,13 +942,18 @@ let compile_letrec input_bindings body =
                 { rev_bindings with functions; static }
               end
             end
+          | Variable { id = id' } ->
+            Misc.fatal_errorf "Definition of %a has a size that depends on %a"
+              Ident.print id Ident.print id'
           end)
       empty_bindings input_bindings
   in
   let body_with_patches =
-    List.fold_left (fun body (id, size, lam) ->
-        Lsequence (compile_update size (Lvar id) lam, body)
-    ) body (all_bindings_rev.static)
+    List.fold_left (fun body (_id, _size, def) ->
+        (* The definition contains a call to [caml_update_dummy] somewhere,
+           so we run it for its side effects and discard the result. *)
+        Lsequence (def, body))
+      body (all_bindings_rev.static)
   in
   let body_with_functions =
     match all_bindings_rev.functions with

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -66,7 +66,7 @@ val byte_name: description -> string
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 val equal_native_repr : native_repr -> native_repr -> bool
 
-(** [native_name_is_externa] returns [true] iff the [native_name] for the
+(** [native_name_is_external] returns [true] iff the [native_name] for the
     given primitive identifies that the primitive is not implemented in the
     compiler itself. *)
 val native_name_is_external : description -> bool


### PR DESCRIPTION
To avoid having two different values (the dummy allocation that gets updated later, and the actual allocation that eventually gets used to do the update), we move the call to `caml_update_dummy` to be immediately around the allocation primitive.
The now initialised value is then used in the rest of the definition where the allocation would have been.

Copying my example from #13933:
```ocaml
(* Before compilation *)
let rec v =
  let r = ref 0 in
  escape r;
  r

(* After compilation, old version *)
let v = alloc_dummy 1 in
caml_update_dummy v
  (let r = ref 0 in
   escape r;
   r)

(* After compilation, new version *)
let v = alloc_dummy 1 in
let r = (caml_update_dummy v (ref 0); v) in
escape r;
ignore r
```

Observing the difference:
```ocaml
let glob = ref None
let escape r = glob := Some r

let rec v =
  let r = ref 0 in
  escape r;
  r

let () =
  match !glob with
  | None -> assert false
  | Some r -> assert (v == r)
```

(The fix to `primitive.mli` is an unrelated typo that I noticed while working on that)