### PR TITLE
Update precondition comment to reflect renaming of cycle_all_domains_callback

### DIFF
--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1022,7 +1022,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   caml_gc_log("Compacting heap start");
   CAML_EV_BEGIN(EV_COMPACT);
   /* Warning: caml_compact_heap must only be called from
-     [cycle_all_domains_callback] in major_gc.c as there are
+     [stw_cycle_all_domains] in major_gc.c as there are
      very specific conditions the compaction algorithm expects.
 
     The following code implements a compaction algorithm that is similar to


### PR DESCRIPTION
`cycle_all_domains_callback` was renamed to `stw_cycle_all_domains` in #12619.

Found while code reading the preconditions for compaction while investigating #13739.

(no change entry needed)