### PR TITLE
Fix test weak-ephe-final/ephe_custom.ml

### DIFF
--- a/testsuite/tests/weak-ephe-final/ephe_custom.ml
+++ b/testsuite/tests/weak-ephe-final/ephe_custom.ml
@@ -4,7 +4,7 @@ let w = Weak.create 1
 
 let major_obj () =
   let n = Sys.opaque_identity 42 in
-  let v = Int64.of_int n in
+  let v = Sys.opaque_identity (Int64.of_int n) in
   Gc.minor ();
   v
 


### PR DESCRIPTION
The test `weak-ephe-final/custom.ml` started failing a bit randomly since #13643 was merged.
After some investigations, it turns out that the function `major_obj` didn't always return an object allocated on the major heap: `v` was unboxed, so the actual allocation happened after the call to `Gc.minor`.
Adding a `Sys.opaque_identity` should prevent unboxing and make sure the allocation exists before the call to `Gc.minor`.
