### PR TITLE
Emit `stlr` instead of `dmb ishld; str` for stores on Apple Silicon macOS

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,12 @@ Working version
 
 ### Code generation and optimizations:
 
+- #13262, #14074: fix performance issue on Apple Silicon macOS by emitting
+  `stlr` instead of `dmb ishld; str`.
+  (KC Sivaramakrishnan, report by François Pottier, analysis by Frédéric Bour,
+  Xavier Leroy, Miod Vallat, Gabriel Scherer and Stephen Dolan, review by Miod
+  Vallat, Vincent Laviron and Xavier Leroy)
+
 ### Standard library:
 
 - #13728: Add Sys.runtime_executable containing the full path (if available) to

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -568,7 +568,7 @@ let emit_instr env fallthrough i =
   | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
       let dest = res i 0 in
       begin match memory_chunk with
-      | Word_int | Word_val ->
+      | Word_int | Word_val | Sixtyfour ->
           I.mov (addressing addressing_mode QWORD i 0) dest
       | Byte_unsigned ->
           I.movzx (addressing addressing_mode BYTE i 0) dest
@@ -590,7 +590,7 @@ let emit_instr env fallthrough i =
       end
   | Lop(Istore(chunk, addr, _)) ->
       begin match chunk with
-      | Word_int | Word_val ->
+      | Word_int | Word_val | Sixtyfour ->
           I.mov (arg i 0) (addressing addr QWORD i 1)
       | Byte_unsigned | Byte_signed ->
           I.mov (arg8 i 0) (addressing addr BYTE i 1)

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -488,15 +488,13 @@ module Size = struct
         match addressing_mode with
         | Iindexed _ -> 0
         | Ibased _ -> 1
-      in
-      let pre_store =
+      and pre_store =
         match memory_chunk, assignment, macosx, addressing_mode with
         | (Word_int | Word_val), true, true, Iindexed 0 -> 0
         | (Word_int | Word_val), true, true, _ -> 1  (* Compute dest address *)
         | (Word_int | Word_val), true, false, _ -> 1 (* Barrier instruction *)
         | _ -> 0
-      in
-      let store = match memory_chunk with Single -> 2 | _ -> 1 in
+      and store = match memory_chunk with Single -> 2 | _ -> 1 in
       based + pre_store + store
     | Lop (Ialloc _) when f.fun_fast -> 5
     | Lop (Ispecific (Ialloc_far _)) when f.fun_fast -> 6
@@ -688,8 +686,22 @@ let name_for_float_comparison = function
   | CFge -> "ge"
   | CFnge -> "lt"
 
-(* Output the assembly code for an instruction *)
+(* Output a release store [stlr] of register [src] at address [base + addr].
+   Since [stlr] does not support addressing modes, we compute [base + addr]
+   explicitly. *)
+let emit_stlr src base addr =
+  assert macosx;
+  let dest_reg =
+    match addr with
+    | Iindexed 0 -> base
+    | Iindexed ofs ->
+        `	add	{emit_reg reg_tmp1}, {emit_reg base}, #{emit_int ofs}\n`;
+        reg_tmp1
+    | Ibased _ -> assert false (* Ibased is not emitted under macOS *)
+  in
+  `	stlr	{emit_reg src}, [{emit_reg dest_reg}]\n`
 
+(* Output the assembly code for an instruction *)
 let emit_instr env i =
     emit_debug_info i.dbg;
     match i.desc with
@@ -855,29 +867,15 @@ let emit_instr env i =
         | Word_int | Word_val ->
             begin match assignment, macosx with
             | true, true ->
-                (* Memory model barrier for non-initializing store on Apple
-                   Silicon processors. See
-                   https://github.com/ocaml/ocaml/issues/13262 *)
-                let dest_reg =
-                  begin match addr with
-                  | Iindexed 0 -> base
-                  | Iindexed ofs ->
-                      `	add	{emit_reg reg_tmp1}, {emit_reg base}, #{emit_int ofs}\n`;
-                      reg_tmp1
-                  | Ibased (s, ofs) ->
-                      assert (not !Clflags.dlcode);
-                      `	add	{emit_reg reg_tmp1}, {emit_reg base}, #:lo12:{emit_symbol_offset s ofs}\n`;
-                      reg_tmp1
-                  end
-                in
-                `	stlr	{emit_reg src}, [{emit_reg dest_reg}]\n`
+                (* Release store for assignments on macOS. See
+                   https://github.com/ocaml/ocaml/issues/13262. *)
+                emit_stlr src base addr
             | true, false ->
-                (* Memory model barrier for non-initializing store on non-Apple
-                   Silicon processors. *)
+                (* Memory model barrier for assignments. *)
                 `	dmb	ishld\n`;
                 `	str	{emit_reg src}, {emit_addressing addr base}\n`
             | _, _ ->
-                (* Initialising store *)
+                (* Initializing store *)
                 `	str	{emit_reg src}, {emit_addressing addr base}\n`
             end
         | Double ->

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -484,13 +484,20 @@ module Size = struct
       and single = match memory_chunk with Single -> 2 | _ -> 1 in
       based + barrier + single
     | Lop (Istore (memory_chunk, addressing_mode, assignment)) ->
-      let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
-      and barrier =
-        match memory_chunk, assignment with
-        | (Word_int | Word_val), true -> 1
+      let based =
+        match addressing_mode with
+        | Iindexed _ -> 0
+        | Ibased _ -> 1
+      in
+      let pre_store =
+        match memory_chunk, assignment, macosx, addressing_mode with
+        | (Word_int | Word_val), true, true, Iindexed 0 -> 0
+        | (Word_int | Word_val), true, true, _ -> 1  (* Compute dest address *)
+        | (Word_int | Word_val), true, false, _ -> 1 (* Barrier instruction *)
         | _ -> 0
-      and single = match memory_chunk with Single -> 2 | _ -> 1 in
-      based + barrier + single
+      in
+      let store = match memory_chunk with Single -> 2 | _ -> 1 in
+      based + pre_store + store
     | Lop (Ialloc _) when f.fun_fast -> 5
     | Lop (Ispecific (Ialloc_far _)) when f.fun_fast -> 6
     | Lop (Ipoll {return_label=None}) -> 3
@@ -823,7 +830,7 @@ let emit_instr env i =
         end
     | Lop(Istore(size, addr, assignment)) ->
         (* NB: assignments other than Word_int and Word_val do not follow the
-        Multicore OCaml memory model and so do not emit a barrier *)
+           Multicore OCaml memory model and so do not emit a barrier *)
         let src = i.arg.(0) in
         let base =
           match addr with
@@ -843,9 +850,33 @@ let emit_instr env i =
             `	fcvt	s7, {emit_reg src}\n`;
             `	str	s7, {emit_addressing addr base}\n`;
         | Word_int | Word_val ->
-            (* memory model barrier for non-initializing store *)
-            if assignment then `	dmb	ishld\n`;
-            `	str	{emit_reg src}, {emit_addressing addr base}\n`
+            begin match assignment, macosx with
+            | true, true ->
+                (* Memory model barrier for non-initializing store on Apple
+                   Silicon processors. See
+                   https://github.com/ocaml/ocaml/issues/13262 *)
+                let dest_reg =
+                  begin match addr with
+                  | Iindexed 0 -> base
+                  | Iindexed ofs ->
+                      `	add	{emit_reg reg_tmp1}, {emit_reg base}, #{emit_int ofs}\n`;
+                      reg_tmp1
+                  | Ibased (s, ofs) ->
+                      assert (not !Clflags.dlcode);
+                      `	add	{emit_reg reg_tmp1}, {emit_reg base}, #:lo12:{emit_symbol_offset s ofs}\n`;
+                      reg_tmp1
+                  end
+                in
+                `	stlr	{emit_reg src}, [{emit_reg dest_reg}]\n`
+            | true, false ->
+                (* Memory model barrier for non-initializing store on non-Apple
+                   Silicon processors. *)
+                `	dmb	ishld\n`;
+                `	str	{emit_reg src}, {emit_addressing addr base}\n`
+            | _, _ ->
+                (* Initialising store *)
+                `	str	{emit_reg src}, {emit_addressing addr base}\n`
+            end
         | Double ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         end

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -818,9 +818,10 @@ let emit_instr env i =
         | Single ->
             `	ldr	s7, {emit_addressing addressing_mode base}\n`;
             `	fcvt	{emit_reg dst}, s7\n`
-        | Word_int | Word_val ->
+        | Sixtyfour | Word_int | Word_val ->
             if is_atomic then begin
               assert (addressing_mode = Iindexed 0);
+              assert (not (memory_chunk = Sixtyfour));
               `	dmb	ishld\n`;
               `	ldar	{emit_reg dst}, [{emit_reg i.arg.(0)}]\n`
             end else
@@ -849,6 +850,8 @@ let emit_instr env i =
         | Single ->
             `	fcvt	s7, {emit_reg src}\n`;
             `	str	s7, {emit_addressing addr base}\n`;
+        | Sixtyfour ->
+            `	str	{emit_reg src}, {emit_addressing addr base}\n`
         | Word_int | Word_val ->
             begin match assignment, macosx with
             | true, true ->

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -32,7 +32,7 @@ let is_offset chunk n =
         n land 1 = 0 && n lsr 1 < 0x1000
     | Thirtytwo_unsigned | Thirtytwo_signed | Single ->
         n land 3 = 0 && n lsr 2 < 0x1000
-    | Word_int | Word_val | Double ->
+    | Sixtyfour | Word_int | Word_val | Double ->
         n land 7 = 0 && n lsr 3 < 0x1000)
 
 let is_logical_immediate n =

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -142,6 +142,7 @@ type memory_chunk =
   | Sixteen_signed
   | Thirtytwo_unsigned
   | Thirtytwo_signed
+  | Sixtyfour
   | Word_int
   | Word_val
   | Single

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -132,11 +132,12 @@ type memory_chunk =
   | Sixteen_signed
   | Thirtytwo_unsigned
   | Thirtytwo_signed
-  | Word_int                           (* integer or pointer outside heap *)
-  | Word_val                           (* pointer inside heap or encoded int *)
+  | Sixtyfour          (* 64-bit integer whose accesses do not follow OCaml
+                          relaxed memory model *)
+  | Word_int           (* Integer or pointer outside heap *)
+  | Word_val           (* Pointer inside heap or encoded int *)
   | Single
-  | Double                             (* word-aligned 64-bit float
-                                          see PR#10433 *)
+  | Double             (* Word-aligned 64-bit float. See PR#10433. *)
 
 and operation =
     Capply of machtype

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -950,9 +950,9 @@ let bigarray_word_kind : Lambda.bigarray_kind -> memory_chunk = function
   | Pbigarray_sint16 -> Sixteen_signed
   | Pbigarray_uint16 -> Sixteen_unsigned
   | Pbigarray_int32 -> Thirtytwo_signed
-  | Pbigarray_int64 -> Word_int
-  | Pbigarray_caml_int -> Word_int
-  | Pbigarray_native_int -> Word_int
+  | Pbigarray_int64 -> Sixtyfour
+  | Pbigarray_caml_int -> Sixtyfour
+  | Pbigarray_native_int -> Sixtyfour
   | Pbigarray_complex32 -> Single
   | Pbigarray_complex64 -> Double
 
@@ -1196,7 +1196,7 @@ let unaligned_set_32 ptr idx newval dbg =
 
 let unaligned_load_64 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(mk_load_mut Word_int, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Sixtyfour, [add_int ptr idx dbg], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
@@ -1234,7 +1234,7 @@ let unaligned_load_64 ptr idx dbg =
 
 let unaligned_set_64 ptr idx newval dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cstore (Word_int, Assignment), [add_int ptr idx dbg; newval], dbg)
+  then Cop(Cstore (Sixtyfour, Assignment), [add_int ptr idx dbg; newval], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -184,7 +184,7 @@ let load_mnemonic = function
   | Sixteen_signed -> "lha"
   | Thirtytwo_unsigned -> "lwz"
   | Thirtytwo_signed -> "lwa"
-  | Word_int | Word_val -> "ld"
+  | Word_int | Word_val | Sixtyfour -> "ld"
   | Single -> "lfs"
   | Double -> "lfd"
 
@@ -192,7 +192,7 @@ let store_mnemonic = function
   | Byte_unsigned | Byte_signed -> "stb"
   | Sixteen_unsigned | Sixteen_signed -> "sth"
   | Thirtytwo_unsigned | Thirtytwo_signed -> "stw"
-  | Word_int | Word_val -> "std"
+  | Word_int | Word_val | Sixtyfour -> "std"
   | Single -> "stfs"
   | Double -> "stfd"
 

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -81,6 +81,7 @@ let chunk = function
   | Sixteen_signed -> "signed int16"
   | Thirtytwo_unsigned -> "unsigned int32"
   | Thirtytwo_signed -> "signed int32"
+  | Sixtyfour -> "int64"
   | Word_int -> "int"
   | Word_val -> "val"
   | Single -> "float32"

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -354,7 +354,7 @@ let emit_instr env i =
       assert (not is_atomic);
       `	flw	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`;
       `	fcvt.d.s	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
-  | Lop(Iload { memory_chunk = Word_int | Word_val; addressing_mode = Iindexed ofs; is_atomic } ) ->
+  | Lop(Iload { memory_chunk = Sixtyfour | Word_int | Word_val; addressing_mode = Iindexed ofs; is_atomic } ) ->
       if is_atomic then `	fence	rw, rw\n`;
       `	ld	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`;
       if is_atomic then `	fence	r, rw\n`
@@ -368,7 +368,7 @@ let emit_instr env i =
         | Sixteen_signed -> "lh"
         | Thirtytwo_unsigned -> "lwu"
         | Thirtytwo_signed -> "lw"
-        | Word_int | Word_val | Single -> assert false
+        | Word_int | Word_val | Single | Sixtyfour -> assert false
         | Double -> "fld"
       in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`
@@ -389,6 +389,7 @@ let emit_instr env i =
         | Sixteen_unsigned | Sixteen_signed -> "sh"
         | Thirtytwo_unsigned | Thirtytwo_signed -> "sw"
         | Word_int | Word_val | Single -> assert false
+        | Sixtyfour -> "sd"
         | Double -> "fsd"
       in
       `	{emit_string instr}	{emit_reg i.arg.(0)}, {emit_int ofs}({emit_reg i.arg.(1)})\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -405,7 +405,7 @@ let emit_instr env i =
           | Sixteen_signed -> "lgh"
           | Thirtytwo_unsigned -> "llgf"
           | Thirtytwo_signed -> "lgf"
-          | Word_int | Word_val -> "lg"
+          | Word_int | Word_val | Sixtyfour -> "lg"
           | Single -> "ley"
           | Double -> "ldy" in
         emit_load_store loadinstr addressing_mode i.arg 0 i.res.(0);
@@ -421,7 +421,7 @@ let emit_instr env i =
             Byte_unsigned | Byte_signed -> "stcy"
           | Sixteen_unsigned | Sixteen_signed -> "sthy"
           | Thirtytwo_unsigned | Thirtytwo_signed -> "sty"
-          | Word_int | Word_val -> "stg"
+          | Word_int | Word_val | Sixtyfour -> "stg"
           | Single -> assert false
           | Double -> "stdy" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)

--- a/asmcomp/thread_sanitizer.ml
+++ b/asmcomp/thread_sanitizer.ml
@@ -34,6 +34,7 @@ let bit_size memory_chunk =
   | Byte_unsigned | Byte_signed -> 8
   | Sixteen_unsigned | Sixteen_signed -> 16
   | Thirtytwo_unsigned | Thirtytwo_signed -> 32
+  | Sixtyfour -> 64
   | Word_int | Word_val -> Sys.word_size
   | Single -> 32
   | Double -> 64
@@ -57,7 +58,7 @@ end
 
 let machtype_of_memory_chunk = function
   | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-  | Thirtytwo_unsigned | Thirtytwo_signed | Word_int ->
+  | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Sixtyfour ->
     typ_int
   | Word_val -> typ_val
   | Single | Double -> typ_float


### PR DESCRIPTION
Fixes #13262. There are a couple of failures, and I'd like to have some thoughts on the design before I proceed further. 

## Failures

The tests `tests/lib-buffer/test.ml` and `tests/lib-bytes/binary.ml` fail. These tests generate unaligned 8-byte stores with memory chunk kind being `Word_int`. Replacing `str` for `stlr` doesn't work since `stlr` expects 8-byte aligned destination address. 

The `Word_int` memory chunk kind is assigned here https://github.com/ocaml/ocaml/blob/8761443617f229d5fe683ed2570aa79c8d64348a/asmcomp/cmm_helpers.ml#L1237. With the current setup, it is not possible to distinguish between aligned `Word_int` writes, such as writing to an integer reference or an integer array, which require the memory ordering fence, and the unaligned accesses.

## Inefficiency of using `Word_int`

In addition, using `Word_int` for such accesses is inefficient, in cases where a memory ordering fence is not necessary. Consider the program below

```ocaml
(* test.ml *)
let buffer_test () =
  let b = Buffer.create 64 in
  Buffer.add_int64_le b 0xdeadbeafdeadbeafL;
  b

let bigarray_test () =
  let module BA1 = Bigarray.Array1 in
  let ba = BA1.create Bigarray.Int64 Bigarray.c_layout 64 in
  BA1.set ba 0 0xfeedfacefeedfaceL;
  ba

let bytes_test () =
  let b = Bytes.create 64 in
  Bytes.set_int64_le b 0 0x0badf00d0badf00dL;
  b
```

Accesses to Buffer, Bytes and Bigarray do not respect the OCaml memory model. They do not store pointers. But the compiler currently generates a fence for the writes.

```bash
% ocamlopt test.ml
% otool -tvV ./a.out > dump
```

```asm
(* dump *)
...
0000000100002128  mov x2, #0xbeaf                                                     
000000010000212c  movk  x2, #0xdead, lsl #16                                     
0000000100002130  movk  x2, #0xbeaf, lsl #32                                          
0000000100002134  movk  x2, #0xdead, lsl #48                                          
0000000100002138  dmb ishld                                                           
000000010000213c  str  x2, [x1] 
...
00000001000021dc  mov x10, #0xface
00000001000021e0  movk  x10, #0xfeed, lsl #16                                         
00000001000021e4  movk  x10, #0xface, lsl #32                                         
00000001000021e8  movk  x10, #0xfeed, lsl #48                                         
00000001000021ec  dmb ishld                                                          
00000001000021f0  stur  x10, [x9, #-0x4] 
...
0000000100002258  mov x15, #0xf00d                                                    
000000010000225c  movk  x15, #0xbad, lsl #16                                     
0000000100002260  movk  x15, #0xf00d, lsl #32                                         
0000000100002264  movk  x15, #0xbad, lsl #48                                          
0000000100002268  dmb ishld                                                           
000000010000226c  str  x15, [x0]
...
```

The `dmb ishld` fences are unnecessary.

## Proposal

I plan to introduce a new `memory_chunk`, `Sixtyfour`, which represents a word-sized access which may potentially be unaligned and has no memory ordering requirement. We will generate `str` for stores to locations of this memory chunk kind rather than `stlr` (on macOS) and `dmb ishld; str` on other Arm64 platforms. 