### PR TITLE
GHA: add a Cygwin x86_64 job, triggered by the `run-cygwin-tests` label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,3 +233,39 @@ jobs:
       - name: Run the testsuite
         run: |
           su ocaml -c "bash -xe tools/ci/actions/runner.sh test"
+
+  cygwin:
+    runs-on: windows-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run-cygwin-tests')
+    defaults:
+      run:
+        shell: bash -eo pipefail -o igncr {0}
+    steps:
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@v3
+        with:
+          packages: make,gcc-core
+          install-dir: 'D:\cygwin'
+      - name: Save Cygwin cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            C:\cygwin-packages
+          key: cygwin-packages
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: true
+      - name: Configure tree
+        run: |
+          set -x
+          MAKE_ARG=-j tools/ci/actions/runner.sh configure
+      - name: Build
+        run: |
+          set -x
+          MAKE_ARG=-j tools/ci/actions/runner.sh build
+      - name: Run the testsuite
+        run: |
+          SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_sequential

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -667,6 +667,19 @@ the following environment variables, which should be set in link:appveyor.yml[]:
 - `CYGWIN_DIST`. Default: `64`. Either `64` or `32`, selects 32-bit or 64-bit
   Cygwin as the build environment.
 
+==== GitHub Actions Continuous Integration (CI)
+
+We use GitHub Actions workflows to test the OCaml compiler and runtime
+in various settings. Some tests are not run by default and are
+triggered by setting a label on the pull request. See below:
+
+- `run-cygwin-tests`: trigger Cygwin tests;
+- `run-crosscompiler-tests`: build various cross-compilers and test them;
+- `run-thread-sanitizer`: build the distribution with the Thread
+  Sanitizer (TSAN), and run the whole testsuite instrumented with TSAN;
+- `run-multicoretests`: run an extensive testsuite convering multicore
+  features.
+
 ==== INRIA's Continuous Integration (CI)
 
 INRIA provides a Jenkins continuous integration service that OCaml

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -127,6 +127,20 @@ let not_windows = make
     "not running on Windows"
     "running on Windows")
 
+let cygwin = make
+  ~name:"Cygwin"
+  ~description:"Pass if running on Cygwin"
+  (Actions_helpers.pass_or_skip Sys.cygwin
+    "running on Cygwin"
+    "not running on Cygwin")
+
+let not_cygwin = make
+  ~name:"not-cygwin"
+  ~description:"Pass if not running on Cygwin"
+  (Actions_helpers.pass_or_skip (not Sys.cygwin)
+    "not running on Cygwin"
+    "running on Cygwin")
+
 let not_msvc = make
   ~name:"not-msvc"
   ~description:"Pass if not using MSVC / clang-cl"
@@ -404,6 +418,8 @@ let _ =
     libwin32unix;
     windows;
     not_windows;
+    cygwin;
+    not_cygwin;
     not_msvc;
     target_windows;
     not_target_windows;

--- a/ocamltest/builtin_actions.mli
+++ b/ocamltest/builtin_actions.mli
@@ -28,6 +28,9 @@ val libwin32unix : Actions.t
 val windows : Actions.t
 val not_windows : Actions.t
 
+val cygwin : Actions.t
+val not_cygwin : Actions.t
+
 val bsd : Actions.t
 val not_bsd : Actions.t
 

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
@@ -1,4 +1,5 @@
 (* TEST
+ not-cygwin;
  include unix;
  include runtime_events;
  hasunix;
@@ -14,6 +15,9 @@
  * - doesn't double-free when it fails to attach to [None]
  * - does manage to attach to this process if we provide the right PID
  *)
+
+(* [make_unreadable] doesn't work on Cygwin with noacl as the
+   read permission cannot be removed. *)
 
 let create_and_free ?(pid) () =
   try

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -23,6 +23,8 @@ nm -A -P "$@" | LC_ALL=C awk '
 $2 ~ /^(\.refptr\.)?(__emutls_v\.)?(_?caml[_A-Z])/ { next }
 # ignore re_foo
 $2 ~ /^(\.refptr\.)?(_?re_)/ { next }
+# ignore "extern char **environ"
+$2 ~ /^(\.refptr\.)?(environ)/ { next }
 # ignore symbols pulled in by SHGetKnownFolderPath
 $2 ~ /^\.refptr\.FOLDERID_[a-zA-Z]+/ { next }
 # ignore local and undefined symbols


### PR DESCRIPTION
I hope this could help us tackle specific Cygwin problems from time to time, when they emerge. I've protected the Cygwin tests under the `run-cygwin-tests`, as the tests take a long time to execute. GNU parallel isn't available in the Cygwin package repository. It is available on MSYS2. I successfully installed it locally, but its install script failed in CI.

Please consider creating the `run-cygwin-tests` label and setting it on this PR.

cc @kit-ty-kate @dra27 