### PR TITLE
Deprecating the representation of a type alias

### DIFF
--- a/Changes
+++ b/Changes
@@ -105,6 +105,16 @@ Working version
   recursive modules.
   (Shivam Acharya, review by Gabriel Scherer and Florian Angeletti)
 
+- ...: new warning "deprecated_repr". `type t = int [@@deprecated_repr]`
+  warns in places that wouldn't type if `t`'s definition changed to `type t`.
+  TODO:
+  - probably use a separate alert, not "deprecated". Or I guess a warning,
+    like deprecated-mutable.
+  - maybe should make an internal alert for the cases when no location is
+    provided, so it's easier to fix the compiler if a warning is missing
+  - the warnings should mention the type and repr that are deprecated
+  - need to add explanation to the manual, in particular the fact that 
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/Makefile
+++ b/Makefile
@@ -1963,7 +1963,7 @@ expect_SOURCES = $(addprefix testsuite/tools/,expect.mli expect.ml)
 expect_LIBRARIES = $(addprefix compilerlibs/,\
   ocamlcommon ocamlbytecomp ocamltoplevel)
 
-testsuite/tools/expect$(EXE): OC_BYTECODE_LINKFLAGS += -linkall
+testsuite/tools/expect$(EXE): OC_BYTECODE_LINKFLAGS += -linkall -g
 
 codegen_SOURCES = $(addprefix testsuite/tools/,\
   parsecmmaux.mli parsecmmaux.ml \

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -244,12 +244,19 @@ let check_alerts loc attrs s =
     (fun kind message -> Location.alert loc ~kind (cat s message))
     (alerts_of_attrs attrs)
 
+let sublocs_of_def_use ~(def : Location.t) ~(use : Location.t) =
+  if not def.loc_ghost && not use.loc_ghost then
+    [ def, "Definition"; use, "Expected signature" ]
+  else
+    []
+
 let check_alerts_inclusion ~def ~use loc attrs1 attrs2 s =
   let m2 = alerts_of_attrs attrs2 in
   Misc.Stdlib.String.Map.iter
     (fun kind msg ->
        if not (Misc.Stdlib.String.Map.mem kind m2) then
-         Location.alert ~def ~use ~kind loc (cat s msg)
+         Location.alert ~sublocs:(sublocs_of_def_use ~def ~use)
+           ~kind loc (cat s msg)
     )
     (alerts_of_attrs attrs1)
 
@@ -271,7 +278,7 @@ let check_deprecated_mutable_inclusion ~def ~use loc attrs1 attrs2 s =
   with
   | None, _ | Some _, Some _ -> ()
   | Some txt, None ->
-      Location.deprecated ~def ~use loc
+      Location.deprecated ~sublocs:(sublocs_of_def_use ~def ~use) loc
         (Printf.sprintf "mutating field %s" (cat s txt))
 
 let rec attrs_of_sig = function

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -423,3 +423,5 @@ let has_boxed attrs = has_attribute "boxed" attrs
 let has_remove_aliases attrs = has_attribute "remove_aliases" attrs
 
 let has_atomic attrs = has_attribute "atomic" attrs
+
+let has_deprecated_repr attrs = has_attribute "deprecated_repr" attrs

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -424,4 +424,17 @@ let has_remove_aliases attrs = has_attribute "remove_aliases" attrs
 
 let has_atomic attrs = has_attribute "atomic" attrs
 
-let has_deprecated_repr attrs = has_attribute "deprecated_repr" attrs
+let has_deprecated_repr attrs =
+  match select_attributes [ "deprecated_repr", Return ] attrs with
+  | [] -> None
+  | _ :: _ as l ->
+     Some (`Debug (List.exists (fun a ->
+                       match a.attr_payload with
+                       | PStr [{ pstr_desc =
+                                   Pstr_eval
+                                     ({ pexp_desc =
+                                          Pexp_ident
+                                            { txt = Lident "debug"; _ }
+                                      ; _ }, _); _ }] ->
+                          true
+                       | _ -> false) l))

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -191,4 +191,4 @@ val has_remove_aliases: Parsetree.attributes -> bool
 
 val has_atomic: Parsetree.attributes -> bool
 
-val has_deprecated_repr : Parsetree.attributes -> bool
+val has_deprecated_repr : Parsetree.attributes -> [ `Debug of bool ] option

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -190,3 +190,5 @@ val has_boxed: Parsetree.attributes -> bool
 val has_remove_aliases: Parsetree.attributes -> bool
 
 val has_atomic: Parsetree.attributes -> bool
+
+val has_deprecated_repr : Parsetree.attributes -> bool

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -946,11 +946,11 @@ let print_alert loc ppf w =
 
 let prerr_alert loc w = print_alert loc !formatter_for_warnings w
 
-let alert ?(def = none) ?(use = none) ~kind loc message =
-  prerr_alert loc {Warnings.kind; message; def; use}
+let alert ?(sublocs = []) ~kind loc message =
+  prerr_alert loc {Warnings.kind; message; sublocs }
 
-let deprecated ?def ?use loc message =
-  alert ?def ?use ~kind:"deprecated" loc message
+let deprecated ?sublocs loc message =
+  alert ?sublocs ~kind:"deprecated" loc message
 
 module Style = Misc.Style
 
@@ -968,7 +968,7 @@ let auto_include_alert lib =
       Style.inline_code "_tags"
       Style.inline_code ("-package " ^ lib) in
   let alert =
-    {Warnings.kind="ocaml_deprecated_auto_include"; use=none; def=none;
+    {Warnings.kind="ocaml_deprecated_auto_include"; sublocs = [];
      message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
   in
   prerr_alert none alert
@@ -984,7 +984,7 @@ let deprecated_script_alert program =
       Style.inline_code (program ^ " ./script-file")
   in
   let alert =
-    {Warnings.kind="ocaml_deprecated_cli"; use=none; def=none;
+    {Warnings.kind="ocaml_deprecated_cli"; sublocs = [];
      message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
   in
   prerr_alert none alert

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -333,10 +333,10 @@ val prerr_alert: t -> Warnings.alert -> unit
 (** Same as [print_alert], but uses [!formatter_for_warnings] as output
    formatter. *)
 
-val deprecated: ?def:t -> ?use:t -> t -> string -> unit
+val deprecated: ?sublocs:(t * string) list -> t -> string -> unit
 (** Prints a deprecation alert. *)
 
-val alert: ?def:t -> ?use:t -> kind:string -> t -> string -> unit
+val alert: ?sublocs:(t * string) list -> kind:string -> t -> string -> unit
 (** Prints an arbitrary alert. *)
 
 val auto_include_alert: string -> unit

--- a/testsuite/tests/warnings/deprecated_repr.ml
+++ b/testsuite/tests/warnings/deprecated_repr.ml
@@ -1,0 +1,267 @@
+(* TEST
+   expect;
+*)
+
+module M : sig
+  type t = int [@@deprecated_repr]
+  val zero : t
+  val print : t -> unit
+  val prints : t list -> unit
+end = struct
+  type t = int
+  let zero = 0
+  let print = Printf.printf "%d\n%!"
+  let prints l = List.iter print l
+end
+
+[%%expect {|
+module M :
+  sig
+    type t = int
+    val zero : t
+    val print : t -> unit
+    val prints : t list -> unit
+  end
+|}]
+
+(* ############## *)
+(* Converting between int and t should trigger warnings, but simply using
+   values of type t shouldn't. *)
+
+let () = M.print M.zero
+[%%expect {|
+|}]
+let () = M.print 0
+[%%expect {|
+Line 1, characters 17-18:
+1 | let () = M.print 0
+                     ^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+|}]
+let () = (fun z -> z 0) M.print
+[%%expect {|
+Line 1, characters 24-31:
+1 | let () = (fun z -> z 0) M.print
+                            ^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+|}]
+let () = M.print (if true then M.zero else 0)
+[%%expect {|
+Line 1, characters 43-44:
+1 | let () = M.print (if true then M.zero else 0)
+                                               ^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+|}]
+let __ x = ((x : int) : M.t)
+[%%expect {|
+Line 1, characters 12-21:
+1 | let __ x = ((x : int) : M.t)
+                ^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : int -> M.t = <fun>
+|}]
+let __ x = ((x : M.t) : int)
+[%%expect {|
+Line 1, characters 12-21:
+1 | let __ x = ((x : M.t) : int)
+                ^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : M.t -> int = <fun>
+|}]
+let __ x = (x : int :> M.t)
+[%%expect {|
+Line 1, characters 11-27:
+1 | let __ x = (x : int :> M.t)
+               ^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 11-27:
+1 | let __ x = (x : int :> M.t)
+               ^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : int -> M.t = <fun>
+|}] (* bug: why two warnings *)
+let __ x = (x : M.t :> int)
+[%%expect {|
+Line 1, characters 11-27:
+1 | let __ x = (x : M.t :> int)
+               ^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 11-27:
+1 | let __ x = (x : M.t :> int)
+               ^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : M.t -> int = <fun>
+|}] (* bug: why two warnings *)
+
+let _ = M.zero (* This expands the type definition to warn if it's a function. It seems
+                  fine to warn or not to warn if the repr is deprecated, I suppose, since
+                  the new state would be not warning. *)
+[%%expect {|
+- : M.t = 0
+|}]
+
+(* ############## *)
+(* Converting between M.t and u shouldn't trigger warnings, since this is correct
+   regardless of t's representation. This implies that the typer shoudn't merely
+   expands all head type constructors during unification and other other operations. *)
+
+type u = M.t
+module F(U : sig
+           val print : u -> unit
+           val zero : u
+         end) : sig end = struct
+  open U
+
+  let _ : M.t -> u = Fun.id
+  let _ : u -> M.t = Fun.id
+
+  let () = print M.zero
+  let () = M.print zero
+  let __ (x : M.t) : u = x
+  let __ (x : u) : M.t = x
+end
+[%%expect {|
+type u = M.t
+module F : (U : sig val print : u -> unit val zero : u end) -> sig end
+|}]
+
+(* ############## *)
+
+(* More cases where a type constructor may get expanded, in types. *)
+
+type _t = [ `A of M.t | `A of int ]
+type _u = [ `A of u | `A of M.t ]
+[%%expect {|
+Line 1, characters 10-35:
+1 | type _t = [ `A of M.t | `A of int ]
+              ^^^^^^^^^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+type _t = [ `A of M.t ]
+type _u = [ `A of u ]
+|}]
+
+type 'a constrained = unit constraint 'a = int
+let _ =
+  let __ (_ : M.t constrained) = () in
+  ()
+[%%expect {|
+type 'a constrained = unit constraint 'a = int
+Line 3, characters 14-17:
+3 |   let __ (_ : M.t constrained) = () in
+                  ^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+- : unit = ()
+|}]
+
+(* More cases where a type constructor may get expanded, in modules. *)
+
+module Z1 : sig
+  val x : int
+end = struct
+  let x = M.zero
+end
+[%%expect {|
+Line 2, characters 2-13:
+2 |   val x : int
+      ^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+module Z1 : sig val x : int end
+|}]
+
+module Z2 : sig
+  type z = int
+end = struct
+  type z = M.t
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type z = M.t
+5 | end
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+module Z2 : sig type z = int end
+|}]
+
+module Z3 : sig
+  type z = int
+end = struct
+  type z = int [@@deprecated_repr]
+end (* bug: missing warning *)
+[%%expect {|
+module Z3 : sig type z = int end
+|}]
+
+(* More cases where a type constructor may get expanded, in pattern. *)
+let _ = fun ((_ : M.t) : int) -> ()
+let _ = fun ((_ : int) : M.t) -> ()
+[%%expect {|
+Line 1, characters 13-22:
+1 | let _ = fun ((_ : M.t) : int) -> ()
+                 ^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+- : int -> unit = <fun>
+Line 2, characters 13-22:
+2 | let _ = fun ((_ : int) : M.t) -> ()
+                 ^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+- : M.t -> unit = <fun>
+|}]
+
+(* More cases where a type constructor may get expanded, filling in of omitted
+   optional parameter. *)
+
+open (struct
+       type fu = unit -> unit
+       let create = Fun.id
+       let to_fun = Fun.id
+     end : sig
+       (* Making the type really opaque would create a type error below, so in
+          principle a warning should be triggered. Which is probably doable, but not
+          done since this problem seems rather niche. *)
+       type fu = unit -> unit [@@deprecated_repr]
+       val create : (unit -> unit) -> fu
+       val to_fun : fu -> (unit -> unit)
+     end)
+let truc : fu -> unit = fun _f -> ()
+[%%expect{|
+type fu = unit -> unit
+val create : (unit -> unit) -> fu = <fun>
+val to_fun : fu -> unit -> unit = <fun>
+val truc : fu -> unit = <fun>
+|}]
+
+let f ?machin:_ = create (fun () -> ())
+let () = truc f
+[%%expect{|
+Line 1, characters 14-15:
+1 | let f ?machin:_ = create (fun () -> ())
+                  ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
+val f : ?machin:'a -> fu = <fun>
+Line 2, characters 14-15:
+2 | let () = truc f
+                  ^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 2, characters 14-15:
+2 | let () = truc f
+                  ^
+Error: The value "f" has type "?machin:'a -> fu"
+       but an expression was expected of type "fu" = "unit -> unit"
+       The first argument is labeled "?machin",
+       but an unlabeled argument was expected
+|}] (* bug? Not clear if warning 16 should trigger here or not. Also not clear if the last
+       function should fail to type or not. *)

--- a/testsuite/tests/warnings/deprecated_repr.ml
+++ b/testsuite/tests/warnings/deprecated_repr.ml
@@ -394,31 +394,19 @@ let x = Phantom.z
 module Phantom : sig type 'a t = int val z : 'a t end
 val x : 'a Phantom.t = 1
 |}]
+
 let __ (x : int Phantom.t) = ()
 [%%expect{|
-Line 1, characters 7-26:
-1 | let __ (x : int Phantom.t) = ()
-           ^^^^^^^^^^^^^^^^^^^
-Alert deprecated: implicitly converting between a type and its deprecated representation
+val __ : int Phantom.t -> unit = <fun>
+|}]
 
-val __ : int -> unit = <fun>
-|}] (* bug: this shouldn't warn *)
 let __ () = (assert false : float Phantom.t)
 [%%expect{|
-Line 1, characters 12-44:
-1 | let __ () = (assert false : float Phantom.t)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Alert deprecated: implicitly converting between a type and its deprecated representation
+val __ : unit -> float Phantom.t = <fun>
+|}]
 
-val __ : unit -> int = <fun>
-|}] (* bug: this shouldn't warn *)
 let __ (x : int Phantom.t) = (x : float Phantom.t)
 [%%expect{|
-Line 1, characters 7-26:
-1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
-           ^^^^^^^^^^^^^^^^^^^
-Alert deprecated: implicitly converting between a type and its deprecated representation
-
 Line 1, characters 30-31:
 1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
                                   ^
@@ -435,25 +423,9 @@ Line 1, characters 30-31:
 Error: The value "x" has type "int Phantom.t" = "int"
        but an expression was expected of type "float Phantom.t" = "int"
        Type "int" is not compatible with type "float"
-|}, Principal{|
-Line 1, characters 7-26:
-1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
-           ^^^^^^^^^^^^^^^^^^^
-Alert deprecated: implicitly converting between a type and its deprecated representation
-
-Line 1, characters 30-31:
-1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
-                                  ^
-Alert deprecated: implicitly converting between a type and its deprecated representation
-
-Line 1, characters 29-50:
-1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
-                                 ^^^^^^^^^^^^^^^^^^^^^
-Alert deprecated: implicitly converting between a type and its deprecated representation
-
-val __ : int -> int = <fun>
-|}] (* bug: apart from the noise from the previous bugs, the divergence between principal
-       and non-principal is weird. *)
+|}] (* This type error is introduced by deprecated_repr, but it seems like an
+       unimportant corner case. Perhaps type aliases should be rejected if they
+       are annotated with @@deprecated_repr. *)
 
 (* When user code has type errors, we probably don't want to emit random deprecation
    warnings. *)

--- a/testsuite/tests/warnings/deprecated_repr.ml
+++ b/testsuite/tests/warnings/deprecated_repr.ml
@@ -22,11 +22,13 @@ module M :
     val print : t -> unit
     val prints : t list -> unit
   end
-|}]
+|}] (* ideally, deprecated_repr would be printed, but the issue exists with
+       [@@deprecated] *)
 
-(* ############## *)
-(* Converting between int and t should trigger warnings, but simply using
-   values of type t shouldn't. *)
+(****
+  Converting between int and t should trigger warnings, but simply using
+  values of type t shouldn't.
+ ****)
 
 let () = M.print M.zero
 [%%expect {|
@@ -106,10 +108,11 @@ let _ = M.zero (* This expands the type definition to warn if it's a function. I
 - : M.t = 0
 |}]
 
-(* ############## *)
-(* Converting between M.t and u shouldn't trigger warnings, since this is correct
-   regardless of t's representation. This implies that the typer shoudn't merely
-   expands all head type constructors during unification and other other operations. *)
+(****
+  Converting between M.t and u shouldn't trigger warnings, since this is correct
+  regardless of t's representation. This implies that the typer shoudn't merely
+  expands all head type constructors during unification and other other operations.
+ ****)
 
 type u = M.t
 module F(U : sig
@@ -131,9 +134,33 @@ type u = M.t
 module F : (U : sig val print : u -> unit val zero : u end) -> sig end
 |}]
 
-(* ############## *)
+(**** in expressions ****)
 
-(* More cases where a type constructor may get expanded, in types. *)
+module F : sig
+  type t = int -> int [@@deprecated_repr]
+  val f : t
+end = struct
+  type t = int -> int
+  let f = Fun.id
+end
+let _ = F.f 1
+[%%expect {|
+module F : sig type t = int -> int val f : t end
+- : int = 1
+|}] (* bug: should warn *)
+
+module C : sig
+  type t = < a : int > [@@deprecated_repr]
+end = struct
+  type t = < a : int >
+end
+let __ (x : C.t) = x#a
+[%%expect {|
+module C : sig type t = < a : int > end
+val __ : C.t -> int = <fun>
+|}] (* bug: should warn *)
+
+(**** in types ****)
 
 type _t = [ `A of M.t | `A of int ]
 type _u = [ `A of u | `A of M.t ]
@@ -161,7 +188,7 @@ Alert deprecated: implicitly converting between a type and its deprecated repres
 - : unit = ()
 |}]
 
-(* More cases where a type constructor may get expanded, in modules. *)
+(**** in modules ****)
 
 module Z1 : sig
   val x : int
@@ -201,7 +228,30 @@ end (* bug: missing warning *)
 module Z3 : sig type z = int end
 |}]
 
-(* More cases where a type constructor may get expanded, in pattern. *)
+let f () =
+  (* nondep expanding local type constructors away. It's hard to imagine why anyone
+     would care about this, but perhaps there are examples involving functors that make
+     sense. *)
+  let module M : sig
+        type t = int [@@deprecated_repr]
+        val x : t
+      end = struct
+        type t = int
+        let x = 0
+      end
+  in
+  M.x
+[%%expect {|
+Line 13, characters 2-5:
+13 |   M.x
+       ^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val f : unit -> int = <fun>
+|}]
+
+(**** in patterns ****)
+
 let _ = fun ((_ : M.t) : int) -> ()
 let _ = fun ((_ : int) : M.t) -> ()
 [%%expect {|
@@ -219,8 +269,50 @@ Alert deprecated: implicitly converting between a type and its deprecated repres
 - : M.t -> unit = <fun>
 |}]
 
-(* More cases where a type constructor may get expanded, filling in of omitted
-   optional parameter. *)
+(**** type-based disambiguation ****)
+
+type record = { a : int }
+type record_alias = record [@@deprecated_repr]
+let __ (x : record_alias) = x.a
+let __ ({ a } : record_alias) = a
+[%%expect {|
+type record = { a : int; }
+type record_alias = record
+val __ : record_alias -> int = <fun>
+val __ : record_alias -> int = <fun>
+|}, Principal{|
+type record = { a : int; }
+type record_alias = record
+val __ : record_alias -> int = <fun>
+Line 4, characters 8-13:
+4 | let __ ({ a } : record_alias) = a
+            ^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : record_alias -> int = <fun>
+|}]
+(* bug: should warn regardless of -principal, and both functions should warn *)
+
+type sum = A of int
+type sum_alias = sum [@@deprecated_repr]
+let __ (A a : sum_alias) = a
+[%%expect {|
+type sum = A of int
+type sum_alias = sum
+val __ : sum_alias -> int = <fun>
+|}, Principal{|
+type sum = A of int
+type sum_alias = sum
+Line 3, characters 8-11:
+3 | let __ (A a : sum_alias) = a
+            ^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : sum_alias -> int = <fun>
+|}]
+(* bug: should warn regardless of -principal *)
+
+(**** when optional parameters are filled in ****)
 
 open (struct
        type fu = unit -> unit
@@ -265,3 +357,122 @@ Error: The value "f" has type "?machin:'a -> fu"
        but an unlabeled argument was expected
 |}] (* bug? Not clear if warning 16 should trigger here or not. Also not clear if the last
        function should fail to type or not. *)
+
+(**** parametric type ****)
+
+module P : sig
+  type 'a t = 'a * int [@@deprecated_repr]
+  val z : 'a list t
+end = struct
+  type 'a t = 'a * int
+  let z = [], 1
+end
+
+let x = P.z
+let __ (x : int P.t) = ()
+let __ () = (assert false : float P.t)
+
+[%%expect{|
+module P : sig type 'a t = 'a * int val z : 'a list t end
+val x : 'a list P.t = ([], 1)
+val __ : int P.t -> unit = <fun>
+val __ : unit -> float P.t = <fun>
+|}]
+
+(**** parametric but phantom type ****)
+
+module Phantom : sig
+  type 'a t = int [@@deprecated_repr]
+  val z : 'a t
+end = struct
+  type 'a t = int
+  let z = 1
+end
+
+let x = Phantom.z
+[%%expect{|
+module Phantom : sig type 'a t = int val z : 'a t end
+val x : 'a Phantom.t = 1
+|}]
+let __ (x : int Phantom.t) = ()
+[%%expect{|
+Line 1, characters 7-26:
+1 | let __ (x : int Phantom.t) = ()
+           ^^^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : int -> unit = <fun>
+|}] (* bug: this shouldn't warn *)
+let __ () = (assert false : float Phantom.t)
+[%%expect{|
+Line 1, characters 12-44:
+1 | let __ () = (assert false : float Phantom.t)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : unit -> int = <fun>
+|}] (* bug: this shouldn't warn *)
+let __ (x : int Phantom.t) = (x : float Phantom.t)
+[%%expect{|
+Line 1, characters 7-26:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+           ^^^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 30-31:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+                                  ^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 30-31:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+                                  ^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 30-31:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+                                  ^
+Error: The value "x" has type "int Phantom.t" = "int"
+       but an expression was expected of type "float Phantom.t" = "int"
+       Type "int" is not compatible with type "float"
+|}, Principal{|
+Line 1, characters 7-26:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+           ^^^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 30-31:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+                                  ^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 1, characters 29-50:
+1 | let __ (x : int Phantom.t) = (x : float Phantom.t)
+                                 ^^^^^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+val __ : int -> int = <fun>
+|}] (* bug: apart from the noise from the previous bugs, the divergence between principal
+       and non-principal is weird. *)
+
+(* When user code has type errors, we probably don't want to emit random deprecation
+   warnings. *)
+
+let f (_ : M.t) (_ : _ Queue.t) = ()
+let () = f (Queue.create ()) M.zero
+
+[%%expect{|
+val f : M.t -> 'a Queue.t -> unit = <fun>
+Line 2, characters 11-28:
+2 | let () = f (Queue.create ()) M.zero
+               ^^^^^^^^^^^^^^^^^
+Alert deprecated: implicitly converting between a type and its deprecated representation
+
+Line 2, characters 11-28:
+2 | let () = f (Queue.create ()) M.zero
+               ^^^^^^^^^^^^^^^^^
+Error: This expression has type "'a Queue.t"
+       but an expression was expected of type "M.t" = "int"
+|}]
+(* bug: we should probably delay emitting the warnings until the surrounding structure
+   item or compilation unit types, or something. *)

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -62,7 +62,7 @@ let match_simple_printer_type env ty ~is_old_style =
   match
     Ctype.with_local_level_generalize begin fun () ->
       let ty_arg = Ctype.newvar() in
-      Ctype.unify env
+      Ctype.unify ~loc:Location.none env
         (make_printer_type ty_arg)
         (Ctype.instance ty);
       ty_arg
@@ -115,7 +115,7 @@ let match_generic_printer_type env ty =
           let ty_expected =
             List.fold_right type_arrow
               printer_args_ty (printer_type_new ty_target) in
-          Ctype.unify env
+          Ctype.unify ~loc:Location.none env
             ty_expected
             (Ctype.instance ty);
           args

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3379,18 +3379,19 @@ let unify_var uenv t1 t2 =
 let _ = unify_var' := unify_var
 
 (* the final versions of unification functions *)
-let unify_var env ty1 ty2 =
+let unify_var ~loc:_ env ty1 ty2 =
   unify_var (Expression {env; in_subst = false}) ty1 ty2
 
 let unify_pairs env ty1 ty2 pairs =
   with_univar_pairs pairs (fun () ->
     unify (Expression {env; in_subst = false}) ty1 ty2)
 
-let unify env ty1 ty2 =
+let unify ~loc:_ env ty1 ty2 =
   unify_pairs env ty1 ty2 []
 
 (* Lower the level of a type to the current level *)
-let enforce_current_level env ty = unify_var env (newvar ()) ty
+let enforce_current_level env ty =
+  unify_var ~loc:Location.none env (newvar ()) ty
 
 
 (**** Special cases of unification ****)
@@ -3584,7 +3585,7 @@ let add_dummy_method env ~scope sign =
   let _, ty, row =
     filter_method_row env dummy_method Private sign.csig_self_row
   in
-  unify env ty (new_scoped_ty scope (Ttuple []));
+  unify ~loc:Location.none env ty (new_scoped_ty scope (Ttuple []));
   sign.csig_self_row <- row
 
 type add_method_failure =
@@ -3617,7 +3618,7 @@ let add_method env label priv virt ty sign =
           | Concrete -> Concrete
           | Virtual -> virt
         in
-        match unify env ty ty' with
+        match unify ~loc:Location.none env ty ty' with
         | () -> priv, virt
         | exception Unify trace ->
             raise (Add_method_failed (Type_mismatch trace))
@@ -3630,7 +3631,7 @@ let add_method env label priv virt ty sign =
           | exception Filter_method_row_failed ->
               raise (Add_method_failed Unexpected_method)
         in
-        match unify env ty ty' with
+        match unify ~loc:Location.none env ty ty' with
         | () ->
             sign.csig_self_row <- row;
             priv, virt
@@ -3666,7 +3667,7 @@ let add_instance_variable ~strict env label mut virt ty sign =
         in
         if strict then begin
           check_mutability mut mut';
-          match unify env ty ty' with
+          match unify ~loc:Location.none env ty ty' with
           | () -> ()
           | exception Unify trace ->
               raise (Add_instance_variable_failed (Type_mismatch trace))
@@ -3687,7 +3688,7 @@ exception Inherit_class_signature_failed of inherit_class_signature_failure
 let unify_self_types env sign1 sign2 =
   let self_type1 = sign1.csig_self in
   let self_type2 = sign2.csig_self in
-  match unify env self_type1 self_type2 with
+  match unify ~loc:Location.none env self_type1 self_type2 with
   | () -> ()
   | exception Unify err -> begin
       match err.trace with
@@ -4079,7 +4080,7 @@ let moregen inst_nongen type_pairs env patt subj =
    Usually, the subject is given by the user, and the pattern
    is unimportant.  So, no need to propagate abbreviations.
 *)
-let moregeneral env inst_nongen pat_sch subj_sch =
+let moregeneral ?loc:(_ = Location.none) env inst_nongen pat_sch subj_sch =
   (* Moregen splits the generic level into two finer levels:
      [generic_level] and [subject_level = generic_level - 1].
      In order to properly detect and print weak variables when
@@ -4112,8 +4113,8 @@ let moregeneral env inst_nongen pat_sch subj_sch =
     | Error trace -> raise (Moregen (expand_to_moregen_error env trace))
   end
 
-let is_moregeneral env inst_nongen pat_sch subj_sch =
-  match moregeneral env inst_nongen pat_sch subj_sch with
+let is_moregeneral ?loc env inst_nongen pat_sch subj_sch =
+  match moregeneral ?loc env inst_nongen pat_sch subj_sch with
   | () -> true
   | exception Moregen _ -> false
 
@@ -4161,7 +4162,7 @@ let matches ~expand_error_trace env ty ty' =
   let snap = snapshot () in
   let vars = rigidify ty in
   cleanup_abbrev ();
-  match unify env ty ty' with
+  match unify ~loc:Location.none env ty ty' with
   | () ->
       if not (all_distinct_vars env vars) then begin
         backtrack snap;
@@ -4433,7 +4434,7 @@ let eqtype rename type_pairs subst env t1 t2 =
   eqtype_list_same_length rename type_pairs subst env [t1] [t2]
 
 (* Two modes: with or without renaming of variables *)
-let equal env rename tyl1 tyl2 =
+let equal ?loc:(_ = Location.none) env rename tyl1 tyl2 =
   if List.length tyl1 <> List.length tyl2 then
     raise_unexplained_for Equality;
   if List.for_all2 eq_type tyl1 tyl2 then () else
@@ -4442,8 +4443,8 @@ let equal env rename tyl1 tyl2 =
   with Equality_trace trace ->
     raise (Equality (expand_to_equality_error env trace !subst))
 
-let is_equal env rename tyl1 tyl2 =
-  match equal env rename tyl1 tyl2 with
+let is_equal ?loc env rename tyl1 tyl2 =
+  match equal ?loc env rename tyl1 tyl2 with
   | () -> true
   | exception Equality _ -> false
 
@@ -4848,7 +4849,8 @@ let rec build_subtype env (visited : transient_expr list)
           let nm =
             if c > Equiv || deep_occur ty ty1' then None else Some(p,tl1) in
           set_type_desc t'' (Tobject (ty1', ref nm));
-          (try unify_var env ty t with Unify _ -> assert false);
+          (try unify_var env ~loc:Location.none ty t
+           with Unify _ -> assert false);
           ( t'', Changed)
       | _ -> raise Not_found
       with Not_found ->
@@ -5109,7 +5111,8 @@ and subtype_package env trace lvl1 pack1 lvl2 pack2 cstrs =
     else begin
       (* need to check module subtyping *)
       let snap = Btype.snapshot () in
-      match List.iter (fun (_, t1, t2, _) -> unify env t1 t2) cstrs' with
+      match List.iter (fun (_, t1, t2, _) ->
+                unify ~loc:Location.none env t1 t2) cstrs' with
       | () when Result.is_ok (!package_subtype env pack1 pack2) ->
         Btype.backtrack snap; cstrs' @ cstrs
       | () | exception Unify _ ->
@@ -5222,7 +5225,7 @@ and subtype_row env trace row1 row2 cstrs =
   | _ ->
       raise Exit
 
-let subtype env ty1 ty2 =
+let subtype ?loc:_ env ty1 ty2 =
   TypePairs.clear subtypes;
   with_univar_pairs [] (fun () ->
     (* Build constraint set. *)
@@ -5719,7 +5722,7 @@ let rec collapse_conj env visited ty =
         (fun (_l,fi) ->
           match row_field_repr fi with
             Reither (_c, t1::(_::_ as tl), _m) ->
-              List.iter (unify env t1) tl
+              List.iter (unify ~loc:Location.none env t1) tl
           | _ ->
               ())
         (row_fields row);

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -902,7 +902,9 @@ let rec update_level env level expand ty =
         in
         begin try
           if not needs_expand then raise Cannot_expand;
-          let ty' = !forward_try_expand_safe env ty in
+          let ty' =
+            !forward_try_expand_safe ~through_deprecated_repr:false env ty
+          in
           link_type ty ty';
           update_level env level expand ty'
         with Cannot_expand ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1709,7 +1709,7 @@ let is_path_of_type_constr_with_deprecated_repr env path =
        when decl.type_private = Public
             || not (Btype.type_kind_is_abstract decl)
             || Btype.has_constr_row body ->
-     Builtin_attributes.has_deprecated_repr decl.type_attributes
+     Option.is_some (Builtin_attributes.has_deprecated_repr decl.type_attributes)
   | exception Not_found | _ -> false
 
 (* Expand the head of a type once.

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -24,6 +24,11 @@ open Errortrace
 
 open Local_store
 
+let with_env_loc ?loc f =
+  match loc with
+  | None -> f ()
+  | Some loc -> Misc.protect_refs [ R (Env.current_loc, loc) ] f
+
 (*
    General notes
    =============
@@ -793,7 +798,7 @@ let copy_spine ty =
   For_copy.with_scope (fun copy_scope -> copy_spine copy_scope ty)
 
 let forward_try_expand_safe = (* Forward declaration *)
-  ref (fun _env _ty -> assert false)
+  ref (fun ?through_deprecated_repr:_ _env _ty -> assert false)
 
 (*
    Lower the levels of a type (assume [level] is not
@@ -983,7 +988,9 @@ let rec lower_contravariant env var_level visited contra ty =
                   else lower_rec contra t)
               variance tyl in
           if maybe_expand then (* we expand cautiously to avoid missing cmis *)
-            match !forward_try_expand_safe env ty with
+            match !forward_try_expand_safe
+                    ~through_deprecated_repr:false env ty
+            with
             | ty -> lower_rec contra ty
             | exception Cannot_expand -> not_expanded ()
           else not_expanded ()
@@ -1696,18 +1703,31 @@ let safe_abbrev env ty =
       cleanup_abbrev ();
       false
 
+let is_path_of_type_constr_with_deprecated_repr env path =
+  match Env.find_type path env with
+  | { type_manifest = Some body; _ } as decl
+       when decl.type_private = Public
+            || not (Btype.type_kind_is_abstract decl)
+            || Btype.has_constr_row body ->
+     Builtin_attributes.has_deprecated_repr decl.type_attributes
+  | exception Not_found | _ -> false
+
 (* Expand the head of a type once.
    Raise Cannot_expand if the type cannot be expanded.
    May raise Escape, if a recursion was hidden in the type. *)
-let try_expand_once env ty =
+let try_expand_once ?(through_deprecated_repr = true) env ty =
   match get_desc ty with
-    Tconstr _ -> expand_abbrev env ty
+  | Tconstr (path, _, _) ->
+     if through_deprecated_repr
+        || not (is_path_of_type_constr_with_deprecated_repr env path)
+     then expand_abbrev env ty
+     else raise Cannot_expand
   | _ -> raise Cannot_expand
 
 (* This one only raises Cannot_expand *)
-let try_expand_safe env ty =
+let try_expand_safe ?through_deprecated_repr env ty =
   let snap = Btype.snapshot () in
-  try try_expand_once env ty
+  try try_expand_once ?through_deprecated_repr env ty
   with Escape _ ->
     Btype.backtrack snap; cleanup_abbrev (); raise Cannot_expand
 
@@ -1719,16 +1739,16 @@ let rec try_expand_head
   with Cannot_expand -> ty'
 
 (* Unsafe full expansion, may raise [Unify [Escape _]]. *)
-let expand_head_unif env ty =
+let expand_head_unif ?through_deprecated_repr env ty =
   try
-    try_expand_head try_expand_once env ty
+    try_expand_head (try_expand_once ?through_deprecated_repr) env ty
   with
   | Cannot_expand -> ty
   | Escape e -> raise_for Unify (Escape e)
 
 (* Safe version of expand_head, never fails *)
-let expand_head env ty =
-  try try_expand_head try_expand_safe env ty
+let expand_head ?through_deprecated_repr env ty =
+  try try_expand_head (try_expand_safe ?through_deprecated_repr) env ty
   with Cannot_expand -> ty
 
 let _ = forward_try_expand_safe := try_expand_safe
@@ -1806,7 +1826,8 @@ let expand_head_opt env ty =
 let full_expand ~may_forget_scope env ty =
   let ty =
     if may_forget_scope then
-      try expand_head_unif env ty with Unify_trace _ ->
+      try expand_head_unif ~through_deprecated_repr:true env ty
+      with Unify_trace _ ->
         (* #10277: forget scopes when printing trace *)
         with_level ~level:(get_level ty) begin fun () ->
           (* The same as [expand_head], except in the failing case we return the
@@ -2707,6 +2728,15 @@ let compare_package env unify_list lv1 pack1 lv2 pack2 =
       (!package_subtype env pack1 pack2)
       (fun () -> !package_subtype env pack2 pack1)
 
+let expand_delaying_deprecated_repr expand env ty1 ty2 =
+  let ty1' = expand ?through_deprecated_repr:(Some false) env ty1 in
+  let ty2' = expand ?through_deprecated_repr:(Some false) env ty2 in
+  match get_desc ty1', get_desc ty2' with
+  | Tconstr (p1, _, _), Tconstr (p2, _, _) when Path.same p1 p2 -> ty1', ty2'
+  | _ ->
+     expand ?through_deprecated_repr:(Some true) env ty1',
+     expand ?through_deprecated_repr:(Some true) env ty2'
+
 (* force unification in Reither when one side has a non-conjunctive type *)
 (* Code smell: this could also be put in unification_environment.
    Only modified by expand_head_rigid, but the corresponding unification
@@ -2833,10 +2863,10 @@ and unify2_expand uenv t1 t1' t2 t2' =
   (* Second step: expansion of abbreviations *)
   (* Expansion may change the representative of the types. *)
   let env = get_env uenv in
-  ignore (expand_head_unif env t1');
-  ignore (expand_head_unif env t2');
-  let t1' = expand_head_unif env t1' in
-  let t2' = expand_head_unif env t2' in
+  ignore (expand_delaying_deprecated_repr expand_head_unif env t1' t2');
+  let t1', t2' =
+    expand_delaying_deprecated_repr expand_head_unif env t1' t2'
+  in
   let lv = Int.min (get_level t1') (get_level t2') in
   let scope = Int.max (get_scope t1') (get_scope t2') in
   update_level_for Unify env lv t2;
@@ -2998,7 +3028,8 @@ and unify3 uenv t1 t1' t2 t2' =
           raise_for Unify (Obj (Abstract_row Second))
       | (Tconstr _,  Tnil ) ->
           raise_for Unify (Obj (Abstract_row First))
-      | (_, _) -> raise_unexplained_for Unify
+      | (_, _) ->
+          raise_unexplained_for Unify
       end;
       (* XXX Commentaires + changer "create_recursion"
          ||| Comments + change "create_recursion" *)
@@ -3006,7 +3037,9 @@ and unify3 uenv t1 t1' t2 t2' =
         match get_desc t2 with
           Tconstr (p, tl, abbrev) ->
             forget_abbrev abbrev p;
-            let t2'' = expand_head_unif (get_env uenv) t2 in
+            let t2'' =
+              expand_head_unif ~through_deprecated_repr:true (get_env uenv) t2
+            in
             if not (closed_parameterized_type tl t2'') then
               link_type t2 t2'
         | _ ->
@@ -3379,15 +3412,17 @@ let unify_var uenv t1 t2 =
 let _ = unify_var' := unify_var
 
 (* the final versions of unification functions *)
-let unify_var ~loc:_ env ty1 ty2 =
-  unify_var (Expression {env; in_subst = false}) ty1 ty2
+let unify_var ~loc env ty1 ty2 =
+  with_env_loc ~loc (fun () ->
+      unify_var (Expression {env; in_subst = false}) ty1 ty2)
 
 let unify_pairs env ty1 ty2 pairs =
   with_univar_pairs pairs (fun () ->
     unify (Expression {env; in_subst = false}) ty1 ty2)
 
-let unify ~loc:_ env ty1 ty2 =
-  unify_pairs env ty1 ty2 []
+let unify ~loc env ty1 ty2 =
+  with_env_loc ~loc (fun () ->
+      unify_pairs env ty1 ty2 [])
 
 (* Lower the level of a type to the current level *)
 let enforce_current_level env ty =
@@ -3398,7 +3433,7 @@ let enforce_current_level env ty =
 
 let expand_head_trace env t =
   let reset_tracing = check_trace_gadt_instances env in
-  let t = expand_head_unif env t in
+  let t = expand_head_unif ~through_deprecated_repr:true env t in
   reset_trace_gadt_instances reset_tracing;
   t
 
@@ -3849,8 +3884,7 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
         ()
     | _ ->
-        let t1' = expand_head env t1 in
-        let t2' = expand_head env t2 in
+        let t1', t2' = expand_delaying_deprecated_repr expand_head env t1 t2 in
         (* Expansion may have changed the representative of the types... *)
         if eq_type t1' t2' then () else
         if not (TypePairs.mem type_pairs (t1', t2')) then begin
@@ -4080,7 +4114,8 @@ let moregen inst_nongen type_pairs env patt subj =
    Usually, the subject is given by the user, and the pattern
    is unimportant.  So, no need to propagate abbreviations.
 *)
-let moregeneral ?loc:(_ = Location.none) env inst_nongen pat_sch subj_sch =
+let moregeneral ?loc env inst_nongen pat_sch subj_sch =
+  with_env_loc ?loc (fun () ->
   (* Moregen splits the generic level into two finer levels:
      [generic_level] and [subject_level = generic_level - 1].
      In order to properly detect and print weak variables when
@@ -4111,7 +4146,7 @@ let moregeneral ?loc:(_ = Location.none) env inst_nongen pat_sch subj_sch =
     end with
     | Ok () -> ()
     | Error trace -> raise (Moregen (expand_to_moregen_error env trace))
-  end
+  end)
 
 let is_moregeneral ?loc env inst_nongen pat_sch subj_sch =
   match moregeneral ?loc env inst_nongen pat_sch subj_sch with
@@ -4187,10 +4222,10 @@ let does_match env ty ty' =
                  (*  Equivalence between parameterized types  *)
                  (*********************************************)
 
-let expand_head_rigid env ty =
+let expand_head_rigid ?through_deprecated_repr env ty =
   let old = !rigid_variants in
   rigid_variants := true;
-  let ty' = expand_head env ty in
+  let ty' = expand_head ?through_deprecated_repr env ty in
   rigid_variants := old; ty'
 
 let eqtype_subst type_pairs subst t1 t2 =
@@ -4227,8 +4262,9 @@ let rec eqtype rename type_pairs subst env t1 t2 =
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
         ()
     | _ ->
-        let t1' = expand_head_rigid env t1 in
-        let t2' = expand_head_rigid env t2 in
+        let t1', t2' =
+          expand_delaying_deprecated_repr expand_head_rigid env t1 t2
+        in
         (* Expansion may have changed the representative of the types... *)
         if check_phys_eq t1' t2' then () else
         if not (TypePairs.mem type_pairs (t1', t2')) then begin
@@ -4434,26 +4470,27 @@ let eqtype rename type_pairs subst env t1 t2 =
   eqtype_list_same_length rename type_pairs subst env [t1] [t2]
 
 (* Two modes: with or without renaming of variables *)
-let equal ?loc:(_ = Location.none) env rename tyl1 tyl2 =
+let equal ?loc env rename tyl1 tyl2 =
+  with_env_loc ?loc (fun () ->
   if List.length tyl1 <> List.length tyl2 then
     raise_unexplained_for Equality;
   if List.for_all2 eq_type tyl1 tyl2 then () else
   let subst = ref [] in
   try eqtype_list_same_length rename (TypePairs.create 11) subst env tyl1 tyl2
   with Equality_trace trace ->
-    raise (Equality (expand_to_equality_error env trace !subst))
+    raise (Equality (expand_to_equality_error env trace !subst)))
 
 let is_equal ?loc env rename tyl1 tyl2 =
   match equal ?loc env rename tyl1 tyl2 with
   | () -> true
   | exception Equality _ -> false
 
-let rec equal_private env params1 ty1 params2 ty2 =
-  match equal env true (params1 @ [ty1]) (params2 @ [ty2]) with
+let rec equal_private ?loc env params1 ty1 params2 ty2 =
+  match equal ?loc env true (params1 @ [ty1]) (params2 @ [ty2]) with
   | () -> ()
   | exception (Equality _ as err) ->
       match try_expand_safe_opt env (expand_head env ty1) with
-      | ty1' -> equal_private env params1 ty1' params2 ty2
+      | ty1' -> equal_private ?loc env params1 ty1' params2 ty2
       | exception Cannot_expand -> raise err
 
                           (*************************)
@@ -5225,7 +5262,8 @@ and subtype_row env trace row1 row2 cstrs =
   | _ ->
       raise Exit
 
-let subtype ?loc:_ env ty1 ty2 =
+let subtype ?loc env ty1 ty2 =
+  with_env_loc ?loc (fun () ->
   TypePairs.clear subtypes;
   with_univar_pairs [] (fun () ->
     (* Build constraint set. *)
@@ -5242,7 +5280,7 @@ let subtype ?loc:_ env ty1 ty2 =
              ~env
              ~trace:trace0
              ~unification_trace:(List.tl trace))
-        (List.rev cstrs))
+        (List.rev cstrs)))
 
                               (*******************)
                               (*  Miscellaneous  *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -269,7 +269,7 @@ val extract_concrete_typedecl:
 
 val get_new_abstract_name : Env.t -> string -> string
 
-val unify: Env.t -> type_expr -> type_expr -> unit
+val unify: loc:Location.t -> Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
     Pattern_env.t -> pat:type_expr -> expected:type_expr -> Btype.TypePairs.t
@@ -280,7 +280,7 @@ val unify_gadt:
            Type variables in [ty1] are always assumed to be non-leaking
            (safely reifiable); if [penv.in_counterexample = true]
            then both [ty1] and [ty2] are assumed to be non-leaking. *)
-val unify_var: Env.t -> type_expr -> type_expr -> unit
+val unify_var: loc:Location.t -> Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)
 val filter_arrow: Env.t -> type_expr -> arg_label -> type_expr * type_expr
@@ -292,9 +292,9 @@ val filter_method: Env.t -> string -> type_expr -> type_expr
 val occur_in: Env.t -> type_expr -> type_expr -> bool
 val deep_occur: type_expr -> type_expr -> bool
 val deep_occur_list: type_expr -> type_expr list -> bool
-val moregeneral: Env.t -> bool -> type_expr -> type_expr -> unit
+val moregeneral: ?loc:Location.t -> Env.t -> bool -> type_expr -> type_expr -> unit
         (* Check if the first type scheme is more general than the second. *)
-val is_moregeneral: Env.t -> bool -> type_expr -> type_expr -> bool
+val is_moregeneral: ?loc:Location.t -> Env.t -> bool -> type_expr -> type_expr -> bool
 val rigidify: type_expr -> type_expr list
         (* "Rigidify" a type and return its type variable *)
 val all_distinct_vars: Env.t -> type_expr list -> bool
@@ -351,11 +351,11 @@ type class_match_failure =
 val match_class_types:
     ?trace:bool -> Env.t -> class_type -> class_type -> class_match_failure list
         (* Check if the first class type is more general than the second. *)
-val equal: Env.t -> bool -> type_expr list -> type_expr list -> unit
+val equal: ?loc:Location.t -> Env.t -> bool -> type_expr list -> type_expr list -> unit
         (* [equal env [x1...xn] tau [y1...yn] sigma]
            checks whether the parameterized types
            [/\x1.../\xn.tau] and [/\y1.../\yn.sigma] are equivalent. *)
-val is_equal : Env.t -> bool -> type_expr list -> type_expr list -> bool
+val is_equal : ?loc:Location.t -> Env.t -> bool -> type_expr list -> type_expr list -> bool
 val equal_private :
         Env.t -> type_expr list -> type_expr ->
         type_expr list -> type_expr -> unit
@@ -370,7 +370,7 @@ val match_class_declarations:
 
 val enlarge_type: Env.t -> type_expr -> type_expr * bool
         (* Make a type larger, flag is true if some pruning had to be done *)
-val subtype: Env.t -> type_expr -> type_expr -> unit -> unit
+val subtype: ?loc:Location.t -> Env.t -> type_expr -> type_expr -> unit -> unit
         (* [subtype env t1 t2] checks that [t1] is a subtype of [t2].
            It accumulates the constraints the type variables must
            enforce and returns a function that enforces this

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -234,7 +234,7 @@ val try_expand_once_opt: Env.t -> type_expr -> type_expr
 val try_expand_safe_opt: Env.t -> type_expr -> type_expr
 
 val expand_head_once: Env.t -> type_expr -> type_expr
-val expand_head: Env.t -> type_expr -> type_expr
+val expand_head: ?through_deprecated_repr:bool -> Env.t -> type_expr -> type_expr
 val expand_head_opt: Env.t -> type_expr -> type_expr
 (** The compiler's own version of [expand_head] necessary for type-based
     optimisations. *)
@@ -357,7 +357,7 @@ val equal: ?loc:Location.t -> Env.t -> bool -> type_expr list -> type_expr list 
            [/\x1.../\xn.tau] and [/\y1.../\yn.sigma] are equivalent. *)
 val is_equal : ?loc:Location.t -> Env.t -> bool -> type_expr list -> type_expr list -> bool
 val equal_private :
-        Env.t -> type_expr list -> type_expr ->
+        ?loc:Location.t -> Env.t -> type_expr list -> type_expr ->
         type_expr list -> type_expr -> unit
 (* [equal_private env t1 params1 t2 params2] checks that [t1::params1]
    equals [t2::params2] but it is allowed to expand [t1] if it is a

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1417,14 +1417,17 @@ let find_type_expansion path env =
   | Some body when decl.type_private = Public
               || not (Btype.type_kind_is_abstract decl)
               || Btype.has_constr_row body ->
-     if Builtin_attributes.has_deprecated_repr decl.type_attributes
-      && not (Location.is_none !current_loc)
-     then
-       Location.deprecated !current_loc
-         (if Location.is_none !current_loc
-          then Printexc.raw_backtrace_to_string (Printexc.get_callstack 100)
-          else "implicitly converting between a type and its deprecated \
-                representation");
+     (match Builtin_attributes.has_deprecated_repr decl.type_attributes with
+      | Some (`Debug debug) when debug || not (Location.is_none !current_loc) ->
+         Location.deprecated !current_loc
+           ((if debug
+             then Printexc.raw_backtrace_to_string (Printexc.get_callstack 100)
+             else "")
+            ^ (if Location.is_none !current_loc
+               then ""
+               else "implicitly converting between a type and its deprecated \
+                     representation"));
+      | _ -> ());
      (decl.type_params, body, decl.type_expansion_scope)
   (* The manifest type of Private abstract data types without
      private row are still considered unknown to the type system.

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1406,6 +1406,8 @@ let find_module path env =
 let find_module_lazy path env =
   find_module_lazy ~alias:false path env
 
+let current_loc = ref Location.none
+
 (* Find the manifest type associated to a type when appropriate:
    - the type should be public or should have a private row,
    - the type should have an associated manifest type. *)
@@ -1415,9 +1417,15 @@ let find_type_expansion path env =
   | Some body when decl.type_private = Public
               || not (Btype.type_kind_is_abstract decl)
               || Btype.has_constr_row body ->
-     (* if Builtin_attributes.has_deprecated_repr decl.type_attributes
-      * then raise Not_found; *)
-      (decl.type_params, body, decl.type_expansion_scope)
+     if Builtin_attributes.has_deprecated_repr decl.type_attributes
+      && not (Location.is_none !current_loc)
+     then
+       Location.deprecated !current_loc
+         (if Location.is_none !current_loc
+          then Printexc.raw_backtrace_to_string (Printexc.get_callstack 100)
+          else "implicitly converting between a type and its deprecated \
+                representation");
+     (decl.type_params, body, decl.type_expansion_scope)
   (* The manifest type of Private abstract data types without
      private row are still considered unknown to the type system.
      Hence, this case is caught by the following clause that also handles

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1415,6 +1415,8 @@ let find_type_expansion path env =
   | Some body when decl.type_private = Public
               || not (Btype.type_kind_is_abstract decl)
               || Btype.has_constr_row body ->
+     (* if Builtin_attributes.has_deprecated_repr decl.type_attributes
+      * then raise Not_found; *)
       (decl.type_params, body, decl.type_expansion_scope)
   (* The manifest type of Private abstract data types without
      private row are still considered unknown to the type system.

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -529,3 +529,4 @@ val scrape_alias: t -> module_type -> module_type
 val check_value_name: string -> Location.t -> unit
 
 val print_address : Format.formatter -> address -> unit
+val current_loc : Location.t ref

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -125,7 +125,7 @@ let is_unit env ty =
 let unifiable env ty1 ty2 =
   let snap = Btype.snapshot () in
   let res =
-    try Ctype.unify env ty1 ty2; true
+    try Ctype.unify ~loc:Location.none env ty1 ty2; true
     with Ctype.Unify _ -> false
   in
   Btype.backtrack snap;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -99,7 +99,9 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  match Ctype.moregeneral env true vd1.val_type vd2.val_type with
+  match
+    Ctype.moregeneral ~loc:vd2.val_loc env true vd1.val_type vd2.val_type
+  with
   | exception Ctype.Moregen err -> raise (Dont_match (Type err))
   | () -> value_descriptions_consistency env vd1 vd2
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -892,8 +892,14 @@ let private_object env fields1 params1 fields2 params2 =
     | () -> None
   end
 
-let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
-  let ty1' = Ctype.expand_head env ty1 and ty2' = Ctype.expand_head env ty2 in
+let type_manifest ~loc env ty1 params1 ty2 params2 priv2 kind2 =
+  let ty1' =
+    Ctype.expand_head ~through_deprecated_repr:false
+      env ty1
+  and ty2' =
+    Ctype.expand_head  ~through_deprecated_repr:false
+      env ty2
+  in
   match get_desc ty1', get_desc ty2' with
   | Tvariant row1, Tvariant row2
     when is_absrow env (row_more row2) -> begin
@@ -927,9 +933,9 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
       in
       match
         if is_private_abbrev_2 then
-          Ctype.equal_private env params1 ty1 params2 ty2
+          Ctype.equal_private ~loc env params1 ty1 params2 ty2
         else
-          Ctype.equal env true (params1 @ [ty1]) (params2 @ [ty2])
+          Ctype.equal ~loc env true (params1 @ [ty1]) (params2 @ [ty2])
       with
       | exception Ctype.Equality err -> Some (Manifest err)
       | () -> None
@@ -964,7 +970,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           | () -> None
         end
     | (Some ty1, Some ty2) ->
-         type_manifest env ty1 decl1.type_params ty2 decl2.type_params
+         type_manifest ~loc env ty1 decl1.type_params ty2 decl2.type_params
            decl2.type_private decl2.type_kind
     | (None, Some ty2) ->
         let ty1 =

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -748,7 +748,7 @@ let close_variant env row =
   if not closed || name != orig_name then begin
     let more' = if static then Btype.newgenty Tnil else Btype.newgenvar () in
     (* this unification cannot fail *)
-    Ctype.unify env more
+    Ctype.unify ~loc:Location.none env more
       (Btype.newgenty
          (Tvariant
             (create_row ~fields:[] ~more:more'

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -249,7 +249,7 @@ let inherit_class_type ~strict loc env sign1 cty2 =
   inherit_class_signature ~strict loc env sign1 sign2
 
 let unify_delayed_method_type loc env label ty expected_ty=
-  match Ctype.unify env ty expected_ty with
+  match Ctype.unify ~loc env ty expected_ty with
   | () -> ()
   | exception Ctype.Unify trace ->
       raise(Error(loc, env, Field_type_mismatch ("method", label, trace)))
@@ -260,7 +260,7 @@ let type_constraint val_env sty sty' loc =
   let cty' = transl_simple_type val_env ~closed:false sty' in
   let ty' = cty'.ctyp_type in
   begin
-    try Ctype.unify val_env ty ty' with Ctype.Unify err ->
+    try Ctype.unify ~loc val_env ty ty' with Ctype.Unify err ->
         raise(Error(loc, val_env, Unconsistent_constraint err));
   end;
   (cty, cty')
@@ -354,7 +354,7 @@ and class_signature virt env pcsig self_scope loc =
   let self_cty = transl_simple_type env ~closed:false sty in
   let self_type = self_cty.ctyp_type in
   begin try
-    Ctype.unify env self_type sign.csig_self
+    Ctype.unify ~loc:sty.ptyp_loc env self_type sign.csig_self
   with Ctype.Unify _ ->
     raise(Error(sty.ptyp_loc, env, Pattern_type_clash self_type))
   end;
@@ -404,7 +404,7 @@ and class_type_aux env virt self_scope scty =
           let cty' = transl_simple_type env ~closed:false sty in
           let ty' = cty'.ctyp_type in
           begin
-           try Ctype.unify env ty' ty with Ctype.Unify err ->
+           try Ctype.unify ~loc:sty.ptyp_loc env ty' ty with Ctype.Unify err ->
                   raise(Error(sty.ptyp_loc, env, Parameter_mismatch err))
             end;
             cty'
@@ -773,7 +773,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                match get_desc ty with
                | Tvar _ ->
                    let ty' = Ctype.newvar () in
-                   Ctype.unify val_env (Ctype.newty (Tpoly (ty', []))) ty;
+                   Ctype.unify ~loc val_env (Ctype.newty (Tpoly (ty', []))) ty;
                    type_approx val_env sbody ty'
                | Tpoly (ty1, tl) ->
                    let _, ty1' = Ctype.instance_poly ~fixed:false tl ty1 in
@@ -989,8 +989,10 @@ and class_structure cl_num virt self_scope final val_env met_env loc
   in
 
   (* Check that the binder has a correct type *)
-  begin try Ctype.unify val_env self_pat.pat_type sign.csig_self with
-    Ctype.Unify _ ->
+  begin
+    try
+      Ctype.unify ~loc:spat.ppat_loc val_env self_pat.pat_type sign.csig_self
+    with Ctype.Unify _ ->
       raise(Error(spat.ppat_loc, val_env,
         Pattern_type_clash self_pat.pat_type))
   end;
@@ -1084,8 +1086,9 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       List.iter2
         (fun cty' ty ->
           let ty' = cty'.ctyp_type in
-           try Ctype.unify val_env ty' ty with Ctype.Unify err ->
-             raise(Error(cty'.ctyp_loc, val_env, Parameter_mismatch err)))
+          try Ctype.unify ~loc:cty'.ctyp_loc val_env ty' ty
+          with Ctype.Unify err ->
+            raise(Error(cty'.ctyp_loc, val_env, Parameter_mismatch err)))
         tyl params;
       (* Check for unexpected virtual methods *)
       check_virtual_clty scl.pcl_loc val_env virt Class clty';
@@ -1573,16 +1576,16 @@ let class_infos define_class kind
   let constr = Ctype.newconstr (Path.Pident obj_id) obj_params in
   begin
     let row = Btype.self_type_row obj_type in
-    Ctype.unify env row (Ctype.newty Tnil);
+    Ctype.unify ~loc:Location.none env row (Ctype.newty Tnil);
     begin try
-      List.iter2 (Ctype.unify env) obj_params obj_params'
+      List.iter2 (Ctype.unify ~loc:cl.pci_loc env) obj_params obj_params'
     with Ctype.Unify _ ->
       raise(Error(cl.pci_loc, env,
             Bad_parameters (obj_id, obj_params, obj_params')))
     end;
     let ty = Btype.self_type obj_type in
     begin try
-      Ctype.unify env ty constr
+      Ctype.unify ~loc:cl.pci_loc env ty constr
     with Ctype.Unify _ ->
       raise(Error(cl.pci_loc, env,
         Abbrev_type_clash (constr, ty, Ctype.expand_head env constr)))
@@ -1596,13 +1599,13 @@ let class_infos define_class kind
     let (cl_params', cl_type) = Ctype.instance_class params typ in
     let ty = Btype.self_type cl_type in
     begin try
-      List.iter2 (Ctype.unify env) cl_params cl_params'
+      List.iter2 (Ctype.unify ~loc:cl.pci_loc env) cl_params cl_params'
     with Ctype.Unify _ ->
       raise(Error(cl.pci_loc, env,
             Bad_class_type_parameters (ty_id, cl_params, cl_params')))
     end;
     begin try
-      Ctype.unify env ty cl_ty
+      Ctype.unify ~loc:cl.pci_loc env ty cl_ty
     with Ctype.Unify _ ->
       let ty_expanded = Ctype.object_fields ty in
       raise(Error(cl.pci_loc, env, Abbrev_type_clash (ty, ty_expanded, cl_ty)))
@@ -1611,7 +1614,7 @@ let class_infos define_class kind
 
   (* Type of the class constructor *)
   begin try
-    Ctype.unify env
+    Ctype.unify ~loc:cl.pci_loc env
       (constructor_type constr obj_type)
       (Ctype.instance constr_type)
   with Ctype.Unify err ->
@@ -1810,7 +1813,8 @@ let check_coercions env { id; id_loc; clty; ty_id; cltydef; obj_id; obj_abbr;
             and obj_params, obj_ty =
               Ctype.instance_parameterized_type obj_abbr.type_params obj_ab
             in
-            List.iter2 (Ctype.unify env) cl_params obj_params;
+            List.iter2 (Ctype.unify ~loc:Location.none env)
+              cl_params obj_params;
             cl_ty, obj_ty
         | _ -> assert false
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -462,7 +462,7 @@ let unify_exp_types loc env ty expected_ty =
   (* Format.eprintf "@[%a@ %a@]@." Printtyp.raw_type_expr exp.exp_type
     Printtyp.raw_type_expr expected_ty; *)
   try
-    unify env ty expected_ty
+    unify ~loc env ty expected_ty
   with
     Unify err ->
       raise(Error(loc, env, Expr_type_clash(err, None, None)))
@@ -506,7 +506,7 @@ let (!!) (penv : Pattern_env.t) = penv.env
 (* If [penv] is available, calling this function requires
    [penv.in_counterexample = false] *)
 let unify_pat_types loc env ty ty' =
-  try unify env ty ty' with
+  try unify ~loc env ty ty' with
   | Unify err ->
       raise(Error(loc, env, Pattern_type_clash(err, None)))
   | Tags(l1,l2) ->
@@ -520,7 +520,7 @@ let unify_pat_types_return_equated_pairs ~refine loc penv ~pat ~expected =
   try
     if refine || penv.Pattern_env.in_counterexample
     then unify_gadt penv ~pat ~expected
-    else (unify !!penv pat expected; nothing_equated)
+    else (unify ~loc !!penv pat expected; nothing_equated)
   with
   | Unify err ->
       raise(Error(loc, !!penv, Pattern_type_clash(err, None)))
@@ -771,8 +771,8 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
             unify_vars rem1 rem2
           else begin
             begin try
-              unify_var env (newvar ()) t1;
-              unify env t1 t2
+              unify_var ~loc env (newvar ()) t1;
+              unify ~loc env t1 t2
             with
             | Unify err ->
                 raise(Error(loc, env, Or_pattern_type_clash(x1, err)))
@@ -2899,7 +2899,8 @@ let collect_unknown_apply_args env funct ty_fun0 rev_args sargs =
               then
                 Location.prerr_warning sarg.pexp_loc
                   Warnings.Ignored_extra_argument;
-              unify env ty_fun (newty (Tarrow(lbl,ty_arg,ty_res,commu_var ())));
+              unify ~loc:Location.none
+                env ty_fun (newty (Tarrow(lbl,ty_arg,ty_res,commu_var ())));
               (ty_arg, ty_res)
           | Tarrow (l, ty_arg, ty_res, _) when labels_match ~param:l ~arg:lbl ->
               (ty_arg, ty_res)
@@ -3279,7 +3280,7 @@ let type_approx_constraint env constraint_ ~loc ty_expected =
   match constraint_ with
   | Pconstraint constrain ->
       let ty_constrain = approx_type env constrain in
-      begin try unify env ty_constrain ty_expected with Unify err ->
+      begin try unify ~loc env ty_constrain ty_expected with Unify err ->
         raise (Error (loc, env, Expr_type_clash (err, None, None)))
       end;
       ty_constrain
@@ -3289,7 +3290,7 @@ let type_approx_constraint env constraint_ ~loc ty_expected =
         | Some sty -> approx_type env sty
       in
       let ty_coerce = approx_type env coerce in
-      begin try unify env ty_coerce ty_expected with Unify err ->
+      begin try unify ~loc env ty_coerce ty_expected with Unify err ->
         raise (Error (loc, env, Expr_type_clash (err, None, None)))
       end;
       ty_constrain
@@ -3329,7 +3330,7 @@ let rec type_approx env sexp ty_expected =
 and type_tuple_approx (env: Env.t) loc ty_expected l =
   let labeled_tys = List.map (fun (label, _) -> label, newvar ()) l in
   let ty = newty (Ttuple labeled_tys) in
-  begin try unify env ty ty_expected with Unify err ->
+  begin try unify ~loc env ty ty_expected with Unify err ->
     raise(Error(loc, env, Expr_type_clash (err, None, None)))
   end;
   List.iter2
@@ -3988,7 +3989,7 @@ and type_expect_
               | Tfunction_cases _ ->
                 newty (Tarrow (Nolabel, newvar (), newvar (), commu_ok)))
           in
-          try unify env ty_function exp_type
+          try unify ~loc env ty_function exp_type
           with Unify trace ->
             let syntactic_arity =
               List.length params +
@@ -4022,7 +4023,8 @@ and type_expect_
         if TypeSet.mem ty seen then () else
           match get_desc ty with
             Tarrow (_l, ty_arg, ty_fun, _com) ->
-              (try Ctype.unify_var env (newvar2 outer_level) ty_arg
+              (try Ctype.unify_var ~loc:Location.none
+                    env (newvar2 outer_level) ty_arg
                with Unify _ -> assert false);
               lower_args (TypeSet.add ty seen) ty_fun
           | _ -> ()
@@ -4507,7 +4509,7 @@ and type_expect_
             snd (instance_poly ~fixed:false tl ty)
         | Tvar _ ->
             let ty' = newvar () in
-            unify env (instance typ) (newty(Tpoly(ty',[])));
+            unify ~loc:Location.none env (instance typ) (newty(Tpoly(ty',[])));
             (* if not !Clflags.nolabels then
                Location.prerr_warning loc (Warnings.Unknown_method met); *)
             ty'
@@ -4768,7 +4770,7 @@ and type_expect_
               newty (Tarrow(Nolabel, ty_func, ty_result, commu_ok)), commu_ok))
           in
           begin try
-            unify env op_type ty_op
+            unify ~loc:let_loc env op_type ty_op
           with Unify err ->
             raise(Error(let_loc, env, Letop_type_clash(slet.pbop_op.txt, err)))
           end;
@@ -4875,7 +4877,7 @@ and type_expect_
         end ~before_generalize: begin fun (newenv, _si, exp) ->
           (* Ensure that local definitions do not leak. *)
           (* Required for implicit unpack *)
-          unify_var newenv tv exp.exp_type
+          unify_var ~loc newenv tv exp.exp_type
         end
       in
       re {
@@ -4942,12 +4944,12 @@ and type_coerce
             let snap = snapshot () in
             let ty, _b = enlarge_type env (generic_instance ty') in
             try
-              force (); Ctype.unify env arg_type ty; true
+              force (); Ctype.unify ~loc:Location.none env arg_type ty; true
             with Unify _ ->
               backtrack snap; false
           then ()
           else begin try
-            let force' = subtype env arg_type (generic_instance ty') in
+            let force' = subtype ~loc env arg_type (generic_instance ty') in
             force (); force' ();
             if not gen && !Clflags.principal then
               Location.prerr_warning loc
@@ -4959,7 +4961,7 @@ and type_coerce
       | _ ->
           let ty, b = enlarge_type env (generic_instance ty') in
           force ();
-          begin try Ctype.unify env arg_type ty with Unify err ->
+          begin try Ctype.unify ~loc:loc_arg env arg_type ty with Unify err ->
             let expanded = full_expand ~may_forget_scope:true env ty' in
             raise(Error(loc_arg, env,
                         Coercion_failure ({ ty = ty'; expanded }, err, b)))
@@ -4979,7 +4981,7 @@ and type_coerce
       in
       begin try
         let force'' =
-          subtype env (generic_instance ty) (generic_instance ty')
+          subtype ~loc env (generic_instance ty) (generic_instance ty')
         in
         force (); force' (); force'' ()
       with Subtype err ->
@@ -5122,7 +5124,7 @@ and split_function_ty env ty_expected ~arg_label ~first ~in_function =
       if is_optional arg_label then
         let tv = newvar () in
         begin
-          try unify env ty_arg (type_option tv)
+          try unify ~loc:Location.none env ty_arg (type_option tv)
           with Unify _ -> assert false
         end;
         type_option tv
@@ -5195,7 +5197,7 @@ and type_function
             assert (is_optional arg_label);
             let ty_default = newvar () in
             begin
-              try unify env (type_option ty_default) ty_arg
+              try unify ~loc:Location.none env (type_option ty_default) ty_arg
               with Unify _ -> assert false;
             end;
             (* Issue#12668: Retain type-directed disambiguation of
@@ -5648,7 +5650,7 @@ and type_label_exp create env loc ty_expected
               (fun () -> instance_label ~fixed:true label)
           in
           begin try
-            unify env (instance ty_res) (instance ty_expected)
+            unify ~loc:lid.loc env (instance ty_res) (instance ty_expected)
           with Unify err ->
             raise (Error(lid.loc, env, Label_mismatch(lid.txt, err)))
           end;
@@ -6646,7 +6648,7 @@ and type_andops env sarg sands expected_ty =
             let ty_op =
               newty (Tarrow(Nolabel, ty_rest, ty_rest_fun, commu_ok)) in
             begin try
-              unify env op_type ty_op
+              unify ~loc:sop.loc env op_type ty_op
             with Unify err ->
               raise(Error(sop.loc, env, Andop_type_clash(sop.txt, err)))
             end;
@@ -6656,7 +6658,7 @@ and type_andops env sarg sands expected_ty =
         let let_arg, rest = loop env let_sarg rest ty_rest in
         let exp = type_expect env sexp (mk_expected ty_arg) in
         begin try
-          unify env (instance ty_result) (instance expected_ty)
+          unify ~loc env (instance ty_result) (instance expected_ty)
         with Unify err ->
           raise(Error(loc, env, Bindings_type_clash(err)))
         end;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2781,7 +2781,7 @@ let is_prim ~name funct =
 
 (* List labels in a function type, and whether return type is a variable *)
 let rec list_labels_aux env visited ls ty_fun =
-  let ty = expand_head env ty_fun in
+  let ty = expand_head ~through_deprecated_repr:false env ty_fun in
   if TypeSet.mem ty visited then
     List.rev ls, false
   else match get_desc ty with
@@ -3455,7 +3455,10 @@ let check_statement exp =
 let check_partial_application ~statement exp =
   let check_statement () = if statement then check_statement exp in
   let doit () =
-    let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
+    let ty =
+      get_desc
+        (expand_head ~through_deprecated_repr:false exp.exp_env exp.exp_type)
+    in
     match ty with
     | Tarrow _ ->
         let rec check {exp_desc; exp_loc; exp_extra; _} =
@@ -3494,7 +3497,10 @@ let check_partial_application ~statement exp =
     | _ ->
         check_statement ()
   in
-  let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
+  let ty =
+    get_desc
+      (expand_head ~through_deprecated_repr:false exp.exp_env exp.exp_type)
+  in
   match ty with
   | Tvar _ ->
       (* The type of [exp] is not known. Delay the check until after
@@ -4019,7 +4025,7 @@ and type_expect_
       assert (sargs <> []);
       let outer_level = get_current_level () in
       let rec lower_args seen ty_fun =
-        let ty = expand_head env ty_fun in
+        let ty = expand_head ~through_deprecated_repr:false env ty_fun in
         if TypeSet.mem ty seen then () else
           match get_desc ty with
             Tarrow (_l, ty_arg, ty_fun, _com) ->
@@ -5681,7 +5687,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
   let may_coerce =
     if not (is_inferred sarg) then None else
     let work () =
-      let te = expand_head env ty_expected' in
+      let te = expand_head ~through_deprecated_repr:false env ty_expected' in
       match get_desc te with
         Tarrow(Nolabel,_,ty_res0,_) ->
           Some (no_labels ty_res0, get_level te)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -501,7 +501,7 @@ let transl_declaration env sdecl (id, uid) =
       (fun (cty, cty', loc) ->
         let ty = cty.ctyp_type in
         let ty' = cty'.ctyp_type in
-        try Ctype.unify env ty ty' with Ctype.Unify err ->
+        try Ctype.unify ~loc env ty ty' with Ctype.Unify err ->
           raise(Error(loc, Inconsistent_constraint (env, err))))
       cstrs;
   (* Add abstract row *)
@@ -975,7 +975,7 @@ let check_regularity ~abs_env env loc path decl to_check =
               let (params, body) =
                 Ctype.instance_parameterized_type params0 body0 in
               begin
-                try List.iter2 (Ctype.unify abs_env) args' params
+                try List.iter2 (Ctype.unify ~loc abs_env) args' params
                 with Ctype.Unify err ->
                   raise (Error(loc, Constraint_failed (abs_env, err)));
               end;
@@ -1087,7 +1087,7 @@ let update_type temp_env env id loc =
          but generalize again after unification. *)
       Ctype.with_local_level_generalize begin fun () ->
         let params = List.map (fun _ -> Ctype.newvar ()) decl.type_params in
-        try Ctype.unify env (Ctype.newconstr path params) ty
+        try Ctype.unify ~loc env (Ctype.newconstr path params) ty
         with Ctype.Unify err ->
           raise (Error(loc, Type_clash (env, err)))
       end
@@ -1287,7 +1287,7 @@ let transl_extension_constructor ~scope env type_path type_params
         in
         begin
           try
-            Ctype.unify env cstr_res res
+            Ctype.unify ~loc:lid.loc env cstr_res res
           with Ctype.Unify err ->
             raise (Error(lid.loc,
                      Rebind_wrong_type(lid.txt, env, err)))
@@ -1343,7 +1343,8 @@ let transl_extension_constructor ~scope env type_path type_params
               in
               let decl = Ctype.instance_declaration decl in
               assert (List.length decl.type_params = List.length tl);
-              List.iter2 (Ctype.unify env) decl.type_params tl;
+              List.iter2 (Ctype.unify ~loc:Location.none env)
+                decl.type_params tl;
               let lbls =
                 match decl.type_kind with
                 | Type_record (lbls, Record_extension _) -> lbls
@@ -1445,7 +1446,7 @@ let transl_type_extension extend env loc styext =
       TyVarEnv.reset();
       let ttype_params = make_params env styext.ptyext_params in
       let type_params = List.map (fun (cty, _) -> cty.ctyp_type) ttype_params in
-      List.iter2 (Ctype.unify_var env)
+      List.iter2 (Ctype.unify_var ~loc:Location.none env)
         (Ctype.instance_list type_decl.type_params)
         type_params;
       let constructors =
@@ -1752,7 +1753,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let arity_ok = arity = sig_decl.type_arity in
   if arity_ok then
     List.iter2 (fun (cty, _) tparam ->
-      try Ctype.unify_var env cty.ctyp_type tparam
+      try Ctype.unify_var ~loc:cty.ctyp_loc env cty.ctyp_type tparam
       with Ctype.Unify err ->
         raise(Error(cty.ctyp_loc, Inconsistent_constraint (env, err)))
     ) tparams sig_decl.type_params;
@@ -1760,7 +1761,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     (* Note: constraints must also be enforced in [sig_env] because
        they may contain parameter variables from [tparams]
        that have now be unified in [sig_env]. *)
-    try Ctype.unify env cty.ctyp_type cty'.ctyp_type
+    try Ctype.unify ~loc env cty.ctyp_type cty'.ctyp_type
     with Ctype.Unify err ->
       raise(Error(loc, Inconsistent_constraint (env, err)))
   ) constraints;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3128,7 +3128,7 @@ let type_package env m pack =
   in
   List.iter
     (fun (n, ty) ->
-      try Ctype.unify env ty (Ctype.newvar ())
+      try Ctype.unify ~loc:modl.mod_loc env ty (Ctype.newvar ())
       with Ctype.Unify _ ->
         let lid = Longident.unflatten n |> Option.get in
         raise (Error(modl.mod_loc, env, Scoping_pack (lid,ty))))

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -590,7 +590,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
           (* Check for tag conflicts *)
           if l <> l' then raise(Error(styp.ptyp_loc, env, Variant_tags(l, l')));
           let ty = mkfield l f and ty' = mkfield l f' in
-          if is_equal env false [ty] [ty'] then () else
+          if is_equal ~loc env false [ty] [ty'] then () else
           try unify ~loc env ty ty'
           with Unify _trace ->
             raise(Error(loc, env, Constructor_mismatch (ty,ty')))

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -330,7 +330,7 @@ end = struct
         if flavor = Unification || is_in_scope name then
           let v = new_global_var () in
           let snap = Btype.snapshot () in
-          if try unify env v ty; true
+          if try unify ~loc env v ty; true
             with
                 Unify err when is_in_scope name ->
                   raise (Error(loc, env, Type_mismatch err))
@@ -352,7 +352,7 @@ end = struct
     fun () ->
       List.iter
         (function (loc, t1, t2) ->
-          try unify env t1 t2 with Unify err ->
+          try unify ~loc env t1 t2 with Unify err ->
             raise (Error(loc, env, Type_mismatch err)))
         !r
 end
@@ -495,7 +495,8 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       in
       List.iter2
         (fun (sty, cty) ty' ->
-           try unify_param env ty' cty.ctyp_type with Unify err ->
+           try unify_param ~loc:sty.ptyp_loc env ty' cty.ctyp_type
+           with Unify err ->
              let err = Errortrace.swap_unification_error err in
              raise (Error(sty.ptyp_loc, env, Type_mismatch err))
         )
@@ -520,7 +521,8 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let (params, body) = instance_parameterized_type decl.type_params body in
       List.iter2
         (fun (sty, cty) ty' ->
-           try unify_var env ty' cty.ctyp_type with Unify err ->
+           try unify_var ~loc:sty.ptyp_loc env ty' cty.ctyp_type
+           with Unify err ->
              let err = Errortrace.swap_unification_error err in
              raise (Error(sty.ptyp_loc, env, Type_mismatch err))
         )
@@ -542,9 +544,11 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
           check_tyvar_name env alias.loc alias.txt;
           let t = TyVarEnv.lookup_local ~row_context alias.txt in
           let ty = transl_type env ~policy ~aliased:true ~row_context st in
-          begin try unify_var env t ty.ctyp_type with Unify err ->
-            let err = Errortrace.swap_unification_error err in
-            raise(Error(alias.loc, env, Alias_type_mismatch err))
+          begin
+            try unify_var ~loc:alias.loc env t ty.ctyp_type
+            with Unify err ->
+              let err = Errortrace.swap_unification_error err in
+              raise(Error(alias.loc, env, Alias_type_mismatch err))
           end;
           ty
         with Not_found ->
@@ -554,9 +558,11 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
               (* Use the whole location, which is used by [Type_mismatch]. *)
               TyVarEnv.remember_used ~check:alias.loc alias.txt t styp.ptyp_loc;
               let ty = transl_type env ~policy ~row_context st in
-              begin try unify_var env t ty.ctyp_type with Unify err ->
-                let err = Errortrace.swap_unification_error err in
-                raise(Error(alias.loc, env, Alias_type_mismatch err))
+              begin
+                try unify_var ~loc:alias.loc env t ty.ctyp_type
+                with Unify err ->
+                  let err = Errortrace.swap_unification_error err in
+                  raise(Error(alias.loc, env, Alias_type_mismatch err))
               end;
               (t, ty)
             end
@@ -585,7 +591,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
           if l <> l' then raise(Error(styp.ptyp_loc, env, Variant_tags(l, l')));
           let ty = mkfield l f and ty' = mkfield l f' in
           if is_equal env false [ty] [ty'] then () else
-          try unify env ty ty'
+          try unify ~loc env ty ty'
           with Unify _trace ->
             raise(Error(loc, env, Constructor_mismatch (ty,ty')))
         with Not_found ->
@@ -686,7 +692,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let ty_list = TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars in
       let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
       let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
-      unify_var env (newvar()) ty';
+      unify_var ~loc:Location.none env (newvar()) ty';
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package ptyp ->
       let path, mty, ptys = transl_package env ~policy ~row_context ptyp in
@@ -716,7 +722,7 @@ and transl_fields env ~policy ~row_context o fields =
     try
       let ty' = Hashtbl.find hfields l in
       if is_equal env false [ty] [ty'] then () else
-        try unify env ty ty'
+        try unify ~loc env ty ty'
         with Unify _trace ->
           raise(Error(loc, env, Method_mismatch (l, ty, ty')))
     with Not_found ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -122,7 +122,7 @@ type t =
    do NOT reuse one of the holes.
 *)
 
-type alert = {kind:string; message:string; def:loc; use:loc}
+type alert = {kind:string; message:string; sublocs : (loc * string) list }
 
 let number = function
   | Comment_start -> 1
@@ -755,7 +755,6 @@ let letter_alert tokens =
   match consecutive_letters with
   | [] -> None
   | example :: _  ->
-      let nowhere = ghost_loc_in_file "_none_" in
       let spelling_hint ppf =
         let max_seq_len =
           List.fold_left (fun l x -> Int.max l (List.length x))
@@ -782,7 +781,7 @@ let letter_alert tokens =
       in
       Some {
         kind="ocaml_deprecated_cli";
-        use=nowhere; def=nowhere;
+        sublocs = [];
         message
       }
 
@@ -1307,13 +1306,7 @@ let report_alert (alert : alert) =
              testsuite
        *)
       let sub_locs =
-        if not alert.def.loc_ghost && not alert.use.loc_ghost then
-          [
-            alert.def, msg "Definition";
-            alert.use, msg "Expected signature";
-          ]
-        else
-          []
+        List.map (fun (loc, name) -> loc, msg "%s" name) alert.sublocs
       in
       `Active
         {

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -123,7 +123,7 @@ type t =
   | Degraded_to_partial_match               (* 74 *)
   | Unnecessarily_partial_tuple_pattern     (* 75 *)
 
-type alert = {kind:string; message:string; def:loc; use:loc}
+type alert = {kind:string; message:string; sublocs : (loc * string) list}
 
 val parse_options : bool -> string -> alert option
 


### PR DESCRIPTION
Hi,

I propose a new form of deprecation warning, intended to make it easier to nicely turn a concrete type into an abstract type. Concretely, given for instance:

```ocaml
type t = string
val open_ : t -> in_channel
```

the module author may want instead:

```ocaml
type t
val from_string : string -> t
(* ... and maybe more functions to create `t`s *)
val open_ : t -> in_channel
```

but going from one api to the other would break things without warning, if the author can't update all callers. Obviously, the author can document "this is deprecated" and wait, but as we've seen with the introduction of the "deprecated" warning a while ago, a compiler warning is much more effective.

So what I'm proposing is this intermediate step:

```ocaml
type t = string [@@deprecated_repr]
val from_string : string -> t
(* ... maybe more functions for create `t`s *)
val open_ : t -> in_channel
```

which would trigger warnings in the callers that rely on the knowledge that `t` is `string`, but not in callers that treat `t` opaquely like in `open_ (from_string "a")`. After waiting a bit, the author could then remove the `= string [@@deprecated_repr]`, and either expose a new concrete representation or leave the type abstract.

An example where this sort of transition could make sense is the `Digest` module.  This also works if the type `t` doesn't exist, i.e., given:

```ocaml
val open_ : string -> in_channel
```

you could switch to:

```ocaml
type t = string [@@deprecated_repr]
val open_ : t -> in_channel
```

Implementation-wise, the change is actually not very complicated. Taking unification as an example, the compiler implements unification along these lines: "if either type is a variable, occur check and unify the variable to the type, otherwise expand head type constructors recursively then unify by analyzing all cases". So given `type t = int [@@deprecated_repr] type u = t`, the trunk compiler unifies `t` and `u` by expanding them both to int, and then int unifies with int. With the current change, unifying `t` and `u` expands them both only to `t`, and `t` unifies with `t`, thus no type error and no warning. Whereas unifying `int` and `u` expands them both to `int`, thus no type error, BUT to expand `u` to `int`, the typer had to expand `t` to `int`, and that triggers the warning, since that's exactly what won't be possible once `t` is opaque.

This is one reason I consider this change to be in a draft state: someone that knows more about the typer might be able to poke holes in the implementation. Or e.g. the expansion change probably changes typing a bit in unimportant ways: I suspect that given `type _ t = string`, `int t` and `string t` unify but not anymore if the type is marked as `[@@deprecated_repr]`. I think that would be fine, it just needs to be documented.

I also think there is more risk than usual to have spammy warnings, so I think this should be a new warning, so it can be specifically disabled if something goes awry. Before working on this kind of polish, I'd like to know if compiler devs agree on the big picture first.

An alternative implementation would be to forget about emitting warnings entirely. Instead `type t = string [@@deprecated_repr]` could be treated as `type t` when a command line flag is passed. Implementation wise, this would touch less of the typer, and maybe be good enough considering dune treats warnings as errors in the dev profile anyway. But errors would surface as errors with no good way to tell the users that a `@@deprecated_repr` is involved (since the typer currently over-expands type constructors, which is what the modifications described above address).

Finally, I tried some real examples. I backported the change to 5.3, put some `[@@deprecated_repr]` on some Cmdliner types, built a few libraries with limited dependencies, and I observed no real issue but got notified in what looked like exactly the expected places (with some sucky errors messages, which are another thing that would need to be improved):

```
# dune-release

File "bin/help.ml", line 252, characters 20-77:
252 |       let conv, _ = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error (alert deprecated): implicitly converting between a type and its deprecated representation

# ocp-indent

File "src/indentArgs.ml", line 48, characters 25-41:
48 |     Arg.(value & opt_all config_converter []
                              ^^^^^^^^^^^^^^^^
Alert deprecated: implicitly converting between a type and its deprecated representation

File "src/indentArgs.ml", line 89, characters 21-36:
89 |     Arg.(value & opt range_converter (None,None)
                          ^^^^^^^^^^^^^^^
Alert deprecated: implicitly converting between a type and its deprecated representation
```

and more such examples in ocp-index and mirage-dns.

In fact, the warnings were more useful than I expected. My expectation was that warnings would be noisy because if two types are treated interchangeably, there might be a lot of back and forth between a type constructor and its representation, and so I thought I'd need to silence all but the first warning. But at least in this case, of the 14 warnings I saw, every single one pointed to a call site that needed to be tweaked.
