### PR TITLE
Fix ocamltest variable handling

### DIFF
--- a/Changes
+++ b/Changes
@@ -645,7 +645,7 @@ OCaml 5.4.0
   (Vincent Laviron, report by Jean-Marie Madiot, review by Gabriel Scherer)
 
 - #13941, #13961: Fix `ocamltest` variable handing.
-  (Damien Doligez, report by Olivier Nicole, review by ???)
+  (Damien Doligez, report by Olivier Nicole, review by Gabriel Scherer)
 
 - #13942: Fix assertion on empty array case
   (Olivier Nicole, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -644,6 +644,9 @@ OCaml 5.4.0
   the non-flambda native compiler
   (Vincent Laviron, report by Jean-Marie Madiot, review by Gabriel Scherer)
 
+- #13941, #13961: Fix `ocamltest` variable handing.
+  (Damien Doligez, report by Olivier Nicole, review by ???)
+
 - #13942: Fix assertion on empty array case
   (Olivier Nicole, review by Gabriel Scherer)
 

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -74,7 +74,7 @@ let get_registered_variables () =
   let f _variable_name variable variable_list = variable::variable_list in
   List.sort compare (Hashtbl.fold f variables [])
 
-let find_or_make name =
+let from_name name =
   match find_variable name with
   | Some var -> var
   | None -> make (name, "User variable")

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -73,3 +73,8 @@ let string_of_binding variable value =
 let get_registered_variables () =
   let f _variable_name variable variable_list = variable::variable_list in
   List.sort compare (Hashtbl.fold f variables [])
+
+let find_or_make name =
+  match find_variable name with
+  | Some var -> var
+  | None -> make (name, "User variable")

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -47,6 +47,6 @@ val string_of_binding : t -> value -> string
 
 val get_registered_variables : unit -> t list
 
-(** Returns the variable if it exists, otherwise creates it as a
+(** Returns the variable if it is registered, otherwise creates it as a
     "User variable". Does not register the variable. *)
-val find_or_make : string -> t
+val from_name : string -> t

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -46,3 +46,7 @@ val find_variable : string -> t option
 val string_of_binding : t -> value -> string
 
 val get_registered_variables : unit -> t list
+
+(** Returns the variable if it exists, otherwise creates it as a
+    "User variable". Does not register the variable. *)
+val find_or_make : string -> t


### PR DESCRIPTION
## How it works before this PR

Variables are handled with two data structures:
- a global hash table of know variables
- a map that stores the environment during script execution.

The map is persistent and handled as expected in a stack-like fashion following the tree structure of the test script. The global hash table, on the other hand, is a mutable data structure where variables are added but never removed.

A variable has two possible states in the global table: registered or unregistered.

In the environment, a variable has three possible states:
- string: defined to a string value
- null: defined to a null value
- absent: not found in the map.

The possible states of a variable are:
- registered/string   `r/str`
- registered/null     `r/nul`
- registered/absent   `r/abs`
- unregistered/absent `u/abs`
- unregistered/null   `u/nul`

There are 4 operations that a test script can do on a variable: `set`, `=`, `+=`, `unset`. They change a variale's state as follows (where * denotes an error).

`set`:
-  `r/str` -> *
-  `r/nul` -> *
-  `r/abs` -> *
-  `u/nul` -> `r/str`
-  `u/abs` -> `r/str`

=, +=:
-  `r/str` -> `r/str`
-  `r/nul` -> `r/str`
-  `r/abs` -> `r/str`
-  `u/abs` -> *
-  `u/nul` -> *

unset:
-  `r/str` -> `r/nul`
-  `r/nul` -> `r/nul`
-  `r/abs` -> `r/nul`
-  `u/abs` -> `u/nul`
-  `u/nul` -> `u/nul`


There are two kinds of variables: built-in variables and user variables. Built-in variables are preloaded in the global hash table, while user variables are inserted on demand by `set`. If a built-in variable is used while absent from the environment, it will get a default value, computed at the time of use.


The problem is that the state `r/abs` represents two things:
- Built-in variables that were not modified by the script. `set` cannot be used on these.
- User variables defined in some other branch of the script. `set` should be usable on these variables, but it isn't.

## The fix

If we stop registering user variables, we remove the problem of user variables that were registered in another branch of the script. We get `u/str` as a new possible state and the following transitions:

`set`:
  `r/str` -> *
  `r/nul` -> *
  `r/abs` -> *
  `u/abs` -> `u/str`
  `u/nul` -> *
  `u/str` -> *

`=`, `+=`:
  `r/str` -> `r/str`
  `r/nul` -> `r/str`
  `r/abs` -> `r/str`
  `u/abs` -> *
  `u/nul` -> `u/str`
  `u/str` -> `u/str`

`unset`:
  `r/str` -> `r/nul`
  `r/nul` -> `r/nul`
  `r/abs` -> `r/nul`
  `u/abs` -> `u/nul`
  `u/nul` -> `u/nul`
  `u/str` -> `u/nul`

Note: I removed the set: `u/nul` -> `u/set` transition that allowed the user to `set` a user variable that was already `unset`; it is quite clear from the code that it was a bug. The intent was that a variable should be initially `set` or `unset`, then modified with `=`, `+=`, or `unset`.

## Alternate design

A more proper fix would be to explicitly insert the built-in variables in the environment (as a 4th state, "default") and make the primitives act purely on the environment. This would be a more invasive fix, with a greater change of breakage.

##
fixes #13941
