### PR TITLE
tests: native-debugger: sanitize GDB+musl output

### DIFF
--- a/testsuite/tests/native-debugger/linux-gdb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.reference
@@ -2,8 +2,6 @@ Breakpoint 1 at 0x00000000000000
 Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
-[Thread debugging using libthread_db enabled]
-Using host libthread_db library "/XXXX/libthread_db.so.1".
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.reference
@@ -2,8 +2,6 @@ Breakpoint 1 at 0x00000000000000
 Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
-[Thread debugging using libthread_db enabled]
-Using host libthread_db library "/XXXX/libthread_db.so.1".
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.reference
@@ -2,8 +2,6 @@ Breakpoint 1 at 0x00000000000000
 Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
-[Thread debugging using libthread_db enabled]
-Using host libthread_db library "/XXXX/libthread_db.so.1".
 Breakpoint 1, <signal handler called>
 frame 0: caml_start_program
 frame 1: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -27,7 +27,7 @@ frame 4: meander`caml_startup
 frame 5: meander`caml_main
 frame 6: meander`main
 frame 7: libc.so.6`__libc_start_call_main
-frame 8: libc.so.6`__libc_start_main_impl
+frame 8: libc.so.6`__libc_start_mainXXXX
 frame 9: meander`_start
 (lldb) continue
 Process XXXX resuming
@@ -44,7 +44,7 @@ frame 5: meander`caml_startup
 frame 6: meander`caml_main
 frame 7: meander`main
 frame 8: libc.so.6`__libc_start_call_main
-frame 9: libc.so.6`__libc_start_main_impl
+frame 9: libc.so.6`__libc_start_mainXXXX
 frame 10: meander`_start
 (lldb) continue
 Process XXXX resuming
@@ -73,7 +73,7 @@ frame 9: meander`caml_startup
 frame 10: meander`caml_main
 frame 11: meander`main
 frame 12: libc.so.6`__libc_start_call_main
-frame 13: libc.so.6`__libc_start_main_impl
+frame 13: libc.so.6`__libc_start_mainXXXX
 frame 14: meander`_start
 (lldb) continue
 Process XXXX resuming
@@ -106,6 +106,6 @@ frame 13: meander`caml_startup
 frame 14: meander`caml_main
 frame 15: meander`main
 frame 16: libc.so.6`__libc_start_call_main
-frame 17: libc.so.6`__libc_start_main_impl
+frame 17: libc.so.6`__libc_start_mainXXXX
 frame 18: meander`_start
 (lldb) quit

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.reference
@@ -27,7 +27,7 @@ frame 4: meander`caml_startup
 frame 5: meander`caml_main
 frame 6: meander`main
 frame 7: libc.so.6`__libc_start_call_main
-frame 8: libc.so.6`__libc_start_main_impl
+frame 8: libc.so.6`__libc_start_mainXXXX
 frame 9: meander`_start
 (lldb) continue
 Process XXXX resuming
@@ -44,7 +44,7 @@ frame 5: meander`caml_startup
 frame 6: meander`caml_main
 frame 7: meander`main
 frame 8: libc.so.6`__libc_start_call_main
-frame 9: libc.so.6`__libc_start_main_impl
+frame 9: libc.so.6`__libc_start_mainXXXX
 frame 10: meander`_start
 (lldb) continue
 Process XXXX resuming
@@ -73,7 +73,7 @@ frame 9: meander`caml_startup
 frame 10: meander`caml_main
 frame 11: meander`main
 frame 12: libc.so.6`__libc_start_call_main
-frame 13: libc.so.6`__libc_start_main_impl
+frame 13: libc.so.6`__libc_start_mainXXXX
 frame 14: meander`_start
 (lldb) continue
 This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
@@ -106,6 +106,6 @@ frame 13: meander`caml_startup
 frame 14: meander`caml_main
 frame 15: meander`main
 frame 16: libc.so.6`__libc_start_call_main
-frame 17: libc.so.6`__libc_start_main_impl
+frame 17: libc.so.6`__libc_start_mainXXXX
 frame 18: meander`_start
 (lldb) quit

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -37,10 +37,9 @@
     gsub(/.c:[0-9]+:[0-9]+/, ".c:XX")
     gsub(/.c:[0-9]+/, ".c:XX")
 
-    # Replace libpath. Different distributions have different naming
-    # schemes.
-    gsub(/Using host libthread_db library "\/(.*)\/libthread_db\.so\.1"\./,
-         "Using host libthread_db library \"/XXXX/libthread_db.so.1\".")
+    # GDB doesn't print these lines with musl.
+    gsub(/\[Thread debugging using libthread_db enabled\]/, "")
+    gsub(/Using host libthread_db library.*/, "")
 
     # Replace line number when setting breakpoints in GDB.
     gsub(/line [0-9]+/, "line XXX")

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -47,6 +47,10 @@
     # Work around inconsistent name mangling
     gsub(/c_to_ocaml_[0-9]+/, "c_to_ocaml")
 
+    # Work around symbol versioning
+    gsub(/__libc_start_main_impl$/, "__libc_start_mainXXXX")
+    gsub(/__libc_start_main@@GLIBC_[0-9]+.[0-9]+$/, "__libc_start_mainXXXX")
+
     gsub("warning: This version of LLDB", "This version of LLDB")
     gsub("This version of LLDB has no plugin for the language \"assembler\". Inspection of frame variables will be limited.", "")
     # Replace printed match results


### PR DESCRIPTION
Fixes #14019 with even more sanitation. Precheck on Alpine Linux (GDB+musl) succeeds: https://ci.inria.fr/ocaml/job/precheck/flambda=false,label=ocaml-alpine/1058/.