### PR TITLE
Manual documentation for external types

### DIFF
--- a/Changes
+++ b/Changes
@@ -275,6 +275,10 @@ Working version
   recursive modules.
   (Shivam Acharya, review by Gabriel Scherer and Florian Angeletti)
 
+- #13994: documentation for external types
+  (Gabriel Scherer, review by Jan Midtgaard, Jacques Garrigue
+   and Florian Angeletti)
+
 - #14076, 14111: error messages, add a short explanation for mismatched
   universal variables and universal quantifications.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/manual/src/refman/Makefile
+++ b/manual/src/refman/Makefile
@@ -16,7 +16,7 @@ EXTENSION_FILES = letrecvalues.tex recursivemodules.tex locallyabstract.tex \
   generativefunctors.tex extensionsyntax.tex inlinerecords.tex \
   doccomments.tex indexops.tex emptyvariants.tex alerts.tex \
   generalizedopens.tex bindingops.tex extensionnodes.tex privatetypes.tex \
-  effects.tex arrayliterals.tex labeledtuples.tex
+  effects.tex arrayliterals.tex labeledtuples.tex externaltypes.tex
 
 FILES =  $(addprefix extensions/,$(EXTENSION_FILES)) \
   refman.tex lex.tex names.tex values.tex const.tex types.tex \

--- a/manual/src/refman/exten.etex
+++ b/manual/src/refman/exten.etex
@@ -34,4 +34,8 @@ that are implemented in OCaml, but not described in chapter \ref{c:refman}.
 \input{arrayliterals.tex}
 \input{labeledtuples.tex}
 
+\section{s:external-types}{External types}
+%HEVEA\cutname{externaltypes.html}
+\input{externaltypes.tex}
+
 %HEVEA\cutend

--- a/manual/src/refman/extensions/externaltypes.etex
+++ b/manual/src/refman/extensions/externaltypes.etex
@@ -1,0 +1,57 @@
+(Introduced in OCaml 5.5)
+
+External types introduce types of values that are defined outside the
+OCaml language (they cannot be defined as standard datatype or formed
+by combining existing type constructors) because they are populated
+from the foreign function interface. For example, a type "gmp" of
+arbitrary-length integers implementing by binding the "Gmp" library
+from C could be defined as follows:
+
+\begin{caml_example*}{verbatim}
+module Gmp : sig
+  type t = external "gmp"
+
+  val of_int : int -> t
+  val add : t -> t -> t
+  (* ... *)
+end = struct[@ellipsis]
+  type t = external "gmp"
+  let of_int _ = assert false
+  let add _ _ = assert false
+end
+\end{caml_example*}
+
+We say that "Gmp.t" is an external type of name "gmp". External names
+are not unique, it is possible to define two (distinct) external types
+with the same name. On the other hand, the type-system enforces that
+two external types with distinct names are different.
+
+Before external types were available, users could use an abstract type
+for this purpose, just with "type gmp". But this is less informative,
+as the OCaml compiler must assume that abstract types could be defined
+in an arbitrary way, and in particular an abstract type from another
+module could be equal to any type.
+
+\paragraph{Predefined types}
+
+External types can be used in particular to define the built-in types
+such as "float", "string", etc.
+
+\begin{caml_example*}{verbatim}
+type float = external "float"
+type string = external "string"
+type 'a array = external "array"
+type +'a iarray = external "iarray"
+(* ... *)
+\end{caml_example*}
+We know for example that "float" and "string" are distinct types, as
+they have different names.
+
+Remark: This is useful in particular when using predefined types as
+GADT indices, incompatible constructors can be ruled out. See
+\ref{s:types-used-as-gadt-indices} for a discussion of GADT indices.
+
+\paragraph{Variance and injectivity} Like abstract types, the variance
+of the parameters of external types must be specified by users, with
+invariance assumed by default. Unlike abstract types, external types
+are always injective.

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -304,12 +304,6 @@ end
 let x : int = let Eq = M.e in M.x
 \end{caml_example*}
 
-Of course, not all abstract types can be refined, as this would
-contradict the exhaustiveness check. Namely, builtin types (those
-defined by the compiler itself, such as "int" or "array"), and
-abstract types defined by the local module, are non-instantiable, and
-as such cause a type error rather than introduce an equation.
-
 
 \section{s:types-used-as-gadt-indices}{Types used as GADT indices}
 

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -373,19 +373,6 @@ end = struct
 end
 \end{caml_example*}
 
-This problem also affects datatype definitions with the same
-constructor or field names, which could be alias of each other.
-\begin{caml_example*}{verbatim}[error]
-module DataTypeNat = struct
-  type zero = TypeNat
-  type 'a succ = TypeNat
-end
-
-let of_singleton : ('a, DataTypeNat.(zero succ)) sized_list -> 'a = function
-  | Cons (v, Nil) -> v
-  | _ -> .
-\end{caml_example*}
-
 The recommended way to avoid this problem is to give a concrete
 definition to types such as "zero" and "succ", that are only meant to
 be used in GADT indices. (This is counter-intuitive, as we will never
@@ -396,6 +383,8 @@ module TypeNat = struct
   type 'a succ = Succ
 end
 \end{caml_example*}
+The types are now incompatibles as their constructor names are exposed
+and distinct.
 
 As an additional refinement, we can define those index types using
 using a "private" annotation, which clarifies that they are not meant
@@ -414,7 +403,7 @@ implementations; see the documentation of private types in
 type is effectively empty. This makes it more explicit that the types
 are only intended to be used as GADT indices.
 
-\subsection{s:abstract-types-current-module}{Legacy behavior: abstract types in the current module}
+\subsection{s:abstract-types-current-module}{Legacy behavior: types in the current module}
 
 Early versions of OCaml, up to OCaml 5.4, had a special handling of
 types defined in the current module. This special case does not apply
@@ -433,7 +422,9 @@ type !'a succ
 The reasoning was that while in general abstract types could be
 defined as anything somewhere in the program, abstract types that we
 just introduced are not defined at all, so it is correct to assume
-that they are distinct.
+that they are distinct. Similarly, datatypes defined in the current
+module were considered distinct even if they used the exact same
+constructors or field names.
 
 This special case made the system more complex and less modular. For
 example, GADT examples would work well when everything is defined in

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -309,3 +309,147 @@ contradict the exhaustiveness check. Namely, builtin types (those
 defined by the compiler itself, such as "int" or "array"), and
 abstract types defined by the local module, are non-instantiable, and
 as such cause a type error rather than introduce an equation.
+
+
+\section{s:types-used-as-gadt-indices}{Types used as GADT indices}
+
+In our discussion of refutation cases (\ref{s:gadt-refutation-cases}), we used the following example:
+
+\begin{caml_example*}{verbatim}
+type _ t =
+  | Int : int t
+  | Bool : bool t
+
+let deep : (char t * int) option -> char = function
+  | None -> 'c'
+  | _ -> .
+\end{caml_example*}
+
+The type-checker is able to verify that the "Some _" case is
+impossible because the type "char t" is empty. This relies on the fact
+that the types occurring in the GADT index are known to be distinct:
+the constructor "Int" returns an "int t", and we know that "int" and
+"char" are distinct types, so "Int" is impossible at type "char t" --
+and similarly for "Bool". In other words, checking that a GADT case is
+impossible (at a specific type) requires reasoning on inequalities
+between types.
+
+For this reason, using abstract types as GADT indices does not work as
+intended. Consider for instance:
+
+\begin{caml_example*}{verbatim}
+(* type-level natural numbers, in unary notation *)
+module TypeNat = struct
+  type zero
+  type !'a succ
+end
+
+type ('a, _) sized_list =
+  | Nil : ('a, TypeNat.zero) sized_list
+  | Cons : 'a * ('a, 'n) sized_list -> ('a, 'n TypeNat.succ) sized_list
+\end{caml_example*}
+
+This definition does not allow to rule out certain cases as impossible
+as we intended, for example the following fails:
+\begin{caml_example}{verbatim}[error]
+let of_singleton : ('a, TypeNat.(zero succ)) sized_list -> 'a = function
+  | Cons (v, Nil) -> v
+  | _ -> .
+\end{caml_example}
+
+Because "zero" and "succ" are abstract types, the compiler assumes
+that their definition is unknown, and that they might in fact be the
+same type. In particular, with this signature the types "zero" and "zero succ"
+are not known to be distinct (even if their implementations
+are distinct) and the compiler cannot agree that the "Nil" case is
+impossible at type "zero succ":\footnote{We also needed an explicit
+  injectivity annotation, "type !'a succ", otherwise the definition of
+  "sized_list" is also rejected because "succ" is abstract.}
+
+One way to reason about this is that a module with the same signature
+\emph{could} have been implemented as follows, where clearly "zero"
+and "zero succ" are not incompatible:
+\begin{caml_example*}{verbatim}
+module OtherTypeNat : sig
+  type zero
+  type !'a succ
+end = struct
+  type zero = unit
+  type 'a succ = 'a
+end
+\end{caml_example*}
+
+This problem also affects datatype definitions with the same
+constructor or field names, which could be alias of each other.
+\begin{caml_example*}{verbatim}[error]
+module DataTypeNat = struct
+  type zero = TypeNat
+  type 'a succ = TypeNat
+end
+
+let of_singleton : ('a, DataTypeNat.(zero succ)) sized_list -> 'a = function
+  | Cons (v, Nil) -> v
+  | _ -> .
+\end{caml_example*}
+
+The recommended way to avoid this problem is to give a concrete
+definition to types such as "zero" and "succ", that are only meant to
+be used in GADT indices. (This is counter-intuitive, as we will never
+manipulate values of this type.) You could use:
+\begin{caml_example*}{verbatim}
+module TypeNat = struct
+  type zero = Zero
+  type 'a succ = Succ
+end
+\end{caml_example*}
+
+As an additional refinement, we can define those index types using
+using a "private" annotation, which clarifies that they are not meant
+to be used to build values:
+\begin{caml_example*}{verbatim}
+module TypeNat = struct
+  type zero = private Zero
+  type 'a succ = private Succ
+end
+\end{caml_example*}
+
+Remark: Usually "private" is meant to be used in interfaces, not in
+implementations; see the documentation of private types in
+\ref{s:private-types}. The constructors of a datatype that is
+\emph{defined} as "private" cannot be used to build values, so the
+type is effectively empty. This makes it more explicit that the types
+are only intended to be used as GADT indices.
+
+\subsection{s:abstract-types-current-module}{Legacy behavior: abstract types in the current module}
+
+Early versions of OCaml, up to OCaml 5.4, had a special handling of
+types defined in the current module. This special case does not apply
+to the definitions of "succ" and "zero" discussed above, which are in
+separate submodules.
+
+So the following definitions used to suffice to define "sized_list",
+as the compiler would accept that "zero" and "'a succ" are always
+distinct:
+
+\begin{caml_example*}{verbatim}
+type zero
+type !'a succ
+\end{caml_example*}
+
+The reasoning was that while in general abstract types could be
+defined as anything somewhere in the program, abstract types that we
+just introduced are not defined at all, so it is correct to assume
+that they are distinct.
+
+This special case made the system more complex and less modular. For
+example, GADT examples would work well when everything is defined in
+the same module, but function definitions located in another module
+would fail, which is very confusing to users.
+
+Programs using this previously-supported feature can always be
+rewritten to use explicit definitions instead:
+
+\begin{caml_example*}{verbatim}
+type zero = private Zero
+type 'a succ = private Succ
+\end{caml_example*}

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -573,6 +573,10 @@ and type_declaration =
  - [type t = ..]
               when [type_kind] is {{!type_kind.Ptype_open}[Ptype_open]},
                and [manifest]  is [None].
+ - [type t = external "gmp"]
+              when [type_kind] is
+                 {{!type_kind.Ptype_external}[Ptype_external("gmp")]}
+               and [manifest]  is [None].
 *)
 
 and type_kind =


### PR DESCRIPTION
This is a proposed manual chapter for external types, as implemented in https://github.com/ocaml/ocaml/pull/13712 -- with an earler version proposed in a now out-of-date RFC, https://github.com/ocaml/RFCs/pull/4 .

External types are the missing piece to remove the current special-case behavior of abstract types defined in the current module ( #8900 ). This change, which is also included in #13712, may break some user programs using abstract types as GADT indices. The present PR also includes documentation for this: a discussion of why abstract types are not appropriate as GADT indices, with a suggestion to use private variants instead.

cc @Octachron, @t6s, @garrigue 