### PR TITLE
Add `Unix.unsetenv`

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,9 @@ Working version
 
 ### Other libraries:
 
+- #14020: Add Unix.unsetenv.
+  (Nicolás Ojeda Bär, review by Antonin Décimo and David Allsopp)
+
 ### Tools:
 
 * #13638: ocamlmklib exits with code 4 if passed an unrecognised option, as it

--- a/otherlibs/unix/putenv.c
+++ b/otherlibs/unix/putenv.c
@@ -53,3 +53,31 @@ CAMLprim value caml_unix_putenv(value name, value val)
 { caml_invalid_argument("putenv not implemented"); }
 
 #endif
+
+#if defined(_WIN32) || defined(HAS_SETENV_UNSETENV)
+
+CAMLprim value caml_unix_unsetenv(value name)
+{
+  int ret;
+
+  if (! caml_string_is_c_safe(name))
+    caml_unix_error(EINVAL, "unsetenv", name);
+#ifdef _WIN32
+  char_os * s = caml_stat_strdup_to_utf16(String_val(name));
+  ret = _wputenv_s(s, L"");
+  caml_stat_free(s);
+#else
+  ret = unsetenv(String_val(name));
+#endif
+  if (ret == -1) {
+    caml_uerror("unsetenv", name);
+  }
+  return Val_unit;
+}
+
+#else
+
+CAMLprim value caml_unix_unsetenv(value name)
+{ caml_invalid_argument("unsetenv not implemented"); }
+
+#endif

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -182,6 +182,11 @@ val putenv : string -> string -> unit
    [name] is the name of the environment variable,
    and [value] its new associated value. *)
 
+val unsetenv : string -> unit
+(** [unsetenv name] removes the variable [name] from the process environment.
+
+    @since 5.5 *)
+
 
 (** {1 Process handling} *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -182,6 +182,11 @@ val putenv : string -> string -> unit
    [name] is the name of the environment variable,
    and [value] its new associated value. *)
 
+val unsetenv : string -> unit
+(** [unsetenv name] removes the variable [name] from the process environment.
+
+    @since 5.5 *)
+
 
 (** {1 Process handling} *)
 

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -198,6 +198,7 @@ external unsafe_environment : unit -> string array
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "caml_unix_putenv"
+external unsetenv: string -> unit = "caml_unix_unsetenv"
 
 type process_status =
     WEXITED of int

--- a/otherlibs/unix/unix_win32.ml
+++ b/otherlibs/unix/unix_win32.ml
@@ -203,6 +203,7 @@ let unsafe_environment = environment
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "caml_unix_putenv"
+external unsetenv: string -> unit = "caml_unix_unsetenv"
 
 type process_status =
     WEXITED of int

--- a/testsuite/tests/lib-unix/win-env/test_env.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env.ml
@@ -43,4 +43,6 @@ let () =
   Unix.putenv "FOO2" "BAR2";
   print "Sys.getenv FOO" (Sys.getenv_opt "FOO");
   print "Unix.environment FOO" (find_env "FOO");
+  print "Sys.getenv FOO2" (Sys.getenv_opt "FOO2");
+  Unix.unsetenv "FOO2";
   print "Sys.getenv FOO2" (Sys.getenv_opt "FOO2")

--- a/testsuite/tests/lib-unix/win-env/test_env.reference
+++ b/testsuite/tests/lib-unix/win-env/test_env.reference
@@ -1,3 +1,4 @@
 Sys.getenv FOO -> Some "BAR"
 Unix.environment FOO -> Some "BAR"
 Sys.getenv FOO2 -> Some "BAR2"
+Sys.getenv FOO2 -> None


### PR DESCRIPTION
This PR:

- Adds `Unix.unsetenv` to remove an environment variable from the process environment block.
- Reimplements `Unix.putenv` to use `SetEnvironmentVariable` (the "native" counterpart to `putenv` on Windows, mirroring our use of `GetEnvironmentVariable` in the implementation of `Unix.getenv`).

The implementation of the C primitive `caml_unix_unsetenv` is not currently guarded by `HAS_UNSETENV` on Unix, I will add that if someone can say whether it is needed or not.