### PR TITLE
domain_create: release the domain lock on failure

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -778,6 +778,7 @@ init_shared_heap_failure:
 alloc_minor_tables_failure:
   caml_memprof_delete_domain(domain_state);
 init_memprof_failure:
+  caml_plat_unlock(&d->domain_lock);
   domain_self = NULL;
 
 


### PR DESCRIPTION
When a new domain is initializing, it starts by taking the domain lock. But if initialization fails later on, it does not release the domain lock. There will be a deadlock on the next attempt to create a domain, which will try to take the domain lock again.

I noticed this while working on #13952. I tested this situation by adding code to unconditionally fail during child domain initialization:

```diff
diff --git i/runtime/domain.c w/runtime/domain.c
index 7ec5675877d..a872402e77a 100644
--- i/runtime/domain.c
+++ w/runtime/domain.c
@@ -661,6 +661,14 @@ static void domain_create(uintnat initial_minor_heap_wsize,
     goto init_memprof_failure;
   }
 
+  /* Simulate a systematic failure of [caml_domain_spawn].
+     We don't do it when [parent == NULL], as this corresponds
+     to the [domain_create] call when initializing the main domain,
+     rather to a child domain spawned from a parent. */
+  if (parent) {
+    goto init_memprof_failure;
+  }
+
   CAMLassert(!interruptor_has_pending(s));
 
   domain_state->extra_heap_resources = 0.0;
```

With this failure-injecting change, and without the fix included in the present PR, I observe the following behavior (a deadlock): 

```
# Domain.spawn Stdlib.ignore;;
Exception: Failure "failed to allocate domain".
# Domain.spawn Stdlib.ignore;;
make: *** [Makefile:1019: runtop] Terminated
```

The second call to `Domain.spawn` deadlocked and I had to kill the process from the outside.

With the failure-injecting change and with the fix in the PR, I observe the following behavior (no deadlock):

```
# Domain.spawn ignore;;
Exception: Failure "failed to allocate domain".
# Domain.spawn ignore;;
Exception: Failure "failed to allocate domain".
```
