### PR TITLE
manual: document modular explicits

### DIFF
--- a/Changes
+++ b/Changes
@@ -431,6 +431,10 @@ OCaml 5.5.0
   fail to load.
   (toastal)
 
+- #14048: document modular explicits
+  (Gabriel Scherer, review by Samuel Vivien, Ali Caglayan,
+   Didier Remy and François Pottier)
+
 - #14077: Add missing `item-attribute` rule for `let-binding`s in documentation
   for attributes.
   (Shon Feder)

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -51,9 +51,9 @@ module parameter appears in the right-hand-side (return type) of the
 arrow "(module MSet : Set.S) -> ...", via occurrences of the type
 "MSet.elt".
 
-To apply the "sort" function, we use the construction "(module M : S)"
-to provide the argument, which can typically be written "(module M)"
-as the signature can be inferred from the function.
+To apply the "sort" function, we use the construction "(module M)" to
+provide the argument, or "(module M : S)" to be explicit about the
+intended signature.
 
 \begin{caml_example*}{verbatim}
 module ISetIncr = Set.Make(Int)
@@ -70,7 +70,7 @@ let example = sort (module ISetDecr) [3; 1; 2];;
 \end{caml_example}
 
 This provides a lightweight alternative to functors. Indeed, the
-"sort" _function_ could also be expressed using a "Sort" _functor_:
+"sort" function could also be expressed using a "Sort" functor:
 
 \begin{caml_example}{verbatim}
 module Sort (MSet : Set.S) = struct
@@ -148,7 +148,7 @@ let _ = Hashtbl.add devices "PDF" (module PDF : DEVICE)
 \end{caml_example*}
 
 The module expression "(val e : S)" can then \emph{unpack}
-a packed-module value "(e : module S)" back into a module. In our
+a packed-module value "(e : (module S))" back into a module. In our
 example, one implementation can be selected based on command-line
 arguments:
 \begin{caml_example*}{verbatim}
@@ -219,7 +219,7 @@ let okay =
   sort (module MSet) [2; 4]
 \end{caml_example}
 
-Notice that "MSet.elt" cannot occur in the type of `okay`, as the
+Notice that "MSet.elt" cannot occur in the type of "okay", as the
 module "MSet" is only defined locally. In this example the return type
 of "sort" does mention "MSet.elt", but this type is equal to "int" so
 it can be simplified away.
@@ -246,8 +246,8 @@ let also_okay =
 
 Note that removing dependencies using "(type a)" like this can only be
 done for non-parameterized types like "elt", not with parameterized
-types like "'a t" -- there is no corresponding "(type 'a t)"
-abstraction. It would not be possible for the "mapM" example earlier,
+types like "'a t"; there is no corresponding "(type 'a t)"
+abstraction. It would not be possible for the "mapM" example above,
 which has a dependency on a module containing a parameterized type "'a
 M.t", and thus cannot be passed dynamically-selected module arguments.
 
@@ -443,7 +443,7 @@ are compared using the structural comparison of module types.
 When typechecking we also consider
 @'(' 'module' module-name ':' package-type ')' '->' typexpr@ and
 @'(' 'module' package-type ')' '->' typexpr@ to be identical when @module-name@
-does not appear in @typexpr@.
+can be erased from @typexpr@.
 
 In general, the module expression @'(' "val" expr ":" package-type
 ')'@ cannot be used in the body of a functor, because this could cause

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -146,7 +146,7 @@ let draw_using_device device_name picture =
   Device.draw picture
 \end{caml_example*}
 
-\lparagraph{p:fst-mod-intro-limitations}{Limitations}
+\lparagraph{p:fst-mod-intro-limitation-dynamic-arg}{Limitation: selecting a module at runtime}
 
 To avoid breaking type soundness, there is a restriction on functions
 that take module parameters "fun (module A : S) -> ...": if the type
@@ -240,6 +240,34 @@ let rec mapM
     M.return (y :: ys)
   in loop li
 \end{caml_example}
+
+\lparagraph{p:fst-mod-intro-limitation-nary-app}{Limitation: n-ary applications}
+
+The following example fails, where "sort" is our module-dependent function from before:
+
+\begin{caml_example}{verbatim}[error]
+let sort (module MSet : Set.S) li =
+  MSet.elements (List.fold_right MSet.add li MSet.empty)
+
+let wrong = Fun.id sort (module ISetIncr) [2; 3]
+\end{caml_example}
+
+The problem comes from subtle details in the type-checking of n-ary
+function applications: this is checked as "Fun.id" to which three
+parameters are passed, and only the type of "Fun.id" (not
+its arguments) is used to resolve the module application, so no
+module-dependent function type is known at that point.
+
+The example can be fixed by first applying "Fun.id sort", and then
+passing the module argument in a separate application. Then the
+module-dependent type of "Fun.id sort" will be used to check the
+module application. This can be done by simply adding extra
+parentheses:
+
+\begin{caml_example}{verbatim}
+let fixed = (Fun.id sort) (module ISetIncr) [2; 3]
+\end{caml_example}
+
 
 \lparagraph{p:fst-mod-compatibility}{Compatibility}
 

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -18,17 +18,17 @@ parameters.
 
 \subsection{ss:fst-mod-intro}{Introduction}
 
-\lparagraph{p:fst-mod-intro-mod-fun}{Functions parametrized over a module}
+\lparagraph{p:fst-mod-intro-mod-fun}{Module-dependent functions: functions parameterized over a module}
 
 One can write a function "sort0" that sorts elements by adding them into
 a sorted set, and then reads them back in order:
 \begin{caml_example}{verbatim}
-let sort0 (type a) li =
-  let module M = struct type t = a let compare = Stdlib.compare end in
+let sort0 (type a) cmp li =
+  let module M = struct type t = a let compare = cmp end in
   let module MSet = Stdlib.Set.Make(M) in
   MSet.elements (List.fold_right MSet.add li MSet.empty)
 
-let example = sort0 [3; 1; 2]
+let example = sort0 Int.compare [3; 1; 2]
 \end{caml_example*}
 
 Using module-dependent functions, it is also possible to express
@@ -46,10 +46,10 @@ let sort (module MSet : Set.S) li =
 The declaration of "sort" uses the pattern syntax "(module M : S)",
 which allows function parameters to be modules instead of ordinary
 values. We call "sort" a \emph{module-dependent} function because in
-its type, "(module Set : Set.S) -> Set.elt list -> Set.elt list", the
+its type, "(module MSet : Set.S) -> MSet.elt list -> MSet.elt list", the
 module parameter appears in the right-hand-side (return type) of the
-arrow "(module Set : Set.S) -> ...", via occurrences of the type
-"Set.elt".
+arrow "(module MSet : Set.S) -> ...", via occurrences of the type
+"MSet.elt".
 
 To apply the "sort" function, we use the construction "(module M : S)"
 to provide the argument, which can typically be written "(module M)"
@@ -64,12 +64,9 @@ module ISetDecr =
   end)
 \end{caml_example*}
 
-\begin{caml_example}{verbatim}
-let example = sort (module ISetIncr) [3; 1; 2]
-let example = sort (module ISetDecr) [3; 1; 2]
-
-(* Note: any module path is accepted, including functor applications *)
-let example = sort (module Set.Make(Int)) [3; 1; 2]
+\begin{caml_example}{toplevel}
+let example = sort (module ISetIncr) [3; 1; 2];;
+let example = sort (module ISetDecr) [3; 1; 2];;
 \end{caml_example}
 
 This provides a lightweight alternative to functors.
@@ -86,13 +83,47 @@ end
 let module S = Sort(ISetDecr) in S.f [3; 1; 2];;
 \end{caml_example}
 
+\lparagraph{p:fst-mod-intro-algebraic-structures}{Use-case: abstracting over algebraic structures}
+
+Module-dependent functions offer a nice way to implement code that is parametric over families of type structures, for example on any monad.
+
+\begin{caml_example*}{verbatim}
+module type Monad = sig
+  type 'a t
+  val return : 'a -> 'a t
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+end
+
+let rec mapM
+: (module M : Monad) -> ('a -> 'b M.t) -> 'a list -> 'b list M.t
+= fun (module M) f li ->
+  let rec loop = function
+  | [] -> M.return []
+  | x::xs ->
+    let ( let* ) = M.bind in
+    let* y = f x in
+    let* ys = mapM (module M) f xs in
+    M.return (y :: ys)
+  in loop li
+
+(* Example use-case: a map on the Result monad *)
+let map_result (type e)
+: ('a -> ('b, e) result) -> 'a list -> ('b list, e) result
+= let module R = struct
+    type 'a t = ('a, e) result
+    let return = Result.ok
+    let bind = Result.bind
+  end in mapM (module R)
+\end{caml_example*}
+
+
 \lparagraph{p:fst-mod-intro-dynamic}{First-class modules}
 
 In the function application "sort (module ISetIncr)" from our example
 above, we say that the module argument is \emph{static}: it is known
 at compile-time.
 
-First-class modules let you build "dynamic" values that represent
+First-class modules let you build \emph{dynamic} values that represent
 modules, where the choice of module depends on runtime
 computations. If "M" is a module of signature "S", then
 "(module M : S)" is an expression of type "(module S)", we say that it
@@ -148,18 +179,20 @@ let draw_using_device device_name picture =
 
 \lparagraph{p:fst-mod-intro-limitation-dynamic-arg}{Limitation: selecting a module at runtime}
 
-To avoid breaking type soundness, there is a restriction on functions
-that take module parameters "fun (module A : S) -> ...": if the type
-of the body of the function (the "...") \emph{depends} on the module
-argument "A", then this function is only allowed to take static module
-arguments of the form "(module M : S)", rather than arbitrary dynamic
-expressions of type "(module S)". We call them \emph{module-dependent}
-functions.
+There is a restriction on module-dependent functions "fun
+(module A : S) -> ...": if the type of the body of the function
+(the "...") \emph{depends} on the module argument "A", then this
+function is only allowed to take static module arguments of the form
+"(module M : S)", rather than arbitrary expressions of type
+"(module S)". There is no such restriction if the type of the body
+does not mention "A", or if the type-checker can easily rewrite it to
+expand away the uses of "A".
 
-Our "process" function of Paragraph~\ref{ss:fst-mod-intro-mod-fun} is
-such a module-dependent function: its type is "(module M : Monoid) ->
-M.t list -> M.t", where the module "M" is used on the right of the
-arrow "(module M : Monoid) -> ...". The following example is rejected:
+Our "sort" function of Paragraph~\ref{p:fst-mod-intro-mod-fun} is such
+a module-dependent function: its type is "(module MSet : Set.S) ->
+MSet.elt list -> MSet.elt list", where the module "MSet" is used on
+the right of the arrow "(module MSet : Set.S) -> ...". The following
+example is rejected:
 
 \begin{caml_example*}{verbatim}
 let sort_order = `Decr
@@ -173,9 +206,8 @@ let wrong =
     [2; 4]
 \end{caml_example}
 
-In some cases, including for "sort", it is possible to rewrite the
-code in a slightly more complex way to make the dependency go
-away:
+In some cases, including this example, it is possible to rewrite the
+code to use a static module argument again:
 
 \begin{caml_example}{verbatim}
 let okay =
@@ -188,12 +220,11 @@ let okay =
   sort (module MSet) [2; 4]
 \end{caml_example}
 
-In this version, the application "sort (module MSet)" takes a static
-module argument again. But notice that the module "MSet" is defined
-locally, so the type of the whole declaration cannot mention "MSet.elt",
-it would be ill-scoped. In this example the return type of "sort" does
-mention "MSet.elt", but this type is equal to "int" so it can be
-simplified away.
+Notice that the module "MSet" is defined locally, so the type of the
+whole declaration cannot mention "MSet.elt", it would be
+ill-scoped. In this example the return type of "sort" does mention
+"MSet.elt", but this type is equal to "int" so it can be simplified
+away.
 
 Finally, it is also possible to remove the dependency from the
 definition of "sort", by replacing the argument signature "Set.S" with
@@ -215,31 +246,12 @@ let also_okay =
     [2; 4]
 \end{caml_example}
 
-Note that removing dependencies on a type within a module can only be
-done for non-parametrized type like "elt", rather than parametrized
-types like "'a t". It would not be possible for the following "mapM"
-function, which has a dependency on a module containing a parametrized
-type, and thus cannot be passed dynamically-selected module arguments:
-
-\begin{caml_example}{verbatim}
-module type Monad = sig
-  type 'a t
-  val return : 'a -> 'a t
-  val bind : 'a t -> ('a -> 'b t) -> 'b t
-end
-
-let rec mapM
-: (module M : Monad) -> ('a -> 'b M.t) -> 'a list -> 'b list M.t
-= fun (module M) f li ->
-  let rec loop = function
-  | [] -> M.return []
-  | x::xs ->
-    let ( let* ) = M.bind in
-    let* y = f x in
-    let* ys = mapM (module M) f xs in
-    M.return (y :: ys)
-  in loop li
-\end{caml_example}
+Note that removing dependencies using "(type a)" like this can only be
+done for non-parameterized types like "elt", not with parameterized
+types like "'a t" -- there is no corresponding "(type 'a t)"
+abstraction. It would not be possible for the "mapM" example earlier,
+which has a dependency on a module containing a parameterized type "'a
+M.t", and thus cannot be passed dynamically-selected module arguments.
 
 \lparagraph{p:fst-mod-intro-limitation-nary-app}{Limitation: n-ary applications}
 
@@ -272,7 +284,7 @@ let fixed = (Fun.id sort) (module ISetIncr) [2; 3]
 \lparagraph{p:fst-mod-compatibility}{Compatibility}
 
 Before OCaml 5.5, module-dependent functions were not supported. One
-could use first-class modules, but all module-parametrized functions
+could use first-class modules, but all module-parameterized functions
 had to be non-dependent, so this "(type a)" workaround was often used.
 
 
@@ -298,7 +310,7 @@ end = struct
 end
 \end{caml_example*}
 
-We can then define a parametrized algebraic data type whose
+We can then define a parameterized algebraic data type whose
 constructors provide some information about the type parameter:
 
 \begin{caml_example*}{verbatim}
@@ -424,7 +436,7 @@ package-type ')'@ type expression, in @'(' 'module' module-name ':'
 package-type ')' '->' typexpr @ type expression and in the annotated forms
 represents a subset of module types.
 This subset consists of named module types with optional constraints
-of a limited form: only non-parametrized types can be specified.
+of a limited form: only non-parameterized types can be specified.
 
 For type-checking purposes (and starting from OCaml 4.02), package types
 are compared using the structural comparison of module types.

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -13,8 +13,8 @@ in 4.02; fewer parentheses required starting from
 Module-dependent functions were introduced in 5.5.)
 
 Module-dependent functions and first-class modules make it possible to
-manipulate modules as values, in particular to pass them as function
-parameters.
+manipulate modules as values, in particular to accept modules as
+function parameters.
 
 \subsection{ss:fst-mod-intro}{Introduction}
 
@@ -69,8 +69,8 @@ let example = sort (module ISetIncr) [3; 1; 2];;
 let example = sort (module ISetDecr) [3; 1; 2];;
 \end{caml_example}
 
-This provides a lightweight alternative to functors.
-Indeed, the "sort" function could also be expressed as follows:
+This provides a lightweight alternative to functors. Indeed, the
+"sort" _function_ could also be expressed using a "Sort" _functor_:
 
 \begin{caml_example}{verbatim}
 module Sort (MSet : Set.S) = struct
@@ -85,7 +85,7 @@ let module S = Sort(ISetDecr) in S.f [3; 1; 2];;
 
 \lparagraph{p:fst-mod-intro-algebraic-structures}{Use-case: abstracting over algebraic structures}
 
-Module-dependent functions offer a nice way to implement code that is parametric over families of type structures, for example on any monad.
+Module-dependent functions offer a nice way to implement code that is parametric over families of type structures, for example over any monad.
 
 \begin{caml_example*}{verbatim}
 module type Monad = sig
@@ -219,11 +219,10 @@ let okay =
   sort (module MSet) [2; 4]
 \end{caml_example}
 
-Notice that the module "MSet" is defined locally, so the type of the
-whole declaration cannot mention "MSet.elt", it would be
-ill-scoped. In this example the return type of "sort" does mention
-"MSet.elt", but this type is equal to "int" so it can be simplified
-away.
+Notice that "MSet.elt" cannot occur in the type of `okay`, as the
+module "MSet" is only defined locally. In this example the return type
+of "sort" does mention "MSet.elt", but this type is equal to "int" so
+it can be simplified away.
 
 Finally, it is also possible to remove the dependency from the
 definition of "sort", by replacing the argument signature "Set.S" with
@@ -278,6 +277,9 @@ parentheses:
 \begin{caml_example}{verbatim}
 let fixed = (Fun.id sort) (module ISetIncr) [2; 3]
 \end{caml_example}
+
+(Explicitly annotating the type of `Fun.id` with a module-dependent
+function type would also work.)
 
 
 \lparagraph{p:fst-mod-compatibility}{Compatibility}

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -94,15 +94,13 @@ module type Monad = sig
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
-let rec mapM
-: (module M : Monad) -> ('a -> 'b M.t) -> 'a list -> 'b list M.t
-= fun (module M) f li ->
+let mapM (module M : Monad) (f : 'a -> 'b M.t) (li : 'a list) : 'b list M.t =
+  let ( let* ) = M.bind in
   let rec loop = function
   | [] -> M.return []
   | x::xs ->
-    let ( let* ) = M.bind in
     let* y = f x in
-    let* ys = mapM (module M) f xs in
+    let* ys = loop xs in
     M.return (y :: ys)
   in loop li
 
@@ -185,8 +183,9 @@ There is a restriction on module-dependent functions "fun
 function is only allowed to take static module arguments of the form
 "(module M : S)", rather than arbitrary expressions of type
 "(module S)". There is no such restriction if the type of the body
-does not mention "A", or if the type-checker can easily rewrite it to
-expand away the uses of "A".
+does not mention "A", or if the type-checker can remove the
+occurrences of "A" by inlining type equalities (for example when
+"A.t" equals "int").
 
 Our "sort" function of Paragraph~\ref{p:fst-mod-intro-mod-fun} is such
 a module-dependent function: its type is "(module MSet : Set.S) ->
@@ -265,7 +264,7 @@ let wrong = Fun.id sort (module ISetIncr) [2; 3]
 \end{caml_example}
 
 The problem comes from subtle details in the type-checking of n-ary
-function applications: this is checked as "Fun.id" to which three
+function applications. This is checked as "Fun.id" to which three
 parameters are passed, and only the type of "Fun.id" (not
 its arguments) is used to resolve the module application, so no
 module-dependent function type is known at that point.
@@ -284,9 +283,8 @@ let fixed = (Fun.id sort) (module ISetIncr) [2; 3]
 \lparagraph{p:fst-mod-compatibility}{Compatibility}
 
 Before OCaml 5.5, module-dependent functions were not supported. One
-could use first-class modules, but all module-parameterized functions
+could use first-class modules, but functions taking a first-class module
 had to be non-dependent, so this "(type a)" workaround was often used.
-
 
 \iffalse
 \lparagraph{p:fst-mod-abstract-types}{Abstract types}
@@ -425,9 +423,8 @@ of functors are, no additional parens are needed: "Map.Make(val key)".
 
 The pattern @'(' 'module' module-name ':' package-type ')'@ matches a
 package with type @package-type@ and binds it to @module-name@.
-It is not allowed in toplevel let bindings. When a function takes an argument
-whose pattern is exactly @'(' 'module' module-name ':' package-type ')'@, then
-this function can be a module-dependent function.
+It is not allowed in toplevel let bindings. A function whose parameter
+has this exact pattern can be module-dependent.
 Again @package-type@ can be omitted if it can be inferred from the
 enclosing pattern.
 
@@ -444,7 +441,7 @@ are compared using the structural comparison of module types.
 When typechecking we also consider
 @'(' 'module' module-name ':' package-type ')' '->' typexpr@ and
 @'(' 'module' package-type ')' '->' typexpr@ to be identical when @module-name@
-does not appear in @typexpr@
+does not appear in @typexpr@.
 
 In general, the module expression @'(' "val" expr ":" package-type
 ')'@ cannot be used in the body of a functor, because this could cause

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -7,12 +7,14 @@
 
 (Introduced in OCaml 3.12; pattern syntax and package type inference
 introduced in 4.00; structural comparison of package types introduced in 4.02.;
-fewer parens required starting from 4.05)
+fewer parens required starting from 4.05; module-dependent functions introduced
+in 5.0x)
 
 \begin{syntax}
 typexpr:
       ...
     | '(''module' package-type')'
+    | '(''module' module-name ':' package-type')' '->' typexpr
 ;
 module-expr:
       ...
@@ -56,18 +58,26 @@ of functors are, no additional parens are needed: "Map.Make(val key)".
 
 The pattern @'(' 'module' module-name ':' package-type ')'@ matches a
 package with type @package-type@ and binds it to @module-name@.
-It is not allowed in toplevel let bindings.
+It is not allowed in toplevel let bindings. When a function takes an argument
+whose pattern is exactly @'(' 'module' module-name ':' package-type ')'@, then
+this function can be a module-dependent function.
 Again @package-type@ can be omitted if it can be inferred from the
 enclosing pattern.
 
 The @package-type@ syntactic class appearing in the  @'(' 'module'
-package-type ')'@ type expression and in the annotated forms represents a
-subset of module types.
+package-type ')'@ type expression, in @'(' 'module' module-name ':'
+package-type ')' '->' typexpr @ type expression and in the annotated forms
+represents a subset of module types.
 This subset consists of named module types with optional constraints
 of a limited form: only non-parametrized types can be specified.
 
 For type-checking purposes (and starting from OCaml 4.02), package types
 are compared using the structural comparison of module types.
+
+When typechecking we also consider
+@'(' 'module' module-name ':' package-type ')' '->' typexpr@ and
+@'(' 'module' package-type ')' '->' typexpr@ to be identical when @module-name@
+does not appear in @typexpr@
 
 In general, the module expression @'(' "val" expr ":" package-type
 ')'@ cannot be used in the body of a functor, because this could cause
@@ -142,6 +152,19 @@ let make_set (type s) cmp =
   end) in
   (module S : Set.S with type elt = s)
 \end{caml_example}
+
+
+Starting from OCaml 5.0x the example of "sort" can be written without the
+"with type elt = s" because we now support module-dependent functions.
+
+\begin{caml_example}{verbatim}
+let sort (module Set : Set.S) l =
+  Set.elements (List.fold_right Set.add l Set.empty)
+\end{caml_example}
+
+However, as a downside from this support, when applying "sort" to an
+argument you will need to pack the argument directly at the application and
+cannot give any value of type @'(' 'module' Set.S ')'@.
 
 \iffalse
 Another advanced use of first-class module is to encode existential

--- a/manual/src/refman/extensions/firstclassmodules.etex
+++ b/manual/src/refman/extensions/firstclassmodules.etex
@@ -1,102 +1,108 @@
-\section{s:first-class-modules}{First-class modules}
+\section{s:first-class-modules}{%
+  Module-dependent functions and first-class modules}
 %HEVEA\cutname{firstclassmodules.html}
 \ikwd{module\@\texttt{module}}
 \ikwd{val\@\texttt{val}}
 \ikwd{with\@\texttt{with}}
 \ikwd{and\@\texttt{and}}
 
-(Introduced in OCaml 3.12; pattern syntax and package type inference
-introduced in 4.00; structural comparison of package types introduced in 4.02.;
-fewer parens required starting from 4.05; module-dependent functions introduced
-in 5.0x)
+(First-class modules were introduced in OCaml 3.12; pattern syntax and
+package type inference in 4.00; structural comparison of package types
+in 4.02; fewer parentheses required starting from
+4.05.\\
+Module-dependent functions were introduced in 5.5.)
 
-\begin{syntax}
-typexpr:
-      ...
-    | '(''module' package-type')'
-    | '(''module' module-name ':' package-type')' '->' typexpr
-;
-module-expr:
-      ...
-    | '(''val' expr [':' package-type]')'
-;
-expr:
-      ...
-    | '(''module' module-expr [':' package-type]')'
-;
-pattern:
-      ...
-    | '(''module' module-name [':' package-type]')'
-;
-package-type:
-      modtype-path
-    | modtype-path 'with' package-constraint { 'and' package-constraint }
-;
-package-constraint:
-          'type' typeconstr '=' typexpr
-;
-\end{syntax}
+Module-dependent functions and first-class modules make it possible to
+manipulate modules as values, in particular to pass them as function
+parameters.
 
-Modules are typically thought of as static components. This extension
-makes it possible to pack a module as a first-class value, which can
-later be dynamically unpacked into a module.
+\subsection{ss:fst-mod-intro}{Introduction}
 
-The expression @'(' 'module' module-expr ':' package-type ')'@ converts the
-module (structure or functor) denoted by module expression @module-expr@
-to a value of the core language that encapsulates this module.  The
-type of this core language value is @'(' 'module' package-type ')'@.
-The @package-type@ annotation can be omitted if it can be inferred
-from the context.
+\lparagraph{p:fst-mod-intro-mod-fun}{Functions parametrized over a module}
 
-Conversely, the module expression @'(' 'val' expr ':' package-type ')'@
-evaluates the core language expression @expr@ to a value, which must
-have type @'module' package-type@, and extracts the module that was
-encapsulated in this value. Again @package-type@ can be omitted if the
-type of @expr@ is known.
-If the module expression is already parenthesized, like the arguments
-of functors are, no additional parens are needed: "Map.Make(val key)".
+One can write a function "sort0" that sorts elements by adding them into
+a sorted set, and then reads them back in order:
+\begin{caml_example}{verbatim}
+let sort0 (type a) li =
+  let module M = struct type t = a let compare = Stdlib.compare end in
+  let module MSet = Stdlib.Set.Make(M) in
+  MSet.elements (List.fold_right MSet.add li MSet.empty)
 
-The pattern @'(' 'module' module-name ':' package-type ')'@ matches a
-package with type @package-type@ and binds it to @module-name@.
-It is not allowed in toplevel let bindings. When a function takes an argument
-whose pattern is exactly @'(' 'module' module-name ':' package-type ')'@, then
-this function can be a module-dependent function.
-Again @package-type@ can be omitted if it can be inferred from the
-enclosing pattern.
+let example = sort0 [3; 1; 2]
+\end{caml_example*}
 
-The @package-type@ syntactic class appearing in the  @'(' 'module'
-package-type ')'@ type expression, in @'(' 'module' module-name ':'
-package-type ')' '->' typexpr @ type expression and in the annotated forms
-represents a subset of module types.
-This subset consists of named module types with optional constraints
-of a limited form: only non-parametrized types can be specified.
+Using module-dependent functions, it is also possible to express
+"sort" as a function parameterized over an ordered-set module. This
+lets callers choose their ordered-set implementation, which may be
+specialized for their type; for example sets of integers can be
+represented with bitsets, or with compact representations of dense
+intervals.
 
-For type-checking purposes (and starting from OCaml 4.02), package types
-are compared using the structural comparison of module types.
+\begin{caml_example}{verbatim}
+let sort (module MSet : Set.S) li =
+  MSet.elements (List.fold_right MSet.add li MSet.empty)
+\end{caml_example}
 
-When typechecking we also consider
-@'(' 'module' module-name ':' package-type ')' '->' typexpr@ and
-@'(' 'module' package-type ')' '->' typexpr@ to be identical when @module-name@
-does not appear in @typexpr@
+The declaration of "sort" uses the pattern syntax "(module M : S)",
+which allows function parameters to be modules instead of ordinary
+values. We call "sort" a \emph{module-dependent} function because in
+its type, "(module Set : Set.S) -> Set.elt list -> Set.elt list", the
+module parameter appears in the right-hand-side (return type) of the
+arrow "(module Set : Set.S) -> ...", via occurrences of the type
+"Set.elt".
 
-In general, the module expression @'(' "val" expr ":" package-type
-')'@ cannot be used in the body of a functor, because this could cause
-unsoundness in conjunction with applicative functors.
-Since OCaml 4.02, this is relaxed in two ways:
-if @package-type@ does not contain nominal type declarations ({\em
-  i.e.} types that are created with a proper identity), then this
-expression can be used anywhere, and even if it contains such types
-it can be used inside the body of a generative
-functor, described in section~\ref{s:generative-functors}.
-It can also be used anywhere in the context of a local module binding
-@'let' 'module' module-name '=' '(' "val" expr_1 ":" package-type ')'
- "in" expr_2@.
+To apply the "sort" function, we use the construction "(module M : S)"
+to provide the argument, which can typically be written "(module M)"
+as the signature can be inferred from the function.
 
-\lparagraph{p:fst-mod-example}{Basic example} A typical use of first-class modules is to
-select at run-time among several implementations of a signature.
-Each implementation is a structure that we can encapsulate as a
-first-class module, then store in a data structure such as a hash
-table:
+\begin{caml_example*}{verbatim}
+module ISetIncr = Set.Make(Int)
+module ISetDecr =
+  Set.Make(struct
+    type t = int
+    let compare i1 i2 = Int.compare i2 i1
+  end)
+\end{caml_example*}
+
+\begin{caml_example}{verbatim}
+let example = sort (module ISetIncr) [3; 1; 2]
+let example = sort (module ISetDecr) [3; 1; 2]
+
+(* Note: any module path is accepted, including functor applications *)
+let example = sort (module Set.Make(Int)) [3; 1; 2]
+\end{caml_example}
+
+This provides a lightweight alternative to functors.
+Indeed, the "sort" function could also be expressed as follows:
+
+\begin{caml_example}{verbatim}
+module Sort (MSet : Set.S) = struct
+  let f li =
+    MSet.elements (List.fold_right MSet.add li MSet.empty)
+end
+\end{caml_example}
+
+\begin{caml_example}{toplevel}
+let module S = Sort(ISetDecr) in S.f [3; 1; 2];;
+\end{caml_example}
+
+\lparagraph{p:fst-mod-intro-dynamic}{First-class modules}
+
+In the function application "sort (module ISetIncr)" from our example
+above, we say that the module argument is \emph{static}: it is known
+at compile-time.
+
+First-class modules let you build "dynamic" values that represent
+modules, where the choice of module depends on runtime
+computations. If "M" is a module of signature "S", then
+"(module M : S)" is an expression of type "(module S)", we say that it
+``packs'' the module "M" as a value.
+
+A typical use of first-class modules is to select at run-time among
+several implementations of a signature. Each implementation is
+a structure that we can pack into a first-class module, then
+store in a data structure such as a hash table:
+
 \begin{caml_example*}{verbatim}
 type picture = unit[@ellipsis]
 module type DEVICE = sig
@@ -112,8 +118,10 @@ module PDF = struct let draw () = () [@@ellipsis] end
 let _ = Hashtbl.add devices "PDF" (module PDF : DEVICE)
 \end{caml_example*}
 
-We can then select one implementation based on command-line
-arguments, for instance:
+The module expression "(val e : S)" can then \emph{unpack}
+a packed-module value "(e : module S)" back into a module. In our
+example, one implementation can be selected based on command-line
+arguments:
 \begin{caml_example*}{verbatim}
 let parse_cmdline () = "SVG"[@ellipsis]
 module Device =
@@ -131,42 +139,118 @@ let draw_using_device device_name picture =
     (val (Hashtbl.find devices device_name) : DEVICE)
   in
   Device.draw picture
+
+(* or, equivalently *)
+let draw_using_device device_name picture =
+  let (module Device : DEVICE) = Hashtbl.find devices device_name in
+  Device.draw picture
 \end{caml_example*}
 
-\lparagraph{p:fst-mod-advexamples}{Advanced examples}
-With first-class modules, it is possible to parametrize some code over the
-implementation of a module without using a functor.
+\lparagraph{p:fst-mod-intro-limitations}{Limitations}
 
-\begin{caml_example}{verbatim}
-let sort (type s) (module Set : Set.S with type elt = s) l =
-  Set.elements (List.fold_right Set.add l Set.empty)
+To avoid breaking type soundness, there is a restriction on functions
+that take module parameters "fun (module A : S) -> ...": if the type
+of the body of the function (the "...") \emph{depends} on the module
+argument "A", then this function is only allowed to take static module
+arguments of the form "(module M : S)", rather than arbitrary dynamic
+expressions of type "(module S)". We call them \emph{module-dependent}
+functions.
+
+Our "process" function of Paragraph~\ref{ss:fst-mod-intro-mod-fun} is
+such a module-dependent function: its type is "(module M : Monoid) ->
+M.t list -> M.t", where the module "M" is used on the right of the
+arrow "(module M : Monoid) -> ...". The following example is rejected:
+
+\begin{caml_example*}{verbatim}
+let sort_order = `Decr
+\end{caml_example*}
+\begin{caml_example}{verbatim}[error]
+let wrong =
+  sort
+    (match sort_order with
+     | `Incr -> (module ISetIncr)
+     | `Decr -> (module ISetDecr))
+    [2; 4]
 \end{caml_example}
 
-To use this function, one can wrap the "Set.Make" functor:
+In some cases, including for "sort", it is possible to rewrite the
+code in a slightly more complex way to make the dependency go
+away:
 
 \begin{caml_example}{verbatim}
-let make_set (type s) cmp =
-  let module S = Set.Make(struct
-    type t = s
-    let compare = cmp
-  end) in
-  (module S : Set.S with type elt = s)
+let okay =
+  let m : (module Set.S with type elt = int) =
+    match sort_order with
+    | `Incr -> (module ISetIncr)
+    | `Decr -> (module ISetDecr)
+  in
+  let module MSet = (val m) in
+  sort (module MSet) [2; 4]
 \end{caml_example}
 
+In this version, the application "sort (module MSet)" takes a static
+module argument again. But notice that the module "MSet" is defined
+locally, so the type of the whole declaration cannot mention "MSet.elt",
+it would be ill-scoped. In this example the return type of "sort" does
+mention "MSet.elt", but this type is equal to "int" so it can be
+simplified away.
 
-Starting from OCaml 5.0x the example of "sort" can be written without the
-"with type elt = s" because we now support module-dependent functions.
+Finally, it is also possible to remove the dependency from the
+definition of "sort", by replacing the argument signature "Set.S" with
+the signature "Set.S with type elt = a", which uses a locally abstract
+type "(type a)" (See \ref{s:locally-abstract}). This was the only
+approach available before module-dependent functions were introduced
+in the language, but it is less flexible as it requires changing the
+function definition and not just the call-site.
 
 \begin{caml_example}{verbatim}
-let sort (module Set : Set.S) l =
-  Set.elements (List.fold_right Set.add l Set.empty)
+let sort_nondep (type a) (module MSet : Set.S with type elt = a) (li : a list) =
+  MSet.elements (List.fold_right MSet.add li MSet.empty)
+
+let also_okay =
+  sort_nondep
+    (match sort_order with
+     | `Incr -> (module ISetIncr)
+     | `Decr -> (module ISetDecr))
+    [2; 4]
 \end{caml_example}
 
-However, as a downside from this support, when applying "sort" to an
-argument you will need to pack the argument directly at the application and
-cannot give any value of type @'(' 'module' Set.S ')'@.
+Note that removing dependencies on a type within a module can only be
+done for non-parametrized type like "elt", rather than parametrized
+types like "'a t". It would not be possible for the following "mapM"
+function, which has a dependency on a module containing a parametrized
+type, and thus cannot be passed dynamically-selected module arguments:
+
+\begin{caml_example}{verbatim}
+module type Monad = sig
+  type 'a t
+  val return : 'a -> 'a t
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+end
+
+let rec mapM
+: (module M : Monad) -> ('a -> 'b M.t) -> 'a list -> 'b list M.t
+= fun (module M) f li ->
+  let rec loop = function
+  | [] -> M.return []
+  | x::xs ->
+    let ( let* ) = M.bind in
+    let* y = f x in
+    let* ys = mapM (module M) f xs in
+    M.return (y :: ys)
+  in loop li
+\end{caml_example}
+
+\lparagraph{p:fst-mod-compatibility}{Compatibility}
+
+Before OCaml 5.5, module-dependent functions were not supported. One
+could use first-class modules, but all module-parametrized functions
+had to be non-dependent, so this "(type a)" workaround was often used.
+
 
 \iffalse
+\lparagraph{p:fst-mod-abstract-types}{Abstract types}
+
 Another advanced use of first-class module is to encode existential
 types. In particular, they can be used to simulate generalized
 algebraic data types (GADT). To demonstrate this, we first define a type
@@ -254,3 +338,83 @@ let rec to_string: 'a. 'a Typ.typ -> 'a -> string =
 Note that this function uses an explicit polymorphic annotation to obtain
 polymorphic recursion.
 \fi
+
+\subsection{ss:fst-mod-reference}{Reference}
+
+\begin{syntax}
+typexpr:
+      ...
+    | '(''module' package-type')'
+    | '(''module' module-name ':' package-type')' '->' typexpr
+;
+module-expr:
+      ...
+    | '(''val' expr [':' package-type]')'
+;
+expr:
+      ...
+    | '(''module' module-expr [':' package-type]')'
+;
+pattern:
+      ...
+    | '(''module' module-name [':' package-type]')'
+;
+package-type:
+      modtype-path
+    | modtype-path 'with' package-constraint { 'and' package-constraint }
+;
+package-constraint:
+          'type' typeconstr '=' typexpr
+;
+\end{syntax}
+
+The expression @'(' 'module' module-expr ':' package-type ')'@ converts the
+module (structure or functor) denoted by module expression @module-expr@
+to a value of the core language that packs this module.  The
+type of this core language value is @'(' 'module' package-type ')'@.
+The @package-type@ annotation can be omitted if it can be inferred
+from the context.
+
+Conversely, the module expression @'(' 'val' expr ':' package-type ')'@
+evaluates the core language expression @expr@ to a value, which must
+have type @'module' package-type@, and extracts the module that was
+encapsulated in this value. Again @package-type@ can be omitted if the
+type of @expr@ is known.
+If the module expression is already parenthesized, like the arguments
+of functors are, no additional parens are needed: "Map.Make(val key)".
+
+The pattern @'(' 'module' module-name ':' package-type ')'@ matches a
+package with type @package-type@ and binds it to @module-name@.
+It is not allowed in toplevel let bindings. When a function takes an argument
+whose pattern is exactly @'(' 'module' module-name ':' package-type ')'@, then
+this function can be a module-dependent function.
+Again @package-type@ can be omitted if it can be inferred from the
+enclosing pattern.
+
+The @package-type@ syntactic class appearing in the  @'(' 'module'
+package-type ')'@ type expression, in @'(' 'module' module-name ':'
+package-type ')' '->' typexpr @ type expression and in the annotated forms
+represents a subset of module types.
+This subset consists of named module types with optional constraints
+of a limited form: only non-parametrized types can be specified.
+
+For type-checking purposes (and starting from OCaml 4.02), package types
+are compared using the structural comparison of module types.
+
+When typechecking we also consider
+@'(' 'module' module-name ':' package-type ')' '->' typexpr@ and
+@'(' 'module' package-type ')' '->' typexpr@ to be identical when @module-name@
+does not appear in @typexpr@
+
+In general, the module expression @'(' "val" expr ":" package-type
+')'@ cannot be used in the body of a functor, because this could cause
+unsoundness in conjunction with applicative functors.
+Since OCaml 4.02, this is relaxed in two ways:
+if @package-type@ does not contain nominal type declarations ({\em
+  i.e.} types that are created with a proper identity), then this
+expression can be used anywhere, and even if it contains such types
+it can be used inside the body of a generative
+functor, described in section~\ref{s:generative-functors}.
+It can also be used anywhere in the context of a local module binding
+@'let' 'module' module-name '=' '(' "val" expr_1 ":" package-type ')'
+ "in" expr_2@.


### PR DESCRIPTION
This is a companion PR to https://github.com/ocaml/ocaml/pull/13275 , which implement Modular Explicits, and is currently under review. The present PRs documents the feature in the manual. I adopted a commit by @samsa1 from #13275 (which extends the reference description of first-class modules to also cover module-dependent functions), and added a substantial amount of new content that tries to provide a readable introduction of how to use module-dependent functions and first-class modules, in a future world where modular explicits have been merged.

I think that it is worth sending this documentation PR in advance, because it can typically be reviewed by other people than #13275, which may be interested in how we describe the feature or opinions on how to do it better.

In 5.3, the [first-class modules section](https://ocaml.org/manual/5.3/firstclassmodules.html) of the "Languages Extension" chapter starts with the usual hard-to-read "reference" part with grammar and minimal mentions of what the grammar does, and is then followed by some nice examples. I decided to reorder things with first an "Introduction" section that tries to explain what the two features are, in an example-based way (reusing the previous examples), and then the obscure reference stuff.

Following a recommendation by @Octachron, I present module-dependent functions first as possibly the most common/natural construct, and then the full expressivity of first-class modules (with dynamic module selection) only second. I try to explain the restrictions/limitations around the two features, and have a short paragraph on how things were before the modular-explicits merge.