### PR TITLE
Fix flaky TSan tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,6 +75,9 @@ Working version
   leaking file descriptors, code style.
   (Antonin Décimo, review by Gabriel Scherer)
 
+- #14059: Fix flaky TSan tests
+  (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer)
+
 - #13966, #13969: Enable "generalized polymorphic #install_printer"
   in the debugger
   (Pierre Boutillier and Gabriel Scherer, review by Florian Angeletti)

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -5,11 +5,10 @@ Entering i
 Calling print_and_raise...
 Hello from print_and_raise
 Caught Failure "test"
-Raised by primitive operation at Exn_from_c.i in file "exn_from_c.ml", line 28, characters 2-20
-Called from Exn_from_c.h in file "exn_from_c.ml", line 33, characters 2-6
-Called from Exn_from_c.g in file "exn_from_c.ml", line 38, characters 2-6
-Called from Exn_from_c.f in file "exn_from_c.ml", line 43, characters 7-11
-Leaving f
+Raised by primitive operation at Exn_from_c.i in file "exn_from_c.ml", line 38, characters 2-20
+Called from Exn_from_c.h in file "exn_from_c.ml", line 43, characters 2-6
+Called from Exn_from_c.g in file "exn_from_c.ml", line 48, characters 2-6
+Called from Exn_from_c.f in file "exn_from_c.ml", line 53, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
@@ -50,4 +49,5 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c$writer_<implemspecific>
 ==================
+Leaving f
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -6,9 +6,8 @@ Entering h
 Entering i
 Throwing ExnB...
 Caught an ExnB
-Raised by primitive operation at Exn_in_callback.g in file "exn_in_callback.ml", line 43, characters 2-27
-Called from Exn_in_callback.f in file "exn_in_callback.ml", line 49, characters 7-11
-Leaving f
+Raised by primitive operation at Exn_in_callback.g in file "exn_in_callback.ml", line 46, characters 2-27
+Called from Exn_in_callback.f in file "exn_in_callback.ml", line 52, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
@@ -49,4 +48,5 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_in_callback$writer_<implemspecific>
 ==================
+Leaving f
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -4,11 +4,10 @@ Entering h
 Entering i
 Throwing ExnA...
 Caught an ExnA
-Raised at Exn_reraise.i in file "exn_reraise.ml", line 28, characters 9-21
-Called from Exn_reraise.h in file "exn_reraise.ml", line 33, characters 6-10
-Called from Exn_reraise.g in file "exn_reraise.ml", line 39, characters 2-6
-Called from Exn_reraise.f in file "exn_reraise.ml", line 44, characters 7-11
-Leaving f
+Raised at Exn_reraise.i in file "exn_reraise.ml", line 31, characters 9-21
+Called from Exn_reraise.h in file "exn_reraise.ml", line 36, characters 6-10
+Called from Exn_reraise.g in file "exn_reraise.ml", line 42, characters 2-6
+Called from Exn_reraise.f in file "exn_reraise.ml", line 47, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
@@ -49,4 +48,5 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_reraise$writer_<implemspecific>
 ==================
+Leaving f
 ThreadSanitizer: reported 1 warnings


### PR DESCRIPTION
(joint with @fabbing)

The first commit makes TSan tests more deterministic which removes flakiness issues.

~~The second commit de-instruments initializing writes for strings and bytes.~~