### PR TITLE
Add missing `item-attribute` rule for `let-binding` in documentation of attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -113,6 +113,10 @@ Working version
   fail to load.
   (toastal)
 
+- #14077: Add missing `item-attribute` rule for `let-binding`s in documentation
+  for attributes.
+  (Shon Feder)
+
 ### Compiler user-interface and warnings:
 
 - #12628: Improved error message for unsafe values: print out the full path for

--- a/manual/src/refman/extensions/attributes.etex
+++ b/manual/src/refman/extensions/attributes.etex
@@ -104,6 +104,9 @@ class-spec: ...
 classtype-def: ...
    | classtype-def item-attribute
 ;
+let-binding: ...
+   | let-binding { item-attribute }
+;
 definition:
           'let' ['rec'] let-binding { 'and' let-binding }
         | 'external' value-name ':' typexpr '=' external-declaration { item-attribute }

--- a/manual/src/refman/extensions/attributes.etex
+++ b/manual/src/refman/extensions/attributes.etex
@@ -105,7 +105,7 @@ classtype-def: ...
    | classtype-def item-attribute
 ;
 let-binding: ...
-   | let-binding { item-attribute }
+   | let-binding item-attribute
 ;
 definition:
           'let' ['rec'] let-binding { 'and' let-binding }


### PR DESCRIPTION
Following conversation in slack with @nojb, this PR adds a missing case for the documentation of the grammar for `item-attribute`s.

This reflects the grammar in
https://github.com/ocaml/ocaml/blob/8761443617f229d5fe683ed2570aa79c8d64348a/parsing/parser.mly#L2742-L2759 and without this rule, the documented grammar doesn't account for forms like

```ocaml
let foo = bar
[@@bax]
```