### PR TITLE
Fix miscompilation / liveness errors for string operations

### DIFF
--- a/Changes
+++ b/Changes
@@ -577,6 +577,9 @@ Working version
 
 ### Bug fixes:
 
+- #14010: Fix miscompilation / liveness errors for string operations
+  (Mark Shinwell, Xavier Clerc)
+
 - #14036: Fix nontermination of cycle printing in recursive modules with
   `-short-paths`. Add error message for types considered abstract while
   checking recursive modules.

--- a/Changes
+++ b/Changes
@@ -578,7 +578,7 @@ Working version
 ### Bug fixes:
 
 - #14010: Fix miscompilation / liveness errors for string operations
-  (Mark Shinwell, Xavier Clerc)
+  (Mark Shinwell, Xavier Clerc, review by Xavier Leroy and Gabriel Scherer)
 
 - #14036: Fix nontermination of cycle printing in recursive modules with
   `-short-paths`. Add error message for types considered abstract while

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1261,7 +1261,8 @@ let unaligned_load_64 ptr idx dbg =
 
 let unaligned_set_64 ptr idx newval dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cstore (Sixtyfour, Assignment), [offset_addr ptr idx dbg; newval], dbg)
+  then
+    Cop(Cstore (Sixtyfour, Assignment), [offset_addr ptr idx dbg; newval], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -151,6 +151,12 @@ let rec add_const c n dbg =
 let incr_int c dbg = add_const c 1 dbg
 let decr_int c dbg = add_const c (-1) dbg
 
+let add_int_addr c1 c2 dbg =
+  match c1, c2 with
+  | Cconst_int (0, _), c | c, Cconst_int (0, _) -> c
+  | Cconst_natint (0n, _), c | c, Cconst_natint (0n, _) -> c
+  | _, _ -> Cop (Cadda, [c1; c2], dbg)
+
 let rec add_int c1 c2 dbg =
   match (c1, c2) with
   | (Cconst_int (n, _), c) | (c, Cconst_int (n, _)) ->
@@ -1106,12 +1112,13 @@ let make_unsigned_int bi arg dbg =
 
 let unaligned_load_16 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(mk_load_mut Sixteen_unsigned, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Sixteen_unsigned, [add_int_addr ptr idx dbg], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
-    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int_addr ptr idx dbg], dbg) in
     let v2 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 1) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg],
+                 dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop(Cor, [lsl_int b1 (cconst_int 8) dbg; b2], dbg)
 
@@ -1119,7 +1126,7 @@ let unaligned_set_16 ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
     Cop(Cstore (Sixteen_unsigned, Assignment),
-      [add_int ptr idx dbg; newval], dbg)
+      [add_int_addr ptr idx dbg; newval], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
@@ -1129,24 +1136,29 @@ let unaligned_set_16 ptr idx newval dbg =
     let v2 = Cop(Cand, [newval; cconst_int 0xFF], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Csequence(
-        Cop(Cstore (Byte_unsigned, Assignment), [add_int ptr idx dbg; b1], dbg),
+        Cop(Cstore (Byte_unsigned, Assignment), [add_int_addr ptr idx dbg; b1],
+            dbg),
         Cop(Cstore (Byte_unsigned, Assignment),
-            [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2], dbg))
+            [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg; b2],
+            dbg))
 
 let unaligned_load_32 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(mk_load_mut Thirtytwo_unsigned, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Thirtytwo_unsigned, [add_int_addr ptr idx dbg], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
-    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int_addr ptr idx dbg], dbg) in
     let v2 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 1) dbg], dbg)
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg],
+                 dbg)
     in
     let v3 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 2) dbg], dbg)
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg],
+                 dbg)
     in
     let v4 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 3) dbg], dbg)
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg],
+                 dbg)
     in
     let b1, b2, b3, b4 =
       if Arch.big_endian
@@ -1161,15 +1173,18 @@ let unaligned_load_32 ptr idx dbg =
 let unaligned_set_32 ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
-    Cop(Cstore (Thirtytwo_unsigned, Assignment), [add_int ptr idx dbg; newval],
+    Cop(Cstore (Thirtytwo_unsigned, Assignment),
+      [add_int_addr ptr idx dbg; newval],
       dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
-      Cop(Cand, [Cop(Clsr, [newval; cconst_int 24], dbg); cconst_int 0xFF], dbg)
+      Cop(Cand, [Cop(Clsr, [newval; cconst_int 24], dbg); cconst_int 0xFF],
+        dbg)
     in
     let v2 =
-      Cop(Cand, [Cop(Clsr, [newval; cconst_int 16], dbg); cconst_int 0xFF], dbg)
+      Cop(Cand, [Cop(Clsr, [newval; cconst_int 16], dbg); cconst_int 0xFF],
+        dbg)
     in
     let v3 =
       Cop(Cand, [Cop(Clsr, [newval; cconst_int 8], dbg); cconst_int 0xFF], dbg)
@@ -1182,38 +1197,48 @@ let unaligned_set_32 ptr idx newval dbg =
     Csequence(
         Csequence(
             Cop(Cstore (Byte_unsigned, Assignment),
-                [add_int ptr idx dbg; b1], dbg),
+                [add_int_addr ptr idx dbg; b1], dbg),
             Cop(Cstore (Byte_unsigned, Assignment),
-                [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
+                [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg;
+                 b2],
                 dbg)),
         Csequence(
             Cop(Cstore (Byte_unsigned, Assignment),
-                [add_int (add_int ptr idx dbg) (cconst_int 2) dbg; b3],
+                [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg;
+                 b3],
                 dbg),
             Cop(Cstore (Byte_unsigned, Assignment),
-                [add_int (add_int ptr idx dbg) (cconst_int 3) dbg; b4],
+                [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg;
+                 b4],
                 dbg)))
 
 let unaligned_load_64 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(mk_load_mut Sixtyfour, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Sixtyfour, [add_int_addr ptr idx dbg], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
-    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int_addr ptr idx dbg], dbg) in
     let v2 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 1) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg],
+                 dbg) in
     let v3 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 2) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg],
+                 dbg) in
     let v4 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 3) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg],
+                 dbg) in
     let v5 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 4) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 4) dbg],
+                 dbg) in
     let v6 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 5) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 5) dbg],
+                 dbg) in
     let v7 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 6) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 6) dbg],
+                 dbg) in
     let v8 = Cop(mk_load_mut Byte_unsigned,
-                 [add_int (add_int ptr idx dbg) (cconst_int 7) dbg], dbg) in
+                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 7) dbg],
+                 dbg) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
       if Arch.big_endian
       then v1, v2, v3, v4, v5, v6, v7, v8
@@ -1234,7 +1259,7 @@ let unaligned_load_64 ptr idx dbg =
 
 let unaligned_set_64 ptr idx newval dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cstore (Sixtyfour, Assignment), [add_int ptr idx dbg; newval], dbg)
+  then Cop(Cstore (Sixtyfour, Assignment), [add_int_addr ptr idx dbg; newval], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
@@ -1274,32 +1299,39 @@ let unaligned_set_64 ptr idx newval dbg =
         Csequence(
             Csequence(
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int ptr idx dbg; b1],
+                    [add_int_addr ptr idx dbg; b1],
                     dbg),
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1)
+                       dbg; b2],
                     dbg)),
             Csequence(
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 2) dbg; b3],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2)
+                       dbg; b3],
                     dbg),
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 3) dbg; b4],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3)
+                       dbg; b4],
                     dbg))),
         Csequence(
             Csequence(
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 4) dbg; b5],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 4)
+                       dbg; b5],
                     dbg),
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 5) dbg; b6],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 5)
+                       dbg; b6],
                     dbg)),
             Csequence(
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 6) dbg; b7],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 6)
+                       dbg; b7],
                     dbg),
                 Cop(Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 7) dbg; b8],
+                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 7)
+                       dbg; b8],
                     dbg))))
 
 let max_or_zero a dbg =
@@ -2272,7 +2304,7 @@ let setfloatfield n init arg1 arg2 dbg =
 
 let stringref_unsafe arg1 arg2 dbg =
   tag_int(Cop(mk_load_mut Byte_unsigned,
-              [add_int arg1 (untag_int arg2 dbg) dbg],
+              [add_int_addr arg1 (untag_int arg2 dbg) dbg],
               dbg)) dbg
 
 let stringref_safe arg1 arg2 dbg =
@@ -2282,7 +2314,7 @@ let stringref_safe arg1 arg2 dbg =
         Csequence(
           make_checkbound dbg [string_length str dbg; idx],
           Cop(mk_load_mut Byte_unsigned,
-            [add_int str idx dbg], dbg))))) dbg
+            [add_int_addr str idx dbg], dbg))))) dbg
 
 let string_load size unsafe arg1 arg2 dbg =
   box_sized size dbg
@@ -2390,7 +2422,7 @@ let setfield_computed ptr init arg1 arg2 arg3 dbg =
 
 let bytesset_unsafe arg1 arg2 arg3 dbg =
       return_unit dbg (Cop(Cstore (Byte_unsigned, Assignment),
-                      [add_int arg1 (untag_int arg2 dbg) dbg;
+                      [add_int_addr arg1 (untag_int arg2 dbg) dbg;
                        ignore_high_bit_int (untag_int arg3 dbg)], dbg))
 
 let bytesset_safe arg1 arg2 arg3 dbg =
@@ -2401,7 +2433,7 @@ let bytesset_safe arg1 arg2 arg3 dbg =
         Csequence(
           make_checkbound dbg [string_length str dbg; idx],
           Cop(Cstore (Byte_unsigned, Assignment),
-              [add_int str idx dbg; newval],
+              [add_int_addr str idx dbg; newval],
               dbg))))))
 
 let arrayset_unsafe kind arg1 arg2 arg3 dbg =


### PR DESCRIPTION
As [described in more detail here](https://github.com/ocaml-flambda/flambda-backend/pull/3960), the Cmm machtypes for "pointer + offset" calculations used for the various string read/write operations appear to be wrong, which can lead to the corresponding derived pointers being live across a GC (in particular after CSE).  This can lead to highly obscure crashes.

This patch isn't as elaborate as the linked one: in particular it doesn't optimize the bigstring cases, where out-of-heap accesses mean that the existing `Int` machtypes are fine.  However I think it is the minimal fix for the bug, and should probably be cherry-picked everywhere first.

Whilst investigating this bug we also noticed that `Ccheckbound`, which can raise, is both treated as a simple operation in `Selectgen` and not treated as a barrier by `Comballoc`.  I am still discussing the consequences of this and will present any patch needed for these cases separately.

(cc @xavierleroy , this was the crash I mentioned on https://github.com/ocaml/ocaml/issues/13739, and turned out not to be arm64 specific even though we have only knowingly seen it on such platforms.)

Joint work with @xclerc 