### PR TITLE
Pprintast: use parentheses around Pexp_struct_item in sequences

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,6 +39,11 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #13839, #14008: Reimplement `let open`, `let module` and `let exception` in
+  terms of a single construct.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer, Samuel Vivien, Ulysse Gérard
+  and Vincent Laviron)
+
 ### Build system:
 
 ### Bug fixes:
@@ -464,11 +469,6 @@ OCaml 5.4.0
   (Florian Angeletti, review by Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
-
-- #13839: Reimplement `let open`, `let module` and `let exception` in terms of a
-  single construct.
-  (Nicolás Ojeda Bär, review by Gabriel Scherer, Samuel Vivien, Ulysse Gérard
-  and Vincent Laviron)
 
 - #13314: Comment the code of Translclass
   (Vincent Laviron and Nathanaëlle Courant, review by Olivier Nicole)

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -817,7 +817,7 @@ and expression ctxt f x =
         paren true (expression reset_ctxt) f x
     | Pexp_ifthenelse _ | Pexp_sequence _ when ctxt.ifthenelse ->
         paren true (expression reset_ctxt) f x
-    | Pexp_let _ | Pexp_letop _
+    | Pexp_let _ | Pexp_letop _ | Pexp_struct_item _
         when ctxt.semi ->
         paren true (expression reset_ctxt) f x
     | Pexp_newtype (lid, e) ->

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7520,3 +7520,8 @@ type t = String.( t )
 
 (* Utf8 identifier *)
 let là = function ça -> ça
+
+(* PR #14008 *)
+let () =
+  (let module M = N in ());
+  (let open M in ())


### PR DESCRIPTION
A small bug fix following #13839: the treatment in `Pprintast` for the new `Pexp_struct_item` needs to be equivalent to `Pexp_let` in order to add parentheses correctly when these expressions appear in sequences.