### PR TITLE
domain_terminate: orphan the shared heap before STW exit

### DIFF
--- a/Changes
+++ b/Changes
@@ -755,6 +755,10 @@ OCaml 5.4.0
   demarshaling.
   (Benoît Vaugon, review by David Allsopp and Gabriel Scherer)
 
+- #14025: fix data race between compaction and domain termination
+  (Gabriel Scherer, review by Jan Midtgaard,
+   report by Jan Midtgaard)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -32,7 +32,9 @@ struct pool;
 
 struct caml_heap_state* caml_init_shared_heap(void);
 void caml_orphan_shared_heap(struct caml_heap_state* heap);
+void caml_adopt_all_orphan_heaps(struct caml_heap_state* heap);
 void caml_free_shared_heap(struct caml_heap_state* heap);
+
 
 value* caml_shared_try_alloc(struct caml_heap_state*,
                              mlsize_t, tag_t, reserved_t);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -31,8 +31,13 @@ struct caml_heap_state;
 struct pool;
 
 struct caml_heap_state* caml_init_shared_heap(void);
-void caml_orphan_shared_heap(struct caml_heap_state* heap);
 void caml_adopt_all_orphan_heaps(struct caml_heap_state* heap);
+void caml_assert_shared_heap_is_empty(struct caml_heap_state *heap);
+
+// ensures that the shared heap is empty
+void caml_orphan_shared_heap(struct caml_heap_state* heap);
+
+// requires that the shared heap is empty
 void caml_free_shared_heap(struct caml_heap_state* heap);
 
 

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -31,7 +31,8 @@ struct caml_heap_state;
 struct pool;
 
 struct caml_heap_state* caml_init_shared_heap(void);
-void caml_teardown_shared_heap(struct caml_heap_state* heap);
+void caml_orphan_shared_heap(struct caml_heap_state* heap);
+void caml_free_shared_heap(struct caml_heap_state* heap);
 
 value* caml_shared_try_alloc(struct caml_heap_state*,
                              mlsize_t, tag_t, reserved_t);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2044,6 +2044,12 @@ int caml_domain_is_terminating (void)
   return domain_terminating(domain_self);
 }
 
+static bool marking_and_sweeping_done(caml_domain_state *domain_state)
+{
+  return (domain_state->marking_done
+          && domain_state->sweeping_done);
+}
+
 void caml_domain_terminate(bool last)
 {
   caml_domain_state* domain_state = domain_self->state;
@@ -2074,10 +2080,8 @@ void caml_domain_terminate(bool last)
     caml_orphan_ephemerons(domain_state);
     caml_orphan_finalisers(domain_state);
 
-    if (domain_state->marking_done &&
-        domain_state->sweeping_done) {
-      caml_orphan_shared_heap(domain_state->shared_heap);
-    }
+    /* Orphaning ephemerons and finalizers may create new marking or
+       sweeping work, so we may need to mark and/or sweep again. */
 
     /* No need to check for interrupts if we are the last domain running. */
     if (last) {
@@ -2085,8 +2089,19 @@ void caml_domain_terminate(bool last)
       break;
     }
 
-    /* take the all_domains_lock to try and exit the STW participant set
-       without racing with a STW section being triggered */
+    /* If new marking or sweeping work appeared during orphaning,
+       run a new loop iteration. */
+    if (!marking_and_sweeping_done(domain_state))
+      continue;
+
+    /* Orphan the local shared heap.
+       This is only valid when [sweeping_done], and does
+       not create any new major GC work. */
+    caml_orphan_shared_heap(domain_state->shared_heap);
+    CAMLassert(marking_and_sweeping_done(domain_state));
+
+    /* Take the all_domains_lock to try and exit the STW participant set
+       without racing with a STW section being triggered. */
     caml_plat_lock_blocking(&all_domains_lock);
 
     /* The interaction of termination and major GC is quite subtle.
@@ -2096,23 +2111,19 @@ void caml_domain_terminate(bool last)
        require this domain to participate, which in turn could involve a major
        GC cycle. This would then require finish marking and sweeping again in
        order to decrement the globals [num_domains_to_mark] and
-       [num_domains_to_sweep] (see major_gc.c).
+       [num_domains_to_sweep] (see major_gc.c). We do this by running a new
+       loop iteration.
      */
-
-    if (!caml_incoming_interrupts_queued() &&
-        domain_state->marking_done &&
-        domain_state->sweeping_done) {
-
+    if (!caml_incoming_interrupts_queued()) {
       finished = 1;
       s->terminating = 0;
       s->running = 0;
 
-      /* Remove this domain from stw_domains */
+      /* Remove this domain from stw_domains. */
       remove_from_stw_domains(domain_self);
 
-      /* signal the interruptor condition variable
-       * because the backup thread may be waiting on it
-       */
+      /* Signal the interruptor condition variable
+         because the backup thread may be waiting on it. */
       caml_plat_lock_blocking(&s->lock);
       caml_plat_broadcast(&s->cond);
       caml_plat_unlock(&s->lock);
@@ -2125,19 +2136,22 @@ void caml_domain_terminate(bool last)
     caml_plat_unlock(&all_domains_lock);
   }
 
-  /* domain_state may be re-used by a fresh domain here (now that we
-   * have done remove_from_stw_domains and released the
-   * all_domains_lock). However, domain_create() won't touch it until
-   * it has claimed the domain_lock, so we hang onto that while we are
-   * tearing down the state. */
+  CAMLassert(last || marking_and_sweeping_done(domain_state));
+
+  /* [domain_state] may be re-used by a fresh domain here, now that we
+     have done [remove_from_stw_domains] and released the
+     [all_domains_lock]. In particular, we cannot touch
+     [domain_self->interruptor] after here because it may be reused.
+
+     However, [domain_create()] won't touch the domain state until
+     it has claimed the [domain_lock], so we hang onto that while we are
+     tearing down the state. */
 
   /* Delete the domain state from statmemprof after any promotion
    * (etc) done by this domain: any remaining memprof state will be
    * handed over to surviving domains. */
   caml_memprof_delete_domain(domain_state);
 
-  /* We can not touch domain_self->interruptor after here
-     because it may be reused */
   caml_remove_generational_global_root(&domain_state->dls_root);
   caml_remove_generational_global_root(&domain_state->backtrace_last_exn);
   caml_stat_free(domain_state->final_info);
@@ -2146,8 +2160,19 @@ void caml_domain_terminate(bool last)
   caml_free_extern_state();
   caml_teardown_major_gc();
 
-  if (last)
+  /* At this point, we know that the shared heap has been orphaned,
+     except if [last], if we are the last domain. In that case we
+     finalise all unswept objects and orphan the shared heap now. */
+  if (last) {
+    /* First adopt all orphan pools, to avoid missing unswept objects. */
+    caml_adopt_all_orphan_heaps(domain_state->shared_heap);
+
+    /* Call all custom finalisers of unswept objects. */
     caml_finalise_heap();
+
+    /* Then orphan all pools again. */
+    caml_orphan_shared_heap(domain_state->shared_heap);
+  }
 
   caml_free_shared_heap(domain_state->shared_heap);
   domain_state->shared_heap = NULL;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2136,7 +2136,7 @@ void caml_domain_terminate(bool last)
     caml_plat_unlock(&all_domains_lock);
   }
 
-  CAMLassert(last || marking_and_sweeping_done(domain_state));
+  if (!last) caml_assert_shared_heap_is_empty(domain_state->shared_heap);
 
   /* [domain_state] may be re-used by a fresh domain here, now that we
      have done [remove_from_stw_domains] and released the
@@ -2173,6 +2173,7 @@ void caml_domain_terminate(bool last)
     /* Then orphan all pools again. */
     caml_orphan_shared_heap(domain_state->shared_heap);
   }
+  caml_assert_shared_heap_is_empty(domain_state->shared_heap);
 
   caml_free_shared_heap(domain_state->shared_heap);
   domain_state->shared_heap = NULL;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -710,17 +710,13 @@ void caml_finalise_heap(void) {
   struct caml_heap_state *local = Caml_state->shared_heap;
   sizeclass sz;
 
-  /* to finalise the whole heap, first adopt
-     orphan pools. */
-  caml_adopt_all_orphan_heaps(local);
-
-  /* local pools */
+  /* Finalise and release unswept local pools. */
   for (sz = 0; sz < NUM_SIZECLASSES; sz++) {
     pool_finalise(local, &local->unswept_avail_pools[sz], sz);
     pool_finalise(local, &local->unswept_full_pools[sz], sz);
   }
 
-  /* global pools */
+  /* Finalise and free large unswept objects. */
   if (local->unswept_large)
     large_alloc_finalise(local);
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -210,9 +210,7 @@ void caml_adopt_all_orphan_heaps(struct caml_heap_state* local) {
   local->next_to_sweep = 0;
 }
 
-void caml_free_shared_heap(struct caml_heap_state* heap) {
-  // The shared heap must have been swept,
-  // and then emptied by [caml_orphan_shared_heap].
+void caml_assert_shared_heap_is_empty(struct caml_heap_state* heap) {
   for (int i = 0; i < NUM_SIZECLASSES; i++) {
     CAMLassert(!heap->avail_pools[i]);
     CAMLassert(!heap->full_pools[i]);
@@ -221,7 +219,10 @@ void caml_free_shared_heap(struct caml_heap_state* heap) {
   }
   CAMLassert(!heap->unswept_large);
   CAMLassert(!heap->swept_large);
+}
 
+void caml_free_shared_heap(struct caml_heap_state* heap) {
+  caml_assert_shared_heap_is_empty(heap);
   caml_stat_free(heap);
 }
 


### PR DESCRIPTION
This is a proposal to try to fix a compaction bug discussed in #13739 (cc @sadiq, @jmid).

In that issue, @jmid is tracking a rare failure in the compaction code when run concurrently with other domain activity. He observed with @sadiqj that there is a race condition between the compactor code, that assumes that all pools are owned by an active domain, and the domain-termination code, which waits until after leaving the STW participant set to orphan its shared heap.

The current PR changes the domain-termination logic to orphan the shared heap before leaving the STW participant set, so that the compactor's assumptions are correct. This is tricky code (that part of the domain-termination logic runs in a loop while answering STW requests) which would need a review or rewrite by concurrent-runtime experts.

To make the present issue self-contained, let me copy below the more detailed explanations I wrote in #13739:

> - Context. The shared heap is a set of "pools". Each domain owns a subset of these pools -- they are in its "local" shared heaps. A domain will allocate/promote new block in its own "local" pools, and take care of those during GC events. There is also a global structure `pool_freelist` that contains "orphan" pools, which are not owned by any domain: when a domain terminates, it pushes its own pools in the free list. Unlike what the name might suggest, the pools in the freelist are not free, they may contain OCaml values. Domains may "adopt" pools from the freelist if they want more space and their local pools are all full.
> 
>  - `caml_cycle_heap` (which happens in a STW section at the end of each major GC cycle) will empty the global freelist by forcing one domain to adopt all its pools. I guess that this is intended to guarantee that all pools in the freelist are swept *eventually*, they don't remain in global limbo forever.
> 
>  - The GC compaction code needs a full view of the OCaml heap, because it will move values around and needs to update the whole heap to update pointers to moved values. This was done by calling the compactor after `caml_cycle_heap`, to guarantee that free list pools have been adopted, and so that all pools are in the local heap of some active domain (a participant to the STW set).
> 
> - In fact this guarantee does not hold, because terminating domains move their pools into the freelist _asynchronously_, after removing themselves from the STW participant set. (The general idea of termination code is to do as much of the book-keeping work as possible after leaving the STW set.)
> 
> - In particular, a terminating domain may go to sleep after removing itself from the STW set and before moving its heap into the major heap, and the rest of the runtime will proceed happily, including by running the compaction code, while some of the shared heap is "missing" (neither in an active domain nor in the global heap). This is not a problem for the normal runtime, the prodigious pools will be moved to the freelist on their return. But it is a bug for compaction, because if compaction happened those returning pools will be in an invalid state -- they have not been updated when values in other pools were moved around.


