### PR TITLE
Refine docs for `In_channel` and `Out_channel`

### DIFF
--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -16,6 +16,7 @@
 (** Input channels.
 
     This module provides functions for working with input channels.
+    For example, you can use this module to read files or get user input.
 
     See {{!examples} the example section} below.
 

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -16,7 +16,8 @@
 (** Input channels.
 
     This module provides functions for working with input channels.
-    For example, you can use this module to read files or get user input.
+    For example, you can use this module to read files or get user
+    input from the terminal.
 
     See {{!examples} the example section} below.
 

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -16,9 +16,8 @@
 (** Output channels.
 
     This module provides functions for working with output channels.
-    For example, you can use this module to write to a file or 
-    print to the terminal
-    
+    For example, you can use this module to write to a file or
+    print to the terminal.
 
     See {{!examples} the example section} below.
 

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -16,6 +16,8 @@
 (** Output channels.
 
     This module provides functions for working with output channels.
+    For example, you can use this module to print to the screen or
+    write to a file.
 
     See {{!examples} the example section} below.
 
@@ -194,6 +196,11 @@ val isatty : t -> bool
     @since 5.1 *)
 
 (** {1:examples Examples}
+    Printing to the screen:
+    {[
+      Out_channel.output_string Out_channel.stdout "hello, world"
+    ]}
+
     Writing the contents of a file:
     {[
       let write_file file s =

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -16,7 +16,7 @@
 (** Output channels.
 
     This module provides functions for working with output channels.
-    For example, you can use this module to print to the screen or
+    For example, you can use this module to print to the terminal or
     write to a file.
 
     See {{!examples} the example section} below.

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -16,8 +16,9 @@
 (** Output channels.
 
     This module provides functions for working with output channels.
-    For example, you can use this module to print to the terminal or
-    write to a file.
+    For example, you can use this module to write to a file or 
+    print to the terminal
+    
 
     See {{!examples} the example section} below.
 
@@ -196,7 +197,7 @@ val isatty : t -> bool
     @since 5.1 *)
 
 (** {1:examples Examples}
-    Printing to the screen:
+    Printing to the terminal:
     {[
       Out_channel.output_string Out_channel.stdout "hello, world"
     ]}


### PR DESCRIPTION
In [a discussion thread about pain points in OCaml](https://discuss.ocaml.org/t/what-are-the-biggest-reasons-newcomers-give-up-on-ocaml/10958/469?u=nicholaslyang), I realized that `In_channel` and `Out_channel` are a little confusing to understand. The description doesn't explain that they can be used to handle files, and the examples are placed at the bottom instead of at the top where they can be seen and understood immediately. This PR moves the examples to the top and adds a sentence explaining how the modules can be used.