### PR TITLE
Made the "remove_aliases" properly treated as a built-in attribute

### DIFF
--- a/.depend
+++ b/.depend
@@ -2079,7 +2079,6 @@ typing/typemod.cmo : \
     utils/clflags.cmi \
     parsing/builtin_attributes.cmi \
     typing/btype.cmi \
-    parsing/attr_helper.cmi \
     parsing/asttypes.cmi \
     typing/typemod.cmi
 typing/typemod.cmx : \
@@ -2119,7 +2118,6 @@ typing/typemod.cmx : \
     utils/clflags.cmx \
     parsing/builtin_attributes.cmx \
     typing/btype.cmx \
-    parsing/attr_helper.cmx \
     parsing/asttypes.cmx \
     typing/typemod.cmi
 typing/typemod.cmi : \

--- a/Changes
+++ b/Changes
@@ -21,6 +21,11 @@ Working version
 
 ### Manual and documentation:
 
+* #13975: documented the `[@remove_aliases]` built-in attribute for signatures
+  (introduced by #1652 in 2018). Small refactor of the code that fetches the
+  attribute.
+  (Clement Blaudeau, review by Gabriel Scherer)
+
 ### Compiler user-interface and warnings:
 
 ### Internal/compiler-libs changes:

--- a/manual/src/refman/extensions/attributes.etex
+++ b/manual/src/refman/extensions/attributes.etex
@@ -304,6 +304,10 @@ Some attributes are understood by the compiler:
   "ocaml.poll" or "poll" with an "error" payload on a function definition emits
   an error whenever the compiler inserts a runtime polling point in the body of
   the annotated function.
+\item
+  "ocaml.remove_aliases" or "remove_aliases", defined on either a	"module type
+	of" signature expression or "with module" constraint instructs the typechecker
+	to drop module aliases in the resulting signature.
 \end{itemize}
 
 \begin{caml_example*}{verbatim}

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -68,6 +68,7 @@ let builtin_attrs =
   ; "noalloc"
   ; "poll"
   ; "ppwarning"
+  ; "remove_aliases"
   ; "specialise"
   ; "specialised"
   ; "tailcall"
@@ -410,3 +411,5 @@ let immediate64 attrs = has_attribute "immediate64" attrs
 let has_unboxed attrs = has_attribute "unboxed" attrs
 
 let has_boxed attrs = has_attribute "boxed" attrs
+
+let has_remove_aliases attrs = has_attribute "remove_aliases" attrs

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -27,6 +27,7 @@
     - ocaml.noalloc
     - ocaml.poll
     - ocaml.ppwarning
+    - ocaml.remove_aliases
     - ocaml.specialise
     - ocaml.specialised
     - ocaml.tailcall
@@ -185,3 +186,5 @@ val immediate64: Parsetree.attributes -> bool
 
 val has_unboxed: Parsetree.attributes -> bool
 val has_boxed: Parsetree.attributes -> bool
+
+val has_remove_aliases: Parsetree.attributes -> bool

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1328,14 +1328,6 @@ end = struct
     List.filter_map simplify_item sg
 end
 
-let has_remove_aliases_attribute attr =
-  let remove_aliases =
-    Attr_helper.get_no_payload_attribute "remove_aliases" attr
-  in
-  match remove_aliases with
-  | None -> false
-  | Some _ -> true
-
 (* Check and translate a module type expression *)
 
 let transl_modtype_longident loc env lid =
@@ -1418,7 +1410,9 @@ and transl_modtype_aux env smty =
   | Pmty_with(sbody, constraints) ->
       let body = transl_modtype env sbody in
       let init_sg = extract_sig env sbody.pmty_loc body.mty_type in
-      let remove_aliases = has_remove_aliases_attribute smty.pmty_attributes in
+      let remove_aliases =
+        Builtin_attributes.has_remove_aliases smty.pmty_attributes
+      in
       let (rev_tcstrs, final_sg) =
         List.fold_left (transl_with ~loc:smty.pmty_loc env remove_aliases)
         ([],init_sg) constraints in
@@ -2987,7 +2981,8 @@ and normalize_signature_item = function
 (* Extract the module type of a module expression *)
 
 let type_module_type_of env smod =
-  let remove_aliases = has_remove_aliases_attribute smod.pmod_attributes in
+  let remove_aliases =
+    Builtin_attributes.has_remove_aliases smod.pmod_attributes in
   let tmty =
     match smod.pmod_desc with
     | Pmod_ident lid -> (* turn off strengthening in this case *)


### PR DESCRIPTION
The `[@remove_aliases]` was implemented but undocumented and not listed as a proper attribute. It can be used on `module type of` or on `with module ` constraints to instruct the typechecker to drop aliases, as in:

```ocaml
module X0 = struct end
module X1 = struct module X = X0 end 

module type T1 = module type of X1 (* sig module X = X0 end *) 
module type T1' = module type of X1 [@remove_aliases] (* sig module X : sig end end *) 

module type T = sig module Y : sig end end
module type T2 =  T with module Y = X1 (* sig module Y : sig module X = X0 end end *)
module type T2' = T with module Y = X1 [@remove_aliases] (* sig module Y : sig module X : sig end end *)
```
 
This PR lists `[@remove_aliases]` as a proper builtin attribute, adds a function `has_remove_aliases` in `builtin_attributes.ml` and removes the corresponding `has_remove_aliases_attributes` in `typemod.ml`. It also extends the manual to document the feature.