### PR TITLE
Fix multicoretests workflow

### DIFF
--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml/dune
-          ref: 3.16.0
+          ref: 3.18.0
           path: dune
           persist-credentials: false
       - name: Build and install dune

--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -36,14 +36,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml-multicore/multicoretests
-          ref: 0.6
+          ref: 0.8
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck
         uses: actions/checkout@v4
         with:
           repository: c-cube/qcheck
-          ref: v0.23
+          ref: v0.25
           path: multicoretests/qcheck
           persist-credentials: false
       - name: Checkout dune


### PR DESCRIPTION
I spotted that the `run-multicoretests` workflow on #13950 was broken:
https://github.com/ocaml/ocaml/actions/runs/14387810550/job/40347443234?pr=13950
The issue is fixed in `dune.3.18.0` - and has to do with the vendored `notty` library: https://github.com/ocaml/dune/pull/11482

Besides bumping dune to 3.18.0 I'm using the opportunity to bump `qcheck` and `multicoretests` to their latest releases.
I've confirmed that this gets the workflows running again with this self PR: https://github.com/jmid/ocaml/pull/3

(no changes entry needed)