### PR TITLE
stale bot: only identify stale issues, don't close them.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues"
+name: "Identify stale issues"
 on:
   schedule:
   - cron: "15 4 * * 1,3,5"
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been open one year with no activity.  Consequently, it is being marked with the "stale" label.  What this means is that the issue will be automatically closed in 30 days unless more comments are added or the "stale" label is removed.  Comments that provide new information on the issue are especially welcome: is it still reproducible? did it appear in other contexts? how critical is it? etc.'
+        stale-issue-message: 'This issue has been open one year with no activity and without being identified as a bug. Consequently, it is being marked with the "stale" label to see if anyone has comments that provide new information on the issue. Is the issue still reproducible? Did it appear in other contexts? How critical is it? Did you miss this feature in a new setting? etc. Without new comments, the issue will *not* be closed and it will remain alive with the "stale" label for triaging reason.'
         days-before-stale: 366
-        days-before-close: 30
+        days-before-close: -1
         exempt-issue-labels: 'bug'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been open one year with no activity and without being identified as a bug. Consequently, it is being marked with the "stale" label to see if anyone has comments that provide new information on the issue. Is the issue still reproducible? Did it appear in other contexts? How critical is it? Did you miss this feature in a new setting? etc. Without new comments, the issue will *not* be closed and it will remain alive with the "stale" label for triaging reason.'
+        stale-issue-message: 'This issue has been open one year with no activity and without being identified as a bug. Consequently, it is being marked with the "stale" label to see if anyone has comments that provide new information on the issue. Is the issue still reproducible? Did it appear in other contexts? How critical is it? Did you miss this feature in a new setting? etc. Note that the issue will *not* be closed in the absence of new activity: the "stale" label is only used for triaging reason.'
         days-before-stale: 366
         days-before-close: -1
         exempt-issue-labels: 'bug'


### PR DESCRIPTION
Recently, I have the impression that I am one of the few maintainers that interact regularly with the stale bot.

I am thus proposing to optimize the stale bot for *my* workflow by restricting it to only marking `stale` issues without closing them.

Indeed, my experience is that having an automated reminder that an issue has been dormant for one year has been often useful to me, but having a bot closes the issue without human interaction mostly loses information. And this part is a bit stressful for me. Moreover, as far I as understand, this is the the most fierily hated part of the stale bot.

Thus removing the "closing issue" part of the stale bot sounds like a good choice to me.
I have checked with other maintainers at Inria and they are fine with the idea.