### PR TITLE
describe atomic record fields in the reference manual

### DIFF
--- a/manual/src/refman/extensions/attributes.etex
+++ b/manual/src/refman/extensions/attributes.etex
@@ -308,6 +308,10 @@ Some attributes are understood by the compiler:
   "ocaml.remove_aliases" or "remove_aliases", defined on either a	"module type
 	of" signature expression or "with module" constraint instructs the typechecker
 	to drop module aliases in the resulting signature.
+ \item
+   "ocaml.atomic" or "atomic" on a record field definition, marks this
+   record field as atomic. See \ref{s:atomic-record-fields} for more
+   details.
 \end{itemize}
 
 \begin{caml_example*}{verbatim}

--- a/manual/src/refman/extensions/extensionnodes.etex
+++ b/manual/src/refman/extensions/extensionnodes.etex
@@ -114,11 +114,10 @@ escaping issues.
 Some extension nodes are understood by the compiler itself:
 \begin{itemize}
   \item
-    ``ocaml.extension_constructor'' or ``extension_constructor''
-    take as payload a constructor from an extensible variant type
+    "ocaml.extension_constructor" or "extension_constructor"
+    extensions take as payload a constructor from an extensible variant type
     (see \ref{s:extensible-variants}) and return its extension
     constructor slot.
-\end{itemize}
 
 \begin{caml_example*}{verbatim}
 type t = ..
@@ -129,3 +128,9 @@ let y = [%extension_constructor Y]
 \begin{caml_example}{toplevel}
  x <> y;;
 \end{caml_example}
+
+  \item
+    "ocaml.atomic.loc" or "atomic.loc" extensions take as payload an
+    OCaml expression denoting an atomic location. See
+    \ref{s:atomic-record-fields} for more details.
+\end{itemize}

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -155,6 +155,9 @@ The field declaration @'mutable' field-name ':' poly-typexpr@
 behaves similarly; in addition, it allows physical modification of
 this field.
 Immutable fields are covariant, mutable fields are non-variant.
+Since OCaml 5.4, mutable fields may be marked "[\@atomic]" for
+concurrent access, see \ref{s:atomic-record-fields}.
+\\
 Both mutable and immutable fields may have explicitly polymorphic
 types.  The polymorphism of the contents is statically checked whenever
 a record value is created or modified.  Extracted values may have their

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -740,3 +740,52 @@ update the atomic reference at the same time. In this case, the "push" and
 allowing competing domains to make progress before retrying the failed
 operation. This lock-free stack implementation is called a 
 \href{https://en.wikipedia.org/wiki/Treiber_stack}{Treiber stack}.
+
+
+\subsection{s:atomic-record-fields}{Atomic record fields}
+
+The type "'a Atomic.t" is the atomic counterpart of the type of OCaml
+references, "'a ref". Since OCaml 5.4, we also support atomic record
+fields, which must be mutable, via the "[@atomic]" attribute.
+
+For example:
+\begin{caml_example*}{verbatim}
+type 'a refcounted = {
+  value : 'a;
+  mutable readers : int [@atomic];
+}
+\end{caml_example*}
+
+The field "readers" is atomic, so that reading and writing to this
+field are atomic operations similar to "Atomic.get" and
+"Atomic.set". It is possible to perform other atomic operations on
+this field by using a built-in extension node, "%atomic.loc": if
+"rc" is a value of type "foo refcounted", then "[%atomic.loc rc.readers]"
+is an expression of the built-in type "foo Atomic.Loc.t", which allows
+atomic operations defined in the the \stdmoduleref{Atomic}.Loc module
+of the standard library, mirroring the operations exposed for atomic
+references in the \stdmoduleref{Atomic} module:
+
+\begin{caml_example}{toplevel}
+let add_reader rc =
+  Atomic.Loc.fetch_and_add [%atomic.loc rc.readers] 1;;
+
+#show Atomic.Loc;;
+\end{caml_example}
+
+\paragraph{Limitation} Currently there is no analogue of
+"Atomic.make_contended" for atomic record fields. If false sharing is
+an issue for a specific record field, the best supported approach is
+to use a field of type "Atomic.t". We hope to implement support for
+on-demand padding of record fields in the future.
+
+\paragraph{Performance note} Internally "[%atomic.loc rc.readers]"
+is represented as a pair of the record value and a field
+offset. Whenever this expression is directly applied to an atomic
+primitive of the \stdmoduleref{Atomic}.Loc module, the compiler will
+optimize away the creation of the pair; it passes the value and the
+offset as separate parameters to an underlying runtime primitive. On
+the other hand, storing an atomic location in a data-structure or
+passing it to another, non-inlined function may allocate a pair. When
+in doubt, you can inspect the "-dcmm" intermediate representation of
+your code.


### PR DESCRIPTION
This is a manual addition, documenting atomic record fields as implemented in #13404.

I sent this as a separate PR to let people review it at its own pace, and also because I haven't managed to build the manual (see #13986) so I'm not fully sure that the output is nice. (I checked the generated `.tex` file to ensure that `caml_example` is processed correctly.)

Note: while working on this I noticed some sharp edges in the manual tooling:
- there is a `caml_example` environment and also apparently some tools support `camlexample` (for example `transf.mll` parses only `camlexample` I think?) I am sticking with `caml_example` as it is the documented one, but this is a bit confusing.
- I looked into this because I got a failure running `make tutorials/parallelism.tex` from the `manual/src` directory. In fact `make -C tutorials parallelism.tex` works, because it uses a different set of rules that is more correct. I find it confusing that there are two different set of rules available to build those `.tex` files.
