### PR TITLE
[minor] use a record in Compenv.process_deferred_actions

### DIFF
--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -61,16 +61,19 @@ val anonymous : string -> unit
 val impl : string -> unit
 val intf : string -> unit
 
-val process_deferred_actions :
-  Format.formatter *
-  (start_from:Clflags.Compiler_pass.t ->
-   source_file:string -> output_prefix:string -> unit) *
-  (* compile implementation *)
-  (source_file:string -> output_prefix:string -> unit) *
-  (* compile interface *)
-  string * (* ocaml module extension *)
-  string -> (* ocaml library extension *)
-  unit
+type action_context = {
+  log : Format.formatter;
+  compile_implementation:
+    start_from:Clflags.Compiler_pass.t ->
+    source_file:string -> output_prefix:string -> unit;
+  compile_interface:
+    source_file:string -> output_prefix:string -> unit;
+  ocaml_mod_ext: string; (* ".cmo" or ".cmx" *)
+  ocaml_lib_ext: string; (* ".cma" or ".cmxa" *)
+}
+
+val process_deferred_actions : action_context -> unit
+
 (* [parse_arguments ?current argv anon_arg program] will parse the arguments,
  using the arguments provided in [Clflags.arg_spec].
 *)

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -32,12 +32,13 @@ let main argv ppf =
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
     begin try
-      Compenv.process_deferred_actions
-        (ppf,
-         Compile.implementation,
-         Compile.interface,
-         ".cmo",
-         ".cma");
+      Compenv.process_deferred_actions {
+        log = ppf;
+        compile_implementation = Compile.implementation;
+        compile_interface = Compile.interface;
+        ocaml_mod_ext = ".cmo";
+        ocaml_lib_ext = ".cma";
+      }
     with Arg.Bad msg ->
       begin
         prerr_endline msg;

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -50,12 +50,13 @@ let main argv ppf =
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
     begin try
-      Compenv.process_deferred_actions
-        (ppf,
-         Optcompile.implementation ~backend,
-         Optcompile.interface,
-         ".cmx",
-         ".cmxa");
+      Compenv.process_deferred_actions {
+        log = ppf;
+        compile_implementation = Optcompile.implementation ~backend;
+        compile_interface = Optcompile.interface;
+        ocaml_mod_ext = ".cmx";
+        ocaml_lib_ext = ".cmxa";
+      }
     with Arg.Bad msg ->
       begin
         prerr_endline msg;


### PR DESCRIPTION
I'm trying to look at #13766 again, and one of the changes touches a tuple type in Compenv that has a documentation comment for each component. This is a case where using a record makes things clearer, so I went to use that instead.