### PR TITLE
Runtime events: dispatch the right event message type

### DIFF
--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -595,7 +595,7 @@ static void write_to_ring(ev_category category, ev_message_type type,
   ring_ptr[ring_tail_offset++] = RUNTIME_EVENTS_HEADER(
                                   length_with_header_ts,
                                   category == EV_RUNTIME,
-                                  (type.runtime | type.user),
+                                  (category == EV_RUNTIME ? type.runtime : type.user),
                                   event_id);
 
   ring_ptr[ring_tail_offset++] = timestamp;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -592,11 +592,12 @@ static void write_to_ring(ev_category category, ev_message_type type,
      of event headers.
   */
 
-  ring_ptr[ring_tail_offset++] = RUNTIME_EVENTS_HEADER(
-                                  length_with_header_ts,
-                                  category == EV_RUNTIME,
-                                  (category == EV_RUNTIME ? type.runtime : type.user),
-                                  event_id);
+  ring_ptr[ring_tail_offset++] =
+    RUNTIME_EVENTS_HEADER(
+      length_with_header_ts,
+      category == EV_RUNTIME,
+      (category == EV_RUNTIME ? type.runtime : type.user),
+      event_id);
 
   ring_ptr[ring_tail_offset++] = timestamp;
   if (content != NULL) {


### PR DESCRIPTION
Prevents a MSVC 19.44.35109.1 warning:

    runtime/runtime_events.c(595): warning C5287: operands are different enum types
    'ev_runtime_message_type' and 'ev_user_message_type'; use an explicit cast to silence this warning
    
No change entry needed.