### PR TITLE
[5.4] revert a type_approx change from labeled tuples

### DIFF
--- a/testsuite/tests/typing-misc/type_approx.ml
+++ b/testsuite/tests/typing-misc/type_approx.ml
@@ -1,0 +1,12 @@
+(* TEST
+expect;
+*)
+
+let rec g x = let x, y = f x in x + y
+and f x = (0:int), (1.:float)
+[%%expect{|
+Line 1, characters 36-37:
+1 | let rec g x = let x, y = f x in x + y
+                                        ^
+Error: The value "y" has type "float" but an expression was expected of type "int"
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3251,7 +3251,7 @@ let rec type_approx env sexp =
   | Pexp_match (_, {pc_rhs=e}::_) -> type_approx env e
   | Pexp_try (e, _) -> type_approx env e
   | Pexp_tuple l ->
-    let labeled_tys = List.map (fun (label, _) -> label, newvar ()) l in
+    let labeled_tys = List.map (fun (label, l) -> label, type_approx env l) l in
     newty (Ttuple labeled_tys)
   | Pexp_ifthenelse (_,e,_) -> type_approx env e
   | Pexp_sequence (_,e) -> type_approx env e


### PR DESCRIPTION
This PR backports to 5.4 a fix from #13980  for a tiny change of behavior in `Typecore.type_approx` introduced by [labeled tuples](#13498). Indeed, in the 5.4 branch, `type_approx` does not propagate type constraints inside tuple to the approximated types used to type the body of mutually recursive function.
Consequently,
```ocaml
let rec g x = let x, y = f x in x + y
and f x = (0:int), (1.:float)
```
fails on the 5.4 branch with
>```
>6  | and f x = (0:int), (1.:float)
>                         ^^^^^^^^^^
>Error: This expression has type float but an expression was expected of type
>         int
>```

This PR uniformize the behavior with 5.3 and trunk, and return the error to
>```
>1 | let rec g x = let x, y = f x in x + y
>                                         ^
>Error: The value "y" has type "float" but an expression was expected of type "int"
>```

cc @samsa1 which has already reviewed the trunk version of the fix.