### PR TITLE
error messages: point mismatched universal type variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,10 @@ Working version
   recursive modules.
   (Shivam Acharya, review by Gabriel Scherer and Florian Angeletti)
 
+- #14076: error messages, add a short explanation for mismatched universal
+  variables.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1162,7 +1162,52 @@ Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The method "m" has type "'c. 'c * ('b * < m : 'c. 'e >) as 'e",
        but the expected method type was
        "'c. 'c * ('c * < m : 'b. 'b * ('b * < m : 'c. 'f >) >) as 'f"
+       The universal variables "'b" and "'c" are distinct.
+       The first type variable "'b" was introduced in an earlier universal
+       quantification.
 |}];;
+
+let f (x: <x: 'a 'b 'c. 'a * 'b * 'b * 'c >) =
+  (x: <x: 'a 'b 'c. 'c * 'a * 'b * 'b>)
+[%%expect {|
+Line 2, characters 3-4:
+2 |   (x: <x: 'a 'b 'c. 'c * 'a * 'b * 'b>)
+       ^
+Error: The value "x" has type "< x : 'c 'a 'c0. 'c * 'a * 'a * 'c0 >"
+       but an expression was expected of type
+         "< x : 'a 'b 'c. 'c * 'a * 'b * 'b >"
+       The method "x" has type "'c 'a 'c0. 'c * 'a * 'a * 'c0",
+       but the expected method type was "'a 'b 'c. 'c * 'a * 'b * 'b"
+       The universal variables "'a" and "'b" are distinct.
+|}]
+
+let f (x: <x: 'a. <x: 'b. 'a * 'b > >) =
+      (x: <x: 'b. <x: 'a. 'a * 'b > >)
+[%%expect {|
+Line 2, characters 7-8:
+2 |       (x: <x: 'b. <x: 'a. 'a * 'b > >)
+           ^
+Error: The value "x" has type "< x : 'a. < x : 'b. 'a * 'b > >"
+       but an expression was expected of type "< x : 'b. < x : 'a. 'a * 'b > >"
+       The method "x" has type "'b. 'a * 'b", but the expected method type was
+       "'a0. 'a0 * 'b"
+       The universal variables "'a" and "'a0" are distinct.
+       The first type variable "'a" was introduced in an earlier universal
+       quantification.
+|}]
+
+let f (o: <x: 'a 'b. ('a * 'a) * 'b >) =
+      (o: <x: 'a 'b. ('a * 'a) * 'a >)
+[%%expect {|
+Line 2, characters 7-8:
+2 |       (o: <x: 'a 'b. ('a * 'a) * 'a >)
+           ^
+Error: The value "o" has type "< x : 'a 'b. ('a * 'a) * 'b >"
+       but an expression was expected of type "< x : 'a. ('a * 'a) * 'a >"
+       The method "x" has type "'a 'b. ('a * 'a) * 'b",
+       but the expected method type was "'a. ('a * 'a) * 'a"
+       The universal variables "'b" and "'a" are distinct.
+|}]
 
 module M
 : sig val f : (<m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>) -> unit end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -18,9 +18,12 @@
 open Types
 
 type position = First | Second
+type order = Less | Equal | More
 
 val swap_position : position -> position
 val print_pos : position Format_doc.printer
+
+val swap_order: order -> order
 
 type expanded_type = { ty: type_expr; expanded: type_expr }
 
@@ -99,6 +102,7 @@ type ('a, 'variety) elt =
   | Tuple_label_mismatch of string option diff
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   | First_class_module: first_class_module -> ('a,_) elt
+  | Univar_mismatch of { order:order; diff:type_expr diff }
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) elt
 


### PR DESCRIPTION
This PR add a short sentence pointing to the mismatched universal type variables when two types cannot be unified because the universal variables are not equivalent under renaming. For instance,

```ocaml
let f (x: <x: 'a 'b 'c. 'a * 'b * 'b * 'c >) =
  (x: <x: 'a 'b 'c. 'c * 'a * 'b * 'b>)
```
now yields the following error message:
>```
>Error: The value "x" has type "< x : 'c 'a 'c0. 'c * 'a * 'a * 'c0 >"
>       but an expression was expected of type
>         "< x : 'a 'b 'c. 'c * 'a * 'b * 'b >"
>       The method "x" has type "'c 'a 'c0. 'c * 'a * 'a * 'c0",
>       but the expected method type was "'a 'b 'c. 'c * 'a * 'b * 'b"
>       The universal variables "'a" and "'b" are distinct.
>```

where the last sentence is new. Similarly, this PR mentions when two universal type variables cannot be equal because they were introduced at different binding time:

```ocaml
let f (x: <x: 'a. <x: 'b. 'a * 'b > >) =
      (x: <x: 'b. <x: 'a. 'a * 'b > >)
```

>```      
>Error: The value "x" has type "< x : 'a. < x : 'b. 'a * 'b > >"
>       but an expression was expected of type "< x : 'b. < x : 'a. 'a * 'b > >"
>       The method "x" has type "'b. 'a * 'b", but the expected method type was
>       "'a0. 'a0 * 'b"
>       The universal variables "'a" and "'a0" are distinct.
>       The first type variable "'a" was introduced in an earlier universal
>       quantification.
>```


