### PR TITLE
Make multicore memprof more compositional

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,11 @@ Working version
   and RISC-V.  This reduces minor GC work in the presence of deep call stacks.
   (Xavier Leroy, review by Miod Vallat, Gabriel Scherer and Olivier Nicole)
 
+- #14053: Statmemprof: it is now possible to replace a profile in the
+  current domain without stopping it in all domains.
+  Added the function [Gc.Memprof.is_sampling].
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -2308,7 +2308,7 @@ CAMLprim value caml_memprof_stop(value unit)
   }
 
   value config = thread_config(thread);
-  if (config == CONFIG_NONE || Status(config) != CONFIG_STATUS_SAMPLING) {
+  if (!Sampling(config)) {
     caml_failwith("Gc.Memprof.stop: no profile running.");
   }
   Set_status(config, CONFIG_STATUS_STOPPED);

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -166,6 +166,8 @@ module Memprof =
       tracker =
       c_start sampling_rate callstack_size tracker
 
+    external is_sampling : unit -> bool = "caml_memprof_is_sampling"
+
     external stop : unit -> unit = "caml_memprof_stop"
 
     external discard : t -> unit = "caml_memprof_discard"

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -549,10 +549,11 @@ module Memprof :
        have evolved between the allocation and the call to the
        callback.
 
-       If a new thread or domain is created when the current domain is
-       sampling for a profile, the child thread or domain joins that
-       profile (using the same [sampling_rate], [callstack_size], and
-       [tracker] callbacks).
+       All the threads belonging to a domain share the same profile
+       (using the same [sampling_rate], [callstack_size], and
+       [tracker] callbacks). In addition, if a new domain is spawned
+       by the current domain while sampling for a profile, then the
+       child domain likewise shares that profile with its parent.
 
        An allocation callback is always run by the thread which
        allocated the block. If the thread exits or the profile is

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -522,8 +522,7 @@ module Memprof :
       ?callstack_size:int ->
       ('minor, 'major) tracker ->
       t
-    (** Start a profile with the given parameters. Raises an exception
-       if a profile is already sampling in the current domain.
+    (** Start a profile with the given parameters.
 
        Sampling begins immediately. The parameter [sampling_rate] is
        the sampling rate in samples per word (including headers).
@@ -566,7 +565,17 @@ module Memprof :
        by a different domain.
 
        Different domains may sample for different profiles
-       simultaneously.  *)
+       simultaneously.
+
+       If a profile is already sampling in the current domain, then
+       calling [start] replaces it with a new profile in this domain.
+       If the old profile was sampling in other domains, it continues
+       doing so. *)
+
+    val is_sampling : unit -> bool
+    (** Returns whether a profile is sampling in the current domain,
+        if any. Returns [None] if the current domain is not
+        sampling. *)
 
     val stop : unit -> unit
     (** Stop sampling for the current profile. Fails if no profile is

--- a/testsuite/tests/statmemprof/restart.ml
+++ b/testsuite/tests/statmemprof/restart.ml
@@ -1,0 +1,57 @@
+(* TEST *)
+
+module M = Gc.Memprof
+
+let start alloc_minor = ignore (M.start ~sampling_rate:1. { M.null_tracker with alloc_minor })
+
+let alloc_some () =
+  let rec f n =
+    if n = 0 then [] else (ref 0) :: (f (n-1))
+  in
+  ignore (Sys.opaque_identity (f 100))
+
+let is_sampling () =
+  Printf.printf "domain %n is_sampling (): %b.\n"
+    (Domain.self () :> int)
+    (M.is_sampling ())
+
+let dom1_witness = Atomic.make 0
+let dom2_witness = Atomic.make 0
+
+let print_witnesses () =
+  Printf.printf "%n, %n\n" (Atomic.get dom1_witness) (Atomic.get dom2_witness)
+
+let dom1_callback _ =
+  let () =
+    let i = Atomic.get dom1_witness in
+    if i = 0 then
+      Atomic.set dom1_witness 1
+    else if i = 1 && Atomic.get dom2_witness = 1 then
+      Atomic.set dom1_witness 2
+  in
+  None
+
+let dom2_callback _ =
+  let () =
+    if Atomic.get dom1_witness = 1 && Atomic.get dom2_witness = 0 then
+      Atomic.set dom2_witness 1
+  in
+  None
+
+let _ =
+  is_sampling () ;
+  start dom1_callback ;
+  is_sampling () ;
+  ignore (alloc_some ()) ;
+  let d = Domain.spawn (fun () ->
+    is_sampling () ;
+    start dom2_callback ;
+    is_sampling () ;
+    alloc_some () ;
+    M.stop () ;
+    is_sampling ())
+  in
+  Domain.join d ;
+  is_sampling () ;
+  alloc_some () ;
+  print_witnesses ()

--- a/testsuite/tests/statmemprof/restart.reference
+++ b/testsuite/tests/statmemprof/restart.reference
@@ -1,0 +1,7 @@
+domain 0 is_sampling (): false.
+domain 0 is_sampling (): true.
+domain 1 is_sampling (): true.
+domain 1 is_sampling (): true.
+domain 1 is_sampling (): false.
+domain 0 is_sampling (): true.
+2, 1

--- a/testsuite/tests/statmemprof/start_stop.ml
+++ b/testsuite/tests/statmemprof/start_stop.ml
@@ -1,6 +1,6 @@
 (* TEST *)
 
-(* Tests various valid and invalid orderings of start/stop/discard
+(* Tests various valid and invalid orderings of start/stop/discard/is_sampling
 statmemprof calls. Doesn't test any callbacks or count any allocations,
 etc.*)
 
@@ -8,11 +8,18 @@ module MP = Gc.Memprof
 
 let prof () = MP.start  ~sampling_rate:1. MP.null_tracker
 
+let is_sampling () =
+  Printf.printf "is_sampling (): %b.\n" (MP.is_sampling ())
+
 (* Null test: start/stop/discard *)
 let _ =
+  is_sampling ();
   let profile = prof () in
+  is_sampling ();
   MP.stop ();
+  is_sampling ();
   MP.discard profile;
+  is_sampling ();
   print_endline "Null test."
 
 (* Stop without starting *)
@@ -24,11 +31,16 @@ with
 (* Second start without stopping. *)
 let _ =
   try
-    Fun.protect ~finally:MP.stop
-      (fun () -> (ignore (prof ());
-                  ignore (prof ())))
+    Fun.protect ~finally:MP.stop (fun () ->
+      ignore (prof ());
+      ignore (prof ());
+      is_sampling ()
+    ) ;
+    print_endline "Start without stopping."
   with
     Failure s -> Printf.printf "Start without stopping fails with \"%s\"\n" s
+
+let () = is_sampling ()
 
 (* Discard without stopping. *)
 let _ =
@@ -101,6 +113,7 @@ let _ =
   MP.stop ();
   let prof2 = prof () in
   MP.discard prof1;
+  is_sampling ();
   MP.stop ();
   MP.discard prof2;
   print_endline "Discarding old profile while sampling."

--- a/testsuite/tests/statmemprof/start_stop.ml
+++ b/testsuite/tests/statmemprof/start_stop.ml
@@ -8,18 +8,17 @@ module MP = Gc.Memprof
 
 let prof () = MP.start  ~sampling_rate:1. MP.null_tracker
 
-let is_sampling () =
-  Printf.printf "is_sampling (): %b.\n" (MP.is_sampling ())
+let check_sampling b = assert(MP.is_sampling () = b)
 
 (* Null test: start/stop/discard *)
 let _ =
-  is_sampling ();
+  check_sampling false;
   let profile = prof () in
-  is_sampling ();
+  check_sampling true;
   MP.stop ();
-  is_sampling ();
+  check_sampling false;
   MP.discard profile;
-  is_sampling ();
+  check_sampling false;
   print_endline "Null test."
 
 (* Stop without starting *)
@@ -34,13 +33,13 @@ let _ =
     Fun.protect ~finally:MP.stop (fun () ->
       ignore (prof ());
       ignore (prof ());
-      is_sampling ()
+      check_sampling true
     ) ;
     print_endline "Start without stopping."
   with
     Failure s -> Printf.printf "Start without stopping fails with \"%s\"\n" s
 
-let () = is_sampling ()
+let () = check_sampling false
 
 (* Discard without stopping. *)
 let _ =
@@ -113,7 +112,7 @@ let _ =
   MP.stop ();
   let prof2 = prof () in
   MP.discard prof1;
-  is_sampling ();
+  check_sampling true;
   MP.stop ();
   MP.discard prof2;
   print_endline "Discarding old profile while sampling."

--- a/testsuite/tests/statmemprof/start_stop.reference
+++ b/testsuite/tests/statmemprof/start_stop.reference
@@ -1,6 +1,12 @@
+is_sampling (): false.
+is_sampling (): true.
+is_sampling (): false.
+is_sampling (): false.
 Null test.
 Stop without starting fails with "Gc.Memprof.stop: no profile running."
-Start without stopping fails with "Gc.Memprof.start: already started."
+is_sampling (): true.
+Start without stopping.
+is_sampling (): false.
 Discard without stopping fails with "Gc.Memprof.discard: profile not stopped."
 Second discard fails with "Gc.Memprof.discard: profile already discarded."
 Double profile.
@@ -8,4 +14,5 @@ Double profile with single discard.
 Double profile, discarding both.
 Double profile, discarding both at end.
 Double profile, discarding in reverse order.
+is_sampling (): true.
 Discarding old profile while sampling.

--- a/testsuite/tests/statmemprof/start_stop.reference
+++ b/testsuite/tests/statmemprof/start_stop.reference
@@ -1,12 +1,6 @@
-is_sampling (): false.
-is_sampling (): true.
-is_sampling (): false.
-is_sampling (): false.
 Null test.
 Stop without starting fails with "Gc.Memprof.stop: no profile running."
-is_sampling (): true.
 Start without stopping.
-is_sampling (): false.
 Discard without stopping fails with "Gc.Memprof.discard: profile not stopped."
 Second discard fails with "Gc.Memprof.discard: profile already discarded."
 Double profile.
@@ -14,5 +8,4 @@ Double profile with single discard.
 Double profile, discarding both.
 Double profile, discarding both at end.
 Double profile, discarding in reverse order.
-is_sampling (): true.
 Discarding old profile while sampling.


### PR DESCRIPTION
This PR introduces two changes to the `Gc.Memprof` interface.
- `start` can be called if a profile is already sampling in the current domain. In this case, the new profile replaces the old one without stopping the latter if it is also sampling in other domains. This change is backwards-compatible: `start` simply fails in fewer situations.
- `is_sampling` is added, which returns whether a profile is sampling in the current domain.

#### Motivations

The multicore adaptation of Memprof added a notion of per-domain "profile": different domains can sample with different choices of sampling rate and callbacks, and sampling can be started/stopped independently. At the same time, the choice was made that a newly-spawned domain inherits the profile of its parent, and stopping would stop sampling in both the parent and the child domains. This seems at odds with the choice to allow different profiles in different domains, because it is not possible to change the profile in the child without stopping sampling in the parent. 

With this patch, it becomes possible to detach a domain from its profile without stopping the profile. `is_sampling` is added so that Memprof clients can intentionally fail if they detect that Memprof is not in the expected state (e.g. two clients interfering).

As evidence that this makes the interface more expressive and compositional, it currently does not seem possible to implement [`Memprof_limits.Memprof`](https://guillaume.munch.name/software/ocaml/memprof-limits/Memprof_limits/Memprof/index.html) in OCaml 5, but with the present patch it will become possible to do so.

#### Reviewing

This PR is best reviewed commit-per-commit. The first commit is the only substantial one. The change inside `caml_memprof_start` only consists in removing the error check (and moving some allocations before `orphans_create`, because these allocations can create new entries). This might seem surprising, but to the best of my understanding this is all that is needed.