### PR TITLE
Minor fix to pre-commit githook

### DIFF
--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -41,14 +41,14 @@ fi
 
 # Git's built-in mechanism for whitespace is neater than ours, so do it first.
 # The strange construction below creates a list of files which have either
-# typo.white-at-eol or typo.white-at-eof included in .gitattributes and by
-# prefixing the names with :! causes git diff-index to skip over them.
+# typo.prune, typo.white-at-eol or typo.white-at-eof included in .gitattributes
+# and by prefixing the names with :! causes git diff-index to skip over them.
 if [[ -n $(git diff-index --cached --name-only $against) ]] ; then
   # NB Technically, $FILES would include files with typo.white-at-eol=false, but
   #    check-typo will catch that nefarious corner case!
   FILES=$(git diff-index --cached --name-only $against \
           | xargs git check-attr --cached --all \
-          | sed -ne 's/\(.*\): typo\.white-at-eo[fl]:/:!\1/p')
+          | sed -ne 's/\(.*\): typo\.\(white-at-eo[fl]\|prune\):/:!\1/p')
   if ! git diff-index --check --cached $against -- $FILES ; then
     exit 1
   fi

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -15,7 +15,7 @@
 
 # Bump this on any changes. It's vital that HOOK_VERSION followed by equals
 # appears nowhere else in these sources!
-HOOK_VERSION=6
+HOOK_VERSION=7
 
 # For what it's worth, allow for empty trees!
 if git rev-parse --verify HEAD >/dev/null 2>&1
@@ -41,12 +41,14 @@ fi
 
 # Git's built-in mechanism for whitespace is neater than ours, so do it first.
 # The strange construction below creates a list of files which have either
-# white-at-eol or white-at-eof included in ocaml-typo in .gitattributes and by
+# typo.white-at-eol or typo.white-at-eof included in .gitattributes and by
 # prefixing the names with :! causes git diff-index to skip over them.
 if [[ -n $(git diff-index --cached --name-only $against) ]] ; then
+  # NB Technically, $FILES would include files with typo.white-at-eol=false, but
+  #    check-typo will catch that nefarious corner case!
   FILES=$(git diff-index --cached --name-only $against \
-          | xargs git check-attr --cached ocaml-typo \
-          | sed -ne 's/\(.*\): ocaml-typo:.*[ ,]white-at-eo[fl]\(,\|$\)/:!\1/p')
+          | xargs git check-attr --cached --all \
+          | sed -ne 's/\(.*\): typo\.white-at-eo[fl]:/:!\1/p')
   if ! git diff-index --check --cached $against -- $FILES ; then
     exit 1
   fi


### PR DESCRIPTION
The switch in #1910 from using `ocaml-typo=foo` in `.gitattributes` to `typo.foo` it turns out didn't update the whitespace check. I happened to be committing a file with strange whitespace. That particular file I'd actually added with `typo.prune` which wasn't being checked.

(trying to commit https://github.com/dra27/ocaml/commit/2050141ad2867ccbef10dbce4ed7c0ff2bdc970d, as it happens)