### PR TITLE
Little ocamltest refactors

### DIFF
--- a/Changes
+++ b/Changes
@@ -326,6 +326,10 @@ Working version
   tests that fail on mono-core systems.
   (Stéphane Glondu, review by Nicolás Ojeda Bär)
 
+- #13962: Little ocamltest refactors. Fix error handling in C code,
+  leaking file descriptors, code style.
+  (Antonin Décimo, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #13694: Fix name for caml_hash_variant in the C interface.

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -157,6 +157,10 @@ static int run_command_child(const command_settings *settings)
   int outputFlags =
     O_CREAT | O_WRONLY | (settings->append ? O_APPEND : O_TRUNC);
   int inputMode = 0400, outputMode = 0666;
+#if defined(O_CLOEXEC)
+  inputFlags |= O_CLOEXEC;
+  outputFlags |= O_CLOEXEC;
+#endif
 
   if (setpgid(0, 0) == -1)
   {

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -294,7 +294,7 @@ static int run_command_parent(const command_settings *settings, pid_t child_pid)
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESETHAND;
     if (sigaction(SIGALRM, &action, NULL) == -1) myperror("sigaction");
-    if (alarm(settings->timeout) == -1) myperror("alarm");
+    alarm(settings->timeout);
   }
 
   while (waiting)

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -102,35 +102,21 @@ static void handle_alarm(int sig)
 static bool paths_same_file(
   const command_settings *settings, const char * path1, const char * path2)
 {
-  bool same_file = false;
-#ifdef __GLIBC__
-  char *realpath1, *realpath2;
-  realpath1 = realpath(path1, NULL);
-  if (realpath1 == NULL)
+  char *realpath1 = realpath(path1, NULL);
+  if (realpath1 == NULL) {
     realpath_error(path1);
-  realpath2 = realpath(path2, NULL);
-  if (realpath2 == NULL)
-  {
+    return false;
+  }
+  char *realpath2 = realpath(path2, NULL);
+  if (realpath2 == NULL) {
     free(realpath1);
-    if (errno == ENOENT) return false;
-    else realpath_error(path2);
+    if (errno != ENOENT)
+      realpath_error(path2);
+    return false;
   }
-#else
-  char realpath1[PATH_MAX], realpath2[PATH_MAX];
-  if (realpath(path1, realpath1) == NULL)
-    realpath_error(path1);
-  if (realpath(path2, realpath2) == NULL)
-  {
-    if (errno == ENOENT) return false;
-    else realpath_error(path2);
-  }
-#endif /* __GLIBC__ */
-  if (strcmp(realpath1, realpath2) == 0)
-    same_file = true;
-#ifdef __GLIBC__
+  bool same_file = (strcmp(realpath1, realpath2) == 0);
   free(realpath1);
   free(realpath2);
-#endif /* __GLIBC__ */
   return same_file;
 }
 

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <sys/types.h>
+#include <stdbool.h>
 
 #include "caml/memory.h"
 #include "caml/osdeps.h"
@@ -179,7 +180,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
   /* Copy process_env to env only if the given names are not in localenv */
   while (*p != L'\0') {
     wchar_t *pos_eq = wcschr(p, L'=');
-    int copy = 1;
+    bool copy = true;
     l = wcslen(p) + 1; /* also count terminating '\0' */
     /* Temporarily change the = to \0 for wcscmp */
     *pos_eq = L'\0';
@@ -187,7 +188,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
       wchar_t *pos_eq2 = wcschr(*q, L'=');
       /* Compare this name in localenv with the current one in processenv */
       if (pos_eq2) *pos_eq2 = L'\0';
-      if (!wcscmp(*q, p)) copy = 0;
+      if (!wcscmp(*q, p)) copy = false;
       if (pos_eq2) *pos_eq2 = L'=';
     }
     *pos_eq = L'=';
@@ -265,9 +266,11 @@ static WCHAR *translate_finename(WCHAR *filename)
 int run_command(const command_settings *settings)
 {
   BOOL process_created = FALSE;
-  int stdin_redirected = 0, stdout_redirected = 0, stderr_redirected = 0;
-  int combined = 0; /* 1 if stdout and stderr are redirected to the same file */
-  int wait_again = 0;
+  bool stdin_redirected = false, stdout_redirected = false,
+      stderr_redirected = false;
+  bool combined = false; /* true if stdout and stderr are redirected to the same
+                          * file */
+  bool wait_again = false;
   WCHAR *program = NULL;
   WCHAR *commandline = NULL;
 
@@ -307,7 +310,7 @@ int run_command(const command_settings *settings)
     checkerr( (startup_info.hStdInput == INVALID_HANDLE_VALUE),
       "Could not redirect standard input",
       stdin_filename);
-    stdin_redirected = 1;
+    stdin_redirected = true;
   } else startup_info.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
 
   if (is_defined(settings->stdout_filename))
@@ -319,7 +322,7 @@ int run_command(const command_settings *settings)
     checkerr( (startup_info.hStdOutput == INVALID_HANDLE_VALUE),
       "Could not redirect standard output",
       stdout_filename);
-    stdout_redirected = 1;
+    stdout_redirected = true;
   } else startup_info.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
 
   if (is_defined(settings->stderr_filename))
@@ -329,8 +332,8 @@ int run_command(const command_settings *settings)
       if (wcscmp(settings->stdout_filename, settings->stderr_filename) == 0)
       {
         startup_info.hStdError = startup_info.hStdOutput;
-        stderr_redirected = 1;
-        combined = 1;
+        stderr_redirected = true;
+        combined = true;
       }
     }
 
@@ -344,7 +347,7 @@ int run_command(const command_settings *settings)
       checkerr( (startup_info.hStdError == INVALID_HANDLE_VALUE),
         "Could not redirect standard error",
         stderr_filename);
-      stderr_redirected = 1;
+      stderr_redirected = true;
     }
   } else startup_info.hStdError = GetStdHandle(STD_ERROR_HANDLE);
 
@@ -406,7 +409,7 @@ int run_command(const command_settings *settings)
     checkerr( (! TerminateJobObject(hJob, 0)),
       "TerminateJob failed", NULL);
     status = -1;
-    wait_again = 1;
+    wait_again = true;
   } else {
     error_with_location(__FILE__, __LINE__, settings,
       "GetQueuedCompletionStatus failed\n");

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -188,7 +188,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
       wchar_t *pos_eq2 = wcschr(*q, L'=');
       /* Compare this name in localenv with the current one in processenv */
       if (pos_eq2) *pos_eq2 = L'\0';
-      if (!wcscmp(*q, p)) copy = false;
+      if (wcscmp(*q, p) == 0) copy = false;
       if (pos_eq2) *pos_eq2 = L'=';
     }
     *pos_eq = L'=';
@@ -260,7 +260,7 @@ if ( (condition) ) \
 
 static WCHAR *translate_finename(WCHAR *filename)
 {
-  if (!wcscmp(filename, L"/dev/null")) return L"NUL"; else return filename;
+  if (wcscmp(filename, L"/dev/null") == 0) return L"NUL"; else return filename;
 }
 
 int run_command(const command_settings *settings)


### PR DESCRIPTION
Since there's some action on ocamltest happening lately, allow me to bring in a few patches that I collected some time ago.
The `realpath` patch stems from running clang-static-analyzer on the code base. The rest are simple little patches.
~I also propose that ocamltest forces `diff` colored output, which (I believe) helps highlighting the diff'ed section between the _full_ actual test output and the smaller reference.~

No change entry needed. The patches may be squashed.