### PR TITLE
Enhance private type documentation.

### DIFF
--- a/Changes
+++ b/Changes
@@ -410,6 +410,9 @@ Working version
 - #13818: better delimited hints in error message
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13978: more detailed private type explanation with emphasize on
+  implementation and interface usage.
+
 ### Internal/compiler-libs changes:
 
 - #13314: Comment the code of Translclass

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -48,8 +48,8 @@ end
 \end{caml_example*}
 Here, the @"private"@ declaration ensures that in any value of type
 "M.t", the argument to the "B" constructor is always a positive integer,
-because client of the "M" module must use the "b" function to construct
-"B" value.
+because users of the "M" module can only use the "b" function to construct
+"B" values.
 
 \begin{caml_example*}{verbatim}[error]
 (* this function compiles because it only uses pattern-matching *)
@@ -57,12 +57,13 @@ let to_string = function
   | M.A -> "M.A"
   | M.B _ -> "M.B"
 
-(* this one does not because it constructs a type *)
+(* this one does not because it tries to construct a new value using
+   a private constructor *)
 let make_b = M.B (-1)
 \end{caml_example*}
 
 Note that if the type is marked as private \emph{in the implementation},
-constructing a type is no longer possible within the implementation. It can
+constructing a value is no longer possible within the implementation. It can
 be useful when types are created externally from a C extension for instance.
 
 With respect to the variance of their parameters, private types are

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -61,6 +61,11 @@ let to_string = function
 let make_b = M.B (-1)
 \end{caml_example*}
 
+Note that if the type is marked as private \emph{in the implementation},
+constructing a type is no longer possible within the implementation. It can
+be usefull when types are created externally (C extension) or used as
+marker in a GADT.
+
 With respect to the variance of their parameters, private types are
 handled like abstract types. That is, if a private type has
 parameters, their variance is the one explicitly given by prefixing

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -53,9 +53,9 @@ because client of the "M" module must use the "b" function to construct
 
 \begin{caml_example*}{verbatim}[error]
 (* this function compiles because it only uses pattern-matching *)
-let test = function
-  | M.A -> "A"
-  | M.B _ -> "B"
+let to_string = function
+  | M.A -> "M.A"
+  | M.B _ -> "M.B"
 
 (* this one does not because it constructs a type *)
 let make_b = M.B (-1)

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -26,8 +26,10 @@ Values of a variant or record type declared @"private"@
 can be de-structured normally in pattern-matching or via
 the @expr '.' field@ notation for record accesses.  However, values of
 these types cannot be constructed directly by constructor application
-or record construction.  Moreover, assignment on a mutable field of a
-private record type is not allowed.
+or record construction \emph{outside} of the module.
+Moreover, assignment on a mutable field of a
+private record type is not allowed. In other word, private types are
+externally accessible but not constructible.
 
 The typical use of private types is in the export signature of a
 module, to ensure that construction of values of the private type always
@@ -45,7 +47,19 @@ end = struct
 end
 \end{caml_example*}
 Here, the @"private"@ declaration ensures that in any value of type
-"M.t", the argument to the "B" constructor is always a positive integer.
+"M.t", the argument to the "B" constructor is always a positive integer,
+because client of the "M" module must use the "b" function to construct
+"B" value.
+
+\begin{caml_example*}{verbatim}[error]
+(* this function compiles because it only uses pattern-matching *)
+let test = function
+  | M.A -> "A"
+  | M.B _ -> "B"
+
+(* this one does not because it constructs a type *)
+let make_b = M.B (-1)
+\end{caml_example*}
 
 With respect to the variance of their parameters, private types are
 handled like abstract types. That is, if a private type has

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -63,8 +63,7 @@ let make_b = M.B (-1)
 
 Note that if the type is marked as private \emph{in the implementation},
 constructing a type is no longer possible within the implementation. It can
-be useful when types are created externally (C extension) or used as
-marker in a GADT.
+be useful when types are created externally from a C extension for instance.
 
 With respect to the variance of their parameters, private types are
 handled like abstract types. That is, if a private type has

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -63,7 +63,7 @@ let make_b = M.B (-1)
 
 Note that if the type is marked as private \emph{in the implementation},
 constructing a type is no longer possible within the implementation. It can
-be usefull when types are created externally (C extension) or used as
+be useful when types are created externally (C extension) or used as
 marker in a GADT.
 
 With respect to the variance of their parameters, private types are


### PR DESCRIPTION
Without the help of maintainers on Discord, it would have been hard to understand how private types work. This PR adds their explanation to the documentation so that everybody can enjoy it.