### PR TITLE
Fix missing version bump in opam file

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -14,8 +14,8 @@ authors: [
 homepage: "https://github.com/ocaml/ocaml/"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 depends: [
-  # This is OCaml 5.4.0
-  "ocaml" {= "5.4.0" & post}
+  # This is OCaml 5.5.0
+  "ocaml" {= "5.5.0" & post}
 
   # General base- packages
   "base-unix" {post}


### PR DESCRIPTION
This was missed while bumping the trunk version to 5.5 in 60494e2.

I found it while attempting to build a local switch with #14010.

Note that this also needs @Octachron's ocaml/opam-repository#27833 to be merged to be able to satisfy the ocaml-variants.5.5 -> ocaml.5.5 requirement.

(no changes entry needed)