### PR TITLE
ocamlopt: pass -fPIC when compiling C files

### DIFF
--- a/Changes
+++ b/Changes
@@ -521,6 +521,9 @@ Working version
 
 ### Bug fixes:
 
+- #13977: Pass `-fPIC` when compiling C files using `ocamlopt`.
+  (Nicolás Ojeda Bär)
+
 - #13957: Allow 'effect' as attribute id.
   (Pieter Goetschalckx, review by Nicolás Ojeda Bär and Florian Angeletti)
 

--- a/Changes
+++ b/Changes
@@ -523,7 +523,7 @@ Working version
 
 - #13977: Pass `-fPIC` when compiling C files using `ocamlopt`. This was a
   regression in OCaml 5.3.
-  (Nicolás Ojeda Bär, review by Daniel Bünzli)
+  (Nicolás Ojeda Bär, review by Daniel Bünzli and Gabriel Scherer)
 
 - #13957: Allow 'effect' as attribute id.
   (Pieter Goetschalckx, review by Nicolás Ojeda Bär and Florian Angeletti)

--- a/Changes
+++ b/Changes
@@ -521,8 +521,9 @@ Working version
 
 ### Bug fixes:
 
-- #13977: Pass `-fPIC` when compiling C files using `ocamlopt`.
-  (Nicolás Ojeda Bär)
+- #13977: Pass `-fPIC` when compiling C files using `ocamlopt`. This was a
+  regression in OCaml 5.3.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli)
 
 - #13957: Allow 'effect' as attribute id.
   (Pieter Goetschalckx, review by Nicolás Ojeda Bär and Florian Angeletti)

--- a/configure
+++ b/configure
@@ -23481,12 +23481,11 @@ oc_bytecode_cflags="$oc_cflags"
 oc_bytecode_cppflags="$oc_cppflags"
 
 oc_native_cflags="$oc_cflags $oc_native_cflags"
-native_cflags="$common_cflags $native_cflags"
 oc_native_cppflags="$oc_cppflags $oc_native_cppflags"
 
-bytecode_cflags="$common_cflags $sharedlib_cflags\
+bytecode_cflags="$common_cflags $sharedlib_cflags $bytecode_cflags\
  $PTHREAD_CFLAGS $COMPILER_BYTECODE_CFLAGS"
-native_cflags="$native_cflags $sharedlib_cflags\
+native_cflags="$common_cflags $sharedlib_cflags $native_cflags\
  $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
 
 bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"

--- a/configure
+++ b/configure
@@ -23486,7 +23486,8 @@ oc_native_cppflags="$oc_cppflags $oc_native_cppflags"
 
 bytecode_cflags="$common_cflags $sharedlib_cflags\
  $PTHREAD_CFLAGS $COMPILER_BYTECODE_CFLAGS"
-native_cflags="$native_cflags $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
+native_cflags="$native_cflags $sharedlib_cflags\
+ $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
 
 bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
 native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -2742,12 +2742,11 @@ oc_bytecode_cflags="$oc_cflags"
 oc_bytecode_cppflags="$oc_cppflags"
 
 oc_native_cflags="$oc_cflags $oc_native_cflags"
-native_cflags="$common_cflags $native_cflags"
 oc_native_cppflags="$oc_cppflags $oc_native_cppflags"
 
-bytecode_cflags="$common_cflags $sharedlib_cflags\
+bytecode_cflags="$common_cflags $sharedlib_cflags $bytecode_cflags\
  $PTHREAD_CFLAGS $COMPILER_BYTECODE_CFLAGS"
-native_cflags="$native_cflags $sharedlib_cflags\
+native_cflags="$common_cflags $sharedlib_cflags $native_cflags\
  $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
 
 bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -2747,7 +2747,8 @@ oc_native_cppflags="$oc_cppflags $oc_native_cppflags"
 
 bytecode_cflags="$common_cflags $sharedlib_cflags\
  $PTHREAD_CFLAGS $COMPILER_BYTECODE_CFLAGS"
-native_cflags="$native_cflags $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
+native_cflags="$native_cflags $sharedlib_cflags\
+ $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
 
 bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
 native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"


### PR DESCRIPTION
Partially reverts to the situation in #8631 (including `-fPIC` when `ocamlopt` compiles C files), which was reverted in #13201 (mistakingly, I think). cc @dra27 @dbuenzli 

Fixes #13798