### PR TITLE
Update FlexDLL to 0.44 and reenable lib-dynlink-domains test on Windows

### DIFF
--- a/testsuite/tests/lib-dynlink-domains/main.ml
+++ b/testsuite/tests/lib-dynlink-domains/main.ml
@@ -2,7 +2,6 @@
  include dynlink;
  libraries = "";
  readonly_files = "store.ml main.ml Plugin_0.ml Plugin_0_0.ml Plugin_0_0_0.ml Plugin_0_0_0_0.ml Plugin_0_0_0_1.ml Plugin_0_0_0_2.ml Plugin_1.ml Plugin_1_0.ml Plugin_1_0_0.ml Plugin_1_0_0_0.ml Plugin_1_1.ml Plugin_1_2.ml Plugin_1_2_0.ml Plugin_1_2_0_0.ml Plugin_1_2_1.ml Plugin_1_2_2.ml Plugin_1_2_2_0.ml Plugin_1_2_3.ml Plugin_1_2_3_0.ml";
- not-windows;
  {
    shared-libraries;
    setup-ocamlc.byte-build-env;


### PR DESCRIPTION
This PR
- updates the `flexdll` submodule to the freshly released 0.44 and
- reenables the `lib-dynlink-domains` test on Windows which was temporarily disabled in #11607

Fixes #13046

CC: @dra27 