### PR TITLE
error messages: explain coercion heuristic failure

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #13120, ????, improved error message for heuristic expression coercion
+   `(x:>typ)`
+   (Florian Angeletti, report by Samuel Vivien, review by ????)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -27,6 +27,7 @@ check-cross-references: cross-reference-checker
 	  $(ROOTDIR)/driver/main_args.ml \
 	  $(ROOTDIR)/lambda/translmod.ml \
 	  $(ROOTDIR)/typing/typemod.ml \
+	  $(ROOTDIR)/typing/typecore.ml \
 	  $(ROOTDIR)/typing/typeclass.ml
 
 # check that all standard library modules are referenced by the

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -374,9 +374,9 @@ let x = ([`B]:>[`A])
 Line 3, characters 9-13:
 3 | let x = ([`B]:>[`A])
              ^^^^
-Error: This expression cannot be coerced to type ""[ `A ]""; it has type
+Error: This expression cannot be coerced to type "[ `A ]"; it has type
          "[> `B ] list"
-       but is here used with type "[< `A ]"
+       but the coercion was expecting type "[< `A ]"
 |}]
 
 (** Unbound instance variable *)
@@ -461,4 +461,114 @@ Line 1, characters 8-19:
 1 | let f [%ocaml.error "Pattern error"] = ()
             ^^^^^^^^^^^
 Error: Pattern error
+|}]
+
+(** Coercion heuristic *)
+
+let ok1 = ((object method m = 0 end, Fun.id) :> < > * _ )
+[%%expect {|
+val ok1 : <  > * ('a -> 'a) = (<obj>, <fun>)
+|}]
+
+let legitimate_failure = ((object method m = 0 end, Fun.id) :> <n: int > * _)
+[%%expect {|
+Line 1, characters 26-59:
+1 | let legitimate_failure = ((object method m = 0 end, Fun.id) :> <n: int > * _)
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression cannot be coerced to type "< n : int > * 'b";
+       it has type "< m : int > * ('a -> 'a)"
+       but the coercion was expecting type "< n : int; .. > * 'b"
+       The first object type has no method "n"
+|}]
+
+
+let simple = ( (object end, Fun.id) :> <m: int -> int > * _)
+[%%expect {|
+Line 1, characters 15-35:
+1 | let simple = ( (object end, Fun.id) :> <m: int -> int > * _)
+                   ^^^^^^^^^^^^^^^^^^^^
+Error: This expression cannot be coerced to type "< m : int -> int > * 'c";
+       it has type "<  > * ('a -> 'a)" but the coercion was expecting type
+         "< m : int -> int; .. > * 'b"
+       The first object type has no method "m"
+|}]
+
+type pos = private int
+let ok2 (x:pos) = (x :> int)
+[%%expect {|
+type pos = private int
+val ok2 : pos -> int = <fun>
+|}]
+
+
+let covariant (x:int) = ( (x, Fun.id) :> pos * _ )
+[%%expect {|
+Line 1, characters 26-37:
+1 | let covariant (x:int) = ( (x, Fun.id) :> pos * _ )
+                              ^^^^^^^^^^^
+Error: This expression cannot be coerced to type "pos * 'a"; it has type
+         "int * ('a -> 'a)"
+       but the coercion was expecting type "pos * 'b"
+       Type "int" is not compatible with type "pos"
+|}]
+
+let long (x:pos) = ( (x, Fun.id) :> int * _ )
+[%%expect {|
+Line 1, characters 21-32:
+1 | let long (x:pos) = ( (x, Fun.id) :> int * _ )
+                         ^^^^^^^^^^^
+Error: This expression cannot be coerced to type "int * 'c" by the coercion
+       heuristic. The expression has type "pos * ('a -> 'a)"
+       but the coercion heuristic was expecting type "int * 'b"
+       Type "pos" is not compatible with type "int"
+Hint: Did you try using a full coercion "(foo : ty1 :> ty2)"?
+If the types of "(foo :> ty2)" contain type variables, the coercion uses a
+partial heuristic that may fail in presence of private types or complex
+object or polymorphic variant types (see manual section 3.12).
+|}]
+
+let contravariant (x: int -> int) =
+  (x :> pos -> int),
+  ((x, Fun.id) :> ( (pos -> int) * _ ))
+[%%expect {|
+Line 3, characters 3-14:
+3 |   ((x, Fun.id) :> ( (pos -> int) * _ ))
+       ^^^^^^^^^^^
+Error: This expression cannot be coerced to type "(pos -> int) * 'c" by the
+       coercion heuristic. The expression has type "(int -> int) * ('a -> 'a)"
+       but the coercion heuristic was expecting type "(pos -> int) * 'b"
+       Type "int" is not compatible with type "pos"
+Hint: Did you try using a full coercion "(foo : ty1 :> ty2)"?
+If the types of "(foo :> ty2)" contain type variables, the coercion uses a
+partial heuristic that may fail in presence of private types or complex
+object or polymorphic variant types (see manual section 3.12).
+|}]
+
+let legitimate_contravariant (x: pos -> int) =
+  ((x, Fun.id) :> ( (int -> int) * _ ))
+[%%expect {|
+Line 2, characters 3-14:
+2 |   ((x, Fun.id) :> ( (int -> int) * _ ))
+       ^^^^^^^^^^^
+Error: This expression cannot be coerced to type "(int -> int) * 'c";
+       it has type "(pos -> int) * ('a -> 'a)"
+       but the coercion was expecting type "(int -> int) * 'b"
+       Type "pos" is not compatible with type "int"
+|}]
+
+type u = private < >
+let error3 (x:u) = ((x,Fun.id) :> < > * _)
+[%%expect {|
+type u = private <  >
+Line 2, characters 20-30:
+2 | let error3 (x:u) = ((x,Fun.id) :> < > * _)
+                        ^^^^^^^^^^
+Error: This expression cannot be coerced to type "<  > * 'a" by the coercion
+       heuristic. The expression has type "u * ('a -> 'a)"
+       but the coercion heuristic was expecting type "< .. > * 'b"
+       Type "u" is not compatible with type "< .. >"
+Hint: Did you try using a full coercion "(foo : ty1 :> ty2)"?
+If the types of "(foo :> ty2)" contain type variables, the coercion uses a
+partial heuristic that may fail in presence of private types or complex
+object or polymorphic variant types (see manual section 3.12).
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4942,6 +4942,34 @@ let enlarge_type env ty =
   let (ty', _) = build_subtype env [] [] true 4 ty in
   (ty', !warn)
 
+let possibly_missed_private_subtyping env arg_ty coerce_ty =
+  let rec find ~positive ~mark env prev ty =
+    prev || try_mark_node mark ty
+    && match get_desc (expand_head env ty) with
+    | Tconstr(p,tl,_) ->
+       begin match Env.find_type p env with
+       | exception Not_found -> false
+       | decl ->
+          positive && decl.type_private = Private
+          || List.fold_left2 (find_parameter ~positive ~mark env) false
+               decl.type_variance tl
+       end
+    | Tarrow(_,ty1,ty2,_) ->
+          find ~mark ~positive env false ty2
+       || find ~mark ~positive:(not positive) env false ty1
+    | _ -> fold_type_expr (find ~mark ~positive env) false ty
+  and find_parameter ~mark ~positive env acc v ty =
+    acc ||
+      match Types.Variance.(mem May_neg v, mem May_pos v) with
+      | false, false | true, true -> false
+      | false, true -> find  ~positive ~mark env false ty
+      | true, false -> find ~positive:(not positive) ~mark env false ty
+  in
+  let find ~positive env ty =
+    with_type_mark (fun mark -> find ~mark ~positive env false ty)
+  in
+  find ~positive:true env arg_ty || find env ~positive:false coerce_ty
+
 (**** Check whether a type is a subtype of another type. ****)
 
 (*

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -370,6 +370,12 @@ val match_class_declarations:
 
 val enlarge_type: Env.t -> type_expr -> type_expr * bool
         (* Make a type larger, flag is true if some pruning had to be done *)
+
+val possibly_missed_private_subtyping: Env.t -> type_expr -> type_expr -> bool
+(* Flag a type if a private type appears in a position with the same variance as
+   [pos] *)
+
+
 val subtype: Env.t -> type_expr -> type_expr -> unit -> unit
         (* [subtype env t1 t2] checks that [t1] is a subtype of [t2].
            It accumulates the constraints the type variables must

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4931,8 +4931,11 @@ and type_coerce
           force ();
           begin try Ctype.unify env arg_type ty with Unify err ->
             let expanded = full_expand ~may_forget_scope:true env ty' in
+            let w =
+              b || Ctype.possibly_missed_private_subtyping env arg_type ty
+            in
             raise(Error(loc_arg, env,
-                        Coercion_failure ({ ty = ty'; expanded }, err, b)))
+                        Coercion_failure ({ ty = ty'; expanded }, err, w)))
           end
       end;
       (arg, ty', Texp_coerce (None, cty'))
@@ -7212,27 +7215,45 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "The instance variable %a is overridden several times"
         Style.inline_code v
-  | Coercion_failure (ty_exp, err, b) ->
+  | Coercion_failure(ty_exp, err, false) ->
+     (* Coercion that cannot succeed *)
      let intro =
        let ty_exp = Out_type.prepare_expansion ty_exp in
        doc_printf "This expression cannot be coerced to type@;<1 2>%a;@ \
                    it has type"
-         (Style.as_inline_code @@ Printtyp.type_expansion Type) ty_exp
+         (Printtyp.type_expansion Type) ty_exp
+     in
+     Location.errorf ~loc "%t" (fun ppf ->
+         Errortrace_report.unification ppf env err
+           intro
+           (Fmt.Doc.msg "but the coercion was expecting type")
+       )
+  | Coercion_failure (ty_exp, err, true) ->
+     (* Failure of the coercion heuristic *)
+     let[@manual.ref "s:using-coercions"] manual = [3; 12] in
+     let intro =
+       let ty_exp = Out_type.prepare_expansion ty_exp in
+       doc_printf
+         "This expression cannot be coerced to type@;<1 2>%a@ by@ the@ \
+          coercion@ heuristic. The expression has type"
+         (Printtyp.type_expansion Type) ty_exp
      in
       Location.errorf ~loc "%t" (fun ppf ->
         Errortrace_report.unification ppf env err
           intro
-          (Fmt.Doc.msg "but is here used with type")
+          (Fmt.Doc.msg "but the coercion heuristic was expecting type")
         )
-         ~sub:(
-           if not b then [] else
-             [ Location.msg "This simple coercion was not fully general";
-               Location.msg
-                 "@{<hint>Hint@}: Consider using a fully explicit coercion@ \
-                  of the form: %a"
-                 Style.inline_code "(foo : ty1 :> ty2)"
-             ]
-         )
+         ~sub:[
+           Location.msg
+             "@{<hint>Hint@}: Did you try using a full coercion@;<1 2>%a?@ \
+              @[If the types of %a contain type variables,@ the@ coercion@ \
+              uses@ a@ partial@ heuristic@ that@ may@ fail@ in@ presence@ of@ \
+              private@ types@, or@ complex@ object@ or@ polymorphic@ variant@ \
+              types@ %a.@]"
+             Style.inline_code "(foo : ty1 :> ty2)"
+             Style.inline_code "(foo :> ty2)"
+             Misc.print_see_manual manual
+         ]
   | Not_a_function (ty, explanation) ->
       Location.errorf ~loc
         "This expression should not be a function,@ \


### PR DESCRIPTION
When the short form of the expression coercion `(x:>typ)` encounters types that contain type variables, the typechecker resorts to a heuristic using unification between the inferred type of `x` and an "enlarged" type of `typ`.

This heuristic does not handle private types, and for instance the following code 
```
type pos = private int
let covariant (x:pos) = ( (x, Fun.id) :> int * _ )
```
fails with 
>``` 
> Error: This expression cannot be coerced to type int * 'c; it has type
>         pos * ('a -> 'a)
>       but is here used with type int * 'b
>       Type pos is not compatible with type int
>```

This PR proposes to be more explicit about the heuristic nature of the coercion:

>``` 
>Error: This expression cannot be coerced to type int * 'a by the coercion
>       heuristic. The expression has type pos * ('a -> 'a)
>       but the coercion heuristic was expecting type int * 'b
>       Type pos is not compatible with type int
>Hint: Did you try using a full coercion (foo : ty1 :> ty2)?
>If the types of (foo :> ty2) contain type variables, the coercion uses a
>partial heuristic that may fail in presence of private types or complex
>object or polymorphic variant types (see manual section 3.12).
>```

Moreover, this PR proposes to print the extended hint as soon as one of the type expression involved contain private types.