### PR TITLE
manual: fallback to user agent for fonts

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,10 @@ Working version
 - #14023: Add documentation for the [row_more] function.
   (Richard Eisenberg, review by Jacques Garrigue)
 
+- #14038: Fall back immediately to user-agent-defined fonts when web fonts
+  fail to load.
+  (toastal)
+
 ### Compiler user-interface and warnings:
 
 - #12628: Improved error message for unsafe values: print out the full path for

--- a/manual/src/html_processing/scss/_common.scss
+++ b/manual/src/html_processing/scss/_common.scss
@@ -19,9 +19,9 @@ $logo_height:67px;
 @import url(https://fonts.googleapis.com/css?family=Noticia+Text:400,400i,700);
 @import url(https://fonts.googleapis.com/css?family=Fira+Sans:400,400i,500,500i,600,600i,700,700i);
 
-$font-sans: "Fira Sans", Helvetica, Arial, sans-serif;
-$font-mono: "Fira Mono", courier, monospace;
-$font-serif: "Noticia Text", Georgia, serif;
+$font-sans: "Fira Sans", sans-serif;
+$font-mono: "Fira Mono", monospace;
+$font-serif: "Noticia Text", serif;
 
 /* Reset */
 .pre,a,b,body,code,div,em,form,h1,h2,h3,h4,h5,h6,header,html,i,img,li,mark,menu,nav,object,output,p,pre,s,section,span,time,ul,td,var{


### PR DESCRIPTION
These font stacks aren’t well-curated & these defaults subjectively don’t look good. Fira Sans is a Humanist font, not a Grotesque one & Courier looks nothing like Fira Sans. If you aren’t falling back to a reasonably-similar font stack for design reasons, it is always better & cheaper to just ask the user agent for the fallback — which the user can configure.

Falling back to the Microsoft™’s “[Core fonts for the Web](https://en.wikipedia.org/wiki/Core_fonts_for_the_Web)” (Courier + Arial):

![Screen Shot 2025-05-16 at 14 36 09](https://github.com/user-attachments/assets/86987a0d-a90c-4f50-9e12-0f91a872d4d3)

Falling back to the user agent (Berkeley Mono + U001):

![Screen Shot 2025-05-16 at 14 37 28](https://github.com/user-attachments/assets/89c63a8e-9314-4165-86e9-2117bed51358)

(Ignoring how odd it is to see non-monospace fonts in code blocks)

Since these are considered “Core fonts for the Web” many, if not all, machines have these fonts installed which means they will _almost always_ take precedence over the user agent fonts that the user set in their browser or OS settings.

When does this come up? This comes up mostly in the scenario where Google™ Fonts fail to load. This can happen under certain proxies, network failure, browser not supporting web fonts, or — as in my case — blocking third-party fonts from leaking user data to corporate CDNs (I use [*Fanboy's Anti-thirdparty Fonts*](https://secure.fanboy.co.nz/fanboy-antifonts.txt) filter list in uBlock Origin).

As a bonus, less bits are sent down to the client — negligible, but an optimization.
