### PR TITLE
Unix.kill: On Windows, make process exit code non-zero

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,7 +36,7 @@ Working version
 
 * #14046: On Windows, processes killed with `Unix.kill` now exit with status
   code 137 instead of 0.
-  (Nicolás Ojeda Bär)
+  (Nicolás Ojeda Bär, review by Miod Vallat and Antonin Décimo)
 
 - #14020: Add Unix.unsetenv.
   (Nicolás Ojeda Bär, review by Antonin Décimo and David Allsopp)

--- a/Changes
+++ b/Changes
@@ -34,6 +34,10 @@ Working version
 
 ### Other libraries:
 
+* #14046: On Windows, processes killed with `Unix.kill` now exit with status
+  code 137 instead of 0.
+  (Nicolás Ojeda Bär)
+
 - #14020: Add Unix.unsetenv.
   (Nicolás Ojeda Bär, review by Antonin Décimo and David Allsopp)
 

--- a/Changes
+++ b/Changes
@@ -34,9 +34,9 @@ Working version
 
 ### Other libraries:
 
-* #14046: On Windows, processes killed with `Unix.kill` now exit with status
-  code 137 instead of 0.
-  (Nicolás Ojeda Bär, review by Miod Vallat and Antonin Décimo)
+* #14046: On Windows, `Unix.kill pid Sys.sigkill` causes the receiving process
+  to exit with code ERROR_PROCESS_ABORTED (= 1067) instead of 0.
+  (Nicolás Ojeda Bär, review by Miod Vallat, Antonin Décimo and David Allsopp)
 
 - #14020: Add Unix.unsetenv.
   (Nicolás Ojeda Bär, review by Antonin Décimo and David Allsopp)

--- a/Changes
+++ b/Changes
@@ -35,7 +35,7 @@ Working version
 ### Other libraries:
 
 * #14046: On Windows, `Unix.kill pid Sys.sigkill` causes the receiving process
-  to exit with code ERROR_PROCESS_ABORTED (= 1067) instead of 0.
+  to exit with code ERROR_PROCESS_ABORTED (1067) instead of 0.
   (Nicolás Ojeda Bär, review by Miod Vallat, Antonin Décimo and David Allsopp)
 
 - #14020: Add Unix.unsetenv.

--- a/otherlibs/unix/createprocess.c
+++ b/otherlibs/unix/createprocess.c
@@ -168,5 +168,5 @@ static int has_console(void)
 
 CAMLprim value caml_unix_terminate_process(value v_pid)
 {
-  return (Val_bool(TerminateProcess((HANDLE) Long_val(v_pid), 0)));
+  return (Val_bool(TerminateProcess((HANDLE) Long_val(v_pid), 137)));
 }

--- a/otherlibs/unix/createprocess.c
+++ b/otherlibs/unix/createprocess.c
@@ -168,5 +168,6 @@ static int has_console(void)
 
 CAMLprim value caml_unix_terminate_process(value v_pid)
 {
-  return (Val_bool(TerminateProcess((HANDLE) Long_val(v_pid), 137)));
+  return (Val_bool(TerminateProcess((HANDLE) Long_val(v_pid),
+                                    ERROR_PROCESS_ABORTED)));
 }

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1161,7 +1161,8 @@ val kill : int -> Sys.signal -> unit
    with id [pid].
 
    On Windows: only the {!Sys.sigkill} signal is emulated, causing the receiving
-   process to exit with [ERROR_PROCESS_ABORTED] (= 1067). *)
+   process to exit with code [ERROR_PROCESS_ABORTED] (1067). Before OCaml 5.5,
+   the receiving process exited with code 0. *)
 
 type sigprocmask_command =
     SIG_SETMASK

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1160,7 +1160,8 @@ val kill : int -> Sys.signal -> unit
 (** [kill pid signal] sends signal number [signal] to the process
    with id [pid].
 
-   On Windows: only the {!Sys.sigkill} signal is emulated. *)
+   On Windows: only the {!Sys.sigkill} signal is emulated, causing the receiving
+   process to exit with [ERROR_PROCESS_ABORTED] (= 1067). *)
 
 type sigprocmask_command =
     SIG_SETMASK

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1161,7 +1161,8 @@ val kill : pid:int -> signal:Sys.signal -> unit
    with id [pid].
 
    On Windows: only the {!Sys.sigkill} signal is emulated, causing the receiving
-   process to exit with [ERROR_PROCESS_ABORTED] (= 1067). *)
+   process to exit with code [ERROR_PROCESS_ABORTED] (1067). Before OCaml 5.5,
+   the receiving process exited with code 0. *)
 
 type sigprocmask_command = Unix.sigprocmask_command =
     SIG_SETMASK

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1160,7 +1160,8 @@ val kill : pid:int -> signal:Sys.signal -> unit
 (** [kill ~pid ~signal] sends signal number [signal] to the process
    with id [pid].
 
-   On Windows: only the {!Sys.sigkill} signal is emulated. *)
+   On Windows: only the {!Sys.sigkill} signal is emulated, causing the receiving
+   process to exit with [ERROR_PROCESS_ABORTED] (= 1067). *)
 
 type sigprocmask_command = Unix.sigprocmask_command =
     SIG_SETMASK


### PR DESCRIPTION
While investigating an unrelated issue today, I noticed that on Windows, processes killed using `Unix.kill` report an exit code of `0`, which is normally interpreted as a successful exit, and which can lead to confusion.

This PR changes it so that they return exit code 137, which is the usual exit code encoding of `SIGKILL` (= 128 + signal number).

Change is technically breaking, but more of a bug fix in my view.