### PR TITLE
Document caml_domain_alone

### DIFF
--- a/Changes
+++ b/Changes
@@ -459,6 +459,9 @@ Working version
 - #13884 Correctly index modules in constructors and labels paths
   (Ulysse Gérard, review by Florian Angeletti)
 
+- #13952: check and document the correctness of `caml_domain_alone ()`.
+  (Gabriel Scherer, review by KC Sivaramakrishnan, report by Olivier Nicole)
+
 ### Build system:
 
 - #13431: Simplify github action responsible for flagging PRs with

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -92,6 +92,20 @@ CAMLextern uintnat caml_minor_heap_max_wsz;
 
 CAMLextern atomic_uintnat caml_num_domains_running;
 
+/* When [caml_domain_alone()] is true, there is a single domain
+   running. In particular, if the test passes while holding the domain
+   lock, then we know that no other domain is running concurrently,
+   and we can use fast paths with fewer synchronization operations.
+
+      // if you hold the domain lock:
+      if (caml_domain_alone()) {
+        // sequential fast path
+        ...
+      } else {
+        // slower concurrent version
+        ...
+      }
+*/
 Caml_inline intnat caml_domain_alone(void)
 {
   return atomic_load_acquire(&caml_num_domains_running) == 1;


### PR DESCRIPTION
While working on #13950, @OlivierNicole asked whether `caml_domain_alone ()` sequential fast paths are really correct.

```c
      if (caml_domain_alone()) {
        // sequential fast path
        ...
      } else {
        // slower concurrent version
        ...
      }
```

Olivier asked: what if a new domain somehow gets spawned during the sequential fast path?

After thinking more about this, I conclude that it is in fact not possible for a new domain to start during a `caml_domain_alone()` critical section. 

Intuitively this is guaranteed by the fact that if we hold the domain lock, and if we don't call `caml_domain_spawn` ourselves in the critical section, then no one else is around to call it either so no new domain can start.  But in practice the reasoning is a bit delicate.

### Commits

In the first commit, I document this assumption and try my best to explain why I believe that it currently holds, in trunk. There is a subtlety, which is that *some* domain initialization code runs after the new domain gets the domain lock, but before `caml_num_domains_running` is incremented (`caml_domain_alone()` is `caml_num_domains_running == 1`). This initialization code could contain sequential fast paths protected by `caml_domain_alone()` for sequential fast paths, but this *should* be okay because the only other domain running is the parent domain, and the parent domain is waiting on the child domain (and listening to the void for STW requests).

In the second commit, I remove the subtlety by making sure that a spawning domain increments `caml_num_domains_running` right after acquiring its own domain lock, so that the domain-initialization code never observes `caml_domain_alone ()`. This makes the reasoning about the correctness of `caml_domain_alone ()` much simpler.


cc @OlivierNicole and maybe @stedolan, @NickBarnes.