### PR TITLE
[minor] Manual extensions: self-contained .etex files

### DIFF
--- a/manual/src/refman/exten.etex
+++ b/manual/src/refman/exten.etex
@@ -6,129 +6,32 @@ that are implemented in OCaml, but not described in chapter \ref{c:refman}.
 
 
 %HEVEA\cutdef{section}
-\section{s:letrecvalues}{Recursive definitions of values}
-%HEVEA\cutname{letrecvalues.html}
+
 \input{letrecvalues.tex}
-
-\section{s:recursive-modules}{Recursive modules}
-\ikwd{module\@\texttt{module}}
-\ikwd{and\@\texttt{and}}
-%HEVEA\cutname{recursivemodules.html}
 \input{recursivemodules.tex}
-
-\section{s:private-types}{Private types}
-%HEVEA\cutname{privatetypes.html}
-\ikwd{private\@\texttt{private}}
 \input{privatetypes.tex}
-
-\section{s:locally-abstract}{Locally abstract types}
-\ikwd{type\@\texttt{type}}
-\ikwd{fun\@\texttt{fun}}
-%HEVEA\cutname{locallyabstract.html}
 \input{locallyabstract.tex}
-
-\section{s:first-class-modules}{First-class modules}
-\ikwd{module\@\texttt{module}}
-\ikwd{val\@\texttt{val}}
-\ikwd{with\@\texttt{with}}
-\ikwd{and\@\texttt{and}}
-%HEVEA\cutname{firstclassmodules.html}
 \input{firstclassmodules.tex}
-
-\section{s:module-type-of}{Recovering the type of a module}
-%HEVEA\cutname{moduletypeof.html}
-\ikwd{module\@\texttt{module}}
-\ikwd{type\@\texttt{type}}
-\ikwd{of\@\texttt{of}}
-\ikwd{include\@\texttt{include}}
 \input{moduletypeof.tex}
-
-\section{s:signature-substitution}{Substituting inside a signature}
-\ikwd{with\@\texttt{with}}
-\ikwd{module\@\texttt{module}}
-\ikwd{type\@\texttt{type}}
-%HEVEA\cutname{signaturesubstitution.html}
 \input{signaturesubstitution.tex}
-
-\section{s:module-alias}{Type-level module aliases}
-\ikwd{module\@\texttt{module}}
-%HEVEA\cutname{modulealias.html}
 \input{modulealias.tex}
-
-\section{s:explicit-overriding-open}{Overriding in open statements}
-\ikwd{open.\@\texttt{open\char33}}
-%HEVEA\cutname{overridingopen.html}
 \input{overridingopen.tex}
-
-\section{s:gadts}{Generalized algebraic datatypes} \ikwd{type\@\texttt{type}}
-\ikwd{match\@\texttt{match}}
-%HEVEA\cutname{gadts.html}
 \input{gadts.tex}
-
-\section{s:bigarray-access}{Syntax for Bigarray access}
-%HEVEA\cutname{bigarray.html}
 \input{bigarray.tex}
-
-\section{s:attributes}{Attributes}
-%HEVEA\cutname{attributes.html}
-\ikwd{when\@\texttt{when}}
 \input{attributes.tex}
-
-\section{s:extension-nodes}{Extension nodes}
-%HEVEA\cutname{extensionnodes.html}
 \input{extensionnodes.tex}
-
-\section{s:extensible-variants}{Extensible variant types}
-%HEVEA\cutname{extensiblevariants.html}
 \input{extensiblevariants.tex}
-
-\section{s:generative-functors}{Generative functors}
-%HEVEA\cutname{generativefunctors.html}
 \input{generativefunctors.tex}
-
-\section{s:extension-syntax}{Extension-only syntax}
-%HEVEA\cutname{extensionsyntax.html}
 \input{extensionsyntax.tex}
-
-\section{s:inline-records}{Inline records}
-%HEVEA\cutname{inlinerecords.html}
 \input{inlinerecords.tex}
-
-\section{s:doc-comments}{Documentation comments}
-%HEVEA\cutname{doccomments.html}
 \input{doccomments.tex}
-
-\section{s:index-operators}{Extended indexing operators }
-%HEVEA\cutname{indexops.html}
 \input{indexops.tex}
-
-\section{s:empty-variants}{Empty variant types}
-%HEVEA\cutname{emptyvariants.html}
-(Introduced in 4.07.0)
 \input{emptyvariants.tex}
-
-\section{s:alerts}{Alerts}
-%HEVEA\cutname{alerts.html}
 \input{alerts.tex}
-
-\section{s:generalized-open}{Generalized open statements}
-%HEVEA\cutname{generalizedopens.html}
 \input{generalizedopens.tex}
-
-\section{s:binding-operators}{Binding operators}
-%HEVEA\cutname{bindingops.html}
 \input{bindingops.tex}
-
-\section{s:effect-handlers}{Effect handlers}
-%HEVEA\cutname{effects.html}
 \input{effects.tex}
-
-\section{s:array-literals}{Type-directed disambiguation of array literals}
-%HEVEA\cutname{arrayliterals.html}
 \input{arrayliterals.tex}
-
-\section{s:labeled-tuples}{Labeled tuples}
-%HEVEA\cutname{labeledtuples.html}
 \input{labeledtuples.tex}
 
 %HEVEA\cutend

--- a/manual/src/refman/extensions/alerts.etex
+++ b/manual/src/refman/extensions/alerts.etex
@@ -1,3 +1,6 @@
+\section{s:alerts}{Alerts}
+%HEVEA\cutname{alerts.html}
+
 (Introduced in 4.08)
 
 Since OCaml 4.08, it is possible to mark components (such as value or

--- a/manual/src/refman/extensions/arrayliterals.etex
+++ b/manual/src/refman/extensions/arrayliterals.etex
@@ -1,3 +1,6 @@
+\section{s:array-literals}{Type-directed disambiguation of array literals}
+%HEVEA\cutname{arrayliterals.html}
+
 (Introduced in OCaml 5.4)
 
 Since OCaml 5.4, array literal syntax @"[|" e1 ';' e2 ';' ... ';' eN "|]"@ can

--- a/manual/src/refman/extensions/attributes.etex
+++ b/manual/src/refman/extensions/attributes.etex
@@ -1,3 +1,7 @@
+\section{s:attributes}{Attributes}
+%HEVEA\cutname{attributes.html}
+\ikwd{when\@\texttt{when}}
+
 (Introduced in OCaml 4.02,
 infix notations for constructs other than expressions added in 4.03)
 

--- a/manual/src/refman/extensions/bigarray.etex
+++ b/manual/src/refman/extensions/bigarray.etex
@@ -1,3 +1,6 @@
+\section{s:bigarray-access}{Syntax for Bigarray access}
+%HEVEA\cutname{bigarray.html}
+
 (Introduced in Objective Caml 3.00)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/bindingops.etex
+++ b/manual/src/refman/extensions/bindingops.etex
@@ -1,3 +1,6 @@
+\section{s:binding-operators}{Binding operators}
+%HEVEA\cutname{bindingops.html}
+
 (Introduced in 4.08.0)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/doccomments.etex
+++ b/manual/src/refman/extensions/doccomments.etex
@@ -1,3 +1,6 @@
+\section{s:doc-comments}{Documentation comments}
+%HEVEA\cutname{doccomments.html}
+
 (Introduced in OCaml 4.03)
 
 Comments which start with "**" are treated specially by the

--- a/manual/src/refman/extensions/effects.etex
+++ b/manual/src/refman/extensions/effects.etex
@@ -1,3 +1,6 @@
+\section{s:effect-handlers}{Effect handlers}
+%HEVEA\cutname{effects.html}
+
 (Introduced in 5.0. The syntax support for deep handlers was introduced in
 5.3.)
 

--- a/manual/src/refman/extensions/emptyvariants.etex
+++ b/manual/src/refman/extensions/emptyvariants.etex
@@ -1,3 +1,7 @@
+\section{s:empty-variants}{Empty variant types}
+%HEVEA\cutname{emptyvariants.html}
+(Introduced in 4.07.0)
+
 \begin{syntax}
 type-representation:
           ...

--- a/manual/src/refman/extensions/extensiblevariants.etex
+++ b/manual/src/refman/extensions/extensiblevariants.etex
@@ -1,3 +1,6 @@
+\section{s:extensible-variants}{Extensible variant types}
+%HEVEA\cutname{extensiblevariants.html}
+
 (Introduced in OCaml 4.02)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/extensionnodes.etex
+++ b/manual/src/refman/extensions/extensionnodes.etex
@@ -1,3 +1,6 @@
+\section{s:extension-nodes}{Extension nodes}
+%HEVEA\cutname{extensionnodes.html}
+
 (Introduced in OCaml 4.02,
 infix notations for constructs other than expressions added in 4.03,
 infix notation (e1 ;\%ext e2) added in 4.04.

--- a/manual/src/refman/extensions/extensionsyntax.etex
+++ b/manual/src/refman/extensions/extensionsyntax.etex
@@ -1,3 +1,6 @@
+\section{s:extension-syntax}{Extension-only syntax}
+%HEVEA\cutname{extensionsyntax.html}
+
 (Introduced in OCaml 4.02.2, extended in 4.03)
 
 Some syntactic constructions are accepted during parsing and rejected

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -1,3 +1,10 @@
+\section{s:first-class-modules}{First-class modules}
+%HEVEA\cutname{firstclassmodules.html}
+\ikwd{module\@\texttt{module}}
+\ikwd{val\@\texttt{val}}
+\ikwd{with\@\texttt{with}}
+\ikwd{and\@\texttt{and}}
+
 (Introduced in OCaml 3.12; pattern syntax and package type inference
 introduced in 4.00; structural comparison of package types introduced in 4.02.;
 fewer parens required starting from 4.05)

--- a/manual/src/refman/extensions/gadts.etex
+++ b/manual/src/refman/extensions/gadts.etex
@@ -1,3 +1,8 @@
+\section{s:gadts}{Generalized algebraic datatypes}
+%HEVEA\cutname{gadts.html}
+\ikwd{type\@\texttt{type}}
+\ikwd{match\@\texttt{match}}
+
 Generalized algebraic datatypes, or GADTs, extend usual sum types in
 two ways: constraints on type parameters may change depending on the
 value constructor, and some type variables may be existentially

--- a/manual/src/refman/extensions/generalizedopens.etex
+++ b/manual/src/refman/extensions/generalizedopens.etex
@@ -1,3 +1,6 @@
+\section{s:generalized-open}{Generalized open statements}
+%HEVEA\cutname{generalizedopens.html}
+
 (Introduced in 4.08)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/generativefunctors.etex
+++ b/manual/src/refman/extensions/generativefunctors.etex
@@ -1,3 +1,6 @@
+\section{s:generative-functors}{Generative functors}
+%HEVEA\cutname{generativefunctors.html}
+
 (Introduced in OCaml 4.02)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/indexops.etex
+++ b/manual/src/refman/extensions/indexops.etex
@@ -1,3 +1,6 @@
+\section{s:index-operators}{Extended indexing operators }
+%HEVEA\cutname{indexops.html}
+
 (Introduced in 4.06)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/inlinerecords.etex
+++ b/manual/src/refman/extensions/inlinerecords.etex
@@ -1,3 +1,6 @@
+\section{s:inline-records}{Inline records}
+%HEVEA\cutname{inlinerecords.html}
+
 (Introduced in OCaml 4.03)
 \begin{syntax}
   constr-args:

--- a/manual/src/refman/extensions/labeledtuples.etex
+++ b/manual/src/refman/extensions/labeledtuples.etex
@@ -1,3 +1,6 @@
+\section{s:labeled-tuples}{Labeled tuples}
+%HEVEA\cutname{labeledtuples.html}
+
 (Introduced in OCaml 5.4)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/letrecvalues.etex
+++ b/manual/src/refman/extensions/letrecvalues.etex
@@ -1,3 +1,6 @@
+\section{s:letrecvalues}{Recursive definitions of values}
+%HEVEA\cutname{letrecvalues.html}
+
 (Introduced in Objective Caml 1.00)
 
 As mentioned in section~\ref{sss:expr-localdef}, the @'let' 'rec'@ binding

--- a/manual/src/refman/extensions/locallyabstract.etex
+++ b/manual/src/refman/extensions/locallyabstract.etex
@@ -1,3 +1,8 @@
+\section{s:locally-abstract}{Locally abstract types}
+%HEVEA\cutname{locallyabstract.html}
+\ikwd{type\@\texttt{type}}
+\ikwd{fun\@\texttt{fun}}
+
 (Introduced in OCaml 3.12, short syntax added in 4.03)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/modulealias.etex
+++ b/manual/src/refman/extensions/modulealias.etex
@@ -1,3 +1,7 @@
+\section{s:module-alias}{Type-level module aliases}
+%HEVEA\cutname{modulealias.html}
+\ikwd{module\@\texttt{module}}
+
 (Introduced in OCaml 4.02)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/moduletypeof.etex
+++ b/manual/src/refman/extensions/moduletypeof.etex
@@ -1,3 +1,10 @@
+\section{s:module-type-of}{Recovering the type of a module}
+%HEVEA\cutname{moduletypeof.html}
+\ikwd{module\@\texttt{module}}
+\ikwd{type\@\texttt{type}}
+\ikwd{of\@\texttt{of}}
+\ikwd{include\@\texttt{include}}
+
 (Introduced in OCaml 3.12)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/overridingopen.etex
+++ b/manual/src/refman/extensions/overridingopen.etex
@@ -1,3 +1,7 @@
+\section{s:explicit-overriding-open}{Overriding in open statements}
+%HEVEA\cutname{overridingopen.html}
+\ikwd{open.\@\texttt{open\char33}}
+
 (Introduced in OCaml 4.01)
 
 \begin{syntax}

--- a/manual/src/refman/extensions/privatetypes.etex
+++ b/manual/src/refman/extensions/privatetypes.etex
@@ -1,3 +1,7 @@
+\section{s:private-types}{Private types}
+%HEVEA\cutname{privatetypes.html}
+\ikwd{private\@\texttt{private}}
+
 Private type declarations in module signatures, of the form
 "type t = private ...", enable libraries to
 reveal some, but not all aspects of the implementation of a type to

--- a/manual/src/refman/extensions/recursivemodules.etex
+++ b/manual/src/refman/extensions/recursivemodules.etex
@@ -1,3 +1,8 @@
+\section{s:recursive-modules}{Recursive modules}
+%HEVEA\cutname{recursivemodules.html}
+\ikwd{module\@\texttt{module}}
+\ikwd{and\@\texttt{and}}
+
 (Introduced in Objective Caml 3.07)
 
 % TODO: relaxed syntax

--- a/manual/src/refman/extensions/signaturesubstitution.etex
+++ b/manual/src/refman/extensions/signaturesubstitution.etex
@@ -1,3 +1,9 @@
+\section{s:signature-substitution}{Substituting inside a signature}
+%HEVEA\cutname{signaturesubstitution.html}
+\ikwd{with\@\texttt{with}}
+\ikwd{module\@\texttt{module}}
+\ikwd{type\@\texttt{type}}
+
 \subsection{ss:destructive-substitution}{Destructive substitutions}
 
 (Introduced in OCaml 3.12, generalized in 4.06)


### PR DESCRIPTION
Currently if you want to create documentation for a new language extension, or to extend the documentation of an existing extension, you go to `manual/src/refman/extensions/firstclassmodules.etex` (for example) and it starts like this:

```
(Introduced in OCaml 3.12; pattern syntax and package type inference
introduced in 4.00; structural comparison of package types introduced in 4.02.;
fewer parens required starting from 4.05)
```

What if you want to change the *title* of this section, or to know what is the TeX label to use to refer to it? Well, you have to go back to `../exten.etex` which has the following:

```latex
\section{s:first-class-modules}{First-class modules}
\ikwd{module\@\texttt{module}}
\ikwd{val\@\texttt{val}}
\ikwd{with\@\texttt{with}}
\ikwd{and\@\texttt{and}}
%HEVEA\cutname{firstclassmodules.html}
\input{firstclassmodules.tex}
```

The fact that the file firstclassmodules.etex is not self-contained is very slightly annoying. I'd like to make it as non-annoying as possible to improve the documentation, so I propose to merge the boilerplate stuff (`\section`, `\ikwd`, `%HEVEA\cutname`) into each extension file, instead of having them in the above file.

This also makes `exten.etex` consistent with the style used in other TeX directory files, for example in allfiles.etex:

```latex
\part{The OCaml language}
\label{p:refman}
\input{refman.tex}
\input{exten.tex}
```