### PR TITLE
Avoid tearing in Array.sub

### DIFF
--- a/Changes
+++ b/Changes
@@ -557,6 +557,10 @@ Working version
 - #13942: Fix assertion on empty array case
   (Olivier Nicole, review by Gabriel Scherer)
 
+- #13950: Avoid tearing in `Array.sub`
+  (Gabriel Scherer and Olivier Nicole, report by Jan Midtgaard, review by
+   Gabriel Scherer)
+
 - #13928, #13944: Fix handling of excessively nested unboxed types
   (Vincent Laviron, review by Gabriel Scherer)
 


### PR DESCRIPTION
A few weeks ago, @jmid discovered a type safety bug https://github.com/ocaml-multicore/multicoretests/issues/528 happening when using the Dynarray module in parallel.

It appears that the root cause is probably in `Array.sub`, which, in some cases, calls `memcpy`. Depending on what assembly instructions `memcpy` is compiled to (which can vary a great deal depending on the platform), the reads from `a` in `Array.sub a ofs len` are not necessarily word-per-word; which, if writes are made to `a` concurrently, can cause tearing and fill the new array with garbage values.

Closing in on the bug was possible thanks to helpful comments and testing work from @jmid, @gasche and @shym.

The bug was observed when using musl, presumably because `memcpy` compiles to different code in that case. But it’s hardly a musl-specific problem. As @shym noted, building OCaml with glibc but with `CFLAGS=-Os` results in `memcpy` copying data byte-per-byte.

## Fix details

- Instead of using `memcpy`, we need to enforce that the source array is read word-wise. To achieve this, I’m using relaxed atomic loads.
- ~~Maybe `memcpy` could be used if `caml_domain_alone ()` is true, as is done elsewhere, but I’m not entirely sure that it’s correct: without any synchronisation, it is in principle possible that a second domain is spawned and writes to the aray before the memcpy/memmove is finished. But I’m happy to be proven wrong.~~ I have been proven wrong, see below.