### PR TITLE
Stabilise the native-debugger tests (take 2!)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
           - name: macos-x86_64
             os: macos-13
           - name: macos-arm64
-            os: macos-14
+            os: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -176,8 +176,8 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
           lldb --version
 
-      - name: MacOS 14 Dependencies
-        if: matrix.os == 'macos-14'
+      - name: MacOS 15 Dependencies
+        if: matrix.os == 'macos-15'
         run: |
           brew install parallel
           # Allows starting up lldb from a remote terminal
@@ -186,7 +186,7 @@ jobs:
           sudo DevToolsSecurity --enable
           spctl developer-mode enable-terminal
           # Select latest supported version
-          sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
           lldb --version
 
       - name: configure tree

--- a/Changes
+++ b/Changes
@@ -310,9 +310,10 @@ Working version
   functionality broken by #13272.
   (Nick Barnes, review by Tim McGilchrist Gabriel Scherer)
 
-- #13199, #13485: Support running native debuggers in ocamltest.
-  (Tim McGilchrist and Sebastien Hinderer, review by Sebastien Hinderer,
-   Gabriel Scherer and Antonin Décimo)
+- #13199, #13485, #13665, #13762, #13965: Support running native debuggers in
+  ocamltest.
+  (Tim McGilchrist, Sebastien Hinderer, David Allsopp, Antonin Décimo, review by
+  Sebastien Hinderer, Gabriel Scherer, Antonin Décimo, and Tim McGilchrist)
 
 - #13764, #13779: add missing "-keywords" flag to ocamldep and ocamlprof
   (Florian Angeletti, report by Prashanth Mundkur, review by Gabriel Scherer)

--- a/testsuite/tests/native-debugger/gdb-script
+++ b/testsuite/tests/native-debugger/gdb-script
@@ -1,3 +1,4 @@
+set disable-randomization off
 break *(&caml_start_program+0)
 break caml_program
 break ocaml_to_c

--- a/testsuite/tests/native-debugger/has_gdb.sh
+++ b/testsuite/tests/native-debugger/has_gdb.sh
@@ -9,7 +9,7 @@ if ! which gdb > /dev/null 2>&1; then
     exit ${TEST_SKIP}
 else
     # Linux check for GDB version
-    GDB_VERSION=$(gdb --version |head -n 1 | awk -F' ' '{print $5}')
+    GDB_VERSION=$(gdb --version | head -n 1 | sed -E 's/^GNU gdb \(.*\) (.*)$/\1/')
     if [ $(version "$GDB_VERSION") -ge $(version "12.1") ]; then
         exit ${TEST_PASS}
     else

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/gdb-script";
    gdb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-             ${test_build_directory} ${ocamltest_response} linux-gdb-amd64";
+   script = "sh ${test_source_directory}/sanitize.sh linux-gdb-amd64";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c gdb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/gdb-script";

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.reference
@@ -22,7 +22,7 @@ frame 5: caml_startup
 frame 6: caml_main
 frame 7: main
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
-4	value ocaml_to_c (value unit) {
+5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
 frame 1: caml_c_call
 frame 2: camlMeander$omain

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.reference
@@ -3,7 +3,7 @@ Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 [Thread debugging using libthread_db enabled]
-Using host libthread_db library "/lib/$ARCH-linux-gnu/libthread_db.so.1".
+Using host libthread_db library "/XXXX/libthread_db.so.1".
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c gdb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/gdb-script";

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/gdb-script";
    gdb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-   ${test_build_directory} ${ocamltest_response} linux-gdb-arm64";
+   script = "sh ${test_source_directory}/sanitize.sh linux-gdb-arm64";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.reference
@@ -3,7 +3,7 @@ Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 [Thread debugging using libthread_db enabled]
-Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
+Using host libthread_db library "/XXXX/libthread_db.so.1".
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c gdb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/gdb-script";

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/gdb-script";
    gdb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-   ${test_build_directory} ${ocamltest_response} linux-gdb-riscv";
+   script = "sh ${test_source_directory}/sanitize.sh linux-gdb-riscv";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.reference
@@ -3,7 +3,7 @@ Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 [Thread debugging using libthread_db enabled]
-Using host libthread_db library "/lib/$ARCH-linux-gnu/libthread_db.so.1".
+Using host libthread_db library "/XXXX/libthread_db.so.1".
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";
    lldb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-             ${test_build_directory} ${ocamltest_response} linux-lldb-amd64";
+   script = "sh ${test_source_directory}/sanitize.sh linux-lldb-amd64";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c lldb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -2,6 +2,7 @@
 Current executable set to 'XXXX' ($ARCH).
 (lldb) command source -s 0 'XXXX'
 Executing commands in 'XXXX'.
+(lldb) settings set target.disable-aslr false
 (lldb) settings set stop-disassembly-display never
 (lldb) command script import ./lldb_test.py
 (lldb) create caml_start_program

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -52,7 +52,7 @@ Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 4.1
     frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX
    2   	#include <caml/callback.h>
-   3   	
+   3
    4   	value ocaml_to_c (value unit) {
 -> 5   	    caml_callback(*caml_named_value
     	                   ^

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -50,14 +50,14 @@ Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 4.1
     frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX
-   1   	#include <caml/mlvalues.h>
    2   	#include <caml/callback.h>
    3   	
--> 4   	value ocaml_to_c (value unit) {
-    	                              ^
-   5   	    caml_callback(*caml_named_value
+   4   	value ocaml_to_c (value unit) {
+-> 5   	    caml_callback(*caml_named_value
+    	                   ^
    6   	                  ("c_to_ocaml"), Val_unit);
    7   	    return Val_int(0);
+   8   	}
 (lldb) backtrace
 frame 0: meander`ocaml_to_c
 frame 1: meander`caml_c_call

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";
    lldb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-   ${test_build_directory} ${ocamltest_response} linux-lldb-arm64";
+   script = "sh ${test_source_directory}/sanitize.sh linux-lldb-arm64";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c lldb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.reference
@@ -2,6 +2,7 @@
 Current executable set to 'XXXX' (aarch64).
 (lldb) command source -s 0 'XXXX'
 Executing commands in 'XXXX'.
+(lldb) settings set target.disable-aslr false
 (lldb) settings set stop-disassembly-display never
 (lldb) command script import ./lldb_test.py
 (lldb) create caml_start_program

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.reference
@@ -53,7 +53,7 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX
    1   	#include <caml/mlvalues.h>
    2   	#include <caml/callback.h>
-   3   	
+   3
 -> 4   	value ocaml_to_c (value unit) {
     	                              ^
    5   	    caml_callback(*caml_named_value

--- a/testsuite/tests/native-debugger/lldb-script
+++ b/testsuite/tests/native-debugger/lldb-script
@@ -1,3 +1,4 @@
+settings set target.disable-aslr false
 settings set stop-disassembly-display never
 command script import ./lldb_test.py
 create caml_start_program

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";
    lldb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-             ${test_build_directory} ${ocamltest_response} macos-lldb-amd64";
+   script = "sh ${test_source_directory}/sanitize.sh macos-lldb-amd64";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c lldb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.reference
@@ -2,6 +2,7 @@
 Current executable set to 'XXXX' ($ARCH).
 (lldb) command source -s 0 'XXXX'
 Executing commands in 'XXXX'.
+(lldb) settings set target.disable-aslr false
 (lldb) settings set stop-disassembly-display never
 (lldb) command script import ./lldb_test.py
 (lldb) create caml_start_program

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.reference
@@ -42,13 +42,12 @@ frame 5: meander`caml_main
 frame 6: meander`main
 frame 7: dyld`start
 (lldb) continue
-warning: meander was compiled with optimization - stepping may behave oddly;
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 4.1
     frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX [opt]
    2   	#include <caml/callback.h>
-   3   	
+   3
    4   	value ocaml_to_c (value unit) {
 -> 5   	    caml_callback(*caml_named_value
     	                   ^

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.ml
@@ -8,7 +8,7 @@
    readonly_files = "meander.ml meander_c.c lldb_test.py";
    setup-ocamlopt.byte-build-env;
    program = "${test_build_directory}/meander";
-   flags = "-g";
+   flags = "-g -ccopt -O0";
    all_modules = "meander.ml meander_c.c";
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.ml
@@ -13,8 +13,7 @@
    ocamlopt.byte;
    debugger_script = "${test_source_directory}/lldb-script";
    lldb;
-   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
-             ${test_build_directory} ${ocamltest_response} macos-lldb-arm64";
+   script = "sh ${test_source_directory}/sanitize.sh macos-lldb-arm64";
    script;
    check-program-output;
  *)

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -2,6 +2,7 @@
 Current executable set to 'XXXX' ($ARCH).
 (lldb) command source -s 0 'XXXX'
 Executing commands in 'XXXX'.
+(lldb) settings set target.disable-aslr false
 (lldb) settings set stop-disassembly-display never
 (lldb) command script import ./lldb_test.py
 (lldb) create caml_start_program

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -13,11 +13,11 @@ Breakpoint created for regex camlMeander\$c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
+Process XXXX launched: 'XXXX' ($ARCH)
 Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
 Target 0: (meander) stopped.
-Process XXXX launched: 'XXXX' ($ARCH)
 (lldb) backtrace
 frame 0: meander`caml_start_program
 frame 1: meander`caml_startup_common
@@ -42,11 +42,10 @@ frame 5: meander`caml_main
 frame 6: meander`main
 frame 7: dyld`start
 (lldb) continue
-warning: meander was compiled with optimization - stepping may behave oddly;
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 4.1
-    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX [opt]
+    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX
    2   	#include <caml/callback.h>
    3   	
    4   	value ocaml_to_c (value unit) {

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -48,7 +48,7 @@ Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 4.1
     frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX
    2   	#include <caml/callback.h>
-   3   	
+   3
    4   	value ocaml_to_c (value unit) {
 -> 5   	    caml_callback(*caml_named_value
     	                   ^

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -37,6 +37,11 @@
     gsub(/.c:[0-9]+:[0-9]+/, ".c:XX")
     gsub(/.c:[0-9]+/, ".c:XX")
 
+    # Replace libpath. Different distributions have different naming
+    # schemes.
+    gsub(/Using host libthread_db library "\/(.*)\/libthread_db\.so\.1"\./,
+         "Using host libthread_db library \"/XXXX/libthread_db.so.1\".")
+
     # Replace line number when setting breakpoints in GDB.
     gsub(/line [0-9]+/, "line XXX")
 

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -53,6 +53,9 @@
     # Replace printed match results
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
 
+    # Remove trailing blanks
+    gsub(/[ \t]+$/, "")
+
     if ($0 != "")
       print $0
 }

--- a/testsuite/tests/native-debugger/sanitize.sh
+++ b/testsuite/tests/native-debugger/sanitize.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-test_source_directory="$1"
-test_build_directory="$2"
-ocamltest_response="$3"
-test_name="$4"
+test_name="$1"
 
 awk -f ${test_source_directory}/sanitize.awk \
     ${test_build_directory}/${test_name}.opt.output > ${test_build_directory}/${test_name}.opt.awk.output


### PR DESCRIPTION
I'm often hit with what @dra27 described in #13762:

> There remains something stranger going on with the gdb test, but this is much less frequent and may actually be a canary for something that is not right (or at least not stable) in the runtime:
> 
> * https://github.com/ocaml/ocaml/actions/runs/12966144331/job/36166671399 
> * https://github.com/ocaml/ocaml/actions/runs/12196881129/job/34025679511
> 
> 
> giving:
> 
> ```diff
> --- a/linux-gdb-amd64.reference
> +++ b/linux-gdb-amd64.opt.output
> @@ -25,7 +25,7 @@
>  frame 7: main
>  
>  Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
> -5	    caml_callback(*caml_named_value
> +4	value ocaml_to_c (value unit) {
>  frame 0: ocaml_to_c
>  frame 1: caml_c_call
>  frame 2: camlMeander$omain
> 
> )
> ```

It seems lld gives us a clue:

> warning: meander was compiled with optimization - stepping may behave oddly;

I've followed that advice by disabling the C compiler optimizations for this particular stub, with ocamltest `flags="-g -ccopt -O0"` command (which overrides the default `-O2`), and I don't experience the bug anymore. Is that an acceptable fix/workaround?

I've first discovered this problem on macOS 15 arm64.

1. My local version of lldb and GitHub Actions' differed, so I updated the GitHub image (available since [2025-04-10](https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/)).
2. I then tested it on Asahi Linux arm64, and discovered that Fedora and Ubuntu (a Debian derivative) have a different naming scheme for the library path, which thus need to be sanitized.
3. I then discovered that GDB 16 (on Arch Linux) and Fedora's have a slightly different versioning scheme, which need to be sanitized.
4. I tested this patchset in various systems and architectures using Docker, but debuggers don't work well in Docker, because they try disabling ASLR. They don't have permission for it (lucky us). Forbid them from trying. If this causes problems because of moving addresses, we should sanitize them.
5. Different LLDB versions would output or not trailing blanks. Sanitize them.
6. Fix some shellcheck warnings and simplify the shell scripts.

cc @dra27, @gasche (who reviewed #13762), and @tmcgilchrist  