### PR TITLE
Pre-requirements of #13945 (polymorphic #install_printers in debugger)

### DIFF
--- a/.depend
+++ b/.depend
@@ -7552,6 +7552,7 @@ toplevel/topprinters.cmo : \
     typing/path.cmi \
     typing/ident.cmi \
     typing/ctype.cmi \
+    typing/btype.cmi \
     parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmx : \
@@ -7560,10 +7561,13 @@ toplevel/topprinters.cmx : \
     typing/path.cmx \
     typing/ident.cmx \
     typing/ctype.cmx \
+    typing/btype.cmx \
     parsing/asttypes.cmx \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmi : \
-    typing/types.cmi
+    typing/types.cmi \
+    typing/path.cmi \
+    typing/env.cmi
 toplevel/topstart.cmo : \
     toplevel/topmain.cmi \
     toplevel/topstart.cmi

--- a/.depend
+++ b/.depend
@@ -7548,18 +7548,24 @@ toplevel/toploop.cmi : \
 toplevel/topmain.cmi :
 toplevel/topprinters.cmo : \
     typing/types.cmi \
+    typing/printtyp.cmi \
     typing/predef.cmi \
     typing/path.cmi \
+    parsing/longident.cmi \
     typing/ident.cmi \
+    typing/env.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmx : \
     typing/types.cmx \
+    typing/printtyp.cmx \
     typing/predef.cmx \
     typing/path.cmx \
+    parsing/longident.cmx \
     typing/ident.cmx \
+    typing/env.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmx \
@@ -7567,6 +7573,7 @@ toplevel/topprinters.cmx : \
 toplevel/topprinters.cmi : \
     typing/types.cmi \
     typing/path.cmi \
+    parsing/longident.cmi \
     typing/env.cmi
 toplevel/topstart.cmo : \
     toplevel/topmain.cmi \

--- a/.depend
+++ b/.depend
@@ -8542,7 +8542,6 @@ debugger/int64ops.cmx : \
 debugger/int64ops.cmi :
 debugger/loadprinter.cmo : \
     parsing/unit_info.cmi \
-    typing/types.cmi \
     toplevel/topprinters.cmi \
     bytecomp/symtable.cmi \
     debugger/printval.cmi \
@@ -8556,12 +8555,10 @@ debugger/loadprinter.cmo : \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
     debugger/debugcom.cmi \
-    typing/ctype.cmi \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi
 debugger/loadprinter.cmx : \
     parsing/unit_info.cmx \
-    typing/types.cmx \
     toplevel/topprinters.cmx \
     bytecomp/symtable.cmx \
     debugger/printval.cmx \
@@ -8575,10 +8572,10 @@ debugger/loadprinter.cmx : \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmx \
     debugger/debugcom.cmx \
-    typing/ctype.cmx \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi
 debugger/loadprinter.cmi : \
+    toplevel/topprinters.cmi \
     parsing/longident.cmi \
     otherlibs/dynlink/dynlink.cmi
 debugger/main.cmo : \

--- a/.depend
+++ b/.depend
@@ -8555,6 +8555,7 @@ debugger/loadprinter.cmo : \
     utils/format_doc.cmi \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
+    debugger/debugcom.cmi \
     typing/ctype.cmi \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi
@@ -8573,6 +8574,7 @@ debugger/loadprinter.cmx : \
     utils/format_doc.cmx \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmx \
+    debugger/debugcom.cmx \
     typing/ctype.cmx \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -1000,7 +1000,7 @@ let instr_load_printer ppf lexbuf =
 let instr_install_printer ppf lexbuf =
   let lid = longident_eol Lexer.lexeme lexbuf in
   try
-    Loadprinter.install_printer ppf lid
+    Loadprinter.install_printer lid
   with Loadprinter.Error e ->
     Loadprinter.report_error ppf e; raise Toplevel
 

--- a/debugger/loadprinter.mli
+++ b/debugger/loadprinter.mli
@@ -23,12 +23,11 @@ val remove_printer : Longident.t -> unit
 
 (* Error report *)
 
-type error =
-  | Load_failure of Dynlink.error
-  | Unbound_identifier of Longident.t
-  | Unavailable_module of string * Longident.t
-  | Wrong_type of Longident.t
-  | No_active_printer of Longident.t
+type error = [
+    Topprinters.error
+  | `Load_failure of Dynlink.error
+  | `Unavailable_module of string * Longident.t
+]
 
 exception Error of error
 

--- a/debugger/loadprinter.mli
+++ b/debugger/loadprinter.mli
@@ -18,7 +18,7 @@
 open Format
 
 val loadfile : formatter -> string -> unit
-val install_printer : formatter -> Longident.t -> unit
+val install_printer : Longident.t -> unit
 val remove_printer : Longident.t -> unit
 
 (* Error report *)

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -70,14 +70,7 @@ module EvalPath =
 
 module Printer = Genprintval.Make(Debugcom.Remote_value)(EvalPath)
 
-let install_printer path ty _ppf fn =
-  Printer.install_printer path ty
-    (fun ppf remote_val ->
-       try
-         fn ppf (Obj.repr (Debugcom.Remote_value.obj remote_val))
-       with
-         Debugcom.Marshalling_error ->
-           fprintf ppf "<cannot fetch remote object>")
+let install_printer = Printer.install_printer
 
 let remove_printer = Printer.remove_printer
 

--- a/debugger/printval.mli
+++ b/debugger/printval.mli
@@ -29,6 +29,6 @@ val reset_named_values : unit -> unit
 val find_named_value : int -> Debugcom.Remote_value.t * Types.type_expr
 
 val install_printer :
-  Path.t -> Types.type_expr -> formatter ->
-    (formatter -> Obj.t -> unit) -> unit
+  Path.t -> Types.type_expr ->
+    (formatter -> Debugcom.Remote_value.t -> unit) -> unit
 val remove_printer : Path.t -> unit

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -35,3 +35,99 @@ let printer_type_old alpha =
 
 let printer_type_new alpha =
   type_arrow (type_formatter ()) (type_arrow alpha type_unit)
+
+type kind =
+  | Old of Types.type_expr
+  (* 'a -> unit *)
+  | Simple of Types.type_expr
+  (* Format.formatter -> 'a -> unit *)
+  | Generic of { ty_path: Path.t; arity: int; }
+  (* (formatter -> 'a1 -> unit) ->
+     (formatter -> 'a2 -> unit) ->
+     ... ->
+     (formatter -> 'an -> unit) ->
+     formatter -> ('a1, 'a2, ..., 'an) t -> unit
+  *)
+
+let match_simple_printer_type env ty ~is_old_style =
+  let make_printer_type =
+    if is_old_style
+    then printer_type_old
+    else printer_type_new
+  in
+  match
+    Ctype.with_local_level_generalize begin fun () ->
+      let ty_arg = Ctype.newvar() in
+      Ctype.unify env
+        (make_printer_type ty_arg)
+        (Ctype.instance ty);
+      ty_arg
+    end
+  with
+  | exception Ctype.Unify _ -> None
+  | ty_arg ->
+      if is_old_style
+      then Some (Old ty_arg)
+      else Some (Simple ty_arg)
+
+let filter_arrow env ty =
+  let ty = Ctype.expand_head env ty in
+  match Types.get_desc ty with
+  | Tarrow (lbl, l, r, _) when not (Btype.is_optional lbl) -> Some (l, r)
+  | _ -> None
+
+let extract_last_arrow env ty =
+  let rec extract last ty =
+    match filter_arrow env ty with
+    | None -> last
+    | Some ((_, rest) as next) -> extract (Some next) rest
+  in extract None ty
+
+let extract_target_type env ty =
+  Option.map fst (extract_last_arrow env ty)
+
+let extract_target_parameters env ty =
+  match extract_target_type env ty with
+  | None -> None
+  | Some tgt ->
+      let tgt = Ctype.expand_head env tgt in
+      match Types.get_desc tgt with
+      | Tconstr (path, (_ :: _ as args), _)
+        when Ctype.all_distinct_vars env args ->
+          Some (path, args)
+      | _ -> None
+
+let match_generic_printer_type env ty =
+  match extract_target_parameters env ty with
+  | None -> None
+  | Some (ty_path, params) ->
+      match
+        Ctype.with_local_level_generalize begin fun () ->
+          let args = List.map (fun _ -> Ctype.newvar ()) params in
+          let ty_target =
+            Ctype.newty (Tconstr (ty_path, args, ref Types.Mnil)) in
+          let printer_args_ty =
+            List.map (fun ty_var -> printer_type_new ty_var) args in
+          let ty_expected =
+            List.fold_right type_arrow
+              printer_args_ty (printer_type_new ty_target) in
+          Ctype.unify env
+            ty_expected
+            (Ctype.instance ty);
+          args
+        end
+      with
+      | exception Ctype.Unify _ -> None
+      | args ->
+          if Ctype.all_distinct_vars env args
+          then
+            Some (Generic { ty_path; arity = List.length params; })
+          else None
+
+let match_printer_type env ty =
+  match match_simple_printer_type env ty ~is_old_style:false with
+  | Some _ as res -> res
+  | None ->
+  match match_simple_printer_type env ty ~is_old_style:true with
+  | Some _ as res -> res
+  | None -> match_generic_printer_type env ty

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -15,8 +15,6 @@
 
 (* Infrastructure to support user-defined printers in toplevels and debugger *)
 
-type printer_type = Types.type_expr -> Types.type_expr
-
 let type_arrow ta tb =
   Ctype.newty (Tarrow (Asttypes.Nolabel, ta, tb, Types.commu_var ()))
 

--- a/toplevel/topprinters.mli
+++ b/toplevel/topprinters.mli
@@ -35,5 +35,12 @@ type kind =
      formatter -> ('a1, 'a2, ..., 'an) t -> unit
   *)
 
-val match_printer_type :
-  Env.t -> Types.type_expr -> kind option
+type error = [
+  | `Unbound_identifier of Longident.t
+  | `Wrong_type of Longident.t
+  | `No_active_printer of Path.t
+]
+
+val find_printer : Env.t -> Longident.t -> (Path.t * kind, error) result
+
+val report_error : Format.formatter -> error -> unit

--- a/toplevel/topprinters.mli
+++ b/toplevel/topprinters.mli
@@ -21,3 +21,19 @@ val type_arrow : Types.type_expr -> Types.type_expr -> Types.type_expr
 
 val printer_type_new : printer_type
 val printer_type_old : printer_type
+
+type kind =
+  | Old of Types.type_expr
+  (* 'a -> unit *)
+  | Simple of Types.type_expr
+  (* Format.formatter -> 'a -> unit *)
+  | Generic of { ty_path: Path.t; arity: int; }
+  (* (formatter -> 'a1 -> unit) ->
+     (formatter -> 'a2 -> unit) ->
+     ... ->
+     (formatter -> 'an -> unit) ->
+     formatter -> ('a1, 'a2, ..., 'an) t -> unit
+  *)
+
+val match_printer_type :
+  Env.t -> Types.type_expr -> kind option

--- a/toplevel/topprinters.mli
+++ b/toplevel/topprinters.mli
@@ -15,13 +15,6 @@
 
 (* Infrastructure to support user-defined printers in toplevels and debugger *)
 
-type printer_type = Types.type_expr -> Types.type_expr
-
-val type_arrow : Types.type_expr -> Types.type_expr -> Types.type_expr
-
-val printer_type_new : printer_type
-val printer_type_old : printer_type
-
 type kind =
   | Old of Types.type_expr
   (* 'a -> unit *)


### PR DESCRIPTION
This PR implements preliminary refactorings that are part of #13945. They should be the "easy" part of that change, so that #13945 can be restricted to just the harder parts and reviewed more easily.

The end goal is to add support for polymorphic printers in the debugger, it is currently available only in the toplevel.

The changes included in the present PR are as follows:
- moving the GADT that describes printer types, and the utility code to manipulate it, from toplevel/topdirs to toplevel/topprinters ; this is useful because the printing code in the debugger depends on the definitions in topprinter.ml .
- simplify/clarify the interface of debugger/printval by moving some of its wrapper logic in debugger/loadprinter