### PR TITLE
Debugger: Fallback to looking for module_name.ml in the loadpath when seeking source files

### DIFF
--- a/Changes
+++ b/Changes
@@ -79,6 +79,11 @@ Working version
   in the debugger
   (Pierre Boutillier and Gabriel Scherer, review by Florian Angeletti)
 
+- #14063 : Debugger fallbacks to "looking for 'module_name'.ml in the
+  loadpath" when seeking source files. It improves hit rate for
+  sources of installed packages.
+  (Pierre Boutillier, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 * #13975: documented the `[@remove_aliases]` built-in attribute for signatures

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -41,8 +41,7 @@ let source_of_module pos mdle =
           acc)
       Debugger_config.load_path_for
       (Load_path.get_path_list ()) in
-  let fname = pos.Lexing.pos_fname in
-  if fname = "" then
+  if pos_fname = "" then
     let innermost_module =
       try
         let dot_index = String.rindex mdle '.' in
@@ -55,8 +54,8 @@ let source_of_module pos mdle =
           try find_in_path_normalized path (innermost_module ^ ext)
           with Not_found -> loop exts
     in loop source_extensions
-  else if Filename.is_relative fname then
-    find_in_path_rel path fname
+  else if Filename.is_relative pos_fname then
+    find_in_path_rel path pos_fname
   else raise Not_found
 
 (*** Buffer cache ***)

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -57,7 +57,6 @@ let source_of_module pos mdle =
     in loop source_extensions
   else if Filename.is_relative fname then
     find_in_path_rel path fname
-  else if Sys.file_exists fname then fname
   else raise Not_found
 
 (*** Buffer cache ***)

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -41,7 +41,11 @@ let source_of_module pos mdle =
           acc)
       Debugger_config.load_path_for
       (Load_path.get_path_list ()) in
-  if pos_fname = "" then
+  try
+    if pos_fname <> "" && Filename.is_relative pos_fname then
+      find_in_path_rel path pos_fname
+    else raise Not_found
+  with Not_found ->
     let innermost_module =
       try
         let dot_index = String.rindex mdle '.' in
@@ -54,9 +58,6 @@ let source_of_module pos mdle =
           try find_in_path_normalized path (innermost_module ^ ext)
           with Not_found -> loop exts
     in loop source_extensions
-  else if Filename.is_relative pos_fname then
-    find_in_path_rel path pos_fname
-  else raise Not_found
 
 (*** Buffer cache ***)
 


### PR DESCRIPTION
Historically, looking for "module_name.ml" in the loadpath when seeking a source file used to be the only heuristic used by the debugger. Later, as `Location.t` have been written among debug infos, they have been used instead. But because sometime filename are empty, the heuristic reappeared of the "no filename given" case ...

Actually, locations refers to where the files were **during compilation**, not where they have been installed and the layout may differ.

For example, take Base64 package (as a canonical example of a lib using `dune`), it follows dune standard to have its code written in file `lib/base64.ml` but later all `base64.*` files are installed at "the root of Base64 package installation path", no more `lib/` folder...)

So the heuristic can always be useful and I cannot find any situation where it can be harmful, Let's systematically try it as fallback, no?

As it strictly improve the situation as such, I don't touch the heuristic itself here. But yes, maybe this is not the inner module that you want when functors are involved and maybe it is worth refining stuff to take into account Dunes' `LibName__FoldersName__ModuleNameInsideLib` simili-modules but that's for future PRs.