### PR TITLE
Use BUILD_PATH_PREFIX_MAP to sanitize debug event paths, do not rewrite shebang

### DIFF
--- a/Changes
+++ b/Changes
@@ -2746,6 +2746,9 @@ Some of those changes will benefit all OCaml packages.
 
 ### Code generation and optimizations:
 
+- #12139: BUILD_PATH_PREFIX_MAP support in bytecomp.
+  (Richard L ford, review by Gabriel Scherer)
+
 - #11967: Remove traces of Obj.truncate, which allows some mutable
   loads to become immutable.
   (Nick Barnes, review by Vincent Laviron and KC Sivaramakrishnan)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -289,11 +289,6 @@ let output_debug_info oc =
 
 (* Transform a file name into an absolute file name *)
 
-let make_absolute file =
-  if not (Filename.is_relative file) then file
-  else Location.rewrite_absolute_path
-         (Filename.concat (Sys.getcwd()) file)
-
 type launch_method =
 | Shebang_bin_sh of string
 | Shebang_runtime
@@ -388,6 +383,10 @@ let find_bin_sh () =
 let write_header outchan =
   let use_runtime, runtime =
     if String.length !Clflags.use_runtime > 0 then
+      (* Do not use BUILD_PATH_PREFIX_MAP mapping for this. *)
+      let make_absolute file =
+        if Filename.is_relative file then Filename.concat (Sys.getcwd()) file
+        else file in
       (true, make_absolute !Clflags.use_runtime)
     else
       (false, "ocamlrun" ^ !Clflags.runtime_variant)

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -186,6 +186,41 @@ and slot_for_c_prim name =
 let events = ref ([] : debug_event list)
 let debug_dirs = ref String.Set.empty
 
+(* Map from absolute paths of .ml files to their sanitized paths. *)
+let sanitize_map = Hashtbl.create 17
+
+let sanitize_event ev =
+  let loc = ev.ev_loc in
+  let sloc = loc.loc_start in
+  let path = sloc.pos_fname in
+  match path with
+  | "_none_" | "" | "//toplevel//" ->
+    (* Leave these as it. *)
+    ev
+  | _ ->
+  let unmapped_abspath =
+    if (Filename.is_relative path) then (Filename.concat (Sys.getcwd ()) path)
+    else path
+  in
+  let mapped_abspath = Location.rewrite_absolute_path unmapped_abspath in
+  (* If mapping did nothing, just keep the event as is. *)
+  if mapped_abspath = unmapped_abspath then ev
+  else begin
+    (* We want to share the same sanitized path to save space *)
+    let new_fname = match Hashtbl.find_opt sanitize_map mapped_abspath with
+    | Some saved_path -> saved_path
+    | None ->
+        Hashtbl.add sanitize_map mapped_abspath mapped_abspath;
+        mapped_abspath
+    in
+    let eloc = loc.loc_end in
+    let nsloc = {sloc with pos_fname=new_fname} in
+    let neloc = {eloc with pos_fname=new_fname} in
+    let new_loc: Location.t = {loc with loc_start=nsloc; loc_end=neloc} in
+    let new_ev: Instruct.debug_event = {ev with ev_loc=new_loc} in
+    new_ev
+  end
+
 let record_event ev =
   let path = ev.ev_loc.Location.loc_start.Lexing.pos_fname in
   let abspath = Location.absolute_path path in
@@ -195,6 +230,7 @@ let record_event ev =
     debug_dirs := String.Set.add cwd !debug_dirs;
   end;
   ev.ev_pos <- !out_position;
+  let ev = sanitize_event ev in
   events := ev :: !events
 
 (* Initialization *)
@@ -205,6 +241,7 @@ let clear() =
   reloc_info := [];
   debug_dirs := String.Set.empty;
   events := [];
+  Hashtbl.clear sanitize_map;
   out_buffer := create_bigarray 0
 
 let init () =


### PR DESCRIPTION
(This is #12139 rebased)

1. bytecomp/emitcode.ml

Sanitize the paths in debug events using
BUILD_PATH_PREFIX_MAP. However if the mapping has no effect, then do nothing.

2. bytecomp/bytelink.ml Do not do BUILD_PATH_PREFIX_MAP mapping of the path supplied by the user with the `-use-runtime` option. This is used to fill in the shebang part of the
executable, and an abstract path is unlikely to
work there.