### PR TITLE
Catch invalid aliases at merging rather than subtyping

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,6 +50,17 @@ Working version
   fails. Similarly for anonymous functor calls (of the form `F(struct ... end))
   (Clement Blaudeau, review by Gabriel Scherer)
 
+* #14066: catch invalid aliases introduced by signature constraints during
+  merging rather than in subtyping:
+  ```ocaml
+    module X = struct end module F (_:sig end) = struct end
+    module type T = (sig module X0 : sig end module X1 = X0 end)
+      with module X0 := F(X)
+  ```
+  Before, it failed with a subtyping error. Now, it fails with a proper error,
+  explaining that `X1` would keep an invalid alias to `F(X)`
+  (Clement Blaudeau, review by ?)
+
 ### Other libraries:
 
 * #14046: On Windows, `Unix.kill pid Sys.sigkill` causes the receiving process

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -719,7 +719,7 @@ Line 3, characters 16-46:
 3 | module type A = Alias with module N := F(List);;
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this "with" constraint, replacing "N" by "F(Stdlib.List)" would
-       introduce an invalid alias (at "M").
+       introduce an invalid alias at "M"
 |}];;
 
 (* Shinwell 2014-04-23 *)

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -715,18 +715,11 @@ module rec Bad : A = Bad;;
 [%%expect{|
 module type Alias = sig module N : sig end module M = N end
 module F : (X : sig end) -> sig type t end
-Line 1:
-Error: Module type declarations do not match:
-         module type A = sig module M = F(List) end
-       does not match
-         module type A = sig module M = F(List) end
-       At position "module type A = <here>"
-       Module types do not match:
-         sig module M = F(List) end
-       is not equal to
-         sig module M = F(List) end
-       At position "module type A = sig module M : <here> end"
-       Module "F(List)" cannot be aliased
+Line 3, characters 16-46:
+3 | module type A = Alias with module N := F(List);;
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, replacing "N" by "F(Stdlib.List)" would
+       introduce an invalid alias (at "M").
 |}];;
 
 (* Shinwell 2014-04-23 *)

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -447,7 +447,7 @@ Lines 3-6, characters 16-26:
 5 |   module X1 = X0
 6 | end with module X0 := F(X)
 Error: In this "with" constraint, replacing "X0" by "F(X)" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]
 
 (* Introduction of an invalid alias via a destructive module constraint should
@@ -467,7 +467,7 @@ Lines 3-6, characters 16-26:
 5 |   module X1 = X0.X
 6 | end with module X0 := F(X)
 Error: In this "with" constraint, replacing "X0.X" by "F(X)" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]
 
 (* Introduction of an invalid alias via a deep destructive module constraint
@@ -508,7 +508,7 @@ Lines 3-6, characters 16-28:
 5 |   module X1 = X0.X
 6 | end with module X0.X := F(X)
 Error: In this "with" constraint, replacing "X0.X" by "F(X)" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]
 
 (* Introduction of an invalid alias via a deep destructive module constraint
@@ -526,7 +526,7 @@ Lines 2-5, characters 18-25:
 4 |     module X1 = X0
 5 |   end with module X0 := Y
 Error: In this "with" constraint, replacing "X0" by "Y" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]
 
 (* Introduction of an invalid alias via a deep destructive module constraint
@@ -544,7 +544,7 @@ Lines 2-5, characters 18-28:
 4 |     module X1 = X0
 5 |   end with module X0 := Xrec
 Error: In this "with" constraint, replacing "X0" by "Xrec" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]
 
 (* Conversely, all those example should succeed for valid aliases (and not
@@ -592,7 +592,7 @@ Lines 4-8, characters 33-26:
 7 |   end)
 8 |     with module X0 := F(X)
 Error: In this "with" constraint, replacing "X0" by "F(X)" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]
 
 (* Invalid aliases should be caught early (bis) *)
@@ -615,5 +615,5 @@ Lines 4-8, characters 18-26:
 7 |   end)
 8 |     with module X0 := F(X)
 Error: In this "with" constraint, replacing "X0" by "F(X)" would
-       introduce an invalid alias (at "X1").
+       introduce an invalid alias at "X1"
 |}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -441,18 +441,13 @@ end with module X0 := F(X)
 [%%expect{|
 module X : sig end
 module F : sig end -> sig module X : sig end end
-Line 1:
-Error: Module type declarations do not match:
-         module type T = sig module X1 = F(X) end
-       does not match
-         module type T = sig module X1 = F(X) end
-       At position "module type T = <here>"
-       Module types do not match:
-         sig module X1 = F(X) end
-       is not equal to
-         sig module X1 = F(X) end
-       At position "module type T = sig module X1 : <here> end"
-       Module "F(X)" cannot be aliased
+Lines 3-6, characters 16-26:
+3 | ................sig
+4 |   module X0 : sig end
+5 |   module X1 = X0
+6 | end with module X0 := F(X)
+Error: In this "with" constraint, replacing "X0" by "F(X)" would
+       introduce an invalid alias (at "X1").
 |}]
 
 (* Introduction of an invalid alias via a destructive module constraint should
@@ -466,18 +461,13 @@ end with module X0 := F(X)
 [%%expect{|
 module X : sig end
 module F : sig end -> sig module X : sig end end
-Line 1:
-Error: Module type declarations do not match:
-         module type T = sig module X1 = F(X).X end
-       does not match
-         module type T = sig module X1 = F(X).X end
-       At position "module type T = <here>"
-       Module types do not match:
-         sig module X1 = F(X).X end
-       is not equal to
-         sig module X1 = F(X).X end
-       At position "module type T = sig module X1 : <here> end"
-       Module "F(X).X" cannot be aliased
+Lines 3-6, characters 16-26:
+3 | ................sig
+4 |   module X0 : sig module X : sig end end
+5 |   module X1 = X0.X
+6 | end with module X0 := F(X)
+Error: In this "with" constraint, replacing "X0.X" by "F(X)" would
+       introduce an invalid alias (at "X1").
 |}]
 
 (* Introduction of an invalid alias via a deep destructive module constraint
@@ -512,18 +502,13 @@ end with module X0.X := F(X)
 [%%expect{|
 module X : sig end
 module F : sig end -> sig module X : sig end end
-Line 1:
-Error: Module type declarations do not match:
-         module type T = sig module X0 : sig end module X1 = F(X) end
-       does not match
-         module type T = sig module X0 : sig end module X1 = F(X) end
-       At position "module type T = <here>"
-       Module types do not match:
-         sig module X0 : sig end module X1 = F(X) end
-       is not equal to
-         sig module X0 : sig end module X1 = F(X) end
-       At position "module type T = sig module X1 : <here> end"
-       Module "F(X)" cannot be aliased
+Lines 3-6, characters 16-28:
+3 | ................sig
+4 |   module X0 : sig module X : sig end end
+5 |   module X1 = X0.X
+6 | end with module X0.X := F(X)
+Error: In this "with" constraint, replacing "X0.X" by "F(X)" would
+       introduce an invalid alias (at "X1").
 |}]
 
 (* Introduction of an invalid alias via a deep destructive module constraint
@@ -535,7 +520,13 @@ module F (Y:sig end) = struct
   end with module X0 := Y
 end
 [%%expect{|
-module F : (Y : sig end) -> sig module type T = sig module X1 = Y end end
+Lines 2-5, characters 18-25:
+2 | ..................sig
+3 |     module X0 : sig end
+4 |     module X1 = X0
+5 |   end with module X0 := Y
+Error: In this "with" constraint, replacing "X0" by "Y" would
+       introduce an invalid alias (at "X1").
 |}]
 
 (* Introduction of an invalid alias via a deep destructive module constraint
@@ -547,7 +538,13 @@ module rec Xrec : sig end = struct
   end with module X0 := Xrec
 end
 [%%expect{|
-module rec Xrec : sig end
+Lines 2-5, characters 18-28:
+2 | ..................sig
+3 |     module X0 : sig end
+4 |     module X1 = X0
+5 |   end with module X0 := Xrec
+Error: In this "with" constraint, replacing "X0" by "Xrec" would
+       introduce an invalid alias (at "X1").
 |}]
 
 (* Conversely, all those example should succeed for valid aliases (and not
@@ -588,19 +585,14 @@ end
 [%%expect{|
 module X : sig end
 module F : sig end -> sig type t end
-Line 11, characters 2-26:
-11 |   struct type t = bool end
-       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = bool end
-       is not included in
-         sig type t = int end
-       Type declarations do not match:
-         type t = bool
-       is not included in
-         type t = int
-       The type "bool" is not equal to the type "int"
+Lines 4-8, characters 33-26:
+4 | .................................(sig
+5 |     module X0 : sig end
+6 |     module X1 = X0
+7 |   end)
+8 |     with module X0 := F(X)
+Error: In this "with" constraint, replacing "X0" by "F(X)" would
+       introduce an invalid alias (at "X1").
 |}]
 
 (* Invalid aliases should be caught early (bis) *)
@@ -616,5 +608,12 @@ end
 [%%expect{|
 module X : sig end
 module F : sig end -> sig type t end
-module ShoudFail : sig end
+Lines 4-8, characters 18-26:
+4 | ..................(sig
+5 |     module X0 : sig end
+6 |     module X1 = X0
+7 |   end)
+8 |     with module X0 := F(X)
+Error: In this "with" constraint, replacing "X0" by "F(X)" would
+       introduce an invalid alias (at "X1").
 |}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -422,3 +422,199 @@ Error: In this "with" constraint, the new definition of "M.N"
          type t = M.r
        The type "X.t" is not equal to the type "M.r" = "M.N.s"
 |}]
+
+(* Module constraints with non-aliasable paths
+
+   The first set of example use paths with functor applications to tests deep
+   substitutions and handling of prefixes. The tests for functor parameters and
+   recursive modules are bellow.
+*)
+
+(* Introduction of an invalid alias via a destructive module constraint should
+   fail *)
+module X = struct end
+module F (_:sig end) = struct module X = struct end end
+module type T = sig
+  module X0 : sig end
+  module X1 = X0
+end with module X0 := F(X)
+[%%expect{|
+module X : sig end
+module F : sig end -> sig module X : sig end end
+Line 1:
+Error: Module type declarations do not match:
+         module type T = sig module X1 = F(X) end
+       does not match
+         module type T = sig module X1 = F(X) end
+       At position "module type T = <here>"
+       Module types do not match:
+         sig module X1 = F(X) end
+       is not equal to
+         sig module X1 = F(X) end
+       At position "module type T = sig module X1 : <here> end"
+       Module "F(X)" cannot be aliased
+|}]
+
+(* Introduction of an invalid alias via a destructive module constraint should
+   fail, also when the alias is made on a submodule *)
+module X = struct end
+module F (_:sig end) = struct module X = struct end end
+module type T = sig
+  module X0 : sig module X : sig end end
+  module X1 = X0.X
+end with module X0 := F(X)
+[%%expect{|
+module X : sig end
+module F : sig end -> sig module X : sig end end
+Line 1:
+Error: Module type declarations do not match:
+         module type T = sig module X1 = F(X).X end
+       does not match
+         module type T = sig module X1 = F(X).X end
+       At position "module type T = <here>"
+       Module types do not match:
+         sig module X1 = F(X).X end
+       is not equal to
+         sig module X1 = F(X).X end
+       At position "module type T = sig module X1 : <here> end"
+       Module "F(X).X" cannot be aliased
+|}]
+
+(* Introduction of an invalid alias via a deep destructive module constraint
+   should fail when the enclosing module is aliased (it should also fail if the
+   alias is not invalid: any destruction on an aliased module is disallowed.) *)
+module X = struct end
+module F (_:sig end) = struct module X = struct end end
+module type T = sig
+  module X0 : sig module X : sig end end
+  module X1 = X0
+end with module X0.X := F(X)
+[%%expect{|
+module X : sig end
+module F : sig end -> sig module X : sig end end
+Lines 3-6, characters 16-28:
+3 | ................sig
+4 |   module X0 : sig module X : sig end end
+5 |   module X1 = X0
+6 | end with module X0.X := F(X)
+Error: This "with" constraint on "X0.X" changes "X0", which is aliased
+       in the constrained signature (as "X1").
+|}]
+
+(* Introduction of an invalid alias via a deep destructive module constraint
+   should fail, even when the alias is made on a submodule *)
+module X = struct end
+module F (_:sig end) = struct module X = struct end end
+module type T = sig
+  module X0 : sig module X : sig end end
+  module X1 = X0.X
+end with module X0.X := F(X)
+[%%expect{|
+module X : sig end
+module F : sig end -> sig module X : sig end end
+Line 1:
+Error: Module type declarations do not match:
+         module type T = sig module X0 : sig end module X1 = F(X) end
+       does not match
+         module type T = sig module X0 : sig end module X1 = F(X) end
+       At position "module type T = <here>"
+       Module types do not match:
+         sig module X0 : sig end module X1 = F(X) end
+       is not equal to
+         sig module X0 : sig end module X1 = F(X) end
+       At position "module type T = sig module X1 : <here> end"
+       Module "F(X)" cannot be aliased
+|}]
+
+(* Introduction of an invalid alias via a deep destructive module constraint
+   should fail for functor arguments *)
+module F (Y:sig end) = struct
+  module type T = sig
+    module X0 : sig end
+    module X1 = X0
+  end with module X0 := Y
+end
+[%%expect{|
+module F : (Y : sig end) -> sig module type T = sig module X1 = Y end end
+|}]
+
+(* Introduction of an invalid alias via a deep destructive module constraint
+   should fail for recursive modules (inside the recursive knot) *)
+module rec Xrec : sig end = struct
+  module type T = sig
+    module X0 : sig end
+    module X1 = X0
+  end with module X0 := Xrec
+end
+[%%expect{|
+module rec Xrec : sig end
+|}]
+
+(* Conversely, all those example should succeed for valid aliases (and not
+   destructive substitution inside an aliased module)*)
+module Valid = struct module X = struct end end
+module type T1 = sig
+  module X0 : sig end
+  module X1 = X0
+end with module X0 := Valid
+module type T2 = sig
+  module X0 : sig module X : sig end end
+  module X1 = X0.X
+end with module X0 := Valid
+module type T3 = sig
+  module X0 : sig module X : sig end end
+  module X1 = X0.X
+end with module X0.X := Valid
+[%%expect{|
+module Valid : sig module X : sig end end
+module type T1 = sig module X1 = Valid end
+module type T2 = sig module X1 = Valid.X end
+module type T3 = sig module X0 : sig end module X1 = Valid end
+|}]
+
+(* Invalid aliases should be caught early *)
+module X = struct end
+module F (_:sig end) = struct type t end
+module M = struct
+  module type Should_fail_here = (sig
+    module X0 : sig end
+    module X1 = X0
+  end)
+    with module X0 := F(X)
+
+  module Should_not_fail_here : sig type t = int end =
+  struct type t = bool end
+end
+[%%expect{|
+module X : sig end
+module F : sig end -> sig type t end
+Line 11, characters 2-26:
+11 |   struct type t = bool end
+       ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = bool end
+       is not included in
+         sig type t = int end
+       Type declarations do not match:
+         type t = bool
+       is not included in
+         type t = int
+       The type "bool" is not equal to the type "int"
+|}]
+
+(* Invalid aliases should be caught early (bis) *)
+module X = struct end
+module F (_:sig end) = struct type t end
+module ShoudFail : sig end = struct
+  module type T = (sig
+    module X0 : sig end
+    module X1 = X0
+  end)
+    with module X0 := F(X)
+end
+[%%expect{|
+module X : sig end
+module F : sig end -> sig type t end
+module ShoudFail : sig end
+|}]

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -110,7 +110,7 @@ Lines 1-2, characters 24-53:
 1 | ........................sig module Id : sig end module Id2 = Id end
 2 |                         with module Id := T'.Term0.Id..........
 Error: In this "with" constraint, replacing "Id" by "T'.Term0.Id" would
-       introduce an invalid alias (at "Id2").
+       introduce an invalid alias at "Id2"
 |}]
 
 module Make3 (T' : S) = struct

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -106,18 +106,11 @@ module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
   module Id2 = Id
 end;;
 [%%expect{|
-Lines 2-5, characters 57-3:
-2 | .........................................................struct
-3 |   module Id = T'.T.Id
-4 |   module Id2 = Id
-5 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig module Id : sig end module Id2 = Id end
-       is not included in
-         sig module Id2 = T'.Term0.Id end
-       In module "Id2":
-       Module "T'.Term0.Id" cannot be aliased
+Lines 1-2, characters 24-53:
+1 | ........................sig module Id : sig end module Id2 = Id end
+2 |                         with module Id := T'.Term0.Id..........
+Error: In this "with" constraint, replacing "Id" by "T'.Term0.Id" would
+       introduce an invalid alias (at "Id2").
 |}]
 
 module Make3 (T' : S) = struct

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -511,11 +511,10 @@ let rec modtypes ~core ~direction ~loc env subst mty1 mty2 shape =
 and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
   match mty1, mty2 with
   | (Mty_alias p1, Mty_alias p2) ->
-      if not (Env.is_aliasable p2 env) then
-        Error (Error.Invalid_module_alias p2)
-      else if not (equal_module_paths env p1 subst p2) then
-          Error Error.(Mt_core Incompatible_aliases)
-      else Ok (Tcoerce_none, orig_shape)
+      if (equal_module_paths env p1 subst p2) then
+          Ok (Tcoerce_none, orig_shape)
+      else
+        Error Error.(Mt_core Incompatible_aliases)
   | (Mty_alias p1, _) -> begin
       match
         Env.normalize_module_path (Some Location.none) env p1

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -38,7 +38,6 @@ type symptom =
       Ident.t * class_declaration * class_declaration *
       Ctype.class_match_failure list
   | Unbound_module_path of Path.t
-  | Invalid_module_alias of Path.t
 
 type pos =
   | Module of Ident.t
@@ -83,7 +82,6 @@ module Error = struct
     | Mt_core of core_module_type_symptom
     | Signature of signature_symptom
     | Functor of functor_symptom
-    | Invalid_module_alias of Path.t
     | After_alias_expansion of module_type_diff
 
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -59,7 +59,6 @@ module Error: sig
     | Mt_core of core_module_type_symptom
     | Signature of signature_symptom
     | Functor of functor_symptom
-    | Invalid_module_alias of Path.t
     | After_alias_expansion of module_type_diff
 
 
@@ -201,7 +200,6 @@ type symptom =
       Ident.t * class_declaration * class_declaration *
       Ctype.class_match_failure list
   | Unbound_module_path of Path.t
-  | Invalid_module_alias of Path.t
 
 type pos =
   | Module of Ident.t

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -810,7 +810,6 @@ let unexpected_functor ~env ~before ~ctx diff =
 
 let rec module_type ~expansion_token ~eqmode ~env ~before ~ctx diff =
   match diff.symptom with
-  | Invalid_module_alias _ (* the difference is non-informative here *)
   | After_alias_expansion _ (* we print only the expanded module types *) ->
       module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx
         diff.symptom
@@ -842,12 +841,6 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
   | Functor f -> functor_symptom ~expansion_token ~env ~before ~ctx f
   | After_alias_expansion diff ->
       module_type ~eqmode ~expansion_token ~env ~before ~ctx diff
-  | Invalid_module_alias path ->
-      let printer =
-        Fmt.dprintf "Module %a cannot be aliased"
-          (Style.as_inline_code Printtyp.path) path
-      in
-      dwith_context ctx printer :: before
 
 and functor_params ~expansion_token ~env ~before ~ctx diff =
   match diff.got.params, diff.expected.params with

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -57,6 +57,7 @@ type error =
   | With_makes_applicative_functor_ill_typed of
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
+  | With_creates_invalid_aliases of Ident.t * Path.t * Path.t
   | With_cannot_remove_constrained_type
   | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string
@@ -249,21 +250,24 @@ let rec iter_path_apply p ~f =
      f p1 p2 (* after recursing, so we know both paths are well typed *)
   | Pextra_ty _ -> assert false
 
-let path_is_strict_prefix =
-  let rec list_is_strict_prefix l ~prefix =
+(** Checks if a flat (without functor applications) path [path] admits [~prefix]
+    as a prefix, i.e. if [path = ~prefix::suffix]. The [~strict] flag indicates
+    if equal paths should be rejected *)
+let path_is_prefix ~strict =
+  let rec list_is_prefix l ~prefix =
     match l, prefix with
-    | [], [] -> false
+    | [], [] -> not strict
     | _ :: _, [] -> true
-    | [], _ :: _ -> false
-    | s1 :: t1, s2 :: t2 ->
-       String.equal s1 s2 && list_is_strict_prefix t1 ~prefix:t2
+    | s1 :: t1, s2 :: t2 when (String.equal s1 s2) ->
+        list_is_prefix t1 ~prefix:t2
+    | _, _ -> false
   in
   fun path ~prefix ->
     match Path.flatten path, Path.flatten prefix with
-    | `Contains_apply, _ | _, `Contains_apply -> false
-    | `Ok (ident1, l1), `Ok (ident2, l2) ->
-       Ident.same ident1 ident2
-       && list_is_strict_prefix l1 ~prefix:l2
+    | `Ok (ident1, l1), `Ok (ident2, l2)
+      when Ident.same ident1 ident2 ->
+        list_is_prefix l1 ~prefix:l2
+    | _,_ -> false
 
 let iterator_with_env super env =
   let env = ref (lazy env) in
@@ -319,8 +323,7 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
       Btype.it_signature_item = (fun self -> function
       | Sig_module (id, _, { md_type = Mty_alias aliased_path; _ }, _, _)
         when List.exists
-               (fun path -> path_is_strict_prefix path ~prefix:aliased_path)
-               paths
+            (fun p -> path_is_prefix p ~prefix:aliased_path ~strict:true) paths
         ->
          let e = With_changes_module_alias (lid.txt, id, aliased_path) in
          raise(Error(loc, Lazy.force !env, e))
@@ -330,8 +333,7 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
       Btype.it_path = (fun referenced_path ->
         iter_path_apply referenced_path ~f:(fun funct arg ->
           if List.exists
-               (fun path -> path_is_strict_prefix path ~prefix:arg)
-               paths
+               (fun path -> path_is_prefix path ~prefix:arg ~strict:true) paths
           then
             let env = Lazy.force !env in
             match retype_applicative_functor_type ~loc env funct arg with
@@ -344,28 +346,60 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
       );
     }
 
-let do_check_after_substitution env ~loc ~lid paths sg =
-  with_type_mark begin fun mark ->
-  let env, iterator = iterator_with_env (Btype.type_iterators mark) env in
-  let last, rest = match List.rev paths with
-    | [] -> assert false
-    | last :: rest -> last, rest
+(** When doing destructive module substitutions [with module X = P], the path
+    [P] can be non-aliasable (by containing a functor parameter, functor
+    application or recursive module). If it is the case, module aliases to [X]
+    or any suffix [X.X'] would become invalid. This function checks that there
+    are no module aliases to suffixes of the list of affected paths [paths]. The
+    [invalid_alias_path] argument is just used for the error message *)
+let check_invalid_aliases paths ~loc env super invalid_alias_path =
+  let would_become_invalid_path aliased_path =
+    List.exists
+      (fun p -> path_is_prefix aliased_path ~prefix:p ~strict:false) paths
   in
-  (* The last item is the one that's removed. We don't need to check how
-        it's used since it's replaced by a more specific type/module. *)
-  assert (match last with Pident _ -> true | _ -> false);
-  let iterator = match rest with
-    | [] -> iterator
-    | _ :: _ ->
-        check_usage_of_path_of_substituted_item rest ~loc ~lid env iterator
-  in
-  iterator.Btype.it_signature iterator sg
-  end
+  { super with
+    Btype.it_signature_item = (fun self -> function
+        | Sig_module (id, _, {md_type = Mty_alias aliased_path}, _, _)
+          when would_become_invalid_path aliased_path ->
+            raise(Error(loc, Lazy.force !env,
+                        With_creates_invalid_aliases
+                          (id, aliased_path, invalid_alias_path)))
+        | sig_item ->
+            super.Btype.it_signature_item self sig_item
+      );
+  }
 
-let check_usage_after_substitution env ~loc ~lid paths sg =
-  match paths with
-  | [_] -> ()
-  | _ -> do_check_after_substitution env ~loc ~lid paths sg
+(** This function checks the effect of destructive substitutions and the
+    introduction of invalid aliases *)
+let check_usage_after_substitution env ~loc ~lid paths ?(invalid_alias=None) sg=
+  match paths, invalid_alias with
+  (* Shallow substitution without introduction of an invalid alias *)
+  | [_], None -> ()
+  (* Deep substitution, or possible introduction of invalid alias *)
+  | _, _ ->
+      with_type_mark begin fun mark ->
+        let env, base_iterator =
+          iterator_with_env (Btype.type_iterators mark) env in
+        let last, rest = match List.rev paths with
+          | [] -> assert false (* affected paths must be a non-empty list *)
+          | last :: rest -> last, rest
+        in
+        (* The last item is the one that's removed. We don't need to check how
+              it's used since it's replaced by a more specific type/module. *)
+        assert (match last with Pident _ -> true | _ -> false);
+        let iterator = match rest with
+          | [] -> base_iterator
+          | _ :: _ ->
+              check_usage_of_path_of_substituted_item rest ~loc ~lid env
+                base_iterator
+        in
+        let iterator' = match invalid_alias with
+          | None -> iterator
+          | Some invalid_alias_path ->
+              check_invalid_aliases paths ~loc env iterator invalid_alias_path
+        in
+        iterator.Btype.it_signature iterator' sg
+      end
 
 (* After substitution one also needs to re-check the well-foundedness
    of type declarations in recursive modules *)
@@ -515,11 +549,13 @@ module Merge = struct
   (* After the item has been patched, post processing does the actual
      destructive substitution and checks wellformedness of the resulting
      signature *)
-  let post_process ~destructive loc lid env paths sg replace =
+  let post_process ~destructive loc lid env paths sg
+      ?(invalid_alias=None) replace =
     let sg =
       if destructive then
         (* Check that the substitution will not make the signature ill-formed *)
-        let () = check_usage_after_substitution ~loc ~lid env paths sg in
+        let () = check_usage_after_substitution ~loc ~lid env paths
+        ~invalid_alias sg in
         (* Actually remove the identifiers *)
         let sub = Subst.change_locs Subst.identity loc in
         let sub = List.fold_left replace sub paths in
@@ -699,13 +735,13 @@ module Merge = struct
   *)
   let merge_module ~destructive env loc sg lid
       (md': Types.module_declaration) path remove_aliases =
+    let aliasable = Env.is_aliasable path env in
     let patch item s sig_env sg_for_env ~ghosts =
       match item with
       | Sig_module(id, pres, md, rs, priv) when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env sig_env in
           let real_path = Pident id in
           if destructive then
-            let aliasable = Env.is_aliasable path sig_env in
             (* Inclusion check with the strengthened definition *)
             let _ =
               Includemod.strengthened_module_decl ~loc ~mark:true
@@ -727,7 +763,9 @@ module Merge = struct
     in
     let real_path,paths,_,sg = merge ~patch ~destructive env sg loc lid in
     let replace s p = Subst.Unsafe.add_module_path p path s in
-    let sg = post_process ~destructive loc lid env paths sg replace in
+    let invalid_alias = if (not aliasable) then (Some path) else None in
+    let sg =
+      post_process ~destructive loc lid env paths sg replace ~invalid_alias in
     real_path, lid, sg
 
   (** Module type constraint [sg with module type lid = mty]
@@ -3439,6 +3477,15 @@ let report_error ~loc _env = function
         Style.inline_code "with"
         (Style.as_inline_code longident) lid
         Style.inline_code (Path.name path)
+        Style.inline_code (Ident.name id)
+  | With_creates_invalid_aliases(id, path, invalid_path) ->
+      Location.errorf ~loc
+        "@[<v>\
+         @[In this %a constraint, replacing %a by %a would @ \
+         introduce an invalid alias (at %a)@].@]"
+        Style.inline_code "with"
+        Style.inline_code (Path.name path)
+        Style.inline_code (Path.name invalid_path)
         Style.inline_code (Ident.name id)
   | With_cannot_remove_constrained_type ->
       Location.errorf ~loc

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -393,7 +393,8 @@ let check_invalid_aliases paths ~loc env invalid_alias super =
     introduction of invalid aliases *)
 let check_usage_after_substitution env ~loc ~lid paths ?(invalid_alias=None) sg=
   match paths, invalid_alias with
-  (* Shallow substitution without introduction of an invalid alias *)
+  (* Shallow substitution without introduction of an invalid alias : nothing to
+     check (so no traversal of the signature) *)
   | [_], None -> ()
   (* Deep substitution, or possible introduction of invalid alias *)
   | _, _ ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -317,13 +317,27 @@ let retype_applicative_functor_type ~loc env funct arg =
    - applicative functor types: F(M).t might not be well typed anymore
    - aliases: module A = M still makes sense but it doesn't mean the same thing
      anymore, so it's forbidden until it's clear what we should do with it.
-   This function would be called with M.N.t and N.t to check for these uses. *)
+   This function would be called with M.N.t and N.t to check for these uses.
+
+   The first argument [paths] must be non-empty.
+*)
 let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
+  match paths with
+  | []  -> assert false (* affected paths must be a non-empty list *)
+  | [_] -> super (* Shallow substitution, nothing to check *)
+  | _   ->
+      let last, rest = match List.rev paths with
+        | [] -> assert false
+        | last :: rest -> last, rest
+      in
+      (* The last item is the one that's removed. We don't need to check how
+            it's used since it's replaced by a more specific type/module. *)
+      assert (match last with Pident _ -> true | _ -> false);
     { super with
       Btype.it_signature_item = (fun self -> function
       | Sig_module (id, _, { md_type = Mty_alias aliased_path; _ }, _, _)
         when List.exists
-            (fun p -> path_is_prefix p ~prefix:aliased_path ~strict:true) paths
+            (fun p -> path_is_prefix p ~prefix:aliased_path ~strict:true) rest
         ->
          let e = With_changes_module_alias (lid.txt, id, aliased_path) in
          raise(Error(loc, Lazy.force !env, e))
@@ -333,7 +347,7 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
       Btype.it_path = (fun referenced_path ->
         iter_path_apply referenced_path ~f:(fun funct arg ->
           if List.exists
-               (fun path -> path_is_prefix path ~prefix:arg ~strict:true) paths
+               (fun path -> path_is_prefix path ~prefix:arg ~strict:true) rest
           then
             let env = Lazy.force !env in
             match retype_applicative_functor_type ~loc env funct arg with
@@ -351,23 +365,29 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
     application or recursive module). If it is the case, module aliases to [X]
     or any suffix [X.X'] would become invalid. This function checks that there
     are no module aliases to suffixes of the list of affected paths [paths]. The
-    [invalid_alias_path] argument is just used for the error message *)
-let check_invalid_aliases paths ~loc env super invalid_alias_path =
-  let would_become_invalid_path aliased_path =
-    List.exists
-      (fun p -> path_is_prefix aliased_path ~prefix:p ~strict:false) paths
-  in
-  { super with
-    Btype.it_signature_item = (fun self -> function
-        | Sig_module (id, _, {md_type = Mty_alias aliased_path}, _, _)
-          when would_become_invalid_path aliased_path ->
-            raise(Error(loc, Lazy.force !env,
-                        With_creates_invalid_aliases
-                          (id, aliased_path, invalid_alias_path)))
-        | sig_item ->
-            super.Btype.it_signature_item self sig_item
-      );
-  }
+    [invalid_alias] argument indicates if the test should be added to the
+    iterator. Its payload [invalid_alias_path] is just used for the error
+    message *)
+let check_invalid_aliases paths ~loc env invalid_alias super =
+  match invalid_alias with
+  | None -> super (* No possible introduction of invalid alias, so no extension
+                     of the iterator*)
+  | Some invalid_alias_path ->
+      let would_become_invalid_path aliased_path =
+        List.exists
+          (fun p -> path_is_prefix aliased_path ~prefix:p ~strict:false) paths
+      in
+      { super with
+        Btype.it_signature_item = (fun self -> function
+            | Sig_module (id, _, {md_type = Mty_alias aliased_path}, _, _)
+              when would_become_invalid_path aliased_path ->
+                raise(Error(loc, Lazy.force !env,
+                            With_creates_invalid_aliases
+                              (id, aliased_path, invalid_alias_path)))
+            | sig_item ->
+                super.Btype.it_signature_item self sig_item
+          );
+      }
 
 (** This function checks the effect of destructive substitutions and the
     introduction of invalid aliases *)
@@ -380,25 +400,12 @@ let check_usage_after_substitution env ~loc ~lid paths ?(invalid_alias=None) sg=
       with_type_mark begin fun mark ->
         let env, base_iterator =
           iterator_with_env (Btype.type_iterators mark) env in
-        let last, rest = match List.rev paths with
-          | [] -> assert false (* affected paths must be a non-empty list *)
-          | last :: rest -> last, rest
+        let iterator =
+          base_iterator
+          |> check_usage_of_path_of_substituted_item paths ~loc ~lid env
+          |> check_invalid_aliases paths ~loc env invalid_alias
         in
-        (* The last item is the one that's removed. We don't need to check how
-              it's used since it's replaced by a more specific type/module. *)
-        assert (match last with Pident _ -> true | _ -> false);
-        let iterator = match rest with
-          | [] -> base_iterator
-          | _ :: _ ->
-              check_usage_of_path_of_substituted_item rest ~loc ~lid env
-                base_iterator
-        in
-        let iterator' = match invalid_alias with
-          | None -> iterator
-          | Some invalid_alias_path ->
-              check_invalid_aliases paths ~loc env iterator invalid_alias_path
-        in
-        iterator.Btype.it_signature iterator' sg
+        iterator.Btype.it_signature iterator sg
       end
 
 (* After substitution one also needs to re-check the well-foundedness

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3480,9 +3480,8 @@ let report_error ~loc _env = function
         Style.inline_code (Ident.name id)
   | With_creates_invalid_aliases(id, path, invalid_path) ->
       Location.errorf ~loc
-        "@[<v>\
-         @[In this %a constraint, replacing %a by %a would @ \
-         introduce an invalid alias (at %a)@].@]"
+        "In this %a constraint,@ replacing %a@ by %a@ would @ \
+         introduce an invalid alias@ at %a"
         Style.inline_code "with"
         Style.inline_code (Path.name path)
         Style.inline_code (Path.name invalid_path)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -256,18 +256,18 @@ let rec iter_path_apply p ~f =
 let path_is_prefix ~strict =
   let rec list_is_prefix l ~prefix =
     match l, prefix with
-    | [], [] -> not strict
+    | [], [] -> (not strict)
     | _ :: _, [] -> true
-    | s1 :: t1, s2 :: t2 when (String.equal s1 s2) ->
-        list_is_prefix t1 ~prefix:t2
-    | _, _ -> false
+    | [], _ :: _ -> false
+    | s1 :: t1, s2 :: t2 ->
+       String.equal s1 s2 && list_is_prefix t1 ~prefix:t2
   in
   fun path ~prefix ->
     match Path.flatten path, Path.flatten prefix with
-    | `Ok (ident1, l1), `Ok (ident2, l2)
-      when Ident.same ident1 ident2 ->
-        list_is_prefix l1 ~prefix:l2
-    | _,_ -> false
+    | `Contains_apply, _ | _, `Contains_apply -> false
+    | `Ok (ident1, l1), `Ok (ident2, l2) ->
+       Ident.same ident1 ident2
+       && list_is_prefix l1 ~prefix:l2
 
 let iterator_with_env super env =
   let env = ref (lazy env) in

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -113,6 +113,7 @@ type error =
   | With_makes_applicative_functor_ill_typed of
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
+  | With_creates_invalid_aliases of Ident.t * Path.t * Path.t
   | With_cannot_remove_constrained_type
   | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string


### PR DESCRIPTION
This PR proposes a refactor of the handling of invalid aliases introduced by module constraints

# Context

Module aliases to non-alisable paths (functor applications, functor parameters, recursive modules inside the recursive knot) can be introduced via destructive module constraints `... with module X := P`, as described in #6376. For instance: 
```ocaml
module X = struct end 
module F (_:sig end) = struct end
module type T = (sig 
  module X0 : sig end 
  module X1 = X0 
end) with module X0 := F(X)
```
Could incorrectly result in `module type T = sig module X1 = F(X) end`. This was addressed by 82e2f35, which adds a check in *subtyping*, when comparing alias signatures, that neither is ill-formed. The code above result in the following subtyping error:

```ocaml
Error: Module type declarations do not match:
         module type T = sig module X1 = F(X) end
       does not match
         module type T = sig module X1 = F(X) end
       At position module type T = <here>
       Module types do not match:
         sig module X1 = F(X) end
       is not equal to
         sig module X1 = F(X) end
       At position module type T = sig module X1 : <here> end
       Module F(X) cannot be aliased
``` 

There are three issues with the current situation: 
1. the check is not done at the right moment, it should prevent the introduction of invalid aliases rather than their subtyping with another alias
   <details>
     <summary>Details</summary>
     
   The error is caught when the invalid signature reaches the top-level, as there is a subtyping check of the signature against itself. In the "mean time" between the introduction of the signature and the toplevel, the invalid signature is in the typing environment, which is an open door to issues. Typically, the following code succeeds: 
   ```ocaml 
   module X = struct end
   module F (_:sig end) = struct type t end
   module ShoudFail : sig end = struct
     module type T = (sig
       module X0 : sig end
       module X1 = X0
     end)
       with module X0 := F(X)
   end
   ``` 
   Indeed, the invalid signature is accepted and then removed by an ascription, so the subtyping check on the content of `T` never triggers. Similarly, consider the following code:
   
   ```ocaml 
   module X = struct end
   module F (_:sig end) = struct type t end
   module M = struct
     module type Should_fail_here = (sig
       module X0 : sig end
       module X1 = X0
     end)
       with module X0 := F(X)
   
     (* here, the env contains an invalid signature *)
     module Should_not_fail_here : sig type t = int end =
     struct type t = bool end
   end 
   ```
   It fails at `Should_not_fail_here` rather than at `Should_fail_here`. I have not looked to hard for more serious errors resulting in having an invalid alias in the typing env, but it is likely usable to (at least) crash to typechecker.
   </details>
2. the subtyping error is misleading
3. not all cases of invalid aliases are caught
   <details>
     <summary>Details</summary>
     
   * Aliases to functor parameters are accepted when they should not:
   ```ocaml
   module F (Y:sig end) = struct
     module type T = sig
       module X0 : sig end
       module X1 = X0
     end with module X0 := Y
   end
   (* module F : (Y : sig end) -> sig module type T = sig module X1 = Y end end *)
   ```
   * Aliases to recursive modules are accepted inside the recursive knot:
   ```ocaml
   module rec Xrec : sig end = struct
     module type T = sig
       module X0 : sig end
       module X1 = X0
     end with module X0 := Xrec
   end
   (* module rec Xrec : sig end *)
   ```
   
   As for 1, it may probably be used to trigger more serious bugs. 
   </details>

# This PR

This PR addresses those issues as follows: 
* It introduces a new check when doing destructive module constraints with a non-aliasable path `check_invalid_aliases`, along with a new error case `With_creates_invalid_aliases`
* it removes the check done in the subtyping for validity of aliases
* It lightly refactors `check_usage_of_path_of_substituted_item` and `path_is_prefix` to accomodate for the extra check (regardless of whether the substitution is deep or not)
* it adds tests (with shallow/deep substitutions, with functor parameters, applications, recursive modules, etc.)

This PR should not affect performance, as it re-uses the visit of the signature done for the other wellformedness checks (`check_usage_of_path_of_substituted_item`). It is almost backward compatible, as it will only prevent aliases that were invalid and not usable anyway (i.e. the incompatibility was out of spec).

However, if there is another way to introduce invalid aliases that I'm not aware of, they will not be caught by subtyping. I believe that it is ok, as the role of subtyping is not to safeguard invalid inference. 

# Examples 

Now, the above example fails with the following error message: 
```ocaml 
module X = struct end 
module F (_:sig end) = struct end
module type T = (sig 
  module X0 : sig end 
  module X1 = X0 
end) with module X0 := F(X)
```
```
Error: In this with constraint, replacing X0 by F(X) would 
       introduce an invalid alias (at X1) .
```

For other examples, see the [added test cases](https://github.com/ocaml/ocaml/pull/14066/files#diff-16475d6e2475e142459277f67dd1087fc001f8d9cf384c35c57c3eb49d67b6dc)