### PR TITLE
error messages: also point tuple label mismatches

### DIFF
--- a/Changes
+++ b/Changes
@@ -814,6 +814,9 @@ OCaml 5.4.0
   (Gabriel Scherer, review by Jan Midtgaard,
    report by Jan Midtgaard)
 
+- #14070: also point to label mismatches in error messages for labelled tuples
+  (Florian Angeletti, review by Gabriel Scherer)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
@@ -206,6 +206,7 @@ Line 1, characters 21-27:
                          ^^^^^^
 Error: This expression has type "x:'a * y:'b"
        but an expression was expected of type "yx" = "y:int * x:int"
+       Labels "x" and "y" do not match
 |}]
 
 let swap (pt : xy) : yx = pt
@@ -215,6 +216,7 @@ Line 1, characters 26-28:
                               ^^
 Error: The value "pt" has type "xy" = "x:int * y:int"
        but an expression was expected of type "yx" = "y:int * x:int"
+       Labels "x" and "y" do not match
 |}]
 
 let swap : xy -> yx = Fun.id
@@ -225,6 +227,7 @@ Line 1, characters 22-28:
 Error: The value "Fun.id" has type "xy -> xy"
        but an expression was expected of type "xy -> yx"
        Type "xy" = "x:int * y:int" is not compatible with type "yx" = "y:int * x:int"
+       Labels "x" and "y" do not match
 |}]
 
 let swap : xy -> yx = xy_id
@@ -235,6 +238,7 @@ Line 1, characters 22-27:
 Error: The value "xy_id" has type "(y:int * x:int) -> xy"
        but an expression was expected of type "xy -> yx"
        Type "y:int * x:int" is not compatible with type "xy" = "x:int * y:int"
+       Labels "y" and "x" do not match
 |}]
 
 let swap : xy -> yx = yx_id
@@ -245,6 +249,7 @@ Line 1, characters 22-27:
 Error: The value "yx_id" has type "yx -> yx"
        but an expression was expected of type "xy -> yx"
        Type "yx" = "y:int * x:int" is not compatible with type "xy" = "x:int * y:int"
+       Labels "y" and "x" do not match
 |}]
 
 (* Reordering and partial matches *)
@@ -536,6 +541,7 @@ Line 4, characters 21-27:
                          ^^^^^^
 Error: This pattern matches values of type "y:'a * x:'b"
        but a pattern was expected which matches values of type "x:int * y:int"
+       Labels "y" and "x" do not match
 |}]
 
 let f = function ~x, ~y -> x + y
@@ -549,6 +555,7 @@ Line 4, characters 34-35:
                                       ^
 Error: The value "z" has type "y:int * x:int"
        but an expression was expected of type "x:int * y:int"
+       Labels "y" and "x" do not match
 |}]
 
 (* More re-ordering stress tests *)

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
@@ -37,6 +37,8 @@ Line 1, characters 22-29:
                           ^^^^^^^
 Error: This expression has type "x:'a * 'b"
        but an expression was expected of type "int * int"
+       The first tuple element is labeled "x",
+       but an unlabeled element was expected
 |}]
 
 let (x : x:string * int) = ~x:1, 2
@@ -55,6 +57,8 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type "x:'a * 'b"
        but an expression was expected of type "int * y:int"
+       The first tuple element is labeled "x",
+       but an unlabeled element was expected
 |}]
 
 (* Happy case *)
@@ -78,6 +82,8 @@ Line 4, characters 3-24:
        ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "a:string * int * c:'a"
        but an expression was expected of type "a:string * int * string"
+       The first tuple element is labeled "c",
+       but an unlabeled element was expected
 |}]
 
 (* Missing labeled component *)
@@ -104,6 +110,7 @@ Line 4, characters 3-24:
        ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "a:string * int * c:'a"
        but an expression was expected of type "a:string * int * b:string"
+       Labels "c" and "b" do not match
 |}]
 
 (* Repeated labels *)
@@ -157,6 +164,7 @@ Line 1, characters 23-37:
                            ^^^^^^^^^^^^^^
 Error: This expression has type "y:'a * x:'b"
        but an expression was expected of type "x:int * y:int"
+       Labels "y" and "x" do not match
 |}]
 
 (* Mutually-recursive definitions *)
@@ -314,6 +322,8 @@ Line 1, characters 14-28:
                   ^^^^^^^^^^^^^^
 Error: This expression has type "foo:'a * bar:'b"
        but an expression was expected of type "int * int"
+       The first tuple element is labeled "foo",
+       but an unlabeled element was expected
 |}]
 
 let _ : tx = { x = ~foo:1, ~bar:2 }
@@ -328,6 +338,7 @@ Line 1, characters 18-27:
                       ^^^^^^^^^
 Error: This expression has type "'a * bar:'b"
        but an expression was expected of type "foo:int * bar:int"
+       A label "foo" was expected
 |}]
 
 let _ : tx = { x = ~foo:1, 2}
@@ -337,6 +348,7 @@ Line 1, characters 19-28:
                        ^^^^^^^^^
 Error: This expression has type "foo:int * 'a"
        but an expression was expected of type "foo:int * bar:int"
+       A label "bar" was expected
 |}]
 
 let _ : tx = { x = 1, 2}
@@ -346,6 +358,7 @@ Line 1, characters 19-23:
                        ^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "foo:int * bar:int"
+       A label "foo" was expected
 |}]
 
 let _ = { x = 1, 2 }

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples_and_constructors.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples_and_constructors.ml
@@ -64,6 +64,7 @@ Line 1, characters 15-20:
                    ^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "x:int * int"
+       A label "x" was expected
 |}]
 
 let _ = f (Foo (5,~x:1))
@@ -73,6 +74,7 @@ Line 1, characters 15-23:
                    ^^^^^^^^
 Error: This expression has type "'a * x:'b"
        but an expression was expected of type "x:int * int"
+       A label "x" was expected
 |}]
 
 let _ = f (Foo (5,~y:1))
@@ -82,4 +84,5 @@ Line 1, characters 15-23:
                    ^^^^^^^^
 Error: This expression has type "'a * y:'b"
        but an expression was expected of type "x:int * int"
+       A label "x" was expected
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3026,8 +3026,10 @@ and unify_labeled_list env labeled_tl1 labeled_tl2 =
     raise_unexplained_for Unify;
   List.iter2
     (fun (label1, ty1) (label2, ty2) ->
-      if not (Option.equal String.equal label1 label2) then
-        raise_unexplained_for Unify;
+      if not (Option.equal String.equal label1 label2) then begin
+        let diff = { Errortrace.got=label1; expected=label2} in
+        raise_for Unify (Errortrace.Tuple_label_mismatch diff)
+      end;
       unify env ty1 ty2)
     labeled_tl1 labeled_tl2
 

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -110,6 +110,7 @@ type ('a, 'variety) elt =
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Function_label_mismatch of Asttypes.arg_label diff
+  | Tuple_label_mismatch of string option diff
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
       (* Could move [Incompatible_fields] into [obj] *)
   | First_class_module: first_class_module -> ('a,_) elt
@@ -127,7 +128,8 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
       Escape { kind = Equation (f x); context }
   | Escape {kind = (Univ _ | Self | Constructor _ | Module_type _ | Constraint);
             _}
-  | Variant _ | Obj _ | Function_label_mismatch _ | Incompatible_fields _
+  | Variant _ | Obj _ | Function_label_mismatch _ | Tuple_label_mismatch _
+  | Incompatible_fields _
   | Rec_occur (_, _) | First_class_module _  as x -> x
 
 let map f t = List.map (map_elt f) t

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -96,6 +96,7 @@ type ('a, 'variety) elt =
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Function_label_mismatch of Asttypes.arg_label diff
+  | Tuple_label_mismatch of string option diff
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   | First_class_module: first_class_module -> ('a,_) elt
   (* Unification & Moregen; included in Equality for simplicity *)


### PR DESCRIPTION
This small PR aligns the error message for mismatched labels in labelled tuples with the one for 
mismatched labels in labelled function arguments.

In other words, it adds after the current error message

>```
>Error: This expression has type "a:string * int * c:'a"
>       but an expression was expected of type "a:string * int * b:string"
>```

a new line

>```
>Error: This expression has type "a:string * int * c:'a"
>       but an expression was expected of type "a:string * int * b:string"
>       Labels "c" and "b" do not match
>```

to highlight that it is the labels `b` and `c` that are mismatched.
This mirrors the current error message for  labelled function argument:

>```
>Error: The value x has type a:string -> int -> c:'a -> unit
>       but an expression was expected of type
>         a:string -> int -> b:string -> unit
>       Labels c and b do not match
>```

I personally tend to consider that this is quite close to an error message bug, and we may want to backport the fix to 5.4 .