### PR TITLE
dynlink: fix exception name in printer

### DIFF
--- a/Changes
+++ b/Changes
@@ -144,6 +144,9 @@ Working version
 
 ### Bug fixes:
 
+- #14071: Fix exception name in Dynlink.Error printer.
+  (Etienne Millon, review by Nicolás Ojeda Bär)
+
 - #13853: Format breaks some line too early when there
   is a break hint at the end.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/otherlibs/dynlink/dynlink_types.ml
+++ b/otherlibs/dynlink/dynlink_types.ml
@@ -98,7 +98,7 @@ let () =
       | Corrupted_interface s ->
         Printf.sprintf "Corrupted_interface %S" s
       | Cannot_open_dynamic_library exn ->
-        Printf.sprintf "Cannot_open_dll %S" (Printexc.to_string exn)
+        Printf.sprintf "Cannot_open_dynamic_library %S" (Printexc.to_string exn)
       | Inconsistent_implementation s ->
         Printf.sprintf "Inconsistent_implementation %S" s
       | Library's_module_initializers_failed exn ->


### PR DESCRIPTION
It looks like the name got changed in #1063.

The `Cannot_open_dll` name in the printer can be misleading because it points to a different type.
