### PR TITLE
GHA: add an optional wider test matrix (Cygwin, static, minimal, etc.)

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -21,23 +21,52 @@ defaults:
     shell: bash -eo pipefail -o igncr {0}
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.result }}
+    steps:
+      - name: Compute matrix for the "build" job
+        id: matrix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // # Always test cl and clang-cl
+            let compilers = ['cl', 'clang-cl'];
+            // # Also test i686 MSVC
+            let include = [
+              {cc: 'cl', x86_64: false}];
+            // # If this is a pull request, see if the PR has the
+            // # 'CI: Full matrix' label. This is done using an API request,
+            // # rather than from context.payload.pull_request.labels, since we
+            // # want the _current_ list of labels. This allows the labelling to
+            // # be changed, and then forcing a re-run of the workflow, rather
+            // # than having labelling triggering a fresh workflow event (which
+            // # is wasteful).
+            if (context.payload.pull_request) {
+              const { data: labels } =
+                await github.rest.issues.listLabelsOnIssue({...context.repo, issue_number: context.payload.pull_request.number});
+              if (labels.some(label => label.name === 'CI: Full matrix')) {
+                console.log('Full matrix requested');
+                // # Test Cygwin as well
+                compilers.push('gcc');
+              }
+            }
+            return {config_arg: [''], x86_64: [true], cc: compilers, include: include};
+
   build:
     permissions: {}
 
     runs-on: windows-latest
+
+    needs: matrix
 
     timeout-minutes: ${{ matrix.cc == 'gcc' && 90 || 60 }}
 
     name: ${{ matrix.cc == 'cl' && 'MSVC' || matrix.cc == 'gcc' && 'Cygwin' || 'clang-cl' }} ${{ matrix.x86_64 && '64 bits' || '32 bits' }} ${{ matrix.config_arg != '' && format('({0})', matrix.config_arg) || '' }}
 
     strategy:
-      matrix:
-        config_arg: ['']
-        x86_64: [true]
-        cc: [cl, clang-cl]
-        include:
-          - cc: cl
-            x86_64: false
+      matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
 
     steps:
 

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -50,6 +50,8 @@ jobs:
                 console.log('Full matrix requested');
                 // # Test Cygwin as well
                 compilers.push('gcc');
+                // # Test bytecode-only Cygwin
+                include.push({cc: 'gcc', x86_64: true, config_arg: '--disable-native-compiler');
               }
             }
             return {config_arg: [''], x86_64: [true], cc: compilers, include: include};

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -36,7 +36,7 @@ jobs:
             let compilers = ['cl', 'clang-cl'];
             // # Also test i686 MSVC
             let include = [
-              {cc: 'cl', x86_64: false}];
+              {cc: 'cl', arch: 'i686'}];
             // # If this is a pull request, see if the PR has the
             // # 'CI: Full matrix' label. This is done using an API request,
             // # rather than from context.payload.pull_request.labels, since we
@@ -52,10 +52,10 @@ jobs:
                 // # Test Cygwin as well
                 compilers.push('gcc');
                 // # Test bytecode-only Cygwin
-                include.push({cc: 'gcc', x86_64: true, config_arg: '--disable-native-compiler'});
+                include.push({cc: 'gcc', arch: 'x86_64', config_arg: '--disable-native-compiler'});
               }
             }
-            return {config_arg: [''], x86_64: [true], cc: compilers, include: include};
+            return {config_arg: [''], arch: ['x86_64'], cc: compilers, include: include};
       - name: Determine if the testsuite should be skipped
         id: skip
         uses: actions/github-script@v7
@@ -79,7 +79,7 @@ jobs:
 
     timeout-minutes: ${{ matrix.cc == 'gcc' && 90 || 60 }}
 
-    name: ${{ matrix.cc == 'cl' && 'MSVC' || matrix.cc == 'gcc' && 'Cygwin' || 'clang-cl' }} ${{ matrix.x86_64 && '64 bits' || '32 bits' }} ${{ matrix.config_arg != '' && format('({0})', matrix.config_arg) || '' }}
+    name: ${{ matrix.cc == 'cl' && 'MSVC' || matrix.cc == 'gcc' && 'Cygwin' || 'clang-cl' }} ${{ matrix.arch }} ${{ matrix.config_arg != '' && format('({0})', matrix.config_arg) || '' }}
 
     strategy:
       matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
@@ -114,13 +114,13 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
+          arch: ${{ matrix.arch == 'x86_64' && 'x64' || 'x86' }}
         if: matrix.cc != 'gcc'
 
       - name: Compute a key to cache configure results
         id: autoconf-cache-key
         env:
-          HOST: ${{ matrix.x86_64 && (matrix.cc == 'gcc' && 'x86_64-pc-cygwin' || 'x86_64-pc-windows') || 'i686-pc-windows' }}
+          HOST: ${{ format('{0}-pc-{1}', matrix.arch, (matrix.cc == 'gcc' && 'cygwin' || 'windows')) }}
         run: |
           echo "key=${{ env.HOST }}-${{ matrix.cc }}-${{ hashFiles('configure') }}" >> $GITHUB_OUTPUT
 
@@ -136,7 +136,7 @@ jobs:
           CONFIG_ARGS: >-
             --cache-file=config.cache
             --prefix "${{ matrix.cc != 'gcc' && '$PROGRAMFILES/Бактріан🐫' || '$(cygpath "$PROGRAMFILES/Бактріан🐫")'}}"
-            ${{ matrix.cc != 'gcc' && format('--host={0}', (matrix.x86_64 && (matrix.cc == 'gcc' && 'x86_64-pc-cygwin' || 'x86_64-pc-windows') || 'i686-pc-windows' )) || '' }}
+            ${{ matrix.cc != 'gcc' && format('--host={0}-pc-windows', matrix.arch) || '' }}
             ${{ matrix.cc != 'gcc' && format('CC={0}', matrix.cc) || '' }}
             ${{ matrix.config_arg }}
         run: |
@@ -181,7 +181,7 @@ jobs:
         # ^ The final wc is there to make sure that the canonical files are
         # reasonable cleaned-up versions of the raw dumpbins and not simply
         # empty
-        if: matrix.x86_64 && matrix.cc != 'gcc'
+        if: endsWith(matrix.arch, '64') && matrix.cc != 'gcc'
 
       - name: Run the test suite
         if: ${{ needs.config.outputs.skip-testsuite != 'true' }}

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -21,10 +21,11 @@ defaults:
     shell: bash -eo pipefail -o igncr {0}
 
 jobs:
-  matrix:
+  config:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.matrix.outputs.result }}
+      matrix: ${{ steps.matrix.outputs.result}}
+      skip-testsuite: ${{ steps.skip.outputs.result }}
     steps:
       - name: Compute matrix for the "build" job
         id: matrix
@@ -51,17 +52,30 @@ jobs:
                 // # Test Cygwin as well
                 compilers.push('gcc');
                 // # Test bytecode-only Cygwin
-                include.push({cc: 'gcc', x86_64: true, config_arg: '--disable-native-compiler');
+                include.push({cc: 'gcc', x86_64: true, config_arg: '--disable-native-compiler'});
               }
             }
             return {config_arg: [''], x86_64: [true], cc: compilers, include: include};
+      - name: Determine if the testsuite should be skipped
+        id: skip
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let skip_testsuite = false;
+            if (context.payload.pull_request) {
+              const { data: labels } =
+                await github.rest.issues.listLabelsOnIssue({...context.repo, issue_number: context.payload.pull_request.number});
+              skip_testsuite = labels.some(label => label.name === 'CI: Skip testsuite');
+            }
+            console.log('Skip testsuite: ' + skip_testsuite);
+            return skip_testsuite;
 
   build:
     permissions: {}
 
     runs-on: windows-latest
 
-    needs: matrix
+    needs: config
 
     timeout-minutes: ${{ matrix.cc == 'gcc' && 90 || 60 }}
 
@@ -170,6 +184,7 @@ jobs:
         if: matrix.x86_64 && matrix.cc != 'gcc'
 
       - name: Run the test suite
+        if: ${{ needs.config.outputs.skip-testsuite != 'true' }}
         run: |
           eval $(tools/msvs-promote-path)
           make tests

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -26,16 +26,17 @@ jobs:
 
     runs-on: windows-latest
 
-    timeout-minutes: 60
+    timeout-minutes: ${{ matrix.cc == 'gcc' && 90 || 60 }}
 
-    name: ${{ matrix.cc == 'cl' && 'MSVC' || 'clang-cl' }} ${{ matrix.x86_64 && '64 bits' || '32 bits' }}
+    name: ${{ matrix.cc == 'cl' && 'MSVC' || matrix.cc == 'gcc' && 'Cygwin' || 'clang-cl' }} ${{ matrix.x86_64 && '64 bits' || '32 bits' }} ${{ matrix.config_arg != '' && format('({0})', matrix.config_arg) || '' }}
 
     strategy:
       matrix:
-        x86_64: [true, false]
+        config_arg: ['']
+        x86_64: [true]
         cc: [cl, clang-cl]
-        exclude:
-          - cc: clang-cl
+        include:
+          - cc: cl
             x86_64: false
 
     steps:
@@ -55,7 +56,7 @@ jobs:
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v3
         with:
-          packages: make,mingw64-x86_64-gcc-core
+          packages: make,${{ matrix.cc != 'gcc' && 'mingw64-x86_64-' || 'gcc-fortran,' }}gcc-core
           install-dir: 'D:\cygwin'
 
       - name: Save Cygwin cache
@@ -69,11 +70,12 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
+        if: matrix.cc != 'gcc'
 
       - name: Compute a key to cache configure results
         id: autoconf-cache-key
         env:
-          HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
+          HOST: ${{ matrix.x86_64 && (matrix.cc == 'gcc' && 'x86_64-pc-cygwin' || 'x86_64-pc-windows') || 'i686-pc-windows' }}
         run: |
           echo "key=${{ env.HOST }}-${{ matrix.cc }}-${{ hashFiles('configure') }}" >> $GITHUB_OUTPUT
 
@@ -86,18 +88,18 @@ jobs:
 
       - name: Configure tree
         env:
-          HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
+          CONFIG_ARGS: >-
+            --cache-file=config.cache
+            --prefix "${{ matrix.cc != 'gcc' && '$PROGRAMFILES/Бактріан🐫' || '$(cygpath "$PROGRAMFILES/Бактріан🐫")'}}"
+            ${{ matrix.cc != 'gcc' && format('--host={0}', (matrix.x86_64 && (matrix.cc == 'gcc' && 'x86_64-pc-cygwin' || 'x86_64-pc-windows') || 'i686-pc-windows' )) || '' }}
+            ${{ matrix.cc != 'gcc' && format('CC={0}', matrix.cc) || '' }}
+            ${{ matrix.config_arg }}
         run: |
           eval $(tools/msvs-promote-path)
-          if ! ./configure --cache-file=config.cache --host=$HOST \
-               --prefix="$PROGRAMFILES/Бактріан🐫" \
-               CC=${{ matrix.cc }}; then
+          if ! ./configure ${{ env.CONFIG_ARGS }} ; then
             rm -rf config.cache
             failed=0
-            ./configure --cache-file=config.cache --host=$HOST \
-                --prefix="$PROGRAMFILES/Бактріан🐫" \
-                CC=${{ matrix.cc }} \
-              || failed=$?
+            ./configure ${{ env.CONFIG_ARGS }} || failed=$?
             if ((failed)) ; then
               echo
               echo "::group::config.log content ($(wc -l config.log) lines)"
@@ -119,6 +121,7 @@ jobs:
           eval $(tools/msvs-promote-path)
           make -j || failed=$?
           if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
+          test -e runtime/libcamlrun.lib || tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a
           runtime/ocamlrun ocamlc -config
 
       - name: Assemble backend with mingw-w64 GASM and compare
@@ -133,7 +136,7 @@ jobs:
         # ^ The final wc is there to make sure that the canonical files are
         # reasonable cleaned-up versions of the raw dumpbins and not simply
         # empty
-        if: matrix.x86_64
+        if: matrix.x86_64 && matrix.cc != 'gcc'
 
       - name: Run the test suite
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 #              minor heap.
   normal:
     name: ${{ matrix.name }}
-    needs: build
+    needs: [build, config]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -107,18 +107,18 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y ${{ matrix.dependencies }}
       - name: Run the testsuite
-        if: matrix.id == 'normal'
+        if: ${{ matrix.id == 'normal' && needs.config.outputs.skip-testsuite != 'true' }}
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh test
       - name: Run the testsuite (debug runtime)
-        if: matrix.id == 'debug'
+        if: ${{ matrix.id == 'debug' && needs.config.outputs.skip-testsuite != 'true' }}
         env:
           OCAMLRUNPARAM: v=0,V=1
           USE_RUNTIME: d
         run: |
           bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test"
       - name: Run the testsuite (s=4096, debug runtime)
-        if: matrix.id == 'debug-s4096'
+        if: ${{ matrix.id == 'debug-s4096' && needs.config.outputs.skip-testsuite != 'true' }}
         env:
           OCAMLRUNPARAM: s=4096,v=0
           USE_RUNTIME: d
@@ -144,13 +144,14 @@ jobs:
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks
 
 # macOS build+testsuite run, and other Linux configurations (-O0, etc.)
-  matrix:
+  config:
     runs-on: ubuntu-latest
     outputs:
-      jobs: ${{ steps.matrix.outputs.result }}
+      jobs: ${{ steps.jobs.outputs.result }}
+      skip-testsuite: ${{ steps.skip.outputs.result }}
     steps:
       - name: Compute matrix for the "others" job
-        id: matrix
+        id: jobs
         uses: actions/github-script@v7
         with:
           script: |
@@ -182,14 +183,27 @@ jobs:
               }
             }
             return jobs;
+      - name: Determine if the testsuite should be skipped
+        id: skip
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let skip_testsuite = false;
+            if (context.payload.pull_request) {
+              const { data: labels } =
+                await github.rest.issues.listLabelsOnIssue({...context.repo, issue_number: context.payload.pull_request.number});
+              skip_testsuite = labels.some(label => label.name === 'CI: Skip testsuite');
+            }
+            console.log('Skip testsuite: ' + skip_testsuite);
+            return skip_testsuite;
 
   others:
     name: ${{ matrix.name }}
-    needs: matrix
+    needs: config
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include: ${{ fromJSON(needs.matrix.outputs.jobs) }}
+        include: ${{ fromJSON(needs.config.outputs.jobs) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -214,11 +228,11 @@ jobs:
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
       - name: Run the testsuite
-        if: ${{ matrix.name != 'linux-O0' }}
+        if: ${{ matrix.name != 'linux-O0' && needs.config.outputs.skip-testsuite != 'true' }}
         run: |
           bash -c 'SHOW_TIMINGS=1 tools/ci/actions/runner.sh test'
       - name: Run the testsuite (linux-O0)
-        if: ${{ matrix.name == 'linux-O0' }}
+        if: ${{ matrix.name == 'linux-O0' && needs.config.outputs.skip-testsuite != 'true' }}
         env:
           OCAMLRUNPARAM: v=0,V=1
           USE_RUNTIME: d
@@ -229,6 +243,7 @@ jobs:
 
   i386:
     runs-on: ubuntu-latest
+    needs: config
     container:
       image: debian:12
       options: --platform linux/i386 --user root
@@ -249,5 +264,6 @@ jobs:
         run: |
           MAKE_ARG=-j su ocaml -c "bash -xe tools/ci/actions/runner.sh build"
       - name: Run the testsuite
+        if: ${{ needs.config.outputs.skip-testsuite != 'true' }}
         run: |
           su ocaml -c "bash -xe tools/ci/actions/runner.sh test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,26 @@ jobs:
               {name: 'linux-arm64', os: 'ubuntu-24.04-arm'},
               {name: 'macos-x86_64', os: 'macos-13'},
               {name: 'macos-arm64', os: 'macos-15'}];
+            // # If this is a pull request, see if the PR has the
+            // # 'CI: Full matrix' label. This is done using an API request,
+            // # rather than from context.payload.pull_request.labels, since we
+            // # want the _current_ list of labels. This allows the labelling to
+            // # be changed, and then forcing a re-run of the workflow, rather
+            // # than having labelling triggering a fresh workflow event (which
+            // # is wasteful).
+            if (context.payload.pull_request) {
+              const { data: labels } =
+                await github.rest.issues.listLabelsOnIssue({...context.repo, issue_number: context.payload.pull_request.number});
+              if (labels.some(label => label.name === 'CI: Full matrix')) {
+                console.log('Full matrix requested');
+                // # Add "static" and "minimal" jobs
+                jobs = jobs.concat([
+                  {name: 'static', os: 'ubuntu-latest',
+                   config_arg: '--disable-shared'},
+                  {name: 'minimal', os: 'ubuntu-latest',
+                   config_arg: '--disable-native-compiler --disable-shared --disable-debug-runtime --disable-instrumented-runtime --disable-systhreads --disable-str-lib --disable-unix-lib --disable-ocamldoc'}]);
+              }
+            }
             return jobs;
 
   others:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,20 +195,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: MacOS 13 Dependencies
-        if: matrix.os == 'macos-13'
-        run: |
-          brew install parallel
-          # Allows starting up lldb from a remote terminal
-          sudo DevToolsSecurity --enable
-          spctl developer-mode enable-terminal
-          # Select latest supported version
-          sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-          lldb --version
-
-      - name: MacOS 15 Dependencies
-        if: matrix.os == 'macos-15'
+      - name: macOS Dependencies
+        if: startsWith(matrix.os, 'macos-')
         run: |
           brew install parallel
           # Allows starting up lldb from a remote terminal
@@ -217,9 +205,8 @@ jobs:
           sudo DevToolsSecurity --enable
           spctl developer-mode enable-terminal
           # Select latest supported version
-          sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.os == 'macos-13' && '15.2' || '16.3' }}.app/Contents/Developer
           lldb --version
-
       - name: configure tree
         run: |
           CONFIG_ARG='--enable-codegen-invariants ${{ matrix.config_arg }}' MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,22 +143,33 @@ jobs:
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks
 
-# MacOS build+testsuite run, and Linux O0 run.
+# macOS build+testsuite run, and other Linux configurations (-O0, etc.)
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: ${{ steps.matrix.outputs.result }}
+    steps:
+      - name: Compute matrix for the "others" job
+        id: matrix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // # Default jobs: Linux -O0, Linux arm64 & macOS
+            let jobs = [
+              {name: 'linux-O0', os: 'ubuntu-latest',
+               config_arg: "CFLAGS='-O0'"},
+              {name: 'linux-arm64', os: 'ubuntu-24.04-arm'},
+              {name: 'macos-x86_64', os: 'macos-13'},
+              {name: 'macos-arm64', os: 'macos-15'}];
+            return jobs;
+
   others:
     name: ${{ matrix.name }}
+    needs: matrix
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - name: linux-O0
-            os: ubuntu-latest
-            config_arg: CFLAGS='-O0'
-          - name: linux-arm64
-            os: ubuntu-24.04-arm
-          - name: macos-x86_64
-            os: macos-13
-          - name: macos-arm64
-            os: macos-15
+        include: ${{ fromJSON(needs.matrix.outputs.jobs) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -673,6 +673,9 @@ We use GitHub Actions workflows to test the OCaml compiler and runtime
 in various settings. Some tests are not run by default and are
 triggered by setting a label on the pull request. See below:
 
+- `CI: Full matrix`: expands the test matrix considerably with additional
+  configurations; useful for PRs which affect the "systems" side of the
+  compiler;
 - `run-crosscompiler-tests`: build various cross-compilers and test them;
 - `run-thread-sanitizer`: build the distribution with the Thread
   Sanitizer (TSAN), and run the whole testsuite instrumented with TSAN;

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -676,6 +676,9 @@ triggered by setting a label on the pull request. See below:
 - `CI: Full matrix`: expands the test matrix considerably with additional
   configurations; useful for PRs which affect the "systems" side of the
   compiler;
+- `CI: Skip testsuite`: turns the tesuite *off* for a PR, which can be useful
+  for PRs which do not affect the compiler _at all_ or while a specific failure
+  is being investigated;
 - `run-crosscompiler-tests`: build various cross-compilers and test them;
 - `run-thread-sanitizer`: build the distribution with the Thread
   Sanitizer (TSAN), and run the whole testsuite instrumented with TSAN;

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -667,6 +667,18 @@ the following environment variables, which should be set in link:appveyor.yml[]:
 - `CYGWIN_DIST`. Default: `64`. Either `64` or `32`, selects 32-bit or 64-bit
   Cygwin as the build environment.
 
+==== GitHub Actions Continuous Integration (CI)
+
+We use GitHub Actions workflows to test the OCaml compiler and runtime
+in various settings. Some tests are not run by default and are
+triggered by setting a label on the pull request. See below:
+
+- `run-crosscompiler-tests`: build various cross-compilers and test them;
+- `run-thread-sanitizer`: build the distribution with the Thread
+  Sanitizer (TSAN), and run the whole testsuite instrumented with TSAN;
+- `run-multicoretests`: run an extensive testsuite convering multicore
+  features.
+
 ==== INRIA's Continuous Integration (CI)
 
 INRIA provides a Jenkins continuous integration service that OCaml

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -23,6 +23,8 @@ nm -A -P "$@" | LC_ALL=C awk '
 $2 ~ /^(\.refptr\.)?(__emutls_v\.)?(_?caml[_A-Z])/ { next }
 # ignore re_foo
 $2 ~ /^(\.refptr\.)?(_?re_)/ { next }
+# ignore "extern char **environ"
+$2 ~ /^(\.refptr\.)?(environ)/ { next }
 # ignore symbols pulled in by SHGetKnownFolderPath
 $2 ~ /^\.refptr\.FOLDERID_[a-zA-Z]+/ { next }
 # ignore local and undefined symbols

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -20,7 +20,7 @@ set -o pipefail
 
 nm -A -P "$@" | LC_ALL=C awk '
 # ignore caml_foo, camlFoo_bar, _caml_foo, _camlFoo_bar
-$2 ~ /^(\.refptr\.)?(__emutls_v\.)?(_?caml[_A-Z])/ { next }
+$2 ~ /^(\.refptr\.)?(_?__emutls_v\.)?(_?caml[_A-Z])/ { next }
 # ignore re_foo
 $2 ~ /^(\.refptr\.)?(_?re_)/ { next }
 # ignore "extern char **environ"


### PR DESCRIPTION
This adds a couple of things I've been using over on my fork for Relocatable OCaml for the last few months:
- Optional additional test matrix items added via a `CI: Full matrix` label
  - A `--disable-shared` job on Linux
  - The "minimal" build (everything which can be turned off turned off), which is run on Jenkins, but which wasn't available for PRs
  - Cygwin testing
- The ability to turn off the testsuite on a PR (intended to be used carefully, or only temporarily!) via a `CI: Skip testsuite` label

I've pulled in and updated the documentation improvements from #13996 and also the fix to `tools/check-symbol-names` as my version hadn't originally been calling that. Unlike in #13996, I opted to fix the `test_create_cursor_failures.ml` test, as the failure was for the same reason as the i386 run originally in #13419. To do, I've adapted a fix in the style of #8797 in `ocamltest` only.

I've included comments in the YAML for the part which generates the matrix, but note that the workflow here is to avoid re-running either of the build workflows automatically if the labels are added/removed - the idea is to re-run the config job in each workflow manually if the labels have been changed. There's more merging work with these workflows to do in the future, but I think this is a reasonable step forward...