### PR TITLE
#install_printer in the debugger: cleanup so that 99% is shared between toplevel and debugger

### DIFF
--- a/.depend
+++ b/.depend
@@ -7557,6 +7557,7 @@ toplevel/topprinters.cmo : \
     typing/path.cmi \
     parsing/longident.cmi \
     typing/ident.cmi \
+    toplevel/genprintval.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
@@ -7569,6 +7570,7 @@ toplevel/topprinters.cmx : \
     typing/path.cmx \
     parsing/longident.cmx \
     typing/ident.cmx \
+    toplevel/genprintval.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
@@ -8538,14 +8540,12 @@ debugger/loadprinter.cmo : \
     parsing/unit_info.cmi \
     toplevel/topprinters.cmi \
     bytecomp/symtable.cmi \
-    debugger/printval.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
-    toplevel/genprintval.cmi \
     utils/format_doc.cmi \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
@@ -8555,14 +8555,12 @@ debugger/loadprinter.cmx : \
     parsing/unit_info.cmx \
     toplevel/topprinters.cmx \
     bytecomp/symtable.cmx \
-    debugger/printval.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
     utils/load_path.cmx \
     typing/ident.cmx \
-    toplevel/genprintval.cmx \
     utils/format_doc.cmx \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmx \
@@ -8686,9 +8684,7 @@ debugger/printval.cmx : \
     debugger/printval.cmi
 debugger/printval.cmi : \
     typing/types.cmi \
-    typing/path.cmi \
     debugger/parser_aux.cmi \
-    toplevel/genprintval.cmi \
     typing/env.cmi \
     debugger/debugcom.cmi
 debugger/program_loading.cmo : \

--- a/Changes
+++ b/Changes
@@ -43,7 +43,7 @@ Working version
   major GC read and write from the mutator (fixes #13427)
   (Olivier Nicole, report by Thomas Leonard, review by Gabriel Scherer)
 
-- #13966: Enable "generalized polymorphic #install_printer"
+- #13966, #13969: Enable "generalized polymorphic #install_printer"
   in the debugger
   (Pierre Boutillier and Gabriel Scherer, review by Florian Angeletti)
 

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -70,12 +70,6 @@ module EvalPath =
 
 module Printer = Genprintval.Make(Debugcom.Remote_value)(EvalPath)
 
-(* TODO: remove this glue below. *)
-let install_printer = Genprintval.User_printer.install_simple
-let install_printer_generic_format =
-  Genprintval.User_printer.install_generic_format
-let remove_printer = Genprintval.User_printer.remove
-
 let max_printer_depth = ref 20
 let max_printer_steps = ref 300
 

--- a/debugger/printval.mli
+++ b/debugger/printval.mli
@@ -27,11 +27,3 @@ val print_named_value :
 
 val reset_named_values : unit -> unit
 val find_named_value : int -> Debugcom.Remote_value.t * Types.type_expr
-
-val install_printer :
-  Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
-val install_printer_generic_format :
-  Path.t -> Path.t ->
-  (formatter -> Obj.t -> unit,
-   formatter -> Obj.t -> unit) Genprintval.User_printer.gen -> unit
-val remove_printer : Path.t -> unit

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -159,19 +159,6 @@ module MakeEvalPrinter (E: EVAL_BASE) = struct
           print_string b;
           backtrace := None
 
-  module User_printer = Genprintval.User_printer
-
-  type ('a, 'b) gen_printer = ('a, 'b) User_printer.gen =
-    | Zero of 'b
-    | Succ of ('a -> ('a, 'b) gen_printer)
-
-  (* TODO: erase the glue below and use the new User_printer API
-     directly through the [User_printer] alias above. *)
-  let install_printer = User_printer.install_simple
-  let install_generic_printer = User_printer.install_generic_outcometree
-  let install_generic_printer' = User_printer.install_generic_format
-  let remove_printer = User_printer.remove
-
 end
 
 

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -115,21 +115,6 @@ module MakeEvalPrinter (_ : EVAL_BASE) : sig
   val outval_of_value:
     Env.t -> Printer.t -> Types.type_expr -> Outcometree.out_value
 
-  type ('a, 'b) gen_printer =
-    | Zero of 'b
-    | Succ of ('a -> ('a, 'b) gen_printer)
-
-  val install_printer :
-    Path.t -> Types.type_expr -> (formatter -> Printer.t -> unit) -> unit
-  val install_generic_printer :
-    Path.t -> Path.t ->
-    (int -> (int -> Printer.t -> Outcometree.out_value,
-            Printer.t-> Outcometree.out_value) gen_printer) -> unit
-  val install_generic_printer' :
-    Path.t -> Path.t -> (formatter -> Printer.t -> unit,
-                         formatter -> Printer.t -> unit) gen_printer -> unit
-  val remove_printer : Path.t -> unit
-
 end
 
 

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -115,21 +115,6 @@ val load_file: formatter -> string -> bool
 val print_value: Env.t -> Obj.t -> formatter -> Types.type_expr -> unit
 val print_untyped_exception: formatter -> Obj.t -> unit
 
-type ('a, 'b) gen_printer =
-  | Zero of 'b
-  | Succ of ('a -> ('a, 'b) gen_printer)
-
-val install_printer :
-  Path.t -> Types.type_expr -> (formatter -> Obj.t -> unit) -> unit
-val install_generic_printer :
-  Path.t -> Path.t ->
-  (int -> (int -> Obj.t -> Outcometree.out_value,
-           Obj.t -> Outcometree.out_value) gen_printer) -> unit
-val install_generic_printer' :
-  Path.t -> Path.t -> (formatter -> Obj.t -> unit,
-                       formatter -> Obj.t -> unit) gen_printer -> unit
-val remove_printer : Path.t -> unit
-
 val max_printer_depth: int ref
 val max_printer_steps: int ref
 

--- a/toplevel/topprinters.mli
+++ b/toplevel/topprinters.mli
@@ -37,3 +37,8 @@ type error = [
 val find_printer : Env.t -> Longident.t -> (Path.t * kind, error) result
 
 val report_error : Format.formatter -> error -> unit
+
+val install :
+  (Env.t -> Path.t -> Obj.t) -> Env.t -> Longident.t -> (unit, error) result
+
+val remove : Env.t -> Longident.t -> (unit, error) result


### PR DESCRIPTION
Comes after #13966 

Continue to move around functions to share them between toplevel and debugger.

Not much to say, it is cut and paste. 2 points aren't perfect:

- `exn_printers` is put in `Topprinters` because it is its first use but that's not a great place
- `Topprinters.install` takes as first argument a function `eval_value_path` whereas we may want to organize the code as a Functor over `Topcommons.EVAL_BASE`. (That's may be "the next refactoring" even if we are digging the rabbit hole here :-) )