### PR TITLE
fix one more definition of fib in the manual

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1941,7 +1941,7 @@ following "mod.ml" OCaml source:
 \begin{verbatim}
 (* File mod.ml -- some "useful" OCaml functions *)
 
-let rec fib n = if n < 2 then 1 else fib(n-1) + fib(n-2)
+let rec fib n = if n < 2 then n else fib(n-1) + fib(n-2)
 
 let format_result n = Printf.sprintf "Result is: %d\n" n
 


### PR DESCRIPTION
This is a follow-up to #13912, which missed another definition of `fib` in chapter 22.
I'm pretty sure this is the last one.
