### PR TITLE
Printexc.reraise

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ Working version
 
 ### Standard library:
 
+* #14030: Add Printexc.reraise (Raphaël Proust)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -380,3 +380,5 @@ external register_named_value : string -> 'a -> unit
 let () =
   register_named_value "Printexc.handle_uncaught_exception"
     handle_uncaught_exception
+
+external reraise : exn -> 'a = "%reraise"

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -412,6 +412,22 @@ val exn_slot_name: exn -> string
     @since 4.02
 *)
 
+(** {1 Reraising} *)
+
+external reraise: exn -> 'a = "%reraise"
+(** [reraise exc] re-raise the exception [exc] adding a location to its
+    backtrace. This is similar to what happens when an exception traverses a
+    non-total handler. E.g.,
+    {[ try f () with Not_found -> () ]}
+    is equivalent to
+    {[ try f () with Not_found -> () | exc -> Printexc.reraise exc ]}
+
+    This function is intended to be used when building your own abstractions on
+    top of exceptions, where the OCaml compiler requires functions to be total.
+
+    @since SINCE
+*)
+
 (**/**)
 
 (**  {1 Obj printer}


### PR DESCRIPTION
The `reraise` internal is useful for defining abstractions that handle exceptions without resorting to the `try`-`with` construct.

E.g., in Lwt, a promise might be rejected with an exception. A `try`-`with`-equivalent is provided in the form of `catch : (unit -> 'a Lwt.t) -> (exn -> 'a Lwt.t) -> 'a Lwt.t`. However, unlike `try`-`with`, it is not possible to leave an exception case unhandled: there is a compiler warning/error, and it replaces the exception with a different one (`Match_failure`).

Lwt exports `reraise` (similarly to the way this PR does) and recommends writing `| exc -> reraise exc` as a catch-all case for the exception handler of `catch`.

------------------

`reraise` may be useful for any similar case where someone wants to provide some sort of logic around exceptions and keep as much of the useful information that exceptions carry. E.g., writing the following and allowing a partial match on exceptions comes to mind

```
val handle : (unit -> ('a, exn) result) -> (exn -> 'a) -> 'a
```