### PR TITLE
Fix Makefile dependencies for ocamldoc, ocamltest and ocamldebug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1857,14 +1857,11 @@ ocamldoc/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 ocamldoc/%: CAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 
 .PHONY: ocamldoc
-ocamldoc: ocamldoc/ocamldoc$(EXE) ocamldoc/odoc_test.cmo
-
-ocamldoc/ocamldoc$(EXE): ocamlc ocamlyacc ocamllex
+ocamldoc: ocamldoc/ocamldoc$(EXE) ocamldoc/odoc_test.cmo \
+  ocamlc ocamlyacc ocamllex
 
 .PHONY: ocamldoc.opt
-ocamldoc.opt: ocamldoc/ocamldoc.opt$(EXE)
-
-ocamldoc/ocamldoc.opt$(EXE): ocamlopt ocamlyacc ocamllex
+ocamldoc.opt: ocamldoc/ocamldoc.opt$(EXE) ocamlopt ocamlyacc ocamllex
 
 # OCamltest
 
@@ -1950,7 +1947,8 @@ ocamltest/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 ocamltest/%: CAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 
 ocamltest: ocamltest/ocamltest$(EXE) \
-  testsuite/lib/lib.cmo testsuite/lib/testing.cma testsuite/tools/expect$(EXE)
+  testsuite/lib/lib.cmo testsuite/lib/testing.cma testsuite/tools/expect$(EXE) \
+  ocamlc ocamlyacc ocamllex
 
 testsuite/lib/%: VPATH += testsuite/lib
 
@@ -1989,12 +1987,9 @@ endif
 
 ocamltest/ocamltest$(EXE): OC_BYTECODE_LINKFLAGS += -custom -g
 
-ocamltest/ocamltest$(EXE): ocamlc ocamlyacc ocamllex
-
 ocamltest.opt: ocamltest/ocamltest.opt$(EXE) \
-  testsuite/lib/testing.cmxa $(asmgen_OBJECT) testsuite/tools/codegen$(EXE)
-
-ocamltest/ocamltest.opt$(EXE): ocamlopt ocamlyacc ocamllex
+  testsuite/lib/testing.cmxa $(asmgen_OBJECT) testsuite/tools/codegen$(EXE) \
+  ocamlopt ocamlyacc ocamllex
 
 # ocamltest does _not_ want to have access to the Unix interface by default,
 # to ensure functions and types are only used via Ocamltest_stdlib.Unix
@@ -2170,14 +2165,12 @@ ocamldebug_BYTECODE_LINKFLAGS = -linkall
 debugger/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 
 .PHONY: ocamldebug ocamldebugger
-ocamldebug: debugger/ocamldebug$(EXE)
-ocamldebugger: debugger/ocamldebug$(EXE)
+ocamldebug: debugger/ocamldebug$(EXE) ocamlc ocamlyacc ocamllex
+ocamldebugger: debugger/ocamldebug$(EXE) ocamlc ocamlyacc ocamllex
 # the 'ocamldebugger' target is an alias of 'ocamldebug' for
 # backward-compatibility with old ./configure scripts; it can be
 # removed after most contributors have re-run ./configure once, for
 # example after 5.2 is branched
-
-debugger/ocamldebug$(EXE): ocamlc ocamlyacc ocamllex
 
 $(ocamldebug_DEBUGGER_OBJECTS): OC_COMMON_COMPFLAGS += -for-pack ocamldebug
 debugger/ocamldebug.cmo: $(ocamldebug_DEBUGGER_OBJECTS)


### PR DESCRIPTION
Some of the tools have lexers and parsers, so they depend on `ocamlyacc` and `ocamllex` being built. At some point (I haven't checked the history), this dependency was added to the executable files.
This is wrong (building the executable itself only depends on the compiler and the object files), but was mostly harmless, except that @gasche noticed in #13993 that some tools were needlessly rebuilt, and this turned out to be the cause.
The exact steps are subtle, but since `ocamlyacc` and `ocamllex` are phony targets (i.e. they don't actually build a file with the same name), every rule that has them as dependencies has to assume its inputs are stale, and rebuild its targets. By moving the dependencies to the generic phony targets for each of the tools, we not only avoid this issue but also ensure that the tools are available before we try to compile the individual modules, instead of before we compile the last ones.
I think the right fix would be to move the dependencies to the individual rules for compiling `.mll` and `.mly` files, but I'm not sure how to do it except by manually adding each individual case.