### PR TITLE
Introduce the `CAMLnonstring` attribute

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -212,6 +212,17 @@ CAMLdeprecated_typedef(addr, char *);
 #else
   #define fallthrough ((void) 0)
 #endif
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#if __has_c_attribute(gnu::nonstring)
+#define CAMLnonstring [[gnu::nonstring]]
+#endif
+#endif
+#if !defined(CAMLnonstring) && __has_attribute(nonstring)
+#define CAMLnonstring __attribute__ ((nonstring))
+#else
+#define CAMLnonstring
+#endif
 #endif /* CAML_INTERNALS */
 
 /* Function attributes to give hints to the C compiler about optimizations and

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -58,9 +58,9 @@ static size_t safe_fwrite(void *ptr, size_t nmemb, FILE *f) {
     return f == NULL ? nmemb : fwrite(ptr, 1, nmemb, f);
 }
 
-static unsigned char caml_ident_start[32] =
+static unsigned char caml_ident_start[32] CAMLnonstring =
 "\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\377\377\177\377\377\377\177\377";
-static unsigned char caml_ident_body[32] =
+static unsigned char caml_ident_body[32] CAMLnonstring =
 "\000\000\000\000\200\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\377\377\177\377\377\377\177\377";
 
 #define In_bitmap(bm,c) (bm[(unsigned char)(c) >> 3] & (1 << ((c) & 7)))


### PR DESCRIPTION
> The `nonstring` attribute can be applied to the declaration of a variable or a field whose type is a character array to specify that the character array is not intended to behave like a null-terminated string. This will silence diagnostics with code like:
>
> ```c
> char BadStr[3] = "foo"; // No space for the null terminator, diagnosed
> __attribute__((nonstring)) char NotAStr[3] = "foo"; // Not diagnosed
> ```

- https://clang.llvm.org/docs/AttributeReference.html#nonstring
- https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-nonstring-variable-attribute

clang-21 warns:

    yacc/reader.c(62,1): error: initializer-string for character array is too long, array size is 32 but initializer has size 33 (including the null terminating character); did you mean to use the 'nonstring' attribute? [-Werror,-Wunterminated-string-initialization]
       62 | "\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\377\377\177\377\377\377\177\377";
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    yacc/reader.c(64,1): error: initializer-string for character array is too long, array size is 32 but initializer has size 33 (including the null terminating character); did you mean to use the 'nonstring' attribute? [-Werror,-Wunterminated-string-initialization]
       64 | "\000\000\000\000\200\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\377\377\177\377\377\377\177\377";
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~