### PR TITLE
Debugger inverts BUILD_PATH_PREFIX_MAP before loading paths stored in cm?

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,9 +133,6 @@ Working version
 
 ### Tools:
 
-- #12139: BUILD_PATH_PREFIX_MAP rewriting in debug-event locations.
-  (Richard L. Ford, review by Gabriel Scherer)
-
 * #13638: ocamlmklib exits with code 4 if passed an unrecognised option, as it
   does with an unrecognised file.
   (David Allsopp, review by Antonin Décimo and Sébastien Hinderer)

--- a/Changes
+++ b/Changes
@@ -133,6 +133,10 @@ Working version
 
 ### Tools:
 
+- #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup
+  by the debugger.
+  (Pierre Boutillier, review by Gabriel Scherer and Daniel Bünzli)
+
 * #13638: ocamlmklib exits with code 4 if passed an unrecognised option, as it
   does with an unrecognised file.
   (David Allsopp, review by Antonin Décimo and Sébastien Hinderer)

--- a/utils/build_path_prefix_map.ml
+++ b/utils/build_path_prefix_map.ml
@@ -116,3 +116,14 @@ let rewrite prefix_map path =
   match rewrite_first prefix_map path with
   | None -> path
   | Some path -> path
+
+let make_source path : pair option -> path option = function
+  | None -> None
+  | Some { target; source } ->
+    if String.starts_with ~prefix:target path then
+      Some (source ^ (String.sub path (String.length target)
+                        (String.length path - String.length target)))
+    else None
+
+let invert_all prefix_map path =
+  List.filter_map (make_source path) (List.rev prefix_map)

--- a/utils/build_path_prefix_map.mli
+++ b/utils/build_path_prefix_map.mli
@@ -59,3 +59,10 @@ val rewrite : map -> path -> path
 (** [rewrite path] uses [rewrite_first] to try to find a
     mapping for path. If found, it returns that, otherwise
     it just returns [path]. *)
+
+val invert_all : map -> path -> path list
+(** [invert_all map path] finds all targets in [map] that are a prefix
+    of the input [path]. For each matching target, in priority order,
+    it replaces this prefix with the corresponding source and adds the
+    result to the returned list. If there are no matches, it just
+    returns [[]]. *)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1138,6 +1138,14 @@ let get_build_path_prefix_map =
     end;
     !map_cache
 
+let invert_build_path_prefix_map path =
+  match get_build_path_prefix_map () with
+  | None -> [path]
+  | Some prefix_map ->
+    match Build_path_prefix_map.invert_all prefix_map path with
+    | [] -> [path]
+    | matches -> matches
+
 let debug_prefix_map_flags () =
   if not Config.as_has_debug_prefix_map then
     []

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -607,6 +607,11 @@ val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
 (** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
     variable. *)
 
+val invert_build_path_prefix_map: string -> string list
+(** Returns the potential paths (in priority order) from which the
+    given path can originate from before rewrite using
+    [BUILD_PATH_PREFIX_MAP] environment variable. *)
+
 val debug_prefix_map_flags: unit -> string list
 (** Returns the list of [--debug-prefix-map] flags to be passed to the
     assembler, built from the [BUILD_PATH_PREFIX_MAP] environment variable. *)


### PR DESCRIPTION
The whole purpose of `BUILD_PATH_PREFIX_MAP` is to be able to rewrite prefixes of absolute paths written into compilation unit. `ocamldebug` reads these paths. But, when it is launched in the folder where the sources have been compiled, theses prefixes don't make sense. This is why `ocamldebug` currently fails to find any information (sources/printers/...) about programs compiled by `dune`.

This patch makes the hypothesis that when it launched while `BUILD_PATH_PREFIX_MAP` is set, it means that it is launched from the repository in which sources have been built using this value for the environment variable. Therefore, it "inverts" it to find files on disk.

This restores the usability of ` ocamldebug` in "the setting it used to work" before dune 3.0.