### PR TITLE
webman: add anchors for API items, headings

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,11 @@ Working version
   attribute.
   (Clement Blaudeau, review by Gabriel Scherer)
 
+- #14002: Add anchors to items and headings of the web version of the API
+  documentation for easier linking.
+  (Nicolás Ojeda Bär, report by Louis Roché, review by Gabriel Scherer and
+  Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 ### Internal/compiler-libs changes:

--- a/manual/src/html_processing/scss/style.scss
+++ b/manual/src/html_processing/scss/style.scss
@@ -356,6 +356,32 @@
 	color: inherit;
     }
 
+    /* Anchors */
+
+    a.anchor{
+        position: absolute;
+        right: 100%;
+        padding-right: 0.4em;
+        opacity: 0;
+        box-shadow: none;
+    }
+
+    a.anchor:before{
+        content: "#";
+    }
+
+    a.anchor:hover{
+        opacity: 1 !important;
+    }
+
+    pre:hover a.anchor, :hover>a.anchor{
+        opacity: 0.5;
+    }
+
+    .anchored {
+        position: relative;
+    }
+
     /* Module member specification */
 
     .spec:not(.include), .spec.include details summary {


### PR DESCRIPTION
Add anchors to the "webman" version (which I believe is used in ocaml.org) of the API documentation for headings and API items: types, values and modules.

To try it:

- build the compiler (`make`)
- build the manual (`make -C manual`)
- build the web manual (`make -C manual/src/html_processing`)
- navigate to `manual/src/webman/5.4/api/index.html` and browse around

Disclaimer: being a CSS beginner, improvements are surely possible. Suggestions welcome!

Fixes #14001