### PR TITLE
Added printing of presence flag in typedtree

### DIFF
--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -1,0 +1,49 @@
+(* TEST
+ flags = "-dtypedtree";
+ expect;
+*)
+
+module X = struct end
+[%%expect{|
+[
+  structure_item ([1,45+0]..[1,45+21])
+    Tstr_module (Present)
+    X/281
+      module_expr ([1,45+11]..[1,45+21])
+        Tmod_structure
+        []
+]
+
+module X : sig end
+|}]
+
+module Y = X
+[%%expect{|
+[
+  structure_item ([1,258+0]..[1,258+12])
+    Tstr_module (Absent)
+    Y/282
+      module_expr ([1,258+11]..[1,258+12])
+        Tmod_ident "X/281"
+]
+
+module Y = X
+|}]
+
+module type T = sig module Y = X end
+[%%expect{|
+[
+  structure_item ([1,452+0]..[1,452+36])
+    Tstr_modtype "T/284"
+      module_type ([1,452+16]..[1,452+36])
+        Tmty_signature
+        [
+          signature_item ([1,452+20]..[1,452+32])
+            Tsig_module "Y/283" (Absent)
+            module_type ([1,452+31]..[1,452+32])
+              Tmty_alias "X/281"
+        ]
+]
+
+module type T = sig module Y = X end
+|}]

--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -1,15 +1,31 @@
 (* TEST
- flags = "-dtypedtree";
+ flags = "-dtypedtree -dno-locations";
  expect;
 *)
 
 module X = struct end
 [%%expect{|
 [
-  structure_item ([1,45+0]..[1,45+21])
+  structure_item
     Tstr_module (Present)
     X/281
-      module_expr ([1,45+11]..[1,45+21])
+      module_expr
+        Tmod_structure
+        []
+]
+
+module X : sig end
+|}]
+
+module X = struct end [@foo]
+[%%expect{|
+[
+  structure_item
+    Tstr_module (Present)
+    X/282
+      module_expr
+        attribute "foo"
+          []
         Tmod_structure
         []
 ]
@@ -20,11 +36,11 @@ module X : sig end
 module Y = X
 [%%expect{|
 [
-  structure_item ([1,258+0]..[1,258+12])
+  structure_item
     Tstr_module (Absent)
-    Y/282
-      module_expr ([1,258+11]..[1,258+12])
-        Tmod_ident "X/281"
+    Y/283
+      module_expr
+        Tmod_ident "X/282"
 ]
 
 module Y = X
@@ -33,15 +49,16 @@ module Y = X
 module type T = sig module Y = X end
 [%%expect{|
 [
-  structure_item ([1,452+0]..[1,452+36])
-    Tstr_modtype "T/284"
-      module_type ([1,452+16]..[1,452+36])
+  structure_item
+    Tstr_modtype "T/285"
+      module_type
         Tmty_signature
         [
-          signature_item ([1,452+20]..[1,452+32])
-            Tsig_module "Y/283" (Absent)
-            module_type ([1,452+31]..[1,452+32])
-              Tmty_alias "X/281"
+          signature_item
+            Tsig_module (Absent)
+            Y/284
+              module_type
+                Tmty_alias "X/282"
         ]
 ]
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -772,11 +772,8 @@ and signature_item i ppf x =
       line i ppf "Tsig_exception\n";
       type_exception i ppf ext
   | Tsig_module md ->
-      line i ppf "Tsig_module \"%a\" %a\n"
-        fmt_modname md.md_id
-        fmt_presence md.md_presence;
-      attributes i ppf md.md_attributes;
-      module_type i ppf md.md_type
+      line i ppf "Tsig_module %a\n" fmt_presence md.md_presence;
+      module_declaration i ppf md
   | Tsig_modsubst ms ->
       line i ppf "Tsig_modsubst \"%a\" = %a\n"
         fmt_ident ms.ms_id fmt_path ms.ms_manifest;
@@ -811,7 +808,7 @@ and signature_item i ppf x =
       attribute i ppf "Tsig_attribute" a
 
 and module_declaration i ppf md =
-  line i ppf "%a" fmt_modname md.md_id;
+  line i ppf "%a\n" fmt_modname md.md_id;
   attributes i ppf md.md_attributes;
   module_type (i+1) ppf md.md_type;
 
@@ -899,8 +896,7 @@ and structure_item i ppf x =
       line i ppf "Tstr_exception\n";
       type_exception i ppf ext;
   | Tstr_module x ->
-      line i ppf "Tstr_module %a\n"
-        fmt_presence x.mb_presence ;
+      line i ppf "Tstr_module %a\n" fmt_presence x.mb_presence;
       module_binding i ppf x
   | Tstr_recmodule bindings ->
       line i ppf "Tstr_recmodule\n";

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -111,6 +111,11 @@ let fmt_partiality f x =
   | Total -> ()
   | Partial -> fprintf f " (Partial)"
 
+let fmt_presence f x =
+  match x with
+  | Types.Mp_present -> fprintf f "(Present)"
+  | Types.Mp_absent -> fprintf f "(Absent)"
+
 let line i f s (*...*) =
   fprintf f "%s" (String.make (2*i) ' ');
   fprintf f s (*...*)
@@ -767,7 +772,9 @@ and signature_item i ppf x =
       line i ppf "Tsig_exception\n";
       type_exception i ppf ext
   | Tsig_module md ->
-      line i ppf "Tsig_module \"%a\"\n" fmt_modname md.md_id;
+      line i ppf "Tsig_module \"%a\" %a\n"
+        fmt_modname md.md_id
+        fmt_presence md.md_presence;
       attributes i ppf md.md_attributes;
       module_type i ppf md.md_type
   | Tsig_modsubst ms ->
@@ -892,7 +899,8 @@ and structure_item i ppf x =
       line i ppf "Tstr_exception\n";
       type_exception i ppf ext;
   | Tstr_module x ->
-      line i ppf "Tstr_module\n";
+      line i ppf "Tstr_module %a\n"
+        fmt_presence x.mb_presence ;
       module_binding i ppf x
   | Tstr_recmodule bindings ->
       line i ppf "Tstr_recmodule\n";


### PR DESCRIPTION
This PR extends the printing of the typed tree to include the presence flag `Mp_present/Mp_absent` in the output. A corresponding test is also added.