### PR TITLE
Pin Cygwin to 3.6.1 until AppVeyor updates

### DIFF
--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -141,7 +141,7 @@ set CYGWIN_INSTALL_PACKAGES=
 set CYGWIN_UPGRADE_REQUIRED=%FORCE_CYGWIN_UPGRADE%
 
 for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
-set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,cygwin=3.5.4-1
+set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,cygwin=3.6.1-1
 call :UpgradeCygwin
 
 "%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh install" || exit /b 1


### PR DESCRIPTION
The release of Cygwin 3.6.1 a couple of days has bumped 3.5.4 off the "old versions" list in Cygwin ... we're therefore ending up with the default 3.5.5 from the AppVeyor image, which is broken. cf #13718