### PR TITLE
Refactor type approx

### DIFF
--- a/Changes
+++ b/Changes
@@ -524,6 +524,9 @@ OCaml 5.4.0
 - #13971 Keep generalized structure from patterns when typing `let`
   (Leo White, review by Samuel Vivien and Florian Angeletti)
 
+- #13980 Refactor `type-approx` and improve some errors' locations.
+  (Leo White, Ulysse Gérard, review by Samuel Vivien and Florian Angeletti)
+
 ### Build system:
 
 - #13431: Simplify github action responsible for flagging PRs with

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -36,3 +36,21 @@ and opt_ok_g ?(foo : M.t option) ?(bar : M.t = M.A) () = opt_ok_f ()
 val opt_ok_f : unit -> 'a = <fun>
 val opt_ok_g : ?foo:M.t -> ?bar:M.t -> unit -> 'a = <fun>
 |}]
+
+module M : sig
+  type t = private int
+  val x : t
+end = struct
+  type t = int
+  let x = 0
+end
+
+let rec f () : M.t :> int = (M.x : M.t)
+[%%expect{|
+module M : sig type t = private int val x : t end
+Line 9, characters 28-39:
+9 | let rec f () : M.t :> int = (M.x : M.t)
+                                ^^^^^^^^^^^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
+|}]

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -48,9 +48,5 @@ end
 let rec f () : M.t :> int = (M.x : M.t)
 [%%expect{|
 module M : sig type t = private int val x : t end
-Line 9, characters 28-39:
-9 | let rec f () : M.t :> int = (M.x : M.t)
-                                ^^^^^^^^^^^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+val f : unit -> int = <fun>
 |}]

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -74,18 +74,18 @@ Error: Uninterpreted extension 'ext'.
 
 let rec f x = ( (), () : _ -> _ -> _ )
 [%%expect{|
-Line 3, characters 14-38:
+Line 3, characters 16-22:
 3 | let rec f x = ( (), () : _ -> _ -> _ )
-                  ^^^^^^^^^^^^^^^^^^^^^^^^
+                    ^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "'c -> 'd -> 'e"
 |}]
 
 let rec g x = ( ((), ()) : _ -> _ :> _ )
 [%%expect{|
-Line 1, characters 14-40:
+Line 1, characters 16-24:
 1 | let rec g x = ( ((), ()) : _ -> _ :> _ )
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    ^^^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "'c -> 'd"
 |}]

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -774,11 +774,10 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                | Tvar _ ->
                    let ty' = Ctype.newvar () in
                    Ctype.unify val_env (Ctype.newty (Tpoly (ty', []))) ty;
-                   Ctype.unify val_env (type_approx val_env sbody) ty'
+                   type_approx val_env sbody ty'
                | Tpoly (ty1, tl) ->
                    let _, ty1' = Ctype.instance_poly ~fixed:false tl ty1 in
-                   let ty2 = type_approx val_env sbody in
-                   Ctype.unify val_env ty2 ty1'
+                   type_approx val_env sbody ty1'
                | _ -> assert false
              with Ctype.Unify err ->
                raise(Error(loc, val_env,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3357,7 +3357,10 @@ and type_approx_function env params c body ty_expected ~in_function ~first =
               ~in_function ~first
           in
           type_approx env e ty_res
-      | Pfunction_cases ([], _, _) ->  ()
+      | Pfunction_cases ([], _, _) ->
+          (* This case is in fact not reachable. Doing nothing would be the
+             correct thing to do if it were to be reachable in the future. *)
+          ()
 
 (* Check that all univars are safe in a type. Both exp.exp_type and
    ty_expected should already be generalized. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3333,7 +3333,7 @@ and type_approx_function env params c body ty_expected ~in_function ~first =
   let loc_function, _ = in_function in
   let loc = loc_rest_of_function ~first ~loc_function params body in
   (* We can approximate types up to the first newtype parameter, whereupon
-    we give up.
+     we give up.
   *)
   match params with
   | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
@@ -3345,7 +3345,7 @@ and type_approx_function env params c body ty_expected ~in_function ~first =
   | { pparam_desc = Pparam_newtype _ } :: _ -> ()
   | [] ->
       (* In the [Pconstraint] case, we override the [ty_expected] that
-        gets passed to the approximating of the rest of the type.
+         gets passed to the approximating of the rest of the type.
       *)
       let ty_expected =
         type_approx_constraint_opt env c ty_expected ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3274,12 +3274,16 @@ let type_approx_constraint env constraint_ ~loc ty_expected =
         raise (Error (loc, env, Expr_type_clash (err, None, None)))
       end;
       ty_constrain
-  | Pcoerce (_constrain, coerce) ->
+  | Pcoerce (constrain, coerce) ->
+      let ty_constrain = match constrain with
+        | None -> newvar ()
+        | Some sty -> approx_type env sty
+      in
       let ty_coerce = approx_type env coerce in
       begin try unify env ty_coerce ty_expected with Unify err ->
         raise (Error (loc, env, Expr_type_clash (err, None, None)))
       end;
-      ty_expected
+      ty_constrain
 
 let type_approx_constraint_opt env constraint_ ~loc ty_expected =
   match constraint_ with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3238,6 +3238,8 @@ let type_pattern_approx env spat ty_expected =
 
 let type_approx_fun_one_param
   env label default spato ty_expected ~first ~in_function =
+  (* [spato] is [None] when approximating a [Pfunction_cases],
+     the parameter is implicit in that case. *)
   let ty_arg, ty_ret =
     try filter_arrow env ty_expected label
     with Filter_arrow_failed err ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -129,8 +129,11 @@ val type_expect:
         Env.t -> Parsetree.expression -> type_expected -> Typedtree.expression
 val type_exp:
         Env.t -> Parsetree.expression -> Typedtree.expression
+
+(** [type_approx env exp ty_expectd] approximates the type of the expression
+    [expr] and unifies the result with [ty_expected]. *)
 val type_approx:
-        Env.t -> Parsetree.expression -> type_expr
+        Env.t -> Parsetree.expression -> type_expr -> unit
 val type_argument:
         Env.t -> Parsetree.expression ->
         type_expr -> type_expr -> Typedtree.expression


### PR DESCRIPTION
This refactoring is a required preliminary for #13806. The flow of `type_approx` is reversed which allows for slightly more precise error messages in some cases.

cc @samsa1 @Octachron 