### PR TITLE
Refactor confusing names for non aliasable modules

### DIFF
--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -911,3 +911,29 @@ module M :
 module N : sig val s : string end
 val s : string = "hello"
 |}]
+
+
+(* Aliases of a recursive module (within the definition) are disallowed *)
+module rec X1 : sig end = struct
+  module Inner : sig module X = X2 end = struct end
+end
+and X2 : sig end = struct end
+[%%expect {|
+Line 2, characters 21-34:
+2 |   module Inner : sig module X = X2 end = struct end
+                         ^^^^^^^^^^^^^
+Error: Functor arguments and recursive modules (within the
+       recursive definition), such as "X2", cannot be aliased
+|}]
+
+
+(* Aliases of a recursive module (outside of the definition) are allowed *)
+module rec X1 : sig end = struct end
+and X2 : sig end = struct end
+
+module X3 : sig module Inner = X1 end = struct module Inner = X1 end
+[%%expect {|
+module rec X1 : sig end
+and X2 : sig end
+module X3 : sig module Inner = X1 end
+|}]

--- a/testsuite/tests/typing-modules/pr13185.ml
+++ b/testsuite/tests/typing-modules/pr13185.ml
@@ -11,5 +11,5 @@ module type S1 = sig end
 Line 2, characters 41-53:
 2 | module type S2 = functor (X : S1) -> sig module M = X end
                                              ^^^^^^^^^^^^
-Error: Functor arguments, such as "X", cannot be aliased
+Error: Functor arguments and recursive modules, such as "X", cannot be aliased
 |}]

--- a/testsuite/tests/typing-modules/pr13185.ml
+++ b/testsuite/tests/typing-modules/pr13185.ml
@@ -11,5 +11,6 @@ module type S1 = sig end
 Line 2, characters 41-53:
 2 | module type S2 = functor (X : S1) -> sig module M = X end
                                              ^^^^^^^^^^^^
-Error: Functor arguments and recursive modules, such as "X", cannot be aliased
+Error: Functor arguments and recursive modules (within the
+       recursive definition), such as "X", cannot be aliased
 |}]

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -208,7 +208,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 8, characters 4-16:
 8 |     module N = M
         ^^^^^^^^^^^^
-Error: Functor arguments, such as "M", cannot be aliased
+Error: Functor arguments and recursive modules, such as "M", cannot be aliased
 |}]
 
 (* Checking that the uses of M.t are rewritten regardless of how they

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -208,7 +208,8 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 8, characters 4-16:
 8 |     module N = M
         ^^^^^^^^^^^^
-Error: Functor arguments and recursive modules, such as "M", cannot be aliased
+Error: Functor arguments and recursive modules (within the
+       recursive definition), such as "M", cannot be aliased
 |}]
 
 (* Checking that the uses of M.t are rewritten regardless of how they

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -68,12 +68,12 @@ let rec env_from_summary sum subst =
           | Error `Functor -> assert false
           | Error `Not_found -> raise (Error (Module_not_found path'))
           end
-      | Env_functor_arg(Env_module(s, id, pres, desc), id')
+      | Env_not_aliasable(Env_module(s, id, pres, desc), id')
             when Ident.same id id' ->
           Env.add_module_declaration ~check:false
             id pres (Subst.module_declaration Keep subst desc)
-            ~arg:true (env_from_summary s subst)
-      | Env_functor_arg _ -> assert false
+            ~noalias:true (env_from_summary s subst)
+      | Env_not_aliasable _ -> assert false
       | Env_constraints(s, map) ->
           Path.Map.fold
             (fun path info ->

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -214,7 +214,7 @@ let rec nondep_mty_with_presence env va ids pres mty =
       let res_env =
         match param with
         | None -> env
-        | Some param -> Env.add_module ~arg:true param Mp_present arg env
+        | Some param -> Env.add_module ~noalias:true param Mp_present arg env
       in
       let mty =
         Mty_functor(Named (param, nondep_mty env var_inv ids arg),

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1828,7 +1828,7 @@ and tree_of_functor_parameter = function
         | None -> None, fun env -> env
         | Some id ->
             Some (Ident.name id),
-            Env.add_module ~arg:true id Mp_present ty_arg
+            Env.add_module ~noalias:true id Mp_present ty_arg
       in
       Some (name, tree_of_modtype ~ellipsis:false ty_arg), env
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3503,7 +3503,8 @@ let report_error ~loc _env = function
         (Style.as_inline_code path) p
   | Cannot_alias p ->
       Location.errorf ~loc
-        "Functor arguments and recursive modules, such as %a, cannot be aliased"
+        "Functor arguments and@ recursive modules@ (within the@ recursive \
+         definition),@ such as %a,@ cannot be aliased"
         (Style.as_inline_code path) p
   | Cannot_scrape_package_type p ->
       Location.errorf ~loc


### PR DESCRIPTION
Following the discussion on #13985, I propose the following refactoring changes, which do not affect the logic of what modules are aliasable, but only rename things.

- In `env.ml`, renamed the internal table used to track non aliasable modules from `Env_functor_arg` to `Env_not_aliasable`, renamed the associated test function from `is_functor_arg` to `is_aliasable`, renamed the `~arg` flags of some functions into `~noalias`. Removed the unused `add_functor_arg` function (marking modules as nonaliasable is done by `add_module_declaration`). 

- In `includemod.ml`, removed the redundant `can_alias` function

- In `typemod.ml`, updated the error message for `Cannot_alias`