### PR TITLE
Add Option.blend

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,10 @@ Working version
   (Nicolás Ojeda Bär, review by Daniel Bünzli, Gabriel Scherer and David
   Allsopp)
 
+- #13995: Add Option.blend.
+  (Kate Deplaix, review by Daniel Bünzli, Gabriel Scherer,
+   Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -31,6 +31,11 @@ let iter f = function Some v -> f v | None -> ()
 let is_none = function None -> true | Some _ -> false
 let is_some = function None -> false | Some _ -> true
 
+let blend f o1 o2 = match o1, o2 with
+  | None, None -> None
+  | (Some _ as x), None | None, (Some _ as x) -> x
+  | Some v1, Some v2 -> Some (f v1 v2)
+
 let equal eq o0 o1 = match o0, o1 with
 | Some v0, Some v1 -> eq v0 v1
 | None, None -> true

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -60,6 +60,12 @@ val fold : none:'a -> some:('b -> 'a) -> 'b option -> 'a
 val iter : ('a -> unit) -> 'a option -> unit
 (** [iter f o] is [f v] if [o] is [Some v] and [()] otherwise. *)
 
+val blend : ('a -> 'a -> 'a) -> 'a option -> 'a option -> 'a option
+(** [blend f o1 o2] is [o1] if [o2] is [None], [o2] if [o1] is [None],
+    and [Some (f v1 v2)] if [o1] is [Some v1] and [o2] is [Some v2].
+
+    @since 5.5 *)
+
 (** {1:preds Predicates and comparisons} *)
 
 val is_none : 'a option -> bool


### PR DESCRIPTION
I needed this function recently and thought it could be useful for others.

Although neither `containers`, `batteries` or `extlib` have it, an example of such function in the ecosystem can be found in `base`: https://github.com/janestreet/base/blob/de1f112320ba021c5f4dea1af9e5f90b1e5afe34/src/option.mli#L147
That function (or vendored versions of it) seems reasonably useful: https://sherlocode.com/?q=Option.merge