### PR TITLE
Improve FlexDLL build tools selection with FlexDLL 0.44 build changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,7 +18,7 @@
 
 # It is not possible to wrap lines lines in .gitattributes files
 .gitattributes typo.long-line=may typo.non-ascii
-.gitmodules typo.long-line=may typo.tab=may
+.gitmodules typo.long-line=may typo.tab=may typo.missing-header=may
 
 .editorconfig typo.missing-header=may
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,9 @@
 	path = flexdll
 	url = https://github.com/ocaml/flexdll.git
 	shallow = true
+	branch = master
 [submodule "winpthreads"]
 	path = winpthreads
 	url = https://github.com/ocaml/winpthreads.git
 	shallow = true
+	branch = master

--- a/Changes
+++ b/Changes
@@ -191,6 +191,9 @@ Working version
   sources of installed packages.
   (Pierre Boutillier, review by Gabriel Scherer)
 
+- #14032, #14034: Update to and require FlexDLL 0.44.
+  (Jan Midtgaard, Antonin Décimo, review by David Allsopp)
+
 ### Manual and documentation:
 
 - #13747: Document support for native debugging with GDB and LLDB.

--- a/Makefile
+++ b/Makefile
@@ -634,6 +634,9 @@ FLEXLINK_BUILD_ENV = \
   MSVCC_ROOT= \
   MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
   CHAINS=$(FLEXDLL_CHAIN) ROOTDIR=..
+ifneq ($(RC),)
+FLEXLINK_BUILD_ENV += RC=$(RC)
+endif
 FLEXDLL_SOURCES = \
   $(addprefix $(FLEXDLL_SOURCE_DIR)/, flexdll.c flexdll_initer.c flexdll.h) \
   $(wildcard $(FLEXDLL_SOURCE_DIR)/*.ml*)

--- a/Makefile
+++ b/Makefile
@@ -637,6 +637,17 @@ FLEXLINK_BUILD_ENV = \
 ifneq ($(RC),)
 FLEXLINK_BUILD_ENV += RC=$(RC)
 endif
+ifeq ($(FLEXDLL_CHAIN),cygwin64)
+FLEXLINK_BUILD_ENV += CYG64CC=$(CC)
+else ifeq ($(FLEXDLL_CHAIN),mingw)
+FLEXLINK_BUILD_ENV += MINCC=$(CC)
+else ifeq ($(FLEXDLL_CHAIN),mingw64)
+FLEXLINK_BUILD_ENV += MIN64CC=$(CC)
+else ifeq ($(FLEXDLL_CHAIN),msvc)
+FLEXLINK_BUILD_ENV += MSVCC=$(CC)
+else ifeq ($(FLEXDLL_CHAIN),msvc64)
+FLEXLINK_BUILD_ENV += MSVCC64=$(CC)
+endif
 FLEXDLL_SOURCES = \
   $(addprefix $(FLEXDLL_SOURCE_DIR)/, flexdll.c flexdll_initer.c flexdll.h) \
   $(wildcard $(FLEXDLL_SOURCE_DIR)/*.ml*)

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -114,6 +114,9 @@ DIFF=@DIFF@
 # Which flags to pass to the diff tool
 DIFF_FLAGS=@DIFF_FLAGS@
 
+# The resource compiler (Windows targets)
+RC=@RC@
+
 # The rlwrap command (for the *runtop targets)
 RLWRAP=@rlwrap@
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -187,6 +187,10 @@ BUILD_TRIPLET = @build@
 # Platform-dependent command to create symbolic links
 LN = @ln@
 
+# Tool to generate manifests for managed assemblies and unmanaged side-by-side
+# assemblies, for the Windows targets.
+MANIFEST_TOOL = @MANIFEST_TOOL@
+
 # Platform-dependent assembler files to use to build the runtime
 runtime_ASM_OBJECTS = $(addprefix runtime/,@runtime_asm_objects@)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -247,7 +247,7 @@ OCAMLYACCFLAGS ?= --strict -v
 # executables
 if_file_exists = ( test ! -f $(1) || $(2) && rm -f $(1) )
 MERGEMANIFESTEXE = $(call if_file_exists, $(1).manifest, \
-  mt -nologo -outputresource:$(1) -manifest $(1).manifest)
+  $(MANIFEST_TOOL) -nologo -outputresource:$(1) -manifest $(1).manifest)
 
 # Macros and rules to compile OCaml programs and libraries
 

--- a/configure
+++ b/configure
@@ -15445,12 +15445,6 @@ case $target in #(
   *) :
     flexdll_chain='' ;;
 esac
-if test -n "$FLEXLINKFLAGS"
-then :
-
-  flexlink_flags="${flexlink_flags:+$flexlink_flags }$FLEXLINKFLAGS"
-
-fi
 
 if test x"$supports_shared_libraries" != 'xfalse'
 then :

--- a/configure
+++ b/configure
@@ -782,6 +782,7 @@ COMPILER_NATIVE_CPPFLAGS
 COMPILER_NATIVE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
 COMPILER_BYTECODE_CFLAGS
+FLEXLINKFLAGS
 PARTIALLD
 csc
 target_os
@@ -1059,6 +1060,7 @@ target_alias
 AS
 ASPP
 PARTIALLD
+FLEXLINKFLAGS
 COMPILER_BYTECODE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
 COMPILER_NATIVE_CFLAGS
@@ -1776,6 +1778,8 @@ Some influential environment variables:
   AS          which assembler to use
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
+  FLEXLINKFLAGS
+              Supplementary flags passed to flexlink (Windows targets)
   COMPILER_BYTECODE_CFLAGS
               CFLAGS for compiling C files to be linked with bytecode
   COMPILER_BYTECODE_CPPFLAGS
@@ -3924,6 +3928,8 @@ esac
 fi
 
 # Environment variables that are taken into account
+
+
 
 
 
@@ -15434,6 +15440,12 @@ case $target in #(
   *) :
     flexdll_chain='' ;;
 esac
+if test -n "$FLEXLINKFLAGS"
+then :
+
+  flexlink_flags="${flexlink_flags:+$flexlink_flags }$FLEXLINKFLAGS"
+
+fi
 
 if test x"$supports_shared_libraries" != 'xfalse'
 then :

--- a/configure
+++ b/configure
@@ -748,7 +748,6 @@ OTOOL
 LIPO
 NMEDIT
 DSYMUTIL
-MANIFEST_TOOL
 AWK
 RANLIB
 STRIP
@@ -773,6 +772,7 @@ CFLAGS
 LIBTOOL
 ac_ct_LD
 LD
+ac_ct_MANIFEST_TOOL
 DEFAULT_STRING
 WINDOWS_UNICODE_MODE
 TARGET_BINDIR
@@ -784,6 +784,7 @@ COMPILER_NATIVE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
 COMPILER_BYTECODE_CFLAGS
 FLEXLINKFLAGS
+MANIFEST_TOOL
 RC
 PARTIALLD
 csc
@@ -1063,6 +1064,7 @@ AS
 ASPP
 PARTIALLD
 RC
+MANIFEST_TOOL
 FLEXLINKFLAGS
 COMPILER_BYTECODE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
@@ -1782,6 +1784,8 @@ Some influential environment variables:
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
   RC          which resource compiler to use
+  MANIFEST_TOOL
+              which manifest generator to use
   FLEXLINKFLAGS
               Supplementary flags passed to flexlink (Windows targets)
   COMPILER_BYTECODE_CFLAGS
@@ -3945,6 +3949,7 @@ fi
 
 
 
+
 # Command-line arguments to configure
 
 # Check whether --enable-debug-runtime was given.
@@ -4385,6 +4390,118 @@ printf "%s\n" "no (5.5.0+dev0-2025-04-28 vs $already_installed_version)" >&6; }
 fi
     cross_compiler=true
 fi
+
+# Bypass libtool check for the manifest tool
+if test -n "$ac_tool_prefix"; then
+  for ac_prog in mt
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_MANIFEST_TOOL+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$MANIFEST_TOOL"; then
+  ac_cv_prog_MANIFEST_TOOL="$MANIFEST_TOOL" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_MANIFEST_TOOL="$ac_tool_prefix$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+MANIFEST_TOOL=$ac_cv_prog_MANIFEST_TOOL
+if test -n "$MANIFEST_TOOL"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $MANIFEST_TOOL" >&5
+printf "%s\n" "$MANIFEST_TOOL" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+    test -n "$MANIFEST_TOOL" && break
+  done
+fi
+if test -z "$MANIFEST_TOOL"; then
+  ac_ct_MANIFEST_TOOL=$MANIFEST_TOOL
+  for ac_prog in mt
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_ac_ct_MANIFEST_TOOL+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$ac_ct_MANIFEST_TOOL"; then
+  ac_cv_prog_ac_ct_MANIFEST_TOOL="$ac_ct_MANIFEST_TOOL" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_MANIFEST_TOOL="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_MANIFEST_TOOL=$ac_cv_prog_ac_ct_MANIFEST_TOOL
+if test -n "$ac_ct_MANIFEST_TOOL"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_MANIFEST_TOOL" >&5
+printf "%s\n" "$ac_ct_MANIFEST_TOOL" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_MANIFEST_TOOL" && break
+done
+
+  if test "x$ac_ct_MANIFEST_TOOL" = x; then
+    MANIFEST_TOOL=":"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    MANIFEST_TOOL=$ac_ct_MANIFEST_TOOL
+  fi
+fi
+
 
 # Initialization of libtool
 # Allow the MSVC linker to be found even if ld isn't installed.
@@ -15445,6 +15562,11 @@ case $target in #(
   *) :
     flexdll_chain='' ;;
 esac
+
+if test -n "$MANIFEST_TOOL"
+then :
+  flexlink_flags="${flexlink_flags:+$flexlink_flags }-use-mt $MANIFEST_TOOL"
+fi
 
 if test x"$supports_shared_libraries" != 'xfalse'
 then :

--- a/configure
+++ b/configure
@@ -738,6 +738,7 @@ CPP_FOR_BUILD
 ac_ct_CC_FOR_BUILD
 CC_FOR_BUILD
 flexlink
+ac_ct_RC
 CPP
 ac_ct_DEP_CC
 DEP_CC
@@ -783,6 +784,7 @@ COMPILER_NATIVE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
 COMPILER_BYTECODE_CFLAGS
 FLEXLINKFLAGS
+RC
 PARTIALLD
 csc
 target_os
@@ -1060,6 +1062,7 @@ target_alias
 AS
 ASPP
 PARTIALLD
+RC
 FLEXLINKFLAGS
 COMPILER_BYTECODE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
@@ -1778,6 +1781,7 @@ Some influential environment variables:
   AS          which assembler to use
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
+  RC          which resource compiler to use
   FLEXLINKFLAGS
               Supplementary flags passed to flexlink (Windows targets)
   COMPILER_BYTECODE_CFLAGS
@@ -3928,6 +3932,7 @@ esac
 fi
 
 # Environment variables that are taken into account
+
 
 
 
@@ -15497,6 +15502,274 @@ else $as_nop
 printf "%s\n" "$flexdll_source_dir$flexmsg" >&6; }
         bootstrapping_flexdll=true
         flexdll_dir=\"+flexdll\"
+        case $target in #(
+  *-pc-windows) :
+    for ac_prog in rc
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_RC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$RC"; then
+  ac_cv_prog_RC="$RC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_RC="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+RC=$ac_cv_prog_RC
+if test -n "$RC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $RC" >&5
+printf "%s\n" "$RC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$RC" && break
+done
+ ;; #(
+  *) :
+     ;;
+esac
+        if $cross_compiler
+then :
+  for ac_prog in windres
+do
+  # Extract the first word of "$target_alias-$ac_prog", so it can be a program name with args.
+set dummy $target_alias-$ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_RC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$RC"; then
+  ac_cv_prog_RC="$RC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_RC="$target_alias-$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+RC=$ac_cv_prog_RC
+if test -n "$RC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $RC" >&5
+printf "%s\n" "$RC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$RC" && break
+done
+if test -z "$RC"; then
+  if test "$build" = "$target"; then
+    ac_ct_RC=$RC
+    for ac_prog in windres
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_ac_ct_RC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$ac_ct_RC"; then
+  ac_cv_prog_ac_ct_RC="$ac_ct_RC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_RC="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_RC=$ac_cv_prog_ac_ct_RC
+if test -n "$ac_ct_RC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_RC" >&5
+printf "%s\n" "$ac_ct_RC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_RC" && break
+done
+
+    RC=$ac_ct_RC
+  else
+    RC=""
+  fi
+fi
+
+else $as_nop
+  if test -n "$ac_tool_prefix"; then
+  for ac_prog in windres
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_RC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$RC"; then
+  ac_cv_prog_RC="$RC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_RC="$ac_tool_prefix$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+RC=$ac_cv_prog_RC
+if test -n "$RC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $RC" >&5
+printf "%s\n" "$RC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+    test -n "$RC" && break
+  done
+fi
+if test -z "$RC"; then
+  ac_ct_RC=$RC
+  for ac_prog in windres
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_ac_ct_RC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$ac_ct_RC"; then
+  ac_cv_prog_ac_ct_RC="$ac_ct_RC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_RC="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_RC=$ac_cv_prog_ac_ct_RC
+if test -n "$ac_ct_RC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_RC" >&5
+printf "%s\n" "$ac_ct_RC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_RC" && break
+done
+
+  if test "x$ac_ct_RC" = x; then
+    RC=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    RC=$ac_ct_RC
+  fi
+fi
+
+fi
 fi ;; #(
   *) :
     if test x"$with_flexdll" != 'x'

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,7 @@ AC_ARG_VAR([AS], [which assembler to use])
 AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
 AC_ARG_VAR([RC], [which resource compiler to use])
+AC_ARG_VAR([MANIFEST_TOOL], [which manifest generator to use])
 
 AC_ARG_VAR([FLEXLINKFLAGS],
   [Supplementary flags passed to flexlink (Windows targets)])
@@ -683,6 +684,9 @@ AS_IF(
         $already_installed_version)]))
       AC_MSG_ERROR([exiting])])
     cross_compiler=true])
+
+# Bypass libtool check for the manifest tool
+AC_CHECK_TOOLS(MANIFEST_TOOL, [mt], :)
 
 # Initialization of libtool
 # Allow the MSVC linker to be found even if ld isn't installed.
@@ -1072,6 +1076,9 @@ AS_CASE([$target],
     [flexdll_chain='msvc64'
     flexlink_flags='-merge-manifest -stack 33554432'],
   [flexdll_chain=''])
+
+AS_IF([test -n "$MANIFEST_TOOL"],
+  [flexlink_flags="${flexlink_flags:+$flexlink_flags }-use-mt $MANIFEST_TOOL"])
 
 AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
   AC_MSG_CHECKING([for flexdll sources])

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,9 @@ AC_ARG_VAR([AS], [which assembler to use])
 AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
 
+AC_ARG_VAR([FLEXLINKFLAGS],
+  [Supplementary flags passed to flexlink (Windows targets)])
+
 AC_ARG_VAR([COMPILER_BYTECODE_CFLAGS],
   [CFLAGS for compiling C files to be linked with bytecode])
 AC_ARG_VAR([COMPILER_BYTECODE_CPPFLAGS],
@@ -1068,6 +1071,9 @@ AS_CASE([$target],
     [flexdll_chain='msvc64'
     flexlink_flags='-merge-manifest -stack 33554432'],
   [flexdll_chain=''])
+AS_IF([test -n "$FLEXLINKFLAGS"], [
+  flexlink_flags="${flexlink_flags:+$flexlink_flags }$FLEXLINKFLAGS"
+])
 
 AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
   AC_MSG_CHECKING([for flexdll sources])

--- a/configure.ac
+++ b/configure.ac
@@ -394,6 +394,7 @@ AS_IF([test -n "$csc"],
 AC_ARG_VAR([AS], [which assembler to use])
 AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
+AC_ARG_VAR([RC], [which resource compiler to use])
 
 AC_ARG_VAR([FLEXLINKFLAGS],
   [Supplementary flags passed to flexlink (Windows targets)])
@@ -1108,7 +1109,11 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
         [AC_MSG_RESULT([no])],
         [AC_MSG_RESULT([$flexdll_source_dir$flexmsg])
         bootstrapping_flexdll=true
-        flexdll_dir=\"+flexdll\"])],
+        flexdll_dir=\"+flexdll\"
+        AS_CASE([$target], [*-pc-windows], [AC_CHECK_PROGS(RC, [rc])])
+        AS_IF([$cross_compiler],
+          [AC_CHECK_TARGET_TOOLS(RC, [windres])],
+          [AC_CHECK_TOOLS(RC, [windres])])])],
       [AS_IF([test x"$with_flexdll" != 'x'],
         [AC_MSG_RESULT([requested but not supported])
         AC_MSG_ERROR([exiting])])])])

--- a/configure.ac
+++ b/configure.ac
@@ -1072,9 +1072,6 @@ AS_CASE([$target],
     [flexdll_chain='msvc64'
     flexlink_flags='-merge-manifest -stack 33554432'],
   [flexdll_chain=''])
-AS_IF([test -n "$FLEXLINKFLAGS"], [
-  flexlink_flags="${flexlink_flags:+$flexlink_flags }$FLEXLINKFLAGS"
-])
 
 AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
   AC_MSG_CHECKING([for flexdll sources])

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -57,7 +57,7 @@ depends: [
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
 
   # Support Packages
-  "flexdll" {>= "0.42" & os = "win32"}
+  "flexdll" {>= "0.44" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/testsuite/tools/toolchain.ml
+++ b/testsuite/tools/toolchain.ml
@@ -39,7 +39,7 @@ let linker_propagates_debug_information =
 
 let c_compiler_always_embeds_build_path =
   (* .obj files always contain the build path, regardless of flags *)
-  is_msvc
+  is_msvc && not is_clang
 
 let asmrun_assembled_with_cc =
   (* The MSVC port directly assembles amd64nt.asm; all other systems use the C


### PR DESCRIPTION
I want to use these for a bigger project but I think this patch series can be reviewed on its own. Patches (2) and (3) stem from https://github.com/ocaml/flexdll/pull/153, a PR that's been released as of FlexDLL 0.44.

1. Mark `FLEXLINKFLAGS` as precious and pass them to flexlink invocation.
   Flexlink reads the `FLEXLINKFLAGS` env var for supplementary flags. They could be used when building the compiler. If we don't add them explicitly to `$flexlinkflags` they're:

   1. not shown in the flexlink invocations;
   2. not retained after the build, when the installed ocaml calls flexlink as a linker.

   Prefer passing the `FLEXLINKFLAGS` explicitly in the invocation, at the risk of duplicating the flags if `FLEXLINKFLAGS` is set in the environment rather than given to configure as an argument.
   This change also marks the variable as precious so that any change to it invalidates the build.

2. Define RC to choose an alternative resource compiler.
   This allow overriding the default resource processor, used during FlexDLL's bootstrap. The variable name is defined by libtool.
   Pass the variable to the flexlink Makefile.

3. Pass `$CC` in the flexdll build env.
   FlexDLL's Makefile has its own mechanism to discover the C compiler. Override it with the selected C compiler.

cc @dra27 @nojb @shym

