### PR TITLE
error messages: missing constrained type in first class modules

### DIFF
--- a/.depend
+++ b/.depend
@@ -852,6 +852,7 @@ typing/errortrace_report.cmo : \
     typing/out_type.cmi \
     typing/oprint.cmi \
     utils/misc.cmi \
+    typing/ident.cmi \
     utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
@@ -868,6 +869,7 @@ typing/errortrace_report.cmx : \
     typing/out_type.cmx \
     typing/oprint.cmx \
     utils/misc.cmx \
+    typing/ident.cmx \
     utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \

--- a/Changes
+++ b/Changes
@@ -197,6 +197,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #14051: Improved error messages for first-class modules with a missing
+  constrained type.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 - #14205: Make inclusion check error message reference the user-written file
   when operating on a ppx-generated file.
   (Liam Stevenson, review by Florian Angeletti)

--- a/testsuite/tests/typing-fstclassmod/errors.ml
+++ b/testsuite/tests/typing-fstclassmod/errors.ml
@@ -1,0 +1,20 @@
+(*TEST
+  expect;
+*)
+(* Error messages for non syntactic type mismatches *)
+module type A = sig type a = char type b type c = float  end
+module type B = sig type a type b = int type c type err end
+let f (x: (module A with type b = int))=
+  (x:(module B with type a = char and type c = float and type err = string))
+[%%expect {|
+module type A = sig type a = char type b type c = float end
+module type B = sig type a type b = int type c type err end
+Line 4, characters 3-4:
+4 |   (x:(module B with type a = char and type c = float and type err = string))
+       ^
+Error: The value "x" has type "(module A with type b = int)"
+       but an expression was expected of type
+         "(module B with type a = char and type c = float and type err =
+          string)"
+       There is no type "err" in the first module type.
+|}]

--- a/testsuite/tests/typing-fstclassmod/errors.ml
+++ b/testsuite/tests/typing-fstclassmod/errors.ml
@@ -42,7 +42,6 @@ Error: The value "x" has type "(module A with type b = int)"
 module type U = sig
   include sig type t end
   type u = t option
-
 end
 
 module type X = sig type t end
@@ -55,18 +54,43 @@ module type Y = sig type t = < m : t * t > end
 val f : (module X with type t = < m : 'a * 'a > as 'a) -> (module Y) = <fun>
 |}]
 
-(* Wrong error message *)
 let f (x: (module A with type b = int))= (x :> (module D))
 [%%expect {|
 Line 1, characters 41-58:
 1 | let f (x: (module A with type b = int))= (x :> (module D))
                                              ^^^^^^^^^^^^^^^^^
 Error: Type "(module A with type b = int)" is not a subtype of "(module D)"
-       There is no type "b" in the second module type.
+       Modules do not match:
+         sig type a = char type b = int type c = float end
+       is not included in
+         D
+       The type "d" is required but not provided
 |}]
 
 
 let f (x: (module A with type b = int))= (x :> (module Empty))
 [%%expect {|
 val f : (module A with type b = int) -> (module Empty) = <fun>
+|}]
+
+module type A = sig type a type b = a type c =int end
+module type B = sig type b = int type c = float end
+
+let f (x: (module A with type a = int)) = (x :> (module B))
+[%%expect {|
+module type A = sig type a type b = a type c = int end
+module type B = sig type b = int type c = float end
+Line 4, characters 42-59:
+4 | let f (x: (module A with type a = int)) = (x :> (module B))
+                                              ^^^^^^^^^^^^^^^^^
+Error: Type "(module A with type a = int)" is not a subtype of "(module B)"
+       Modules do not match:
+         sig type a = int type b = a type c = int end
+       is not included in
+         B
+       Type declarations do not match:
+         type c = int
+       is not included in
+         type c = float
+       The type "int" is not equal to the type "float"
 |}]

--- a/testsuite/tests/typing-fstclassmod/errors.ml
+++ b/testsuite/tests/typing-fstclassmod/errors.ml
@@ -2,19 +2,71 @@
   expect;
 *)
 (* Error messages for non syntactic type mismatches *)
+module type D = sig type d end
+module type Empty = sig end
 module type A = sig type a = char type b type c = float  end
 module type B = sig type a type b = int type c type err end
+module type C = sig type a type 'a b type c end
 let f (x: (module A with type b = int))=
   (x:(module B with type a = char and type c = float and type err = string))
 [%%expect {|
+module type D = sig type d end
+module type Empty = sig end
 module type A = sig type a = char type b type c = float end
 module type B = sig type a type b = int type c type err end
-Line 4, characters 3-4:
-4 |   (x:(module B with type a = char and type c = float and type err = string))
+module type C = sig type a type 'a b type c end
+Line 7, characters 3-4:
+7 |   (x:(module B with type a = char and type c = float and type err = string))
        ^
 Error: The value "x" has type "(module A with type b = int)"
        but an expression was expected of type
          "(module B with type a = char and type c = float and type err =
           string)"
        There is no type "err" in the first module type.
+|}]
+
+
+let f (x: (module A with type b = int))=
+  (x:(module C with type a = char and type c = float))
+[%%expect {|
+Line 2, characters 3-4:
+2 |   (x:(module C with type a = char and type c = float))
+       ^
+Error: The value "x" has type "(module A with type b = int)"
+       but an expression was expected of type
+         "(module C with type a = char and type c = float)"
+       The constraint on "b" in the first module type is not compatible
+       with the declaration of type 'a b in the second module type.
+|}]
+
+module type U = sig
+  include sig type t end
+  type u = t option
+
+end
+
+module type X = sig type t end
+module type Y = sig type t = <m: t * t> end
+let f (x: (module X with type t = < m : 'a * 'a > as 'a)) = (x : (module Y));;
+[%%expect {|
+module type U = sig type t type u = t option end
+module type X = sig type t end
+module type Y = sig type t = < m : t * t > end
+val f : (module X with type t = < m : 'a * 'a > as 'a) -> (module Y) = <fun>
+|}]
+
+(* Wrong error message *)
+let f (x: (module A with type b = int))= (x :> (module D))
+[%%expect {|
+Line 1, characters 41-58:
+1 | let f (x: (module A with type b = int))= (x :> (module D))
+                                             ^^^^^^^^^^^^^^^^^
+Error: Type "(module A with type b = int)" is not a subtype of "(module D)"
+       There is no type "b" in the second module type.
+|}]
+
+
+let f (x: (module A with type b = int))= (x :> (module Empty))
+[%%expect {|
+val f : (module A with type b = int) -> (module Empty) = <fun>
 |}]

--- a/testsuite/tests/typing-fstclassmod/nondep_instance.ml
+++ b/testsuite/tests/typing-fstclassmod/nondep_instance.ml
@@ -49,4 +49,5 @@ Line 3, characters 21-22:
 Error: The value "s" has type "(module Scalar with type t = s)"
        but an expression was expected of type
          "(module Vector_space with type scalar = 'a and type t = 'b)"
+       There is no type "scalar" in the first module type.
 |}];;

--- a/testsuite/tests/typing-fstclassmod/nondep_instance.ml
+++ b/testsuite/tests/typing-fstclassmod/nondep_instance.ml
@@ -49,5 +49,26 @@ Line 3, characters 21-22:
 Error: The value "s" has type "(module Scalar with type t = s)"
        but an expression was expected of type
          "(module Vector_space with type scalar = 'a and type t = 'b)"
-       There is no type "scalar" in the first module type.
+       The type "scalar" depends on internal types in the first module type.
 |}];;
+
+module type A = sig type a type b = a end
+module type B = sig type a type b end
+let g (type t s) (_:(module B with type a = t and type b = s)) = ()
+[%%expect {|
+module type A = sig type a type b = a end
+module type B = sig type a type b end
+val g : (module B with type a = 't and type b = 's) -> unit = <fun>
+|}]
+
+let f (x: (module A with type a = int)) =
+  (x: (module B with type a = int and type b = int))
+[%%expect {|
+Line 2, characters 3-4:
+2 |   (x: (module B with type a = int and type b = int))
+       ^
+Error: The value "x" has type "(module A with type a = int)"
+       but an expression was expected of type
+         "(module B with type a = int and type b = int)"
+       The type "b" depends on internal types in the first module type.
+|}]

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -34,6 +34,7 @@ Lines 7-10, characters 2-22:
 10 |     with type t = M.t)
 Error: This expression has type "(module S with type t = M.t)"
        but an expression was expected of type "(module S)"
+       There is no type "t" in the second module type.
 |}];;
 
 let rec k =

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -34,7 +34,8 @@ Lines 7-10, characters 2-22:
 10 |     with type t = M.t)
 Error: This expression has type "(module S with type t = M.t)"
        but an expression was expected of type "(module S)"
-       There is no type "t" in the second module type.
+       The constraint on "t" in the first module type is not compatible
+       with the declaration of type t in the second module type.
 |}];;
 
 let rec k =

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -35,6 +35,7 @@ Line 1, characters 19-20:
 Error: The value "x" has type "(module Original.T)"
        but an expression was expected of type
          "(module Original.T with type t = int)"
+       There is no type "t" in the first module type.
 |}]
 
 let () = Middle.f (module struct end)

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -126,6 +126,7 @@ Line 3, characters 6-7:
           ^
 Error: The value "m" has type "(module Typ with type t = int)"
        but an expression was expected of type "(module Typ)"
+       There is no type "t" in the second module type.
 |}]
 
 (** From here we will test things with labels *)

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -126,7 +126,8 @@ Line 3, characters 6-7:
           ^
 Error: The value "m" has type "(module Typ with type t = int)"
        but an expression was expected of type "(module Typ)"
-       There is no type "t" in the second module type.
+       The constraint on "t" in the first module type is not compatible
+       with the declaration of type t in the second module type.
 |}]
 
 (** From here we will test things with labels *)

--- a/testsuite/tests/typing-modular-explicits/typedefs.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs.ml
@@ -238,8 +238,7 @@ Line 3, characters 31-32:
 Error: The value "x" has type "t0" = "(module M : T) -> M.t -> M.t"
        but an expression was expected of type
          "'a t5" = "(module M : T with type t = 'a) -> 'a -> 'a"
-       Type "(module T)" is not compatible with type
-         "(module T with type t = 'a)"
+       There is no type "t" in the first module type.
 |}]
 
 let id_fail2 (x : _ t5) : t0 = x
@@ -252,8 +251,7 @@ Error: The value "x" has type
          "'a t5" = "(module M : T with type t = 'a) -> 'a -> 'a"
        but an expression was expected of type
          "t0" = "(module M : T) -> M.t -> M.t"
-       Type "(module T with type t = 'a)" is not compatible with type
-         "(module T)"
+       There is no type "t" in the second module type.
 |}]
 
 (* This test check that no scope escape happens when trying to replace 'a by

--- a/testsuite/tests/typing-modular-explicits/typedefs.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs.ml
@@ -238,7 +238,8 @@ Line 3, characters 31-32:
 Error: The value "x" has type "t0" = "(module M : T) -> M.t -> M.t"
        but an expression was expected of type
          "'a t5" = "(module M : T with type t = 'a) -> 'a -> 'a"
-       There is no type "t" in the first module type.
+       The constraint on "t" in the second module type is not compatible
+       with the declaration of type t in the first module type.
 |}]
 
 let id_fail2 (x : _ t5) : t0 = x
@@ -251,7 +252,8 @@ Error: The value "x" has type
          "'a t5" = "(module M : T with type t = 'a) -> 'a -> 'a"
        but an expression was expected of type
          "t0" = "(module M : T) -> M.t -> M.t"
-       There is no type "t" in the second module type.
+       The constraint on "t" in the first module type is not compatible
+       with the declaration of type t in the second module type.
 |}]
 
 (* This test check that no scope escape happens when trying to replace 'a by

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -59,8 +59,8 @@ module type S3 = sig type u type t val x : int end
 Line 3, characters 2-67:
 3 |   (x : (module S3 with type t = 'a and type u = 'b) :> (module S'));; (* fail *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "(module S3 with type t = int and type u = bool)"
-       is not a subtype of "(module S')"
+Error: Type "(module S3 with type t = 'a and type u = 'b)" is not a subtype of
+         "(module S')"
        The two first-class module types differ by their runtime size.
 |}];;
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3169,6 +3169,7 @@ let complete_type_list ?(allow_absent=false) env fl1 lv2 pack2 =
 
      It'd be nice if we avoided creating such temporary dummy modules and broken
      environments though. *)
+  let exception Missing of string list in
   let id2 = Ident.create_local "Pkg" in
   let env' = Env.add_module id2 Mp_present (Mty_ident pack2.pack_path) env in
   let rec complete fl1 fl2 =
@@ -3188,24 +3189,33 @@ let complete_type_list ?(allow_absent=false) env fl1 lv2 pack2 =
                 if allow_absent then
                   complete nl fl2
                 else
-                  raise Exit
+                  raise (Missing n)
             end
         | (_, {type_arity = 0; type_kind = Type_abstract _;
                type_private = Public; type_manifest = None})
           when allow_absent ->
             complete nl fl2
-        | _ -> raise Exit
-        | exception Not_found when allow_absent->
+        | _ -> raise (Missing n)
+        | exception Not_found ->
+           if allow_absent then
             complete nl fl2
+           else raise (Missing n)
   in
   match complete fl1 pack2.pack_constraints with
-  | res -> res
-  | exception Exit -> raise Not_found
+  | res -> Ok res
+  | exception (Missing n) -> Error n
 
 (* raise Not_found rather than Unify if the module types are incompatible *)
 let compare_package env unify_list lv1 pack1 lv2 pack2 =
   let ntl2 = complete_type_list env pack1.pack_constraints lv2 pack2
   and ntl1 = complete_type_list env pack2.pack_constraints lv1 pack1 in
+  let missing pos name =
+     raise_for Unify (First_class_module (Missing_type_constraint (pos,name)))
+  in
+  match ntl1, ntl2 with
+  | Error g, Ok _ -> missing First g
+  | _, Error e -> missing Second e
+  | Ok ntl1, Ok ntl2 ->
   unify_list (List.map snd ntl1) (List.map snd ntl2);
   if eq_package_path env pack1.pack_path pack2.pack_path then Ok ()
   else Result.bind
@@ -3559,6 +3569,10 @@ and unify_list env tl1 tl2 =
     raise_unexplained_for Unify;
   List.iter2 (unify env) tl1 tl2
 
+and unify_list_same_length env tl1 tl2 =
+  assert (List.compare_lengths tl1 tl2 = 0);
+  List.iter2 (unify env) tl1 tl2
+
 and unify_labeled_list env labeled_tl1 labeled_tl2 =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
     raise_unexplained_for Unify;
@@ -3573,7 +3587,8 @@ and unify_labeled_list env labeled_tl1 labeled_tl2 =
 
 and unify_package uenv lvl1 pack1 lvl2 pack2 =
   match
-    compare_package (get_env uenv) (unify_list uenv) lvl1 pack1 lvl2 pack2
+    compare_package (get_env uenv) (unify_list_same_length uenv)
+      lvl1 pack1 lvl2 pack2
   with
   | Ok () -> ()
   | Error fm_err ->
@@ -4665,6 +4680,10 @@ and moregen_list type_pairs env tl1 tl2 =
     raise_unexplained_for Moregen;
   List.iter2 (moregen type_pairs env) tl1 tl2
 
+and moregen_list_same_length type_pairs env tl1 tl2 =
+  assert (List.compare_lengths tl1 tl2 = 0);
+  List.iter2 (moregen type_pairs env) tl1 tl2
+
 and moregen_labeled_list type_pairs env labeled_tl1
     labeled_tl2 =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
@@ -4678,7 +4697,7 @@ and moregen_labeled_list type_pairs env labeled_tl1
 
 and moregen_package type_pairs env lvl1 pack1 lvl2 pack2 =
   match
-    compare_package env (moregen_list type_pairs env)
+    compare_package env (moregen_list_same_length type_pairs env)
       lvl1 pack1 lvl2 pack2
   with
   | Ok () -> ()
@@ -5947,6 +5966,9 @@ and subtype_package env trace lvl1 pack1 lvl2 pack2 constraints =
     and ntl2 =
       complete_type_list env pack1.pack_constraints lvl2 pack2
         ~allow_absent:true in
+    match ntl1, ntl2 with
+    | Error _, _ | _, Error _ -> raise Not_found
+    | Ok ntl1, Ok ntl2 ->
     let constraints' =
       List.map
         (fun (n2,t2) -> (env, trace, List.assoc n2 ntl1, t2, !univar_pairs))

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4707,7 +4707,6 @@ and moregen_package type_pairs env lvl1 pack1 lvl2 pack2 =
   with
   | Ok () -> ()
   | Error fme -> raise_for Moregen (First_class_module fme)
-  | exception Not_found -> raise_unexplained_for Moregen
 
 and moregen_fields type_pairs env ty1 ty2 =
   let (fields1, rest1) = flatten_fields ty1
@@ -5114,7 +5113,6 @@ and eqtype_package rename type_pairs subst env lvl1 pack1 lvl2 pack2 =
   with
   | Ok () -> ()
   | Error fme -> raise_for Equality (First_class_module fme)
-  | exception Not_found -> raise_unexplained_for Equality
 
 and eqtype_fields rename type_pairs subst env ty1 ty2 =
   let (fields1, rest1) = flatten_fields ty1 in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3157,8 +3157,8 @@ let nondep_instance env level id ty =
   with_level ~level (fun () -> instance ty)
 
 (* Find the type paths nl1 in the module type pack2, and add them to the
-   list (nl2, tl2). raise Not_found if impossible *)
-let complete_type_list ?(allow_absent=false) env fl1 lv2 pack2 =
+   list (nl2, tl2). *)
+let complete_type_list ~pos ?(allow_absent=false) env fl1 lv2 pack2 =
   (* This is morally WRONG: we're adding a (dummy) module without a scope in the
      environment. However no operation which cares about levels/scopes is going
      to happen while this module exists.
@@ -3169,7 +3169,9 @@ let complete_type_list ?(allow_absent=false) env fl1 lv2 pack2 =
 
      It'd be nice if we avoided creating such temporary dummy modules and broken
      environments though. *)
-  let exception Missing of string list in
+  let exception Exit of Errortrace.first_class_module in
+  let mismatch lhs decl =
+    Exit(Constraint_on_mismatched_type {pos; decl; lhs}) in
   let id2 = Ident.create_local "Pkg" in
   let env' = Env.add_module id2 Mp_present (Mty_ident pack2.pack_path) env in
   let rec complete fl1 fl2 =
@@ -3189,33 +3191,36 @@ let complete_type_list ?(allow_absent=false) env fl1 lv2 pack2 =
                 if allow_absent then
                   complete nl fl2
                 else
-                  raise (Missing n)
+                  raise (Exit (Constraint_with_deps(pos,n)))
             end
-        | (_, {type_arity = 0; type_kind = Type_abstract _;
-               type_private = Public; type_manifest = None})
-          when allow_absent ->
-            complete nl fl2
-        | _ -> raise (Missing n)
+        | (_, ({type_arity = 0; type_kind = Type_abstract _;
+               type_private = Public; type_manifest = None} as decl))
+           ->
+            if allow_absent then
+              complete nl fl2
+            else raise (mismatch n decl)
+        | _, decl -> raise (mismatch n decl)
         | exception Not_found ->
            if allow_absent then
             complete nl fl2
-           else raise (Missing n)
+           else raise (Exit (Constraint_on_missing_type (pos,n)))
   in
   match complete fl1 pack2.pack_constraints with
   | res -> Ok res
-  | exception (Missing n) -> Error n
+  | exception (Exit e) -> Error e
 
-(* raise Not_found rather than Unify if the module types are incompatible *)
 let compare_package env unify_list lv1 pack1 lv2 pack2 =
-  let ntl2 = complete_type_list env pack1.pack_constraints lv2 pack2
-  and ntl1 = complete_type_list env pack2.pack_constraints lv1 pack1 in
-  let missing pos name =
-     raise_for Unify (First_class_module (Missing_type_constraint (pos,name)))
+  let check = function
+    | Error e -> raise_for Unify (First_class_module e)
+    | Ok ntl -> ntl
   in
-  match ntl1, ntl2 with
-  | Error g, Ok _ -> missing First g
-  | _, Error e -> missing Second e
-  | Ok ntl1, Ok ntl2 ->
+  let ntl2 =
+    complete_type_list ~pos:Second env pack1.pack_constraints lv2 pack2
+  and ntl1 =
+    complete_type_list ~pos:First env pack2.pack_constraints lv1 pack1
+  in
+  let ntl2 = check ntl2 in
+  let ntl1 = check ntl1 in
   unify_list (List.map snd ntl1) (List.map snd ntl2);
   if eq_package_path env pack1.pack_path pack2.pack_path then Ok ()
   else Result.bind
@@ -5962,9 +5967,9 @@ and subtype_labeled_list env trace labeled_tl1 labeled_tl2 constraints =
 
 and subtype_package env trace lvl1 pack1 lvl2 pack2 constraints =
   try
-    let ntl1 = complete_type_list env pack2.pack_constraints lvl1 pack1
+    let ntl1 = complete_type_list ~pos:Second env pack2.pack_constraints lvl1 pack1
     and ntl2 =
-      complete_type_list env pack1.pack_constraints lvl2 pack2
+      complete_type_list ~pos:First env pack1.pack_constraints lvl2 pack2
         ~allow_absent:true in
     match ntl1, ntl2 with
     | Error _, _ | _, Error _ -> raise Not_found

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3209,7 +3209,7 @@ let complete_type_list ~pos ?(allow_absent=false) env fl1 lv2 pack2 =
   | res -> Ok res
   | exception (Exit e) -> Error e
 
-let compare_package env unify_list lv1 pack1 lv2 pack2 =
+let compare_package env unify lv1 pack1 lv2 pack2 =
   let check = function
     | Error e -> raise_for Unify (First_class_module e)
     | Ok ntl -> ntl
@@ -3221,7 +3221,8 @@ let compare_package env unify_list lv1 pack1 lv2 pack2 =
   in
   let ntl2 = check ntl2 in
   let ntl1 = check ntl1 in
-  unify_list (List.map snd ntl1) (List.map snd ntl2);
+  (* ntl1 and ntl2 have the same length by construction *)
+  List.iter2 unify (List.map snd ntl1) (List.map snd ntl2);
   if eq_package_path env pack1.pack_path pack2.pack_path then Ok ()
   else Result.bind
       (!package_subtype env pack1 pack2)
@@ -3574,10 +3575,6 @@ and unify_list env tl1 tl2 =
     raise_unexplained_for Unify;
   List.iter2 (unify env) tl1 tl2
 
-and unify_list_same_length env tl1 tl2 =
-  assert (List.compare_lengths tl1 tl2 = 0);
-  List.iter2 (unify env) tl1 tl2
-
 and unify_labeled_list env labeled_tl1 labeled_tl2 =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
     raise_unexplained_for Unify;
@@ -3591,10 +3588,7 @@ and unify_labeled_list env labeled_tl1 labeled_tl2 =
     labeled_tl1 labeled_tl2
 
 and unify_package uenv lvl1 pack1 lvl2 pack2 =
-  match
-    compare_package (get_env uenv) (unify_list_same_length uenv)
-      lvl1 pack1 lvl2 pack2
-  with
+  match compare_package (get_env uenv) (unify uenv) lvl1 pack1 lvl2 pack2 with
   | Ok () -> ()
   | Error fm_err ->
       if not (in_pattern_mode uenv) then
@@ -4685,10 +4679,6 @@ and moregen_list type_pairs env tl1 tl2 =
     raise_unexplained_for Moregen;
   List.iter2 (moregen type_pairs env) tl1 tl2
 
-and moregen_list_same_length type_pairs env tl1 tl2 =
-  assert (List.compare_lengths tl1 tl2 = 0);
-  List.iter2 (moregen type_pairs env) tl1 tl2
-
 and moregen_labeled_list type_pairs env labeled_tl1
     labeled_tl2 =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
@@ -4702,7 +4692,7 @@ and moregen_labeled_list type_pairs env labeled_tl1
 
 and moregen_package type_pairs env lvl1 pack1 lvl2 pack2 =
   match
-    compare_package env (moregen_list_same_length type_pairs env)
+    compare_package env (moregen type_pairs env)
       lvl1 pack1 lvl2 pack2
   with
   | Ok () -> ()
@@ -5091,11 +5081,6 @@ let rec eqtype rename type_pairs subst env t1 t2 =
 and eqtype_list_same_length rename type_pairs subst env tl1 tl2 =
   List.iter2 (eqtype rename type_pairs subst env) tl1 tl2
 
-and eqtype_list rename type_pairs subst env tl1 tl2 =
-  if List.length tl1 <> List.length tl2 then
-    raise_unexplained_for Equality;
-  eqtype_list_same_length rename type_pairs subst env tl1 tl2
-
 and eqtype_labeled_list rename type_pairs subst env labeled_tl1 labeled_tl2 =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
     raise_unexplained_for Equality;
@@ -5108,7 +5093,7 @@ and eqtype_labeled_list rename type_pairs subst env labeled_tl1 labeled_tl2 =
 
 and eqtype_package rename type_pairs subst env lvl1 pack1 lvl2 pack2 =
   match
-    compare_package env (eqtype_list rename type_pairs subst env)
+    compare_package env (eqtype rename type_pairs subst env)
       lvl1 pack1 lvl2 pack2
   with
   | Ok () -> ()

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5964,34 +5964,39 @@ and subtype_labeled_list env trace labeled_tl1 labeled_tl2 constraints =
     constraints labeled_tl1 labeled_tl2
 
 and subtype_package env trace lvl1 pack1 lvl2 pack2 constraints =
-  try
-    let ntl1 = complete_type_list ~pos:Second env pack2.pack_constraints lvl1 pack1
-    and ntl2 =
-      complete_type_list ~pos:First env pack1.pack_constraints lvl2 pack2
-        ~allow_absent:true in
-    match ntl1, ntl2 with
-    | Error _, _ | _, Error _ -> raise Not_found
-    | Ok ntl1, Ok ntl2 ->
-    let constraints' =
-      List.map
-        (fun (n2,t2) -> (env, trace, List.assoc n2 ntl1, t2, !univar_pairs))
-        ntl2
-    in
-    if eq_package_path env pack1.pack_path pack2.pack_path
-    then constraints' @ constraints
-    else begin
-      (* need to check module subtyping *)
-      let snap = Btype.snapshot () in
-      match List.iter (fun (env, _, t1, t2, _) -> unify env t1 t2) constraints'
-      with
-      | () when Result.is_ok (!package_subtype env pack1 pack2) ->
-        Btype.backtrack snap; constraints' @ constraints
-      | () | exception Unify _ ->
-        Btype.backtrack snap; raise Not_found
-    end
-  with Not_found ->
-    (env, trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
-      ::constraints
+  let ntl1 =
+    complete_type_list ~pos:Second env pack2.pack_constraints lvl1 pack1
+  and ntl2 =
+    complete_type_list ~pos:First env pack1.pack_constraints lvl2 pack2
+      ~allow_absent:true
+  in
+  match ntl1, ntl2 with
+  | Error e, _ | _, Error e ->
+      subtype_error ~env ~trace ~unification_trace:[First_class_module e]
+  | Ok ntl1, Ok ntl2 ->
+      let constraints' =
+        List.map
+          (fun (n2,t2) -> (env, trace, List.assoc n2 ntl1, t2, !univar_pairs))
+          ntl2
+      in
+      if eq_package_path env pack1.pack_path pack2.pack_path then
+        constraints' @ constraints
+      else
+        (* need to check module subtyping *)
+        let snap = Btype.snapshot () in
+        let apply_constraint (env,_,t1,t2,_) = unify env t1 t2 in
+        match List.iter apply_constraint constraints' with
+        | exception Unify {trace=unification_trace} ->
+            Btype.backtrack snap;
+            subtype_error ~env ~trace ~unification_trace
+        | () ->
+            match !package_subtype env pack1 pack2 with
+            | Ok () ->
+                Btype.backtrack snap; constraints' @ constraints
+            | Error e ->
+                Btype.backtrack snap;
+                subtype_error ~env ~trace
+                  ~unification_trace:[First_class_module e]
 
 and subtype_functor env trace ?id1 id pack u1 u2 constraints =
   let mty = modtype_of_package env Location.none pack in

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -112,6 +112,7 @@ type first_class_module =
     | Package_cannot_scrape of Path.t
     | Package_inclusion of Format_doc.doc
     | Package_coercion of Format_doc.doc
+    | Missing_type_constraint of position * string list
 
 type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -112,7 +112,13 @@ type first_class_module =
     | Package_cannot_scrape of Path.t
     | Package_inclusion of Format_doc.doc
     | Package_coercion of Format_doc.doc
-    | Missing_type_constraint of position * string list
+    | Constraint_on_missing_type of position * string list
+    | Constraint_with_deps of position * string list
+    | Constraint_on_mismatched_type of {
+        pos:position;
+        decl:Types.type_declaration;
+        lhs:string list
+      }
 
 type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
@@ -172,6 +178,15 @@ let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
         diff = swap_diff d.diff
       })
   | Univar (Quantification_mismatch _) as x -> x
+  | First_class_module (Constraint_on_missing_type (pos,lhs)) ->
+    First_class_module (Constraint_on_missing_type (swap_position pos,lhs))
+  | First_class_module (Constraint_with_deps (pos,lhs)) ->
+    First_class_module (Constraint_with_deps (swap_position pos,lhs))
+  | First_class_module (Constraint_on_mismatched_type r) ->
+      let c =
+        Constraint_on_mismatched_type { r with pos = swap_position r.pos}
+      in
+      First_class_module c
   | x -> x
 
 let swap_trace e = List.map swap_elt e

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -94,6 +94,7 @@ type first_class_module =
     | Package_cannot_scrape of Path.t
     | Package_inclusion of Format_doc.doc
     | Package_coercion of Format_doc.doc
+    | Missing_type_constraint of position * string list
 
 type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -94,7 +94,13 @@ type first_class_module =
     | Package_cannot_scrape of Path.t
     | Package_inclusion of Format_doc.doc
     | Package_coercion of Format_doc.doc
-    | Missing_type_constraint of position * string list
+    | Constraint_on_missing_type of position * string list
+    | Constraint_with_deps of position * string list
+    | Constraint_on_mismatched_type of {
+        pos:position;
+        decl:Types.type_declaration;
+        lhs:string list
+      }
 
 type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -329,6 +329,17 @@ let explain_first_class_module = function
       Some(doc_printf "@,@[%a@]" Fmt.pp_doc pr)
   | Errortrace.Package_coercion pr ->
       Some(doc_printf "@,@[%a@]" Fmt.pp_doc pr)
+  | Errortrace.Missing_type_constraint (position,name) ->
+      let name = String.concat "." name in
+      let expl = match position with
+        | First ->
+            doc_printf "@,@[There is no type %a in the first module type.@]"
+              Style.inline_code name
+        | Second ->
+            doc_printf "@,@[There is no type %a in the second module type.@]"
+              Style.inline_code name
+      in
+      Some expl
 
 let explain_univar prev = function
   | Errortrace.Var_mismatch { diff; order} ->

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -329,7 +329,7 @@ let explain_first_class_module = function
       Some(doc_printf "@,@[%a@]" Fmt.pp_doc pr)
   | Errortrace.Package_coercion pr ->
       Some(doc_printf "@,@[%a@]" Fmt.pp_doc pr)
-  | Errortrace.Missing_type_constraint (position,name) ->
+  | Errortrace.Constraint_on_missing_type (position,name) ->
       let name = String.concat "." name in
       let expl = match position with
         | First ->
@@ -338,6 +338,41 @@ let explain_first_class_module = function
         | Second ->
             doc_printf "@,@[There is no type %a in the second module type.@]"
               Style.inline_code name
+      in
+      Some expl
+  | Errortrace.Constraint_with_deps (position,name) ->
+      let name = String.concat "." name in
+      let expl = match position with
+        | First ->
+            doc_printf
+              "@,@[The type %a depends on internal types@ in@ the@ \
+               first@ module@ type.@]"
+              Style.inline_code name
+        | Second ->
+            doc_printf
+              "@,@[The type %a depends on internal types@ in@ the@ \
+               second@ module@ type.@]"
+              Style.inline_code name
+      in
+      Some expl
+  | Errortrace.Constraint_on_mismatched_type {pos; decl; lhs }  ->
+      let name = String.concat "." lhs in
+      let id = Ident.create_local name in
+      let expl = match pos with
+        | First ->
+            doc_printf
+              "@,@[The constraint on %a in the second module type@ \
+               is not compatible@ with the declaration of@;<1 2>@[%a@]@ in \
+               the first module type.@]"
+              Style.inline_code name
+              (Printtyp.Doc.type_declaration id) decl
+        | Second ->
+            doc_printf
+              "@,@[The constraint on %a in the first module type@ \
+               is not compatible@ with the declaration of@;<1 2>@[%a@]@ in \
+               the second module type.@]"
+              Style.inline_code name
+              (Printtyp.Doc.type_declaration id) decl
       in
       Some expl
 


### PR DESCRIPTION
Currently, whenever the typecheck detects that a constrained type is missing when
trying to unify two first class modules, for instance in
```ocaml
module type A = sig type a = char type b type c = float  end
module type B = sig type a type b = int type c type err end
let f (x: (module A with type b = int)) =
  (x:(module B with type a = char and type c = float and type err = string))
```
it fails immediately without keeping track in the error message of which constrained type was absent:
>```ocaml
>Error: The value x has type (module A with type b = int)
>        but an expression was expected of type
>         (module B with type a = char and type c = float and type err =  string)
>```
However, as illustrated by the error above, the source of the error (the  missing type constraint) cannot be inferred from the syntactic information present in the error message.
 
This PR proposes to fix this issue by adding the missing semantic information to the error message:
>```ocaml
>       There is no type "err" in the first module type.
>```




