### PR TITLE
Fix TSan false alarms on string/bytes initializating writes

### DIFF
--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -172,6 +172,9 @@ CAMLexport value caml_alloc_tuple(mlsize_t n)
 }
 
 /* [len] is a number of bytes (chars) */
+CAMLno_tsan /* Avoid instrumenting initializing writes with TSan: they should
+               never cause data races (albeit for reasons outside of the C11
+               memory model). */
 CAMLexport value caml_alloc_string (mlsize_t len)
 {
   value result;
@@ -192,6 +195,9 @@ CAMLexport value caml_alloc_string (mlsize_t len)
 }
 
 /* [len] is a number of bytes (chars) */
+CAMLno_tsan /* Avoid instrumenting initializing writes with TSan: they should
+               never cause data races (albeit for reasons outside of the C11
+               memory model). */
 CAMLexport value caml_alloc_initialized_string (mlsize_t len, const char *p)
 {
   value result = caml_alloc_string (len);


### PR DESCRIPTION
This is an attempt at de-instrumenting initializing writes for strings and bytes to avoid TSan false alarms that show up in the new test `weak-ephe-final/weak_array_par.ml`.

Unfortunately, annotating `CAMLno_tsan` does not seem to prevent it from calling an instrumented version of memcpy, so I’m making this a draft PR for now.