### PR TITLE
Fix compilation failures in some nested recursive value definitions

### DIFF
--- a/Changes
+++ b/Changes
@@ -568,6 +568,10 @@ Working version
   (Guillaume Bury and Vincent Laviron, review by Stefan Muenzel
    and Gabriel Scherer)
 
+- #13931: fix bugs in nested recursive value definitions.
+  (Gabriel Scherer, review by Vincent Laviron,
+   report by Vincent Laviron)
+
 - #13875, #13878: Add dedicated constructor for mutable variable access in
   Cmm to prevent bugs linked to incorrect handling of coeffects.
   (Vincent Laviron, review by Gabriel Scherer)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -43,6 +43,25 @@
 
 open Lambda
 
+(** Allocation and backpatching primitives *)
+
+let alloc_prim =
+  Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
+
+let alloc_float_record_prim =
+  Primitive.simple ~name:"caml_alloc_dummy_float" ~arity:1 ~alloc:true
+
+let alloc_lazy_prim =
+  Primitive.simple ~name:"caml_alloc_dummy_lazy" ~arity:1 ~alloc:true
+
+let update_prim =
+  (* Note: [alloc] could be false, but it probably doesn't matter *)
+  Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
+
+let update_lazy_prim =
+  Primitive.simple ~name:"caml_update_dummy_lazy" ~arity:2 ~alloc:true
+
+
 (** {1. Sizing} *)
 
 (* Simple blocks *)
@@ -688,23 +707,7 @@ let empty_bindings =
     dynamic = [];
   }
 
-(** Allocation and backpatching primitives *)
-
-let alloc_prim =
-  Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
-
-let alloc_float_record_prim =
-  Primitive.simple ~name:"caml_alloc_dummy_float" ~arity:1 ~alloc:true
-
-let alloc_lazy_prim =
-  Primitive.simple ~name:"caml_alloc_dummy_lazy" ~arity:1 ~alloc:true
-
-let update_prim =
-  (* Note: [alloc] could be false, but it probably doesn't matter *)
-  Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
-
-let update_lazy_prim =
-  Primitive.simple ~name:"caml_update_dummy_lazy" ~arity:2 ~alloc:true
+(** Allocation and backpatching code *)
 
 let compile_indirect newval =
   let indirect = Lambda.transl_prim "CamlinternalLazy" "indirect" in

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -126,6 +126,39 @@ let join_sizes size1 size2 =
   | Unreachable, size | size, Unreachable -> size
   | _, _ -> dynamic_size ()
 
+(* We need to recognize the Pmakeblock that we transformed into
+   primitive calls, to support size compilation in nested recursive
+   definitions. Consider this example from Vincent Laviron:
+   {[let f a =
+       let rec x =
+         let rec y = Some a in y
+       in x
+   ]}
+
+   [let rec y = Some a in y] gets compiled to
+   {[let y = caml_alloc_dummy 1 in
+     caml_update_dummy(y, ...);
+     y]}
+   and we need to recognize from this definition that this
+   value has known size [1].
+*)
+let find_size_of_alloc_prim prim args =
+  let same_as other_prim =
+    let open Primitive in
+    String.equal prim.prim_name other_prim.prim_name
+  in
+  let int_arg = match args with
+    | [Lconst (Const_base (Const_int n))] -> Some n
+    | _ ->  None
+  in
+  if same_as alloc_prim then
+    Option.map (fun n -> Regular_block n) int_arg
+  else if same_as alloc_float_record_prim then
+    Option.map (fun n -> Float_record n) int_arg
+  else if same_as alloc_lazy_prim then
+    Some Lazy_block
+  else None
+
 let compute_static_size lam =
   let rec compute_expression_size env lam =
     match lam with
@@ -266,6 +299,12 @@ let compute_static_size lam =
            so we should never end up here; but these are constants anyway. *)
         Constant
 
+    | Pccall prim ->
+        begin match find_size_of_alloc_prim prim args with
+        | Some size -> Block size
+        | None -> dynamic_size ()
+        end
+
     | Pbytes_to_string
     | Pbytes_of_string
     | Pgetglobal _
@@ -277,7 +316,6 @@ let compute_static_size lam =
     | Pperform
     | Presume
     | Preperform
-    | Pccall _
     | Psequand | Psequor | Pnot
     | Pnegint | Paddint | Psubint | Pmulint
     | Pdivint _ | Pmodint _
@@ -726,6 +764,8 @@ let compile_alloc size =
            [Lconst (Lambda.const_int size)],
            no_loc)
   in
+  (* if you add new allocation primitives below,
+     you should update {!find_size_of_alloc_prim} as well. *)
   match size with
   | Regular_block size ->
       alloc alloc_prim size

--- a/testsuite/tests/letrec-compilation/nested2.ml
+++ b/testsuite/tests/letrec-compilation/nested2.ml
@@ -1,0 +1,8 @@
+(* TEST *)
+
+(* #13931 *)
+
+let f a =
+  let rec x =
+    let rec y = Some a in y
+  in x


### PR DESCRIPTION
fixes #13931 

The issue is explained in a code comment:

```
(* We need to recognize the Pmakeblock that we transformed into
   primitive calls, to support size compilation in nested recursive
   definitions. Consider this example from Vincent Laviron:
   {[let f a =
       let rec x =
         let rec y = Some a in y
       in x
   ]}
   [let rec y = Some a in y] gets compiled to
   {[let y = caml_alloc_dummy 1 in
     caml_update_dummy(y, ...);
     y]}
   and we need to recognize from this definition that this
   value has known size [1].
*)
```

The fix is morally the same as the one by @lthls in #13938. I decided to extract that one to become a separate quick fix, but in the end I changed the implementation slightly. (I didn't want to rely on physical equality between primitive descriptions.)

cc @lthls 