### PR TITLE
Fix Genprintval.Generic printers (for the toplevel and debugger)

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -53,7 +53,7 @@ module type S =
     type t
     val install_printer :
           Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
-    val install_generic_printer' :
+    val install_generic_printer :
            Path.t -> Path.t ->
            (formatter -> t -> unit,
             formatter -> t -> unit) gen_printer ->
@@ -171,7 +171,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       let printer obj = Oval_printer (fun ppf -> print_val ppf obj) in
       printers := (path, Simple (ty, printer)) :: !printers
 
-    let install_generic_printer' function_path ty_path fn =
+    let install_generic_printer function_path ty_path fn =
       let rec build gp depth =
         match gp with
         | Zero fn ->

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -46,7 +46,7 @@ module type EVALPATH =
 
 type 't gen_printer =
   | Zero : (formatter -> 't -> unit) -> 't gen_printer
-  | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
+  | Succ : ((formatter -> 'a -> unit) -> 't gen_printer) -> 't gen_printer
 
 module type S =
   sig
@@ -70,7 +70,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
     type internal_gen_printer =
       | IZero : (t -> Outcometree.out_value) -> internal_gen_printer
       | ISucc :
-          ((int -> t -> Outcometree.out_value) -> internal_gen_printer) ->
+          ((int -> 'a -> Outcometree.out_value) -> internal_gen_printer) ->
           internal_gen_printer
 
     module ObjTbl = Hashtbl.Make(struct

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -688,7 +688,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       | (Zero fn, []) ->
           (fun (obj : O.t)-> try fn obj with exn -> out_exn path exn)
       | (Succ fn, arg :: args) ->
-          let printer = fn (fun depth obj -> tree_of_val depth obj arg) in
+          let printer =
+            fn (fun depth obj -> tree_of_val depth (O.repr obj) arg) in
           apply_generic_printer path printer args
       | _ ->
           (fun _obj ->

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -53,11 +53,6 @@ module type S =
     type t
     val install_printer :
           Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
-    val install_generic_printer :
-           Path.t -> Path.t ->
-           (int -> (int -> t -> Outcometree.out_value,
-                    t -> Outcometree.out_value) gen_printer) ->
-           unit
     val install_generic_printer' :
            Path.t -> Path.t ->
            (formatter -> t -> unit,
@@ -175,9 +170,6 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       let print_val ppf obj = user_printer path fn ppf obj in
       let printer obj = Oval_printer (fun ppf -> print_val ppf obj) in
       printers := (path, Simple (ty, printer)) :: !printers
-
-    let install_generic_printer function_path constr_path fn =
-      printers := (function_path, Generic (constr_path, fn))  :: !printers
 
     let install_generic_printer' function_path ty_path fn =
       let rec build gp depth =

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -44,9 +44,9 @@ module type EVALPATH =
     val same_value: valu -> valu -> bool
   end
 
-type ('a, 'b) gen_printer =
-  | Zero of 'b
-  | Succ of ('a -> ('a, 'b) gen_printer)
+type 't gen_printer =
+  | Zero : (formatter -> 't -> unit) -> 't gen_printer
+  | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
 
 module type S =
   sig
@@ -54,10 +54,7 @@ module type S =
     val install_printer :
           Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
     val install_generic_printer :
-           Path.t -> Path.t ->
-           (formatter -> t -> unit,
-            formatter -> t -> unit) gen_printer ->
-           unit
+           Path.t -> Path.t -> t gen_printer -> unit
     val remove_printer : Path.t -> unit
     val outval_of_untyped_exception : t -> Outcometree.out_value
     val outval_of_value :
@@ -69,6 +66,12 @@ module type S =
 module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
     type t = O.t
+
+    type internal_gen_printer =
+      | IZero : (t -> Outcometree.out_value) -> internal_gen_printer
+      | ISucc :
+          ((int -> t -> Outcometree.out_value) -> internal_gen_printer) ->
+          internal_gen_printer
 
     module ObjTbl = Hashtbl.Make(struct
         type t = O.t
@@ -126,8 +129,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
     type printer =
       | Simple of Types.type_expr * (O.t -> Outcometree.out_value)
-      | Generic of Path.t * (int -> (int -> O.t -> Outcometree.out_value,
-                                     O.t -> Outcometree.out_value) gen_printer)
+      | Generic of Path.t * (int -> internal_gen_printer)
 
     let printers = ref ([
       ( Pident(Ident.create_local "print_int"),
@@ -178,13 +180,13 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             let out_printer obj =
               let printer ppf = user_printer function_path fn ppf obj in
               Oval_printer printer in
-            Zero out_printer
+            IZero out_printer
         | Succ fn ->
             let print_val fn_arg =
               let print_arg ppf o =
                 !Oprint.out_value ppf (fn_arg (depth+1) o) in
               build (fn print_arg) depth in
-            Succ print_val in
+            ISucc print_val in
       printers := (function_path, Generic (ty_path, build fn)) :: !printers
 
     let remove_printer path =
@@ -677,9 +679,9 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
     and apply_generic_printer path printer args =
       match (printer, args) with
-      | (Zero fn, []) ->
+      | (IZero fn, []) ->
           (fun (obj : O.t)-> try fn obj with exn -> out_exn path exn)
-      | (Succ fn, arg :: args) ->
+      | (ISucc fn, arg :: args) ->
           let printer =
             fn (fun depth obj -> tree_of_val depth (O.repr obj) arg) in
           apply_generic_printer path printer args

--- a/toplevel/genprintval.mli
+++ b/toplevel/genprintval.mli
@@ -48,12 +48,12 @@ module type S =
     type t
     val install_printer :
           Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
-    val install_generic_printer' :
+    val install_generic_printer :
            Path.t -> Path.t ->
            (formatter -> t -> unit,
             formatter -> t -> unit) gen_printer ->
            unit
-    (** [install_generic_printer' function_path constructor_path printer]
+    (** [install_generic_printer function_path constructor_path printer]
         function_path is used to remove the printer. *)
 
     val remove_printer : Path.t -> unit

--- a/toplevel/genprintval.mli
+++ b/toplevel/genprintval.mli
@@ -48,11 +48,6 @@ module type S =
     type t
     val install_printer :
           Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
-    val install_generic_printer :
-          Path.t -> Path.t ->
-          (int -> (int -> t -> Outcometree.out_value,
-                   t -> Outcometree.out_value) gen_printer) ->
-          unit
     val install_generic_printer' :
            Path.t -> Path.t ->
            (formatter -> t -> unit,

--- a/toplevel/genprintval.mli
+++ b/toplevel/genprintval.mli
@@ -39,9 +39,9 @@ module type EVALPATH =
     val same_value: valu -> valu -> bool
   end
 
-type ('a, 'b) gen_printer =
-  | Zero of 'b
-  | Succ of ('a -> ('a, 'b) gen_printer)
+type 't gen_printer =
+  | Zero : (formatter -> 't -> unit) -> 't gen_printer
+  | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
 
 module type S =
   sig
@@ -49,10 +49,7 @@ module type S =
     val install_printer :
           Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
     val install_generic_printer :
-           Path.t -> Path.t ->
-           (formatter -> t -> unit,
-            formatter -> t -> unit) gen_printer ->
-           unit
+           Path.t -> Path.t -> t gen_printer -> unit
     (** [install_generic_printer function_path constructor_path printer]
         function_path is used to remove the printer. *)
 

--- a/toplevel/genprintval.mli
+++ b/toplevel/genprintval.mli
@@ -41,7 +41,7 @@ module type EVALPATH =
 
 type 't gen_printer =
   | Zero : (formatter -> 't -> unit) -> 't gen_printer
-  | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
+  | Succ : ((formatter -> 'a -> unit) -> 't gen_printer) -> 't gen_printer
 
 module type S =
   sig

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -157,7 +157,7 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
 
   type 't gen_printer = 't Genprintval.gen_printer =
     | Zero : (formatter -> 't -> unit) -> 't gen_printer
-    | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
+    | Succ : ((formatter -> 'a -> unit) -> 't gen_printer) -> 't gen_printer
 
   let install_printer = Printer.install_printer
   let install_generic_printer = Printer.install_generic_printer

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -160,7 +160,6 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
     | Succ of ('a -> ('a, 'b) gen_printer)
 
   let install_printer = Printer.install_printer
-  let install_generic_printer = Printer.install_generic_printer
   let install_generic_printer' = Printer.install_generic_printer'
   let remove_printer = Printer.remove_printer
 

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -160,7 +160,7 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
     | Succ of ('a -> ('a, 'b) gen_printer)
 
   let install_printer = Printer.install_printer
-  let install_generic_printer' = Printer.install_generic_printer'
+  let install_generic_printer = Printer.install_generic_printer
   let remove_printer = Printer.remove_printer
 
 end

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -155,9 +155,9 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
           print_string b;
           backtrace := None
 
-  type ('a, 'b) gen_printer = ('a, 'b) Genprintval.gen_printer =
-    | Zero of 'b
-    | Succ of ('a -> ('a, 'b) gen_printer)
+  type 't gen_printer = 't Genprintval.gen_printer =
+    | Zero : (formatter -> 't -> unit) -> 't gen_printer
+    | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
 
   let install_printer = Printer.install_printer
   let install_generic_printer = Printer.install_generic_printer

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -121,10 +121,6 @@ module MakeEvalPrinter (_ : EVAL_BASE) : sig
 
   val install_printer :
     Path.t -> Types.type_expr -> (formatter -> Printer.t -> unit) -> unit
-  val install_generic_printer :
-    Path.t -> Path.t ->
-    (int -> (int -> Printer.t -> Outcometree.out_value,
-            Printer.t-> Outcometree.out_value) gen_printer) -> unit
   val install_generic_printer' :
     Path.t -> Path.t -> (formatter -> Printer.t -> unit,
                          formatter -> Printer.t -> unit) gen_printer -> unit

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -117,7 +117,7 @@ module MakeEvalPrinter (_ : EVAL_BASE) : sig
 
   type 't gen_printer =
     | Zero : (formatter -> 't -> unit) -> 't gen_printer
-    | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
+    | Succ : ((formatter -> 'a -> unit) -> 't gen_printer) -> 't gen_printer
 
   val install_printer :
     Path.t -> Types.type_expr -> (formatter -> Printer.t -> unit) -> unit

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -121,7 +121,7 @@ module MakeEvalPrinter (_ : EVAL_BASE) : sig
 
   val install_printer :
     Path.t -> Types.type_expr -> (formatter -> Printer.t -> unit) -> unit
-  val install_generic_printer' :
+  val install_generic_printer :
     Path.t -> Path.t -> (formatter -> Printer.t -> unit,
                          formatter -> Printer.t -> unit) gen_printer -> unit
   val remove_printer : Path.t -> unit

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -115,15 +115,14 @@ module MakeEvalPrinter (_ : EVAL_BASE) : sig
   val outval_of_value:
     Env.t -> Printer.t -> Types.type_expr -> Outcometree.out_value
 
-  type ('a, 'b) gen_printer =
-    | Zero of 'b
-    | Succ of ('a -> ('a, 'b) gen_printer)
+  type 't gen_printer =
+    | Zero : (formatter -> 't -> unit) -> 't gen_printer
+    | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
 
   val install_printer :
     Path.t -> Types.type_expr -> (formatter -> Printer.t -> unit) -> unit
   val install_generic_printer :
-    Path.t -> Path.t -> (formatter -> Printer.t -> unit,
-                         formatter -> Printer.t -> unit) gen_printer -> unit
+    Path.t -> Path.t -> Printer.t gen_printer -> unit
   val remove_printer : Path.t -> unit
 
 end

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -201,7 +201,7 @@ let install_printer_by_kind path kind =
        | n ->
           Succ
             (fun fn -> build ((Obj.obj v : _ -> Obj.t) fn) (n - 1)) in
-     install_generic_printer' path ty_path (build v arity)
+     install_generic_printer path ty_path (build v arity)
 
 let remove_installed_printer path =
   match remove_printer path with

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -121,10 +121,6 @@ type ('a, 'b) gen_printer =
 
 val install_printer :
   Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
-val install_generic_printer :
-  Path.t -> Path.t ->
-  (int -> (int -> Obj.t -> Outcometree.out_value,
-           Obj.t -> Outcometree.out_value) gen_printer) -> unit
 val install_generic_printer' :
   Path.t -> Path.t -> (formatter -> Obj.t -> unit,
                        formatter -> Obj.t -> unit) gen_printer -> unit

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -115,15 +115,14 @@ val load_file: formatter -> string -> bool
 val print_value: Env.t -> Obj.t -> formatter -> Types.type_expr -> unit
 val print_untyped_exception: formatter -> Obj.t -> unit
 
-type ('a, 'b) gen_printer =
-  | Zero of 'b
-  | Succ of ('a -> ('a, 'b) gen_printer)
+type 't gen_printer =
+  | Zero : (formatter -> 't -> unit) -> 't gen_printer
+  | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
 
 val install_printer :
   Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
 val install_generic_printer :
-  Path.t -> Path.t -> (formatter -> Obj.t -> unit,
-                       formatter -> Obj.t -> unit) gen_printer -> unit
+  Path.t -> Path.t -> Obj.t gen_printer -> unit
 val remove_printer : Path.t -> unit
 
 val max_printer_depth: int ref

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -121,7 +121,7 @@ type ('a, 'b) gen_printer =
 
 val install_printer :
   Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
-val install_generic_printer' :
+val install_generic_printer :
   Path.t -> Path.t -> (formatter -> Obj.t -> unit,
                        formatter -> Obj.t -> unit) gen_printer -> unit
 val remove_printer : Path.t -> unit

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -117,7 +117,7 @@ val print_untyped_exception: formatter -> Obj.t -> unit
 
 type 't gen_printer =
   | Zero : (formatter -> 't -> unit) -> 't gen_printer
-  | Succ : ((formatter -> 't -> unit) -> 't gen_printer) -> 't gen_printer
+  | Succ : ((formatter -> 'a -> unit) -> 't gen_printer) -> 't gen_printer
 
 val install_printer :
   Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit


### PR DESCRIPTION
The actual fix (the thing that will make #13945 not SEGFAULT) is the first commit. The rest is "noise" to reflect in the types (my understanding of) what's going on.

This PR what @gasche qualified as the "weird" part of #13945; the one that requires experts of the debugger/toplevel internals (@damiendoligez ? maybe @chambart who is the author of the function).

As said in the commit message, we don't see anything in the toplevel because `O = Obj` so `O.repr = %identity` it is "fine" to omit it...
