### PR TITLE
Actually "generalized polymorphic #install_printer" in debugger

### DIFF
--- a/.depend
+++ b/.depend
@@ -8551,6 +8551,7 @@ debugger/loadprinter.cmo : \
     parsing/longident.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
+    toplevel/genprintval.cmi \
     utils/format_doc.cmi \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
@@ -8568,6 +8569,7 @@ debugger/loadprinter.cmx : \
     parsing/longident.cmx \
     utils/load_path.cmx \
     typing/ident.cmx \
+    toplevel/genprintval.cmx \
     utils/format_doc.cmx \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmx \
@@ -8694,6 +8696,7 @@ debugger/printval.cmi : \
     typing/types.cmi \
     typing/path.cmi \
     debugger/parser_aux.cmi \
+    toplevel/genprintval.cmi \
     typing/env.cmi \
     debugger/debugcom.cmi
 debugger/program_loading.cmo : \

--- a/Changes
+++ b/Changes
@@ -318,6 +318,10 @@ Working version
   tests that fail on mono-core systems.
   (Stéphane Glondu, review by Nicolás Ojeda Bär)
 
+- #13945, #13946, #13948: Actually "generalized polymorphic #install_printer"
+  in the debugger
+  (Pierre Boutillier)
+
 ### Manual and documentation:
 
 - #13694: Fix name for caml_hash_variant in the C interface.

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -117,8 +117,14 @@ let eval_value_path env path =
           let print_function ppf remote_val =
             print_with_fallback ppf (Obj.obj v ppf) remote_val in
           Printval.install_printer path ty_arg print_function
-      | Topprinters.Generic _ ->
-          raise (Error (`Wrong_type lid))
+      | Topprinters.Generic { ty_path ; arity } ->
+          let rec build v = function
+            | 0 -> Genprintval.Zero (fun ppf remote_val ->
+                print_with_fallback ppf (Obj.obj v ppf) remote_val)
+            | n ->
+                Genprintval.Succ
+                  (fun fn -> build ((Obj.obj v : _ -> Obj.t) fn) (n - 1)) in
+          Printval.install_generic_printer' path ty_path (build v arity)
 
 let remove_printer lid =
   match Topprinters.find_printer Env.empty lid with

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -72,6 +72,8 @@ module Printer = Genprintval.Make(Debugcom.Remote_value)(EvalPath)
 
 let install_printer = Printer.install_printer
 
+let install_generic_printer' = Printer.install_generic_printer'
+
 let remove_printer = Printer.remove_printer
 
 let max_printer_depth = ref 20

--- a/debugger/printval.mli
+++ b/debugger/printval.mli
@@ -30,5 +30,9 @@ val find_named_value : int -> Debugcom.Remote_value.t * Types.type_expr
 
 val install_printer :
   Path.t -> Types.type_expr ->
-    (formatter -> Debugcom.Remote_value.t -> unit) -> unit
+  (formatter -> Debugcom.Remote_value.t -> unit) -> unit
+val install_generic_printer' :
+  Path.t -> Path.t ->
+  (formatter -> Debugcom.Remote_value.t -> unit,
+   formatter -> Debugcom.Remote_value.t -> unit) Genprintval.gen_printer -> unit
 val remove_printer : Path.t -> unit

--- a/testsuite/tests/tool-debugger/printer/debuggee.ml
+++ b/testsuite/tests/tool-debugger/printer/debuggee.ml
@@ -11,10 +11,10 @@
 
 
 
-
 *)
 
 let f x =
+  let _d = Printer.[D (0, A); D (42, B)] in
   for _i = 0 to x do
     print_endline "..."
   done

--- a/testsuite/tests/tool-debugger/printer/debuggee.reference
+++ b/testsuite/tests/tool-debugger/printer/debuggee.reference
@@ -2,4 +2,5 @@ File printer.cmo loaded
 Loading program... done.
 Breakpoint: 1
 18   <|b|>for _i = 0 to x do
+_d: (int, Printer.t) Printer.v list = [D<0, Printer.A>; D<42, Printer.B>]
 x: int = S S O

--- a/testsuite/tests/tool-debugger/printer/input_script
+++ b/testsuite/tests/tool-debugger/printer/input_script
@@ -1,7 +1,9 @@
 load_printer printer.cmo
-install_printer Printer.p
-set print_depth 2
+install_printer Printer.print_generic
 break @ Debuggee 18
 run
+p _d
+install_printer Printer.p
+set print_depth 2
 print x
 quit

--- a/testsuite/tests/tool-debugger/printer/printer.ml
+++ b/testsuite/tests/tool-debugger/printer/printer.ml
@@ -1,3 +1,23 @@
+type t = A | B
+
+let print_t out t =
+  Format.fprintf out "%s"
+    (match t with
+     | A -> "~A"
+     | B -> "~B"
+    )
+
+(* A polymorphic type to test generic printers *)
+type ('a, 'b) v = D of 'a * 'b
+
+type 'a printer = Format.formatter -> 'a -> unit
+
+let print_generic (type a b) (pa : a printer) (pb : b printer) : (a, b) v printer =
+  fun ppf (D (a, b)) ->
+  Format.fprintf ppf "D<%a, %a>"
+    pa a
+    pb b
+
 let p : Format.formatter -> int -> unit = fun fmt n ->
   (* We use `max_printer_depth` to tweak the output so that
      this test shows that the printer not only compiles


### PR DESCRIPTION
DO NOT MERGE before #13948 ! (Well, that's pretty obvious as the test suite SEGFAULT as long as the underlying bug is not fixed but it is always better to make things explicit)

10 years later than claimed by the changelog of version 4.02, this changes makes the final bit (and add a test) to allow you to `#install_printer default_array_printer` (where `let default_array_printer = Format.pp_print_array ?pp_sep:None`) in **ocamldebug**

(useless for arrays as the debugger knows how to print them I know but you've got the idea :))
