### PR TITLE
Add cut_on_char and rcut_on_char to String/Bytes/StringLabels

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,9 @@ Working version
   (Kate Deplaix, review by Daniel Bünzli, Gabriel Scherer,
    Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
 
+- #14068: Add cut_on_char and rcut_on_char to String/Bytes/StringLabels.
+  (Kate Deplaix, review by ???)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -405,6 +405,21 @@ let split_on_char sep s =
   done;
   sub s 0 !j :: !r
 
+(* duplicated in string.ml *)
+let cut_gen f sep s =
+  match f s sep with
+  | Some idx ->
+      let l = length s in
+      let sidx = idx + 1 in
+      Some (sub s 0 idx, sub s sidx (l - sidx))
+  | None -> None
+
+(* duplicated in string.ml *)
+let cut_on_char sep s = cut_gen index_opt sep s
+
+(* duplicated in string.ml *)
+let rcut_on_char sep s = cut_gen rindex_opt sep s
+
 (** {1 Iterators} *)
 
 let to_seq s =

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -473,6 +473,18 @@ val split_on_char: char -> bytes -> bytes list
     @since 4.13
 *)
 
+val cut_on_char : char -> bytes -> (bytes * bytes) option
+(** [cut_on_char sep s] splits the byte sequence [s] at the first character [sep]
+    starting from left. Returns [None] if [sep] couldn't be found.
+
+    @since 5.5 *)
+
+val rcut_on_char : char -> bytes -> (bytes * bytes) option
+(** [rcut_on_char sep s] splits the bytes sequence [s] at the first character [sep]
+    starting from right. Returns [None] if [sep] couldn't be found.
+
+    @since 5.5 *)
+
 (** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -239,6 +239,21 @@ let split_on_char sep s =
   done;
   sub s 0 !j :: !r
 
+(* duplicated in bytes.ml *)
+let cut_gen f sep s =
+  match f s sep with
+  | Some idx ->
+      let l = length s in
+      let sidx = idx + 1 in
+      Some (sub s 0 idx, sub s sidx (l - sidx))
+  | None -> None
+
+(* duplicated in bytes.ml *)
+let cut_on_char sep s = cut_gen index_opt sep s
+
+(* duplicated in bytes.ml *)
+let rcut_on_char sep s = cut_gen rindex_opt sep s
+
 type t = string
 
 let compare (x: t) (y: t) = Stdlib.compare x y

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -207,6 +207,18 @@ val split_on_char : char -> string -> string list
 
     @since 4.04 (4.05 in StringLabels) *)
 
+val cut_on_char : char -> string -> (string * string) option
+(** [cut_on_char sep s] splits the string [s] at the first character [sep]
+    starting from left. Returns [None] if [sep] couldn't be found.
+
+    @since 5.5 *)
+
+val rcut_on_char : char -> string -> (string * string) option
+(** [rcut_on_char sep s] splits the string [s] at the first character [sep]
+    starting from right. Returns [None] if [sep] couldn't be found.
+
+    @since 5.5 *)
+
 (** {1:transforming Transforming} *)
 
 val map : (char -> char) -> string -> string

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -207,6 +207,18 @@ val split_on_char : sep:char -> string -> string list
 
     @since 4.04 (4.05 in StringLabels) *)
 
+val cut_on_char : sep:char -> string -> (string * string) option
+(** [cut_on_char ~sep s] splits the string [s] at the first character [sep]
+    starting from left. Returns [None] if [sep] couldn't be found.
+
+    @since 5.5 *)
+
+val rcut_on_char : sep:char -> string -> (string * string) option
+(** [rcut_on_char ~sep s] splits the string [s] at the first character [sep]
+    starting from right. Returns [None] if [sep] couldn't be found.
+
+    @since 5.5 *)
+
 (** {1:transforming Transforming} *)
 
 val map : f:(char -> char) -> string -> string


### PR DESCRIPTION
`String.cut` is a function i recently had to reimplement in every single one of my personal [1] and work projects.
I feel like this is especially useful when for example parsing `Unix.environment` and similar things, where `String.split_on_char` is inappropriate at worst and inefficient at best, given that the right side of an environment binding can very well contain multiple `=` characters.

In terms of naming, looking at sherlocode.com quickly:
- `opam` has `OpamStd.String.cut` and `rcut`: https://github.com/ocaml/opam/blob/8c0e68e7eb527223353cca1926b433c664f729c4/src/core/opamStd.ml#L694
- `patch` has `Lib.cut`: https://github.com/hannesm/patch/blob/fe7077c7e5e55721e77e7dbc2af2c044851cef20/src/lib.mli#L4
- `base` has `Base.String.lsplit2`: https://github.com/janestreet/base/blob/01857ea5364018edb77460517872164f501d1091/src/string_intf.ml#L334
- `omod` has `String.cut` and `rev_cut`: https://github.com/dbuenzli/omod/blob/51430c07bfe46cd46edb785715c8f49e06dec546/src/omod.ml#L14
- `topkg` has `Topkg_string.cut ?rev`: https://github.com/dbuenzli/topkg/blob/5118b194ad08df97298b206648dd2f521b65d9e3/src/topkg_string.mli#L24
- `flow` used to have `String_utils.split2`: https://github.com/facebook/flow/blob/cdc8cc8dbe3f3813908d95d9ce02476f87669632/src/hack_forked/utils/string/string_utils.mli#L72
- For the sake of completeness: Containers and Batteries only have the version of these functions taking a string as separator instead of a character and Extlib has no such function.

[1]: https://codeberg.org/kit-ty-kate/ocaml-posixutils/src/commit/49ba0e1b3c6ccd0421047bccaf96a6e92031f647/src/env.ml#L1 and 2 other unpublished projects.