### PR TITLE
Correct bug with invalid "Unbound module" when typing recursive functions

### DIFF
--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -36,3 +36,29 @@ and opt_ok_g ?(foo : M.t option) ?(bar : M.t = M.A) () = opt_ok_f ()
 val opt_ok_f : unit -> 'a = <fun>
 val opt_ok_g : ?foo:M.t -> ?bar:M.t -> unit -> 'a = <fun>
 |}]
+
+module type T = sig type t end
+
+let rec f (x : (module T with type t = int)) =
+       let (module LocalModule) = x in (3 : LocalModule.t)
+
+[%%expect{|
+module type T = sig type t end
+Line 4, characters 44-55:
+4 |        let (module LocalModule) = x in (3 : LocalModule.t)
+                                                ^^^^^^^^^^^
+Error: Unbound module "LocalModule"
+|}]
+
+type t = C : 'a -> t
+
+let rec f x =
+       let C (type a) v  = x in (v : a)
+
+[%%expect{|
+type t = C : 'a -> t
+Line 4, characters 37-38:
+4 |        let C (type a) v  = x in (v : a)
+                                         ^
+Error: Unbound type constructor "a"
+|}]

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -44,10 +44,7 @@ let rec f (x : (module T with type t = int)) =
 
 [%%expect{|
 module type T = sig type t end
-Line 4, characters 44-55:
-4 |        let (module LocalModule) = x in (3 : LocalModule.t)
-                                                ^^^^^^^^^^^
-Error: Unbound module "LocalModule"
+val f : (module T with type t = int) -> int = <fun>
 |}]
 
 type t = C : 'a -> t
@@ -57,8 +54,9 @@ let rec f x =
 
 [%%expect{|
 type t = C : 'a -> t
-Line 4, characters 37-38:
+Line 4, characters 22-23:
 4 |        let C (type a) v  = x in (v : a)
-                                         ^
-Error: Unbound type constructor "a"
+                          ^
+Error: Existential types introduced in a constructor pattern
+       must be bound by a type constraint on the argument.
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3189,11 +3189,14 @@ let rec approx_type env sty =
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
   | Ptyp_constr (lid, ctl) ->
-      let path, decl = Env.lookup_type ~use:false ~loc:lid.loc lid.txt env in
-      if List.length ctl <> decl.type_arity then newvar ()
-      else begin
-        let tyl = List.map (approx_type env) ctl in
-        newconstr path tyl
+      begin match Env.lookup_type ~use:false ~loc:lid.loc lid.txt env with
+      | (path, decl) ->
+        if List.length ctl <> decl.type_arity then newvar ()
+        else begin
+          let tyl = List.map (approx_type env) ctl in
+          newconstr path tyl
+        end
+      | exception Env.Error(Lookup_error(_, _, _)) -> newvar ()
       end
   | Ptyp_poly (_, sty) ->
       approx_type env sty


### PR DESCRIPTION
Currently when typing the following code :
```ocaml
module type T = sig type t end

let rec f (x : (module T with type t = int)) =
       let (module LocalModule) = x in (3 : LocalModule.t)
 ```
OCaml fails with the error message :
```
Line 4, characters 44-55: 
4 |        let (module LocalModule) = x in (3 : LocalModule.t)
                                                ^^^^^^^^^^^
Error: Unbound module "LocalModule"
|}]
```

The culprit in the type approximation that is done when typing recursive functions. We never look inside the patterns, resulting in a smaller environment than the real when the code contains first class modules.

This patch modifies slightly `approx_type` to accept unknown modules.