### PR TITLE
Lazy.Atomic_repeating: concurrency-safe lazy thunks

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,10 @@ Working version
   (Kate Deplaix, review by Daniel Bünzli, Gabriel Scherer,
    Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
 
+- #14043: Lazy.Atomic_repeating.t: concurrency-safe lazy thunks that may
+  repeat initialization computation on forcing races.
+  (Gabriel Scherer, review by KC Sivaramakrishnan and ??)
+
 - #14086: Add Domain.count.
   (Nicolás Ojeda Bär, review by David Allsopp, Gabriel Scherer, Daniel Bünzli
   and KC Sivaramakrishnan)

--- a/Changes
+++ b/Changes
@@ -122,7 +122,8 @@ Working version
 
 - #14043: Lazy.Atomic_repeating.t: concurrency-safe lazy thunks that may
   repeat initialization computation on forcing races.
-  (Gabriel Scherer, review by KC Sivaramakrishnan and ??)
+  (Gabriel Scherer,
+   review by KC Sivaramakrishnan and Pierre Chambart and ??)
 
 - #14086: Add Domain.count.
   (Nicolás Ojeda Bär, review by David Allsopp, Gabriel Scherer, Daniel Bünzli

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -483,10 +483,12 @@ stdlib__Int64.cmi : int64.mli
 stdlib__Lazy.cmo : lazy.ml \
     stdlib__Obj.cmi \
     camlinternalLazy.cmi \
+    stdlib__Atomic.cmi \
     stdlib__Lazy.cmi
 stdlib__Lazy.cmx : lazy.ml \
     stdlib__Obj.cmx \
     camlinternalLazy.cmx \
+    stdlib__Atomic.cmx \
     stdlib__Lazy.cmi
 stdlib__Lazy.cmi : lazy.mli \
     camlinternalLazy.cmi

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -106,14 +106,6 @@ module Atomic_repeating = struct
   let from_fun ?(discard = ignore) f =
     Atomic.make (Thunk { make = f; discard })
 
-  let finish ops =
-    match ops.make () with
-    | exception exn ->
-        let bt = get_raw_backtrace () in
-        Failed (exn, bt)
-    | v ->
-        Val v
-
   let rec force th =
     match Atomic.get th with
     | Val v -> v
@@ -125,17 +117,25 @@ module Atomic_repeating = struct
       ignore (Atomic.compare_and_set th thunk (Forcing ops));
       force th
     | (Forcing ops) as forcing ->
-        let finished = finish ops in
-        (* [compare_and_set] returns [false] when another domain has
-           set the thunk to a finished state. In this case our
-           [finished] value is discarded. *)
-        if not (Atomic.compare_and_set th forcing finished)
-        then begin match finished with
-          | Val v ->
-              (* Ignore exceptions raised by discard: we already
-                 have a finished result to return. *)
-              (try ops.discard v with _ -> ())
-          | Thunk _ | Forcing _ | Failed _ -> ()
-        end;
-        force th
+        begin match ops.make () with
+        | exception exn ->
+            let bt = get_raw_backtrace () in
+            let failed = Failed (exn, bt) in
+            (* [compare_and_set] returns [false] when another domain
+               has set the thunk to a finished state. We re-raise our
+               exception in any case to avoid losing it. *)
+            ignore (Atomic.compare_and_set th forcing failed);
+            raise_with_backtrace exn bt
+        | v ->
+            (* [compare_and_set] returns [false] when another domain
+               has set the thunk to a finished state. In this case we
+               [discard] our value, and reuse the finished state. *)
+            if Atomic.compare_and_set th forcing (Val v)
+            then v
+            else begin
+              (* Exceptions from [discard] are propagated to the caller. *)
+              ops.discard v;
+              force th
+            end
+        end
 end

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -78,3 +78,64 @@ let map_val f x =
   if is_val x
   then from_val (f (force x))
   else lazy (f (force x))
+
+
+
+module Atomic_repeating = struct
+  (* we define these as primitives to avoid a dependency on Printexc *)
+  type raw_backtrace
+  external get_raw_backtrace:
+    unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
+  external raise_with_backtrace: exn -> raw_backtrace -> 'a
+    = "%raise_with_backtrace"
+
+  type 'a ops = {
+    make : unit -> 'a;
+    discard : 'a -> unit;
+  }
+
+  type 'a state =
+    | Thunk of 'a ops
+    | Forcing of 'a ops
+    | Val of 'a
+    | Failed of exn * raw_backtrace
+
+  type 'a t = 'a state Atomic.t
+
+  let from_val v = Atomic.make (Val v)
+  let from_fun ?(discard = ignore) f =
+    Atomic.make (Thunk { make = f; discard })
+
+  let finish ops =
+    match ops.make () with
+    | exception exn ->
+        let bt = get_raw_backtrace () in
+        Failed (exn, bt)
+    | v ->
+        Val v
+
+  let rec force th =
+    match Atomic.get th with
+    | Val v -> v
+    | Failed (exn, bt) ->
+      raise_with_backtrace exn bt
+    | (Thunk ops) as thunk ->
+      (* [compare_and_set] returns [false] when another domain has
+         set the thunk to [Forcing] or a finished state. *)
+      ignore (Atomic.compare_and_set th thunk (Forcing ops));
+      force th
+    | (Forcing ops) as forcing ->
+        let finished = finish ops in
+        (* [compare_and_set] returns [false] when another domain has
+           set the thunk to a finished state. In this case our
+           [finished] value is discarded. *)
+        if not (Atomic.compare_and_set th forcing finished)
+        then begin match finished with
+          | Val v ->
+              (* Ignore exceptions raised by discard: we already
+                 have a finished result to return. *)
+              (try ops.discard v with _ -> ())
+          | Thunk _ | Forcing _ | Failed _ -> ()
+        end;
+        force th
+end

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -150,8 +150,9 @@ module Atomic_repeating : sig
      another computation. Forcing an [Atomic_repeating.t] thunk does
      not block when races happen, instead it may repeat the
      computation of the result several times. We do guarantee that
-     calling {!force} on the same suspended computation will always
-     return the same value, even in presence of forcing races.
+     if two calls to {!force} on the same suspended computation return
+     a value, then they return the same value, even in presence of
+     forcing races.
 
      A typical use-case for atomic, repeating deferred computations is
      optional library initialization code that is moderately
@@ -195,19 +196,23 @@ module Atomic_repeating : sig
       in the case of concurrent races.
 
       If [f] is called several times, one result will be stored as the
-      result of this computation, and the value of any other result
-      will be passed to the [discard] function -- a no-op by default.
-      Exceptions raised by [discard] are themselves discarded. *)
+      result of this computation. Other values computed concurrently
+      will be discarded, after being passed to the [discard] function
+      (a no-op by default). On the other hand, exceptions raised by
+      concurrent computations will be re-raised, as well as exceptions
+      raised by [discard].
+*)
 
   val force : 'a t -> 'a
-  (** [force x] forces the suspension [x]. If [x] has
-      already been forced, [Lazy.force x] returns the same value again without
-      recomputing it. If it raised an exception, the same exception is raised
-      again.
+  (** [force x] forces the suspension [x]. If [x] has already been
+      forced, [Lazy.force x] returns the same value again without
+      recomputing it. If it raised an exception, the same exception is
+      raised again.
 
       If there is a race between several calls to [force], the
-      computation may be repeated and some of the finished results
-      will be discarded. All forcing calls will return the same result. *)
+      computation may be repeated several times. If some of them fail
+      with an exception, they will re-raise it; but all those that
+      return a value will return the same value. *)
 
 
   (** {1:examples Examples}

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -139,3 +139,150 @@ val force_val : 'a t -> 'a
 
     @raise Undefined (see {!Undefined}).
 *)
+
+module Atomic_repeating : sig
+  (** Atomic, repeating deferred computations.
+
+     This implementation is less optimized than [Lazy.t], but it can
+     be used in a concurrent setting.
+
+     OCaml domains do not provide a common abstraction to block on
+     another computation. Forcing an [Atomic_repeating.t] thunk does
+     not block when races happen, instead it may repeat the
+     computation of the result several times. We do guarantee that
+     calling {!force} on the same suspended computation will always
+     return the same value, even in presence of forcing races.
+
+     A typical use-case for atomic, repeating deferred computations is
+     optional library initialization code that is moderately
+     expensive, or acquires resources. The library author does not
+     want to do this work on startup, because it may not be needed,
+     but using ['a Lazy.t] is incorrect if the library may be used in
+     concurrent settings. ['a Lazy.Atomic_repeating.t] can be used, as
+     long as the fact that duplications are repeated is acceptable.
+
+     {b Warning}: ['a Lazy.t] contains a protection against recursively
+     forcing a thunk, it will raise {!Undefined}. On the other hand,
+     ['a Lazy.Atomic_repeating.t] will recursively repeat the computation,
+     which may loop.
+
+     See {{!examples} the examples} below.
+  *)
+
+  type 'a t
+  (* A value of type ['a Lazy.Atomic_repeating.t] is similar to a value
+     of type ['a Lazy.t], it represents a deferred computation, but it can
+     safely be used in concurrent settings.
+
+     If a calling domain attempts to {!force} a value that is already
+     being forced, the calling domain is not suspended. Instead, the
+     computation of the value will be repeated on the calling
+     domain. In other words, [Atomic_repeating.t] can duplicate
+     computations.
+
+     The implementation ensures that all call to {!force} return the
+     same value or raise the same exception: if a repeated terminates
+     on a result, its value or exception will be discarded.
+  *)
+
+  val from_val : 'a -> 'a t
+  (** [from_val v] is a deferred computation which is already
+      finished and whose result is the value [v]. *)
+
+  val from_fun : ?discard:('a -> unit) -> (unit -> 'a) -> 'a t
+  (** [from_fun ?discard f] is a deferred computation that will call
+      [f] when forced. Note that [f] may be called several times
+      in the case of concurrent races.
+
+      If [f] is called several times, one result will be stored as the
+      result of this computation, and the value of any other result
+      will be passed to the [discard] function -- a no-op by default.
+      Exceptions raised by [discard] are themselves discarded. *)
+
+  val force : 'a t -> 'a
+  (** [force x] forces the suspension [x]. If [x] has
+      already been forced, [Lazy.force x] returns the same value again without
+      recomputing it. If it raised an exception, the same exception is raised
+      again.
+
+      If there is a race between several calls to [force], the
+      computation may be repeated and some of the finished results
+      will be discarded. All forcing calls will return the same result. *)
+
+
+  (** {1:examples Examples}
+
+      A typical use-case is to initialize some library-local
+      state that is used by library functions.
+
+      {[
+        let config = Lazy.Atomic_repeating.from_fun (fun () ->
+          match Sys.getenv "MYLIB_CONFIG_PATH" with
+          | exception _ -> Config.default ()
+          | path -> Config.read_from_path path
+        )
+      ]}
+
+      The environment access and file read may be repeated several
+      times in the case of concurrent forcing, but the "first"
+      configuration to be computed will be returned by all callers.
+
+      {3:examples_discard Using the [?discard] parameter.}
+
+      The [?discard] argument is useful to release resources if
+      a repeated result is discarded.
+
+      {[
+        let log_file_and_channel =
+          let acquire () =
+            match Sys.getenv "MYLIB_LOG_PATH" with
+            | exception _ ->
+                let path, chan = Filename.open_temp_file "mylib" ".log" in
+                (`Temp path), chan
+            | path ->
+                let chan = Out_channel.open_bin path in
+                (`User path), chan
+          in
+          let discard (source, chan) =
+            Out_channel.close chan;
+            match source with
+            | `User _ -> ()
+            | `Temp path -> Sys.remove path
+          in
+          Lazy.Atomic_repeating.from_fun ~discard acquire
+      ]}
+
+      {3:examples_sync User synchronization}
+
+      Users of this module can add their own synchronization logic to
+      avoid repeated computations. For example, in an application
+      which uses threads and mutex:
+
+      {[
+        let entropy =
+          (* we use a mibibyte of random data from /dev/urandom *)
+          let init_mutex = Mutex.create () in
+          let result = ref None in
+          Lazy.Atomic_repeating.from_fun (fun () ->
+            Mutex.protect init_mutex (fun () ->
+              match !result with
+              | Some v -> v
+              | None ->
+                  let v =
+                    In_channel.with_open_bin "/dev/urandom" (fun chan ->
+                      In_channel.really_input_string chan (1024 * 1024)
+                    )
+                  in
+                  result := Some v;
+                  v
+            )
+          )
+      ]}
+
+      A program using this definition will open "/dev/urandom" at most
+      once. Note that the mutex is only taken on [force] calls that
+      happen while the initialization is not yet finished -- typically
+      the first call, or possibly several concurrent first calls. Once
+      initialization is finished, the value will be returned directly.
+ *)
+end

--- a/testsuite/tests/lib-lazy/repeating.ml
+++ b/testsuite/tests/lib-lazy/repeating.ml
@@ -1,0 +1,152 @@
+(* TEST
+ expect;
+*)
+
+module LazyAR = Lazy.Atomic_repeating
+[%%expect{|
+module LazyAR = Lazy.Atomic_repeating
+|}]
+
+(* direct value return *)
+let it =
+  let v = LazyAR.from_val 42 in
+  (LazyAR.force v, LazyAR.force v)
+[%%expect{|
+val it : int * int = (42, 42)
+|}]
+
+(* value return *)
+let it =
+  let v = LazyAR.from_fun (fun () -> 43) in
+  (LazyAR.force v, LazyAR.force v)
+[%%expect{|
+val it : int * int = (43, 43)
+|}]
+
+
+(* exception case *)
+let it =
+  let fail = LazyAR.from_fun (fun () -> raise Exit) in
+  let check () = match LazyAR.force fail with
+  | exception Exit -> true
+  | exception _ | _ -> false
+  in
+  check () && check ()
+[%%expect{|
+val it : bool = true
+|}]
+
+(* sharing check *)
+let it =
+  let r = ref 0 in
+  let test = LazyAR.from_fun (fun () -> incr r) in
+  (* side-effects must not be repeated in sequential settings. *)
+  LazyAR.force test;
+  LazyAR.force test;
+  if !r = 1 then Ok () else Error !r
+[%%expect{|
+val it : (unit, int) result = Ok ()
+|}]
+
+(* Fake concurrency tests : we can use reentrancy to emulate concurrency. *)
+let it =
+  let step = ref 0 in
+  let thunk =
+    let self = ref (LazyAR.from_fun (fun () -> 500)) in
+    self := begin
+      (* The first call to reach !step = 100 will finish with the value 0.
+         Other calls will finish with higher values, but those will be discarded. *)
+      let discard n =
+        if n = 0 then prerr_endline "Discard error!"
+      in
+      LazyAR.from_fun ~discard (fun () ->
+        if !step >= 100 then 0
+        else (incr step; LazyAR.force !self + 1)
+      )
+    end;
+    !self
+  in
+  let result1 = LazyAR.force thunk in
+  let result2 = LazyAR.force thunk in
+  if result1 = 0 && result2 = 0 && !step = 100
+  then Ok ()
+  else Error (~result1, ~result2, ~step:!step)
+[%%expect{|
+val it : (unit, result1:int * result2:int * step:int) result = Ok ()
+|}]
+
+
+(* Check that the documentation examples are well-typed. *)
+module Example1 (Config : sig
+  type t
+  val default : unit -> t
+  val read_from_path : string -> t
+end) = struct
+  let config = Lazy.Atomic_repeating.from_fun (fun () ->
+    match Sys.getenv "MYLIB_CONFIG_PATH" with
+    | exception _ -> Config.default ()
+    | path -> Config.read_from_path path
+  )
+end
+[%%expect{|
+module Example1 :
+  (Config : sig
+              type t
+              val default : unit -> t
+              val read_from_path : string -> t
+            end)
+    -> sig val config : Config.t Lazy.Atomic_repeating.t end
+|}]
+
+module Example2 () = struct
+  let log_file_and_channel =
+    let acquire () =
+      match Sys.getenv "MYLIB_LOG_PATH" with
+      | exception _ ->
+          let path, chan = Filename.open_temp_file "mylib" ".log" in
+          (`Temp path), chan
+      | path ->
+          let chan = Out_channel.open_bin path in
+          (`User path), chan
+    in
+    let discard (source, chan) =
+      Out_channel.close chan;
+      match source with
+      | `User _ -> ()
+      | `Temp path -> Sys.remove path
+    in
+    Lazy.Atomic_repeating.from_fun ~discard acquire
+end
+[%%expect{|
+module Example2 :
+  () ->
+    sig
+      val log_file_and_channel :
+        ([ `Temp of string | `User of string ] * Out_channel.t)
+        Lazy.Atomic_repeating.t
+    end
+|}]
+
+module Example3 = struct
+  let entropy =
+    (* we use a mibibyte of random data from /dev/urandom *)
+    let init_mutex = Mutex.create () in
+    let result = ref None in
+    Lazy.Atomic_repeating.from_fun (fun () ->
+      Mutex.protect init_mutex (fun () ->
+        match !result with
+        | Some v -> v
+        | None ->
+            let v =
+              In_channel.with_open_bin "/dev/urandom" (fun chan ->
+                In_channel.really_input_string chan (1024 * 1024)
+              )
+            in
+            result := Some v;
+            v
+      )
+    )
+end
+[%%expect {|
+module Example3 : sig val entropy : string option Lazy.Atomic_repeating.t end
+|}]


### PR DESCRIPTION
Library authors often use lazy thunks for initialization code that is only necessary for certain parts of the library -- the initialization code runs on-demand when the library user first calls one of those functions.

This idiom is not safe anymore with OCaml 5, as lazy thunks cannot be forced concurrently. Using it make the library itself non-concurrency-safe.

We have tried to make `'a Lazy.t` concurrency-safe in the past, but a significant blocker is that we don't know what to do concurrent forcing is detected: ideally one forcing caller would block until the result has been computed by the other, but there is no standard blocking abstraction in the OCaml runtime or standard library that can be used for this purpose. Some people would want blocking at the level of Threads, others at the level of Eio fibers, etc. See for example this Discuss thread: [How to block in an agnostic way?](https://discuss.ocaml.org/t/how-to-block-in-an-agnostic-way/9368). Some approaches have been proposed, but their design is complex and no one is actively trying to achieve a consensus in this area.

This PR is based on the remark that, for many use-cases, library authors do not actually need concurrent forcing calls to block. It may be okay to run the initialization code several times instead. In fact, we can guarantee that even if the initialization code is run several time, only a unique value will be returned by all `force` calls -- the other values, initialized by domains that "lost" the forcing race, are discarded.

This PR proposes a new submodule `Lazy.Atomic_repeating` that implements this idea. The code is very simple -- the documentation is longer. The name is a bit long as well, to emphasize this limitation.

Relevant bits from the documentation:

```ocaml
  (** Atomic, repeating deferred computations.

     This implementation is less optimized than [Lazy.t], but it can
     be used in a concurrent setting.

     OCaml domains do not provide a common abstraction to block on
     another computation. Forcing an [Atomic_repeating.t] thunk does
     not block when races happen, instead it may repeat the
     computation of the result several times. We do guarantee that
     calling {!force} on the same suspended computation will always
     return the same value, even in presence of forcing races.

     A typical use-case for atomic, repeating deferred computations is
     optional library initialization code that is moderately
     expensive, or acquires resources. The library author does not
     want to do this work on startup, because it may not be needed,
     but using ['a Lazy.t] is incorrect if the library may be used in
     concurrent settings. ['a Lazy.Atomic_repeating.t] can be used, as
     long as the fact that duplications are repeated is acceptable.

     {b Warning}: ['a Lazy.t] contains a protection against recursively
     forcing a thunk, it will raise {!Undefined}. On the other hand,
     ['a Lazy.Atomic_repeating.t] will recursively repeat the computation,
     which may loop.

     See {{!examples} the examples} below.
  *)

  type 'a t

  val from_val : 'a -> 'a t

  val from_fun : ?discard:('a -> unit) -> (unit -> 'a) -> 'a t
  (** [from_fun f] is a deferred computation that will call
      [f] when forced. Note that [f] may be called several times
      in the case of concurrent races.

      If [f] is called several times, one result will be stored as the
      result of this computation, and the value of any other result
      will be passed to the [discard] function -- a no-op by default.
      Exceptions raised by [discard] are themselves discarded.
  *)

  val force : 'a t -> 'a

  (** {1:examples Examples}

      A typical use-case is to initialize some library-local
      state that is used by library functions.

      {[
        let config = Lazy.Atomic_repeating.from_fun (fun () ->
          match Sys.getenv "MYLIB_CONFIG_PATH" with
          | exception _ -> Config.default ()
          | path -> Config.read_from_path path
        )
      ]}

      The environment access and file read may be repeated several
      times in the case of concurrent forcing, but the "first"
      configuration to be computed will be returned by all callers.

      {3:examples_discard Using the [?discard] parameter.}

      The [?discard] argument is useful to release resources if
      a repeated result is discarded.

      {[
        let log_file_and_channel =
          let acquire () =
            match Sys.getenv "MYLIB_LOG_PATH" with
            | exception _ ->
                let path, chan = Filename.open_temp_file "mylib" ".log" in
                (`Temp path), chan
            | path ->
                let chan = Out_channel.open_bin path in
                (`User path), chan
          in
          let discard (source, chan) =
            Out_channel.close chan;
            match source with
            | `User _ -> ()
            | `Temp path -> Sys.remove path
          in
          Lazy.Atomic_repeating.from_fun ~discard acquire
      ]}

      {3:examples_sync User synchronization}

      Users of this module can add their own synchronization logic to
      avoid repeated computations. For example, in an application
      which uses threads and mutex:

      {[
        let entropy =
          (* we use a mibibyte of random data from /dev/urandom *)
          let init_mutex = Mutex.create () in
          let result = ref None in
          Lazy.Atomic_repeating.from_fun (fun () ->
            Mutex.protect init_mutex (fun () ->
              match !result with
              | Some v -> v
              | None ->
                  let v =
                    In_channel.with_open_bin "/dev/urandom" (fun chan ->
                      In_channel.really_input_string chan (1024 * 1024)
                    )
                  in
                  result := Some v;
                  v
            )
          )
      ]}

      A program using this definition will open "/dev/urandom" at most
      once.  Note that the mutex is only taken on [force] calls that
      happen while the initialization is not yet finished -- typically
      the first call, or possibly several concurrent first calls. Once
      initialization is finished, the value will be returned directly.
 *)
```
