### PR TITLE
Fix nontermination with `-short-paths` and recursive modules (#14036)

### DIFF
--- a/Changes
+++ b/Changes
@@ -341,6 +341,11 @@ Working version
 
 ### Bug fixes:
 
+- #14036: Fix nontermination of cycle printing in recursive modules with
+  `-short-paths`. Add error message for types considered abstract while
+  checking recursive modules.
+  (Brandon Stride, review by Florian Angeletti)
+
 - #14065: Fix function signature mismatch of `__tsan_func_exit` with GCC 15.
   Check in the configure step if the TSan provided internal builtins are the
   same as what we expect, introduce `caml_tsan_*` wrappers for the `__tsan_*`

--- a/testsuite/tests/typing-recmod/inconsistent_constraints.ml
+++ b/testsuite/tests/typing-recmod/inconsistent_constraints.ml
@@ -1,0 +1,20 @@
+(* TEST
+  expect;
+*)
+
+(* Type constraints are inconsistent because of double vision *)
+
+module rec X : sig
+  type 'a t = 'a X.s as 'b
+    constraint 'b = int
+  type 'a s = int
+end = X
+[%%expect {|
+Line 3, characters 15-23:
+3 |     constraint 'b = int
+                   ^^^^^^^^
+Error: The type constraints are not consistent.
+       Type "'a X.s" is not compatible with type "int"
+       Type "X.s" was considered abstract when checking constraints in this
+       recursive module definition.
+|}]

--- a/testsuite/tests/typing-short-paths/cycles.ml
+++ b/testsuite/tests/typing-short-paths/cycles.ml
@@ -1,0 +1,193 @@
+(* TEST
+ flags = " -short-paths ";
+ ocamlrunparam += "l=100000";
+ expect;
+*)
+
+(* These tests may run forever on failure. ocamlrunparam+="l=100000" limits stack size to cut them short. *)
+
+(* Immediate cycle *)
+
+module Test1 = struct
+  module rec X : sig type t = X.t end = struct type t = int end
+end
+[%%expect {|
+Line 2, characters 2-63:
+2 |   module rec X : sig type t = X.t end = struct type t = int end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation "X.t" is cyclic:
+         "X.t" = "X.t"
+|}]
+
+
+(* 2-cycle *)
+
+module Test2 = struct
+  module rec X : sig type t = Y.t end = struct type t = Y.t end
+  and Y : sig type t = X.t end = struct type t = int end
+end
+[%%expect {|
+Line 2, characters 2-63:
+2 |   module rec X : sig type t = Y.t end = struct type t = Y.t end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "X.t" contains a cycle:
+         "Y.t" = "X.t",
+         "X.t" = "Y.t",
+         "Y.t" = "X.t"
+|}]
+
+
+(* Cycle with exactly equal parameters *)
+
+module Test3 = struct
+  module rec X : sig
+    type ('a, 'b) t = ('a, 'b) Y.t
+  end = struct
+    type ('a, 'b) t = ('a, 'b) Y.t
+  end
+  and Y : sig
+    type ('a, 'b) t = ('a, 'b) X.t
+  end = struct
+    type ('a, 'b) t = int
+  end
+end
+[%%expect{|
+Lines 2-6, characters 2-5:
+2 | ..module rec X : sig
+3 |     type ('a, 'b) t = ('a, 'b) Y.t
+4 |   end = struct
+5 |     type ('a, 'b) t = ('a, 'b) Y.t
+6 |   end
+Error: The definition of "X.t" contains a cycle:
+         "('a, 'b) Y.t" = "('a, 'b) X.t",
+         "('a, 'b) X.t" = "('a, 'b) Y.t",
+         "('a, 'b) Y.t" = "('a, 'b) X.t"
+|}]
+
+(* Cycle with unequal parameters *)
+
+module Test4 = struct
+  module rec X : sig
+    type ('a, 'b) t = ('b, 'a) Y.t
+  end = struct
+    type ('a, 'b) t = ('b, 'a) Y.t
+  end
+  and Y : sig
+    type ('a, 'b) t = ('b, 'a) X.t
+  end = struct
+    type ('a, 'b) t = int
+  end
+end
+[%%expect{|
+Lines 2-6, characters 2-5:
+2 | ..module rec X : sig
+3 |     type ('a, 'b) t = ('b, 'a) Y.t
+4 |   end = struct
+5 |     type ('a, 'b) t = ('b, 'a) Y.t
+6 |   end
+Error: The definition of "X.t" contains a cycle:
+         "('a, 'b) Y.t" = "('b, 'a) X.t",
+         "('b, 'a) X.t" = "('a, 'b) Y.t",
+         "('a, 'b) Y.t" = "('b, 'a) X.t"
+|}]
+
+(* Cycle with unequal number of parameters *)
+
+module Test5 = struct
+  module rec X : sig
+    type ('a, 'b) t = ('b, 'a, bool) Y.t
+  end = struct
+    type ('a, 'b) t = ('b, 'a, bool) Y.t
+  end
+  and Y : sig
+    type ('a, 'b, 'c) t = ('b, 'a) X.t
+  end = struct
+    type ('a, 'b, 'c) t = int
+  end
+end
+[%%expect{|
+Lines 2-6, characters 2-5:
+2 | ..module rec X : sig
+3 |     type ('a, 'b) t = ('b, 'a, bool) Y.t
+4 |   end = struct
+5 |     type ('a, 'b) t = ('b, 'a, bool) Y.t
+6 |   end
+Error: The definition of "X.t" contains a cycle:
+         "('a, 'b, bool) Y.t" = "('b, 'a) X.t",
+         "('b, 'a) X.t" = "('a, 'b, bool) Y.t",
+         "('a, 'b, bool) Y.t" = "('b, 'a) X.t"
+|}]
+
+(* Cycle is more than just aliasing *)
+
+module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
+       and B : sig type t = A.t end = struct type t = A.t end
+[%%expect {|
+Line 1, characters 0-75:
+1 | module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "A.t" contains a cycle:
+         "B.t -> int" contains "B.t",
+         "B.t" = "A.t",
+         "A.t" = "B.t -> int",
+         "B.t -> int" contains "B.t",
+         "B.t" = "A.t"
+|}]
+
+(* Short paths are actually short *)
+
+type a__name__that__shall__not__be__printed
+module type T = sig type t end
+module Fix(F: T -> T) = struct
+  module Atlas = struct type t = a__name__that__shall__not__be__printed end
+  module rec Fixed: sig
+    type t = F(Fixed).t
+  end = F(Fixed)
+end
+module Err = Fix(functor (X:T) -> struct type t = a__name__that__shall__not__be__printed -> X.t end)
+[%%expect{|
+type a__name__that__shall__not__be__printed
+module type T = sig type t end
+module Fix :
+  (F : T -> T) ->
+    sig
+      module Atlas : sig type t = a__name__that__shall__not__be__printed end
+      module rec Fixed : sig type t = F(Fixed).t end
+    end
+Line 9, characters 13-100:
+9 | module Err = Fix(functor (X:T) -> struct type t = a__name__that__shall__not__be__printed -> X.t end)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the signature of this functor application:
+       The definition of "Fixed.t" contains a cycle:
+         "Fixed.t" = "Atlas.t -> Fixed.t",
+         "Atlas.t -> Fixed.t" contains "Fixed.t",
+         "Fixed.t" = "Fixed.t",
+         "Fixed.t" = "Atlas.t -> Fixed.t"
+|}]
+
+module Constraint(F:sig type 'a t end-> sig type 'a t end) = struct
+  type 'a x = 'b constraint 'a = 'b * 'b
+  module rec Fixed: sig
+    type 'a s = < x: 'a F(Fixed).t >
+    type 'a t = ('a  * 'a) x s
+  end = Fixed
+end
+[%%expect {|
+module Constraint :
+  (F : sig type 'a t end -> sig type 'a t end) ->
+    sig
+      type 'a x = 'b constraint 'a = 'b * 'b
+      module rec Fixed :
+        sig type 'a s = < x : 'a F(Fixed).t > type 'a t = ('a * 'a) x s end
+    end
+|}]
+
+module Ok = Constraint(functor (X:sig type 'a t end) -> X)
+[%%expect {|
+module Ok :
+  sig
+    type 'a x = 'b constraint 'a = 'b * 'b
+    module rec Fixed :
+      sig type 'a s = < x : 'a Fixed.t > type 'a t = ('a * 'a) x s end
+  end
+|}]

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -126,8 +126,8 @@ Line 1, characters 0-75:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of "A.t" contains a cycle:
          "B.t -> int" contains "B.t",
-         "B.t" = "B.t",
-         "B.t" = "B.t -> int",
+         "B.t" = "A.t",
+         "A.t" = "B.t -> int",
          "B.t -> int" contains "B.t",
-         "B.t" = "B.t"
+         "B.t" = "A.t"
 |}]

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -446,6 +446,11 @@ let warn_on_missing_def env ppf t =
               "@,@[<hov>Type %a was considered abstract@ when checking\
                @ constraints@ in this@ recursive type definition.@]"
               pp_path p
+        | Approx_recmod ->
+            fprintf ppf
+              "@,@[<hov>Type %a was considered abstract@ when checking\
+               @ constraints@ in this@ recursive module definition.@]"
+              pp_path p
         | Definition | Existential _ -> ()
       end
   | _ -> ()

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -745,7 +745,7 @@ end = struct
                   let prev = String.Map.find_opt constr acc in
                   let prev = Option.value ~default:[] prev in
                   String.Map.add constr (tree_of_path None p :: prev) acc
-              | Definition | Rec_check_regularity -> acc)
+              | Definition | Rec_check_regularity | Approx_recmod -> acc)
         !names String.Map.empty
     in
     String.Map.iter

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1923,12 +1923,15 @@ let approx_type_decl sdecl_list =
 (* Check the well-formedness conditions on type abbreviations defined
    within recursive modules. *)
 
-let check_recmod_typedecl env loc recmod_ids path decl =
+(* [abs_env] is an abstract environment without physical cycles.
+  It is used as a printing environment in the case of cycles.
+  [env] is the main typing environment, which may contain cycles. *)
+let check_recmod_typedecl ~abs_env env loc recmod_ids path decl =
   (* recmod_ids is the list of recursively-defined module idents.
      (path, decl) is the type declaration to be checked. *)
   let to_check path = Path.exists_free recmod_ids path in
-  check_well_founded_decl ~abs_env:env env loc path decl to_check;
-  check_regularity ~abs_env:env env loc path decl to_check;
+  check_well_founded_decl ~abs_env env loc path decl to_check;
+  check_regularity ~abs_env env loc path decl to_check;
   (* additional coherence check, as one might build an incoherent signature,
      and use it to build an incoherent module, cf. #7851 *)
   check_coherence env loc path decl

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1890,13 +1890,13 @@ let transl_package_constraint ~loc env ty =
 
 (* Approximate a type declaration: just make all types abstract *)
 
-let abstract_type_decl ~injective arity =
+let abstract_type_decl ~injective ~explanation arity =
   let rec make_params n =
     if n <= 0 then [] else Ctype.newvar() :: make_params (n-1) in
   Ctype.with_local_level_generalize begin fun () ->
     { type_params = make_params arity;
       type_arity = arity;
-      type_kind = Type_abstract Definition;
+      type_kind = Type_abstract explanation;
       type_private = Public;
       type_manifest = None;
       type_variance = Variance.unknown_signature ~injective ~arity;
@@ -1911,13 +1911,14 @@ let abstract_type_decl ~injective arity =
     }
   end
 
-let approx_type_decl sdecl_list =
+let approx_type_decl ~explanation sdecl_list =
   let scope = Ctype.create_scope () in
   List.map
     (fun sdecl ->
       let injective = sdecl.ptype_kind <> Ptype_abstract in
       (Ident.create_scoped ~scope sdecl.ptype_name.txt,
-       abstract_type_decl ~injective (List.length sdecl.ptype_params)))
+       abstract_type_decl ~injective ~explanation
+        (List.length sdecl.ptype_params)))
     sdecl_list
 
 (* Check the well-formedness conditions on type abbreviations defined

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -51,8 +51,18 @@ val abstract_type_decl: injective:bool -> int -> type_declaration
 val approx_type_decl:
     Parsetree.type_declaration list ->
                                   (Ident.t * type_declaration) list
+
+(** [check_recmod_typedecl ~abs_env env loc recmod_ids path decl]
+   - [recmod_ids] is the list of recursively-defined module idents.
+   - [path, decl] is the type declaration to be checked.
+   - [abs_env] is an abstract environment without physical cycles. It is used
+      as a printing environment.
+   - [env] is the main environment, which may contain cycles introduced by the
+      recursive module definitions.
+*)
 val check_recmod_typedecl:
-    Env.t -> Location.t -> Ident.t list -> Path.t -> type_declaration -> unit
+    abs_env:Env.t -> Env.t -> Location.t -> Ident.t list -> Path.t ->
+    type_declaration -> unit
 val check_coherence:
     Env.t -> Location.t -> Path.t -> type_declaration -> unit
 

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -47,9 +47,13 @@ val transl_with_constraint:
 val transl_package_constraint:
   loc:Location.t -> Env.t -> type_expr -> Types.type_declaration
 
-val abstract_type_decl: injective:bool -> int -> type_declaration
+val abstract_type_decl:
+    injective:bool -> explanation:Types.type_origin -> int -> type_declaration
+
+(** Approximate a list of type declarations with abstract types of the
+    given origin. *)
 val approx_type_decl:
-    Parsetree.type_declaration list ->
+    explanation:Types.type_origin -> Parsetree.type_declaration list ->
                                   (Ident.t * type_declaration) list
 
 (** [check_recmod_typedecl ~abs_env env loc recmod_ids path decl]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1038,7 +1038,9 @@ and approx_sig env ssg =
   | item :: srem ->
       match item.psig_desc with
       | Psig_type (rec_flag, sdecls) ->
-          let decls = Typedecl.approx_type_decl sdecls in
+          let decls =
+            Typedecl.approx_type_decl ~explanation:Approx_recmod sdecls
+          in
           let rem = approx_sig env srem in
           map_rec_type ~rec_flag
             (fun rs (id, info) -> Sig_type(id, info, rs, Exported)) decls rem

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -279,6 +279,7 @@ and ('lbl, 'cstr) type_kind =
 and type_origin =
     Definition
   | Rec_check_regularity
+  | Approx_recmod
   | Existential of string
 
 and record_representation =

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -574,6 +574,7 @@ and ('lbl, 'cstr) type_kind =
 and type_origin =
     Definition
   | Rec_check_regularity       (* See Typedecl.transl_type_decl *)
+  | Approx_recmod
   | Existential of string
 
 and record_representation =


### PR DESCRIPTION
This pull request proposes a potential solution to #14036.

Disclaimer: I am not versed in the OCaml compiler internals. This PR contains a possibly suboptimal fix, and I discuss what I might have done if I had more experience with the compiler.

When resolving short paths for certain cyclic type abbreviations in recursive modules, `Out_type.normalize_type_path` enters a loop because the typing environment contains a cycle of paths. A similar issue was fixed in #12645, which abstracted the environment to prevent nonterminating resolution of most other cyclic type definitions. That approach, however, does not immediately extend to this case.

## Proposed change

I propose detecting the cycle directly where the loop occurs. The change is localized to `typing/out_type.ml`.

## Performance

Since this logic only runs when printing with `-short-paths`, and both cycles and paths are expected to be small, I expect the performance impact of this PR is negligible.

## Tests

I've added tests at `testsuite/tests/typing-short-paths/cycles.ml`, including the example from #14036 and several new related cases.

Currently, test failure is only detected at the 10-minute timeout, which is excessive--just a few seconds would suffice. I don't know how to configure a shorter timeout in `ocamltest`. I recommend caution in merging these tests until the timeout issue is addressed.

## Implementation concerns

The changes might be at odds with the intention of `normalize_type_path`, which is expected to evaluate to a normalized or canonical type path. Here, an arbitrary path is chosen from the cycle, which may not be ideal. Other parts of the code rely on `normalize_type_path` to check for path ambiguity, which this change may affect. That said, no existing tests fail, so it may be safe in practice. Further, `normalize_type_path` was previously a partial function, and the inputs affected by this PR were already undefined. This patch makes its behavior in those cases defined and terminating.

In #12645, the issue was addressed with a more principled approach by printing paths from an abstract environment. However, when checking recursive modules, the necessary information to construct such an abstract environment is not readily available, so the concrete environment with the physical cycle is used (see `check_recmod_typedecl` at `typedecl.ml`, lines 1916-1924, and its use at `typemod.ml`, lines 200-209). Ideally, an abstract environment would be used here as well, but in this PR I settle for a localized fix.

While this patch resolves the issue in a localized way and causes no regressions in any existing test, it may not be the maintainers' preferred fix.
