### PR TITLE
#install_printer in the debugger: another attempt

### DIFF
--- a/.depend
+++ b/.depend
@@ -8560,6 +8560,7 @@ debugger/loadprinter.cmo : \
     parsing/longident.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
+    toplevel/genprintval.cmi \
     utils/format_doc.cmi \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
@@ -8576,6 +8577,7 @@ debugger/loadprinter.cmx : \
     parsing/longident.cmx \
     utils/load_path.cmx \
     typing/ident.cmx \
+    toplevel/genprintval.cmx \
     utils/format_doc.cmx \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmx \
@@ -8701,6 +8703,7 @@ debugger/printval.cmi : \
     typing/types.cmi \
     typing/path.cmi \
     debugger/parser_aux.cmi \
+    toplevel/genprintval.cmi \
     typing/env.cmi \
     debugger/debugcom.cmi
 debugger/program_loading.cmo : \

--- a/.depend
+++ b/.depend
@@ -8563,7 +8563,6 @@ debugger/loadprinter.cmo : \
     utils/format_doc.cmi \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
-    debugger/debugcom.cmi \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi
 debugger/loadprinter.cmx : \
@@ -8580,7 +8579,6 @@ debugger/loadprinter.cmx : \
     utils/format_doc.cmx \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmx \
-    debugger/debugcom.cmx \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi
 debugger/loadprinter.cmi : \

--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
   does with an unrecognised file.
   (David Allsopp, review by Antonin Décimo and Sébastien Hinderer)
 
+- #13966: Enable "generalized polymorphic #install_printer"
+  in the debugger
+  (Pierre Boutillier and Gabriel Scherer, review by Florian Angeletti)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:
@@ -528,6 +532,9 @@ OCaml 5.4.0
 
 - #13884 Correctly index modules in constructors and labels paths
   (Ulysse Gérard, review by Florian Angeletti)
+
+- #13946: refactor the #install_printer code in the debugger and toplevel
+  (Pierre Boutillier, review by Gabriel Scherer and Florian Angeletti)
 
 - #13952: check and document the correctness of `caml_domain_alone ()`.
   (Gabriel Scherer, review by KC Sivaramakrishnan, report by Olivier Nicole)

--- a/debugger/debugcom.ml
+++ b/debugger/debugcom.ml
@@ -276,6 +276,11 @@ module Remote_value =
         with End_of_file | Failure _ ->
           raise Marshalling_error
 
+    let base_obj v =
+      try obj v with
+      | Marshalling_error ->
+         invalid_arg "Debugcom.Remote_value.base_obj: marshalling error"
+
     let is_block = function
     | Local obj -> Obj.is_block obj
     | Remote v -> Obj.is_block (Array.unsafe_get (Obj.magic v : Obj.t array) 0)

--- a/debugger/debugcom.mli
+++ b/debugger/debugcom.mli
@@ -105,15 +105,13 @@ val update_follow_fork_mode : unit -> unit
 
 (* Handling of remote values *)
 
-exception Marshalling_error
-
 module Remote_value :
   sig
     type t
 
     val repr : 'a -> t
     val base_obj : t -> 'a
-    val obj : t -> Obj.t
+    val obj : t -> (Obj.t, string) result
     val is_block : t -> bool
     val tag : t -> int
     val size : t -> int

--- a/debugger/debugcom.mli
+++ b/debugger/debugcom.mli
@@ -112,7 +112,8 @@ module Remote_value :
     type t
 
     val repr : 'a -> t
-    val obj : t -> 'a
+    val base_obj : t -> 'a
+    val obj : t -> Obj.t
     val is_block : t -> bool
     val tag : t -> int
     val size : t -> int

--- a/debugger/eval.ml
+++ b/debugger/eval.ml
@@ -100,7 +100,8 @@ let rec expression event env = function
                 in
                 let v = value_path event env p0 in
                 let i = value_path event env p in
-                Debugcom.Remote_value.field v (Debugcom.Remote_value.obj i)
+                Debugcom.Remote_value.field v
+                  (Debugcom.Remote_value.base_obj i : int)
             | _ ->
                 value_path event env p
           in
@@ -145,7 +146,7 @@ let rec expression event env = function
               nth (pos + 1) (Debugcom.Remote_value.field v 1)
           in nth 0 v
       | Tconstr(path, [], _) when Path.same path Predef.path_string ->
-          let s = (Debugcom.Remote_value.obj v : string) in
+          let s = (Debugcom.Remote_value.base_obj v : string) in
           if n >= String.length s
           then raise(Error(String_index(s, String.length s, n)))
           else (Debugcom.Remote_value.of_int(Char.code s.[n]),

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -102,21 +102,13 @@ let eval_value_path env path =
         with Symtable.Error(Symtable.Undefined_global global) ->
           let s = Symtable.Global.name global in
           raise (Error (`Unavailable_module(s, lid))) in
-      let print_with_fallback ppf f remote_val =
-        try
-          f (Debugcom.Remote_value.obj remote_val)
-        with
-          Debugcom.Marshalling_error ->
-            fprintf ppf "<cannot fetch remote object>" in
       match kind with
       | Topprinters.Old ty_arg ->
-          let print_function ppf remote_val =
-            print_with_fallback ppf (Obj.obj v) remote_val in
-          Printval.install_printer path ty_arg print_function
+          Printval.install_printer path ty_arg
+            (fun _ppf -> (Obj.obj v : Obj.t -> unit))
       | Topprinters.Simple ty_arg ->
-          let print_function ppf remote_val =
-            print_with_fallback ppf (Obj.obj v ppf) remote_val in
-          Printval.install_printer path ty_arg print_function
+          Printval.install_printer path ty_arg
+            (Obj.obj v : Format.formatter -> Obj.t -> unit)
       | Topprinters.Generic _ ->
           raise (Error (`Wrong_type lid))
 

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -70,9 +70,9 @@ module EvalPath =
 
 module Printer = Genprintval.Make(Debugcom.Remote_value)(EvalPath)
 
-let install_printer = Printer.install_printer
-
-let remove_printer = Printer.remove_printer
+(* TODO: remove this glue below. *)
+let install_printer = Genprintval.User_printer.install_simple
+let remove_printer = Genprintval.User_printer.remove
 
 let max_printer_depth = ref 20
 let max_printer_steps = ref 300

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -72,6 +72,8 @@ module Printer = Genprintval.Make(Debugcom.Remote_value)(EvalPath)
 
 (* TODO: remove this glue below. *)
 let install_printer = Genprintval.User_printer.install_simple
+let install_printer_generic_format =
+  Genprintval.User_printer.install_generic_format
 let remove_printer = Genprintval.User_printer.remove
 
 let max_printer_depth = ref 20

--- a/debugger/printval.mli
+++ b/debugger/printval.mli
@@ -30,4 +30,8 @@ val find_named_value : int -> Debugcom.Remote_value.t * Types.type_expr
 
 val install_printer :
   Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
+val install_printer_generic_format :
+  Path.t -> Path.t ->
+  (formatter -> Obj.t -> unit,
+   formatter -> Obj.t -> unit) Genprintval.User_printer.gen -> unit
 val remove_printer : Path.t -> unit

--- a/debugger/printval.mli
+++ b/debugger/printval.mli
@@ -29,6 +29,5 @@ val reset_named_values : unit -> unit
 val find_named_value : int -> Debugcom.Remote_value.t * Types.type_expr
 
 val install_printer :
-  Path.t -> Types.type_expr ->
-    (formatter -> Debugcom.Remote_value.t -> unit) -> unit
+  Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
 val remove_printer : Path.t -> unit

--- a/testsuite/tests/tool-debugger/printer/debuggee.ml
+++ b/testsuite/tests/tool-debugger/printer/debuggee.ml
@@ -11,10 +11,10 @@
 
 
 
-
 *)
 
 let f x =
+  let _d = Printer.[D (0, A); D (42, B)] in
   for _i = 0 to x do
     print_endline "..."
   done

--- a/testsuite/tests/tool-debugger/printer/debuggee.reference
+++ b/testsuite/tests/tool-debugger/printer/debuggee.reference
@@ -2,4 +2,5 @@ File printer.cmo loaded
 Loading program... done.
 Breakpoint: 1
 18   <|b|>for _i = 0 to x do
+_d: (int, Printer.t) Printer.v list = [D<0, Printer.A>; D<42, Printer.B>]
 x: int = S S O

--- a/testsuite/tests/tool-debugger/printer/input_script
+++ b/testsuite/tests/tool-debugger/printer/input_script
@@ -1,7 +1,9 @@
 load_printer printer.cmo
-install_printer Printer.p
-set print_depth 2
+install_printer Printer.print_generic
 break @ Debuggee 18
 run
+p _d
+install_printer Printer.p
+set print_depth 2
 print x
 quit

--- a/testsuite/tests/tool-debugger/printer/printer.ml
+++ b/testsuite/tests/tool-debugger/printer/printer.ml
@@ -1,3 +1,23 @@
+type t = A | B
+
+let print_t out t =
+  Format.fprintf out "%s"
+    (match t with
+     | A -> "~A"
+     | B -> "~B"
+    )
+
+(* A polymorphic type to test generic printers *)
+type ('a, 'b) v = D of 'a * 'b
+
+type 'a printer = Format.formatter -> 'a -> unit
+
+let print_generic (type a b) (pa : a printer) (pb : b printer) : (a, b) v printer =
+  fun ppf (D (a, b)) ->
+  Format.fprintf ppf "D<%a, %a>"
+    pa a
+    pb b
+
 let p : Format.formatter -> int -> unit = fun fmt n ->
   (* We use `max_printer_depth` to tweak the output so that
      this test shows that the printer not only compiles

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -27,7 +27,8 @@ module type OBJ =
   sig
     type t
     val repr : 'a -> t
-    val obj : t -> 'a
+    (* [base_obj] assumes that the value has a marshallable base type. *)
+    val base_obj : t -> 'a
     val is_block : t -> bool
     val tag : t -> int
     val size : t -> int
@@ -97,13 +98,14 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
         for i = start_offset to O.size obj - 1 do
           let arg = O.field obj i in
           if not (O.is_block arg) then
-            list := Oval_int (O.obj arg : int) :: !list
+            list := Oval_int (O.base_obj arg : int) :: !list
                (* Note: this could be a char or a constant constructor... *)
           else if O.tag arg = Obj.string_tag then
             list :=
-              Oval_string ((O.obj arg : string), max_int, Ostr_string) :: !list
+              Oval_string ((O.base_obj arg : string), max_int, Ostr_string)
+              :: !list
           else if O.tag arg = Obj.double_tag then
-            list := Oval_float (O.obj arg : float) :: !list
+            list := Oval_float (O.base_obj arg : float) :: !list
           else
             list := Oval_constr (tree_of_name "_", []) :: !list
         done;
@@ -113,10 +115,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
     let outval_of_untyped_exception bucket =
       if O.tag bucket <> 0 then
-        let name = (O.obj (O.field bucket 0) : string)in
+        let name = (O.base_obj (O.field bucket 0) : string)in
         Oval_constr (tree_of_name name, [])
       else
-      let name = (O.obj(O.field(O.field bucket 0) 0) : string) in
+      let name = (O.base_obj(O.field(O.field bucket 0) 0) : string) in
       let args =
         if (name = "Match_failure"
             || name = "Assert_failure"
@@ -137,22 +139,22 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
     let printers = ref ([
       ( Pident(Ident.create_local "print_int"),
         Simple (Predef.type_int,
-                (fun x -> Oval_int (O.obj x : int))) );
+                (fun x -> Oval_int (O.base_obj x : int))) );
       ( Pident(Ident.create_local "print_float"),
         Simple (Predef.type_float,
-                (fun x -> Oval_float (O.obj x : float))) );
+                (fun x -> Oval_float (O.base_obj x : float))) );
       ( Pident(Ident.create_local "print_char"),
         Simple (Predef.type_char,
-                (fun x -> Oval_char (O.obj x : char))) );
+                (fun x -> Oval_char (O.base_obj x : char))) );
       ( Pident(Ident.create_local "print_int32"),
         Simple (Predef.type_int32,
-                (fun x -> Oval_int32 (O.obj x : int32))) );
+                (fun x -> Oval_int32 (O.base_obj x : int32))) );
       ( Pident(Ident.create_local "print_nativeint"),
         Simple (Predef.type_nativeint,
-                (fun x -> Oval_nativeint (O.obj x : nativeint))) );
+                (fun x -> Oval_nativeint (O.base_obj x : nativeint))) );
       ( Pident(Ident.create_local "print_int64"),
         Simple (Predef.type_int64,
-                (fun x -> Oval_int64 (O.obj x : int64)) ))
+                (fun x -> Oval_int64 (O.base_obj x : int64)) ))
     ] : (Path.t * printer) list)
 
     let exn_printer path ppf exn =
@@ -332,16 +334,17 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
               | Tconstr(path, [], _)
                   when Path.same path Predef.path_string ->
-                Oval_string ((O.obj obj : string), !printer_steps, Ostr_string)
+                Oval_string ((O.base_obj obj : string),
+                             !printer_steps, Ostr_string)
 
               | Tconstr (path, [], _)
                   when Path.same path Predef.path_bytes ->
-                let s = Bytes.to_string (O.obj obj : bytes) in
+                let s = Bytes.to_string (O.base_obj obj : bytes) in
                 Oval_string (s, !printer_steps, Ostr_bytes)
 
               | Tconstr(path, [], _)
                   when Path.same path Predef.path_floatarray ->
-                Oval_floatarray (O.obj obj : floatarray)
+                Oval_floatarray (O.base_obj obj : floatarray)
 
               | Tconstr (path, [ty_arg], _)
                 when Path.same path Predef.path_lazy_t ->
@@ -483,7 +486,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           if unbx then Cstr_unboxed
           else if O.is_block obj
           then Cstr_block(O.tag obj)
-          else Cstr_constant(O.obj obj) in
+          else Cstr_constant(O.base_obj obj) (* immediate *) in
         match Datarepr.find_constr_by_tag tag constr_list with
         | exception Datarepr.Constr_not_found ->
             Oval_stuff "<unknown constructor>"
@@ -562,7 +565,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
       and tree_of_polyvariant depth obj row =
         if O.is_block obj then
-          let tag : int = O.obj (O.field obj 0) in
+          let tag : int = O.base_obj (O.field obj 0) in
           let rec find = function
             | (l, f) :: fields ->
                 if Btype.hash_variant l = tag then
@@ -577,7 +580,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             | [] -> Oval_stuff "<variant>" in
           find (row_fields row)
         else
-          let tag : int = O.obj obj in
+          let tag : int = O.base_obj obj in
           let rec find = function
             | (l, _) :: fields ->
                 if Btype.hash_variant l = tag then
@@ -620,7 +623,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
         if O.tag bucket <> 0 then bucket
         else O.field bucket 0
       in
-      let name = (O.obj(O.field slot 0) : string) in
+      let name = (O.base_obj (O.field slot 0) : string) in
       try
         (* Attempt to recover the constructor description for the exn
            from its name *)

--- a/toplevel/genprintval.mli
+++ b/toplevel/genprintval.mli
@@ -24,6 +24,7 @@ module type OBJ =
     val repr : 'a -> t
     (* [base_obj] assumes that the value has a marshallable base type. *)
     val base_obj : t -> 'a
+    val obj : t -> (Obj.t, string) result
     val is_block : t -> bool
     val tag : t -> int
     val size : t -> int
@@ -40,29 +41,32 @@ module type EVALPATH =
     val same_value: valu -> valu -> bool
   end
 
-type ('a, 'b) gen_printer =
-  | Zero of 'b
-  | Succ of ('a -> ('a, 'b) gen_printer)
+module User_printer : sig
+  type ('a, 'b) gen =
+    | Zero of 'b
+    | Succ of ('a -> ('a, 'b) gen)
+
+  val install_simple :
+        Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
+  val install_generic_outcometree :
+        Path.t -> Path.t ->
+        (int -> (int -> Obj.t -> Outcometree.out_value,
+                 Obj.t -> Outcometree.out_value) gen) ->
+        unit
+  val install_generic_format :
+         Path.t -> Path.t ->
+         (formatter -> Obj.t -> unit,
+          formatter -> Obj.t -> unit) gen ->
+         unit
+  (** [install_generic_format function_path constructor_path printer]
+      function_path is used to remove the printer. *)
+
+  val remove : Path.t -> unit
+end
 
 module type S =
   sig
     type t
-    val install_printer :
-          Path.t -> Types.type_expr -> (formatter -> t -> unit) -> unit
-    val install_generic_printer :
-          Path.t -> Path.t ->
-          (int -> (int -> t -> Outcometree.out_value,
-                   t -> Outcometree.out_value) gen_printer) ->
-          unit
-    val install_generic_printer' :
-           Path.t -> Path.t ->
-           (formatter -> t -> unit,
-            formatter -> t -> unit) gen_printer ->
-           unit
-    (** [install_generic_printer' function_path constructor_path printer]
-        function_path is used to remove the printer. *)
-
-    val remove_printer : Path.t -> unit
     val outval_of_untyped_exception : t -> Outcometree.out_value
     val outval_of_value :
           int -> int ->

--- a/toplevel/genprintval.mli
+++ b/toplevel/genprintval.mli
@@ -22,7 +22,8 @@ module type OBJ =
   sig
     type t
     val repr : 'a -> t
-    val obj : t -> 'a
+    (* [base_obj] assumes that the value has a marshallable base type. *)
+    val base_obj : t -> 'a
     val is_block : t -> bool
     val tag : t -> int
     val size : t -> int

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -119,8 +119,11 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
   let eval_class_path env path =
     eval_path Env.find_class_address env path
 
-
-  module Printer = Genprintval.Make(Obj)(struct
+  module My_obj = struct
+    include Obj
+    let base_obj = obj
+  end
+  module Printer = Genprintval.Make(My_obj)(struct
       type valu = Obj.t
       exception Error
       let eval_address addr =

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -122,6 +122,7 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
   module My_obj = struct
     include Obj
     let base_obj = obj
+    let obj v = Ok (obj v)
   end
   module Printer = Genprintval.Make(My_obj)(struct
       type valu = Obj.t
@@ -158,14 +159,18 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
           print_string b;
           backtrace := None
 
-  type ('a, 'b) gen_printer = ('a, 'b) Genprintval.gen_printer =
+  module User_printer = Genprintval.User_printer
+
+  type ('a, 'b) gen_printer = ('a, 'b) User_printer.gen =
     | Zero of 'b
     | Succ of ('a -> ('a, 'b) gen_printer)
 
-  let install_printer = Printer.install_printer
-  let install_generic_printer = Printer.install_generic_printer
-  let install_generic_printer' = Printer.install_generic_printer'
-  let remove_printer = Printer.remove_printer
+  (* TODO: erase the glue below and use the new User_printer API
+     directly through the [User_printer] alias above. *)
+  let install_printer = User_printer.install_simple
+  let install_generic_printer = User_printer.install_generic_outcometree
+  let install_generic_printer' = User_printer.install_generic_format
+  let remove_printer = User_printer.remove
 
 end
 


### PR DESCRIPTION
This PR, co-written with @pirbo, is an alternative implementation of #13945 and #13948, which enable `#install_printer` in the debugger.

The key issue solved by those PRs is to decide what part of the code is responsible for converting possibly-remote values (Debugcom.Remote_value.t) into whole Obj.t that user-defined printers expect. In the first iteration by @pirbo, the interface of registered printers would expect a possibly-remote value at the glue, and the printer arguments (called on subvalues) would expect a whole Obj.t value.

(The debugger fetches values deeply before calling user-provided printers, unlike its default printers that are careful to fetch values incrementally, on demand, and not fail on un-marshallable types.)

In the new PR, all types involving user-defined printers expect a whole Obj.t value, and the fetching logic is somewhere else. (There is now an explicit type for marshalling failure instead of an exception.) This gives a simpler overall codebase, as the printer registration, lookup and uninstall functions are lifted outside the Genprintval.Make module.

(cc @Octachron @damiendoligez)