### PR TITLE
Restore run-multicoretests workflow with trunk-compatible dune

### DIFF
--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml/dune
-          ref: 3.18.0
+          ref: 3.18.2
           path: dune
           persist-credentials: false
       - name: Build and install dune


### PR DESCRIPTION
This one-character PR gets the `run-multicoretests` workflow going again :slightly_smiling_face: 

The issue was that dune (temporarily) did not compile with trunk, which yesterday's 3.18.2 release restores:
https://github.com/ocaml/dune/releases/tag/3.18.2

(no-change-entry-needed)