### PR TITLE
`__tsan_func_exit()` signature mismatch (#14065)

### DIFF
--- a/Changes
+++ b/Changes
@@ -2258,11 +2258,12 @@ OCaml 5.2.0 (13 May 2024)
 
 ### Bug fixes:
 
-- #14065: Fix function signature mismatch of `__tsan_func_exit` in gcc15.
-  Adds checks in the configure step to check if the tsan internal builtins
-  provided by the tsan library are the same as what we expect, introduces
-  wrappers for `caml_tsan_*` wrappers for the `__tsan_*` functions we use.
-  (Hari Hara Naveen S, report by Hari Hara Naveen S, review by TBD)
+- #14065: Fix function signature mismatch of `__tsan_func_exit` with GCC 15.
+  Check in the configure step if the TSan provided internal builtins are the
+  same as what we expect, introduce `caml_tsan_*` wrappers for the `__tsan_*`
+  functions we use.
+  (Hari Hara Naveen S, report by Hari Hara Naveen S,
+  review by Gabriel Scherer, Antonin Décimo, Olivier Nicole)
 
 - #10652, #12720: fix evaluation order in presence of optional arguments
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)

--- a/Changes
+++ b/Changes
@@ -2262,7 +2262,7 @@ OCaml 5.2.0 (13 May 2024)
   Adds checks in the configure step to check if the tsan internal builtins
   provided by the tsan library are the same as what we expect, introduces
   wrappers for `caml_tsan_*` wrappers for the `__tsan_*` functions we use.
-  (Hari Hara Naveen S, report by Hari Hara Naveen S, review by TBD) 
+  (Hari Hara Naveen S, report by Hari Hara Naveen S, review by TBD)
 
 - #10652, #12720: fix evaluation order in presence of optional arguments
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)

--- a/Changes
+++ b/Changes
@@ -2258,6 +2258,12 @@ OCaml 5.2.0 (13 May 2024)
 
 ### Bug fixes:
 
+- #14065: Fix function signature mismatch of `__tsan_func_exit` in gcc15.
+  Adds checks in the configure step to check if the tsan internal builtins
+  provided by the tsan library are the same as what we expect, introduces
+  wrappers for `caml_tsan_*` wrappers for the `__tsan_*` functions we use.
+  (Hari Hara Naveen S, report by Hari Hara Naveen S, review by TBD) 
+
 - #10652, #12720: fix evaluation order in presence of optional arguments
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
 

--- a/asmcomp/thread_sanitizer.ml
+++ b/asmcomp/thread_sanitizer.ml
@@ -69,13 +69,14 @@ let wrap_entry_exit expr =
   let call_entry =
     Cmm_helpers.return_unit dbg_none
       (Cop
-         ( Cextcall ("__tsan_func_entry", typ_void, [], false),
+         ( Cextcall ("caml_tsan_func_entry_asm", typ_void, [], false),
            [Creturn_addr],
            dbg_none ))
   in
   let call_exit =
     Cmm_helpers.return_unit dbg_none
-      (Cop (Cextcall ("__tsan_func_exit", typ_void, [], false), [], dbg_none))
+      (Cop (Cextcall ("caml_tsan_func_exit_asm", typ_void, [], false),
+            [], dbg_none))
   in
   (* [is_tail] is true when the expression is in tail position *)
   let rec insert_call_exit is_tail = function

--- a/configure
+++ b/configure
@@ -19646,12 +19646,17 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
   LDFLAGS="$SAVED_LDFLAGS"
 
-  # We use tsan builtins which are internal functions and might not be backwards compatible.
+  # We use tsan builtins which are internal functions
+  # and might not be backwards compatible.
   # We explicitly check if the compiler uses the same declarations we expect
 
-  # Some tsan builtins like __tsan_func_exit have either of 2 signatures void(void) or void(void *) (PR #14082)
-  # We first do a single check for all builtins for which we expect only one signature
-  # Then check builtins for which we expect one of multiple signatures and set a #define according to which one is found
+  # Some tsan builtins like __tsan_func_exit have either of
+  # 2 signatures void(void) or void(void *) (PR #14082)
+  # We first do a single check for all builtins
+  # for which we expect only one signature
+
+  # Then check builtins for which we expect one of multiple signatures
+  # and set a preprocessor definition according to which one is found
 
   SAVED_LDFLAGS="$LDFLAGS"
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ThreadSanitizer builtins" >&5
@@ -19745,7 +19750,8 @@ printf "%s\n" "#define TSAN_FUNC_EXIT_SIGNATURE 1" >>confdefs.h
 printf "%s\n" "#define TSAN_FUNC_EXIT_SIGNATURE 2" >>confdefs.h
  ;; #(
   *) :
-    as_fn_error $? "libtsan provided uses unexpected type of builtin __tsan_func_exit" "$LINENO" 5 ;;
+    as_fn_error $? "libtsan provided uses
+                        unexpected type of builtin __tsan_func_exit" "$LINENO" 5 ;;
 esac
 
   case $ocaml_cc_vendor in #(

--- a/configure
+++ b/configure
@@ -796,7 +796,6 @@ build_os
 build_vendor
 build_cpu
 build
-TSAN_FUNC_EXIT_SIGNATURE
 ar_supports_response_files
 QS
 TARGET_LIBDIR
@@ -3507,7 +3506,6 @@ LINEAR_MAGIC_NUMBER=Caml1999L037
 
 
  # TODO: rename this variable
-
 
 
 
@@ -19666,7 +19664,6 @@ else $as_nop
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-
 void AnnotateHappensBefore(const char *f, int l, void *addr);
 void AnnotateHappensAfter (const char *f, int l, void *addr);
 void __tsan_func_entry   (void *);
@@ -19680,7 +19677,6 @@ main (void)
   AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
   __tsan_func_entry   ((void*)0);
   __tsan_write8       ((void*)0);
-
 
   ;
   return 0;
@@ -19716,22 +19712,6 @@ else $as_nop
     LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-void __tsan_func_exit(void *);
-int
-main (void)
-{
-__tsan_func_exit((void*)0);
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  ocaml_cv_func_which___tsan_func_exit=void_void_p
-else $as_nop
-  # Else branch if the first program fails to link
-      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 void __tsan_func_exit(void);
 int
 main (void)
@@ -19744,6 +19724,22 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
   ocaml_cv_func_which___tsan_func_exit=void_void
+else $as_nop
+  # Else branch if the first program fails to link
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+void __tsan_func_exit(void *);
+int
+main (void)
+{
+__tsan_func_exit((void *)0);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ocaml_cv_func_which___tsan_func_exit=void_void_p
 else $as_nop
   ocaml_cv_func_which___tsan_func_exit=no
 fi

--- a/configure
+++ b/configure
@@ -19646,112 +19646,129 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
   LDFLAGS="$SAVED_LDFLAGS"
 
-  # We use tsan builtins which are internal functions
-  # and might not be backwards compatible.
-  # We explicitly check if the compiler uses the same declarations we expect
-
-  # Some tsan builtins like __tsan_func_exit have either of
-  # 2 signatures void(void) or void(void *) (PR #14082)
-  # We first do a single check for all builtins
-  # for which we expect only one signature
-
-  # Then check builtins for which we expect one of multiple signatures
-  # and set a preprocessor definition according to which one is found
-
-  SAVED_LDFLAGS="$LDFLAGS"
+# We use tsan builtins which are internal functions and might not be
+# backwards compatible. We explicitly check if the compiler uses the
+# same declarations we expect.
+# Some tsan builtins like __tsan_func_exit() have either of two
+# signatures, void (void) or void (void *) (PR #14082).
+# We first do a single check for all builtins for which we expect
+# only one signature, then we check builtins for which we expect one
+# of multiple signatures and set a preprocessor definition according
+# to which one is found.
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ThreadSanitizer builtins" >&5
 printf %s "checking for ThreadSanitizer builtins... " >&6; }
-  LDFLAGS="$LDFLAGS -fsanitize=thread"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-      void AnnotateHappensBefore(const char *f, int l, void *addr);
-      void AnnotateHappensAfter (const char *f, int l, void *addr);
-      void __tsan_func_entry   (void *);
-      void __tsan_write8       (void *location);
-
-      int main(void) {
-        AnnotateHappensBefore(__FILE__, __LINE__, (void*)0);
-        AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
-        __tsan_func_entry   ((void*)0);
-        __tsan_write8       ((void*)0);
-        return 0;
-      }
-
-
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
+if test ${ocaml_cv_tsan_builtins+y}
 then :
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+  printf %s "(cached) " >&6
 else $as_nop
-   as_fn_error $? "libtsan provided uses unexpected builtins" "$LINENO" 5
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-  LDFLAGS="$SAVED_LDFLAGS"
-
-  SAVED_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS -fsanitize=thread"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+  saved_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 
-      void __tsan_func_exit(void *);
+void AnnotateHappensBefore(const char *f, int l, void *addr);
+void AnnotateHappensAfter (const char *f, int l, void *addr);
+void __tsan_func_entry   (void *);
+void __tsan_write8       (void *location);
 
-      int main(void) {
-        __tsan_func_exit((void*)0);
-        return 0;
-      }
+int
+main (void)
+{
+
+  AnnotateHappensBefore(__FILE__, __LINE__, (void*)0);
+  AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
+  __tsan_func_entry   ((void*)0);
+  __tsan_write8       ((void*)0);
 
 
+  ;
+  return 0;
+}
 _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
-   tsan_func_exit_signature=VOID_VOID_PTR;
+  ocaml_cv_tsan_builtins=yes
+else $as_nop
+  ocaml_cv_tsan_builtins=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
-  LDFLAGS="$SAVED_LDFLAGS"
+    LDFLAGS="$saved_LDFLAGS"
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_tsan_builtins" >&5
+printf "%s\n" "$ocaml_cv_tsan_builtins" >&6; }
 
-  SAVED_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS -fsanitize=thread"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+  if test "$ocaml_cv_tsan_builtins" = no
+then :
+  as_fn_error $? "libtsan doesn't provide the expected builtins" "$LINENO" 5
+fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how many arguments __tsan_func_exit() takes" >&5
+printf %s "checking how many arguments __tsan_func_exit() takes... " >&6; }
+if test ${ocaml_cv_func_which___tsan_func_exit+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  saved_LDFLAGS="$LDFLAGS"
+
+    # We need warning flags as using the wrong builtins is often a warning
+    LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-
-      void __tsan_func_exit();
-
-      int main(void) {
-        __tsan_func_exit();
-        return 0;
-      }
-
-
+void __tsan_func_exit(void *);
+int
+main (void)
+{
+__tsan_func_exit((void*)0);
+  ;
+  return 0;
+}
 _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
-   tsan_func_exit_signature=VOID_VOID;
+  ocaml_cv_func_which___tsan_func_exit=void_void_p
+else $as_nop
+  # Else branch if the first program fails to link
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+void __tsan_func_exit(void);
+int
+main (void)
+{
+__tsan_func_exit();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ocaml_cv_func_which___tsan_func_exit=void_void
+else $as_nop
+  ocaml_cv_func_which___tsan_func_exit=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
-  LDFLAGS="$SAVED_LDFLAGS"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+    LDFLAGS="$saved_LDFLAGS"
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_func_which___tsan_func_exit" >&5
+printf "%s\n" "$ocaml_cv_func_which___tsan_func_exit" >&6; }
 
   # Define a C macro based on the detected __tsan_func_exit signature
-  case $tsan_func_exit_signature in #(
-  VOID_VOID_PTR) :
+  case $ocaml_cv_func_which___tsan_func_exit in #(
+  void_void_p) :
 
-printf "%s\n" "#define TSAN_FUNC_EXIT_SIGNATURE 1" >>confdefs.h
+printf "%s\n" "#define HAVE___TSAN_FUNC_EXIT_VOID_VOID_P 1" >>confdefs.h
  ;; #(
-  VOID_VOID) :
+  void_void) :
 
-printf "%s\n" "#define TSAN_FUNC_EXIT_SIGNATURE 2" >>confdefs.h
+printf "%s\n" "#define HAVE___TSAN_FUNC_EXIT_VOID_VOID 1" >>confdefs.h
  ;; #(
   *) :
-    as_fn_error $? "libtsan provided uses
-                        unexpected type of builtin __tsan_func_exit" "$LINENO" 5 ;;
+    as_fn_error $? "libtsan uses an unexpected signature for __tsan_func_exit" "$LINENO" 5 ;;
 esac
 
   case $ocaml_cc_vendor in #(

--- a/configure
+++ b/configure
@@ -796,6 +796,7 @@ build_os
 build_vendor
 build_cpu
 build
+TSAN_FUNC_EXIT_SIGNATURE
 ar_supports_response_files
 QS
 TARGET_LIBDIR
@@ -3506,6 +3507,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L037
 
 
  # TODO: rename this variable
+
 
 
 
@@ -19643,6 +19645,108 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
   LDFLAGS="$SAVED_LDFLAGS"
+
+  # We use tsan builtins which are internal functions and might not be backwards compatible.
+  # We explicitly check if the compiler uses the same declarations we expect
+
+  # Some tsan builtins like __tsan_func_exit have either of 2 signatures void(void) or void(void *) (PR #14082)
+  # We first do a single check for all builtins for which we expect only one signature
+  # Then check builtins for which we expect one of multiple signatures and set a #define according to which one is found
+
+  SAVED_LDFLAGS="$LDFLAGS"
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ThreadSanitizer builtins" >&5
+printf %s "checking for ThreadSanitizer builtins... " >&6; }
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+      void AnnotateHappensBefore(const char *f, int l, void *addr);
+      void AnnotateHappensAfter (const char *f, int l, void *addr);
+      void __tsan_func_entry   (void *);
+      void __tsan_write8       (void *location);
+
+      int main(void) {
+        AnnotateHappensBefore(__FILE__, __LINE__, (void*)0);
+        AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
+        __tsan_func_entry   ((void*)0);
+        __tsan_write8       ((void*)0);
+        return 0;
+      }
+
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
+   as_fn_error $? "libtsan provided uses unexpected builtins" "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LDFLAGS="$SAVED_LDFLAGS"
+
+  SAVED_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+      void __tsan_func_exit(void *);
+
+      int main(void) {
+        __tsan_func_exit((void*)0);
+        return 0;
+      }
+
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+   tsan_func_exit_signature=VOID_VOID_PTR;
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LDFLAGS="$SAVED_LDFLAGS"
+
+  SAVED_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+      void __tsan_func_exit();
+
+      int main(void) {
+        __tsan_func_exit();
+        return 0;
+      }
+
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+   tsan_func_exit_signature=VOID_VOID;
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LDFLAGS="$SAVED_LDFLAGS"
+
+  # Define a C macro based on the detected __tsan_func_exit signature
+  case $tsan_func_exit_signature in #(
+  VOID_VOID_PTR) :
+
+printf "%s\n" "#define TSAN_FUNC_EXIT_SIGNATURE 1" >>confdefs.h
+ ;; #(
+  VOID_VOID) :
+
+printf "%s\n" "#define TSAN_FUNC_EXIT_SIGNATURE 2" >>confdefs.h
+ ;; #(
+  *) :
+    as_fn_error $? "libtsan provided uses unexpected type of builtin __tsan_func_exit" "$LINENO" 5 ;;
+esac
 
   case $ocaml_cc_vendor in #(
   gcc-[0123456789]-*|gcc-10-*|clang-*) :

--- a/configure.ac
+++ b/configure.ac
@@ -1981,89 +1981,64 @@ AS_IF([$tsan],
                    Try installing it on your system.])])
   LDFLAGS="$SAVED_LDFLAGS"
 
-  # We use tsan builtins which are internal functions
-  # and might not be backwards compatible.
-  # We explicitly check if the compiler uses the same declarations we expect
+# We use tsan builtins which are internal functions and might not be
+# backwards compatible. We explicitly check if the compiler uses the
+# same declarations we expect.
+# Some tsan builtins like __tsan_func_exit() have either of two
+# signatures, void (void) or void (void *) (PR #14082).
+# We first do a single check for all builtins for which we expect
+# only one signature, then we check builtins for which we expect one
+# of multiple signatures and set a preprocessor definition according
+# to which one is found.
+  AC_CACHE_CHECK([for ThreadSanitizer builtins],
+    [ocaml_cv_tsan_builtins],
+    [saved_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 
-  # Some tsan builtins like __tsan_func_exit have either of
-  # 2 signatures void(void) or void(void *) (PR #14082)
-  # We first do a single check for all builtins
-  # for which we expect only one signature
+void AnnotateHappensBefore(const char *f, int l, void *addr);
+void AnnotateHappensAfter (const char *f, int l, void *addr);
+void __tsan_func_entry   (void *);
+void __tsan_write8       (void *location);
+      ]],[[
+  AnnotateHappensBefore(__FILE__, __LINE__, (void*)0);
+  AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
+  __tsan_func_entry   ((void*)0);
+  __tsan_write8       ((void*)0);
 
-  # Then check builtins for which we expect one of multiple signatures
-  # and set a preprocessor definition according to which one is found
+      ]])],
+      [ocaml_cv_tsan_builtins=yes],
+      [ocaml_cv_tsan_builtins=no])
+    LDFLAGS="$saved_LDFLAGS"])
 
-  SAVED_LDFLAGS="$LDFLAGS"
-  AC_MSG_CHECKING([for ThreadSanitizer builtins])
-  LDFLAGS="$LDFLAGS -fsanitize=thread"
-  AC_LINK_IFELSE(
-    [AC_LANG_SOURCE([
+  AS_IF([test "$ocaml_cv_tsan_builtins" = no],
+    [AC_MSG_ERROR([libtsan doesn't provide the expected builtins])])
 
-      void AnnotateHappensBefore(const char *f, int l, void *addr);
-      void AnnotateHappensAfter (const char *f, int l, void *addr);
-      void __tsan_func_entry   (void *);
-      void __tsan_write8       (void *location);
+  AC_CACHE_CHECK([how many arguments __tsan_func_exit() takes],
+    [ocaml_cv_func_which___tsan_func_exit],
+    [saved_LDFLAGS="$LDFLAGS"
 
-      int main(void) {
-        AnnotateHappensBefore(__FILE__, __LINE__, (void*)0);
-        AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
-        __tsan_func_entry   ((void*)0);
-        __tsan_write8       ((void*)0);
-        return 0;
-      }
-
-    ])],
-    [ AC_MSG_RESULT([yes]) ],
-    [ AC_MSG_ERROR([libtsan provided uses unexpected builtins]) ]
-  )
-  LDFLAGS="$SAVED_LDFLAGS"
-
-  SAVED_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS -fsanitize=thread"
-  AC_LINK_IFELSE(
-    [AC_LANG_SOURCE([
-
-      void __tsan_func_exit(void *);
-
-      int main(void) {
-        __tsan_func_exit((void*)0);
-        return 0;
-      }
-
-    ])],
-    [ tsan_func_exit_signature=VOID_VOID_PTR; ],
-    [  ]
-  )
-  LDFLAGS="$SAVED_LDFLAGS"
-
-  SAVED_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS -fsanitize=thread"
-  AC_LINK_IFELSE(
-    [AC_LANG_SOURCE([
-
-      void __tsan_func_exit();
-
-      int main(void) {
-        __tsan_func_exit();
-        return 0;
-      }
-
-    ])],
-    [ tsan_func_exit_signature=VOID_VOID; ],
-    [  ]
-  )
-  LDFLAGS="$SAVED_LDFLAGS"
+    # We need warning flags as using the wrong builtins is often a warning
+    LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[void __tsan_func_exit(void *);]],
+        [[__tsan_func_exit((void*)0);]])],
+      [ocaml_cv_func_which___tsan_func_exit=void_void_p],
+      # Else branch if the first program fails to link
+      [AC_LINK_IFELSE([AC_LANG_PROGRAM(
+          [[void __tsan_func_exit(void);]],
+          [[__tsan_func_exit();]])],
+        [ocaml_cv_func_which___tsan_func_exit=void_void],
+        [ocaml_cv_func_which___tsan_func_exit=no])])
+    LDFLAGS="$saved_LDFLAGS"])
 
   # Define a C macro based on the detected __tsan_func_exit signature
-  AS_CASE([$tsan_func_exit_signature],
-    [VOID_VOID_PTR],
-      [AC_DEFINE([TSAN_FUNC_EXIT_SIGNATURE], [1],
-                 [ThreadSanitizer exit function signature: void(void*)])],
-    [VOID_VOID],
-      [AC_DEFINE([TSAN_FUNC_EXIT_SIGNATURE], [2],
-                 [ThreadSanitizer exit function signature: void(void)])],
-    [AC_MSG_ERROR([libtsan provided uses
-                        unexpected type of builtin __tsan_func_exit])])
+  AS_CASE([$ocaml_cv_func_which___tsan_func_exit],
+    [void_void_p], [AC_DEFINE([HAVE___TSAN_FUNC_EXIT_VOID_VOID_P], [1],
+                    [ThreadSanitizer exit function signature: void (void*)])],
+    [void_void], [AC_DEFINE([HAVE___TSAN_FUNC_EXIT_VOID_VOID], [1],
+                    [ThreadSanitizer exit function signature: void (void)])],
+    [AC_MSG_ERROR([libtsan uses an unexpected signature for __tsan_func_exit])])
 
   AS_CASE([$ocaml_cc_vendor],
     [gcc-[[0123456789]]-*|gcc-10-*|clang-*],

--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,7 @@ AC_SUBST([ocaml_libdir])
 AC_SUBST([TARGET_LIBDIR])
 AC_SUBST([QS])
 AC_SUBST([ar_supports_response_files])
+AC_SUBST([TSAN_FUNC_EXIT_SIGNATURE])
 
 ## Generated files
 
@@ -1979,6 +1980,84 @@ AS_IF([$tsan],
     [AC_MSG_ERROR([libtsan is necessary for TSan but cannot be found.
                    Try installing it on your system.])])
   LDFLAGS="$SAVED_LDFLAGS"
+
+  # We use tsan builtins which are internal functions and might not be backwards compatible.
+  # We explicitly check if the compiler uses the same declarations we expect
+
+  # Some tsan builtins like __tsan_func_exit have either of 2 signatures void(void) or void(void *) (PR #14082)
+  # We first do a single check for all builtins for which we expect only one signature
+  # Then check builtins for which we expect one of multiple signatures and set a #define according to which one is found
+
+  SAVED_LDFLAGS="$LDFLAGS"
+  AC_MSG_CHECKING([for ThreadSanitizer builtins])
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([
+
+      void AnnotateHappensBefore(const char *f, int l, void *addr);
+      void AnnotateHappensAfter (const char *f, int l, void *addr);
+      void __tsan_func_entry   (void *);
+      void __tsan_write8       (void *location);
+
+      int main(void) {
+        AnnotateHappensBefore(__FILE__, __LINE__, (void*)0);
+        AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
+        __tsan_func_entry   ((void*)0);
+        __tsan_write8       ((void*)0);
+        return 0;
+      }
+
+    ])],
+    [ AC_MSG_RESULT([yes]) ],
+    [ AC_MSG_ERROR([libtsan provided uses unexpected builtins]) ]
+  )
+  LDFLAGS="$SAVED_LDFLAGS"
+
+  SAVED_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([
+
+      void __tsan_func_exit(void *);
+
+      int main(void) {
+        __tsan_func_exit((void*)0);
+        return 0;
+      }
+
+    ])],
+    [ tsan_func_exit_signature=VOID_VOID_PTR; ],
+    [  ]
+  )
+  LDFLAGS="$SAVED_LDFLAGS"
+
+  SAVED_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([
+
+      void __tsan_func_exit();
+
+      int main(void) {
+        __tsan_func_exit();
+        return 0;
+      }
+
+    ])],
+    [ tsan_func_exit_signature=VOID_VOID; ],
+    [  ]
+  )
+  LDFLAGS="$SAVED_LDFLAGS"
+
+  # Define a C macro based on the detected __tsan_func_exit signature
+  AS_CASE([$tsan_func_exit_signature],
+    [VOID_VOID_PTR],
+      [AC_DEFINE([TSAN_FUNC_EXIT_SIGNATURE], [1],
+                 [ThreadSanitizer exit function signature: void(void*)])],
+    [VOID_VOID],
+      [AC_DEFINE([TSAN_FUNC_EXIT_SIGNATURE], [2],
+                 [ThreadSanitizer exit function signature: void(void)])],
+    [AC_MSG_ERROR([libtsan provided uses unexpected type of builtin __tsan_func_exit])])
 
   AS_CASE([$ocaml_cc_vendor],
     [gcc-[[0123456789]]-*|gcc-10-*|clang-*],

--- a/configure.ac
+++ b/configure.ac
@@ -264,7 +264,6 @@ AC_SUBST([ocaml_libdir])
 AC_SUBST([TARGET_LIBDIR])
 AC_SUBST([QS])
 AC_SUBST([ar_supports_response_files])
-AC_SUBST([TSAN_FUNC_EXIT_SIGNATURE])
 
 ## Generated files
 
@@ -1995,7 +1994,6 @@ AS_IF([$tsan],
     [saved_LDFLAGS="$LDFLAGS"
     LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-
 void AnnotateHappensBefore(const char *f, int l, void *addr);
 void AnnotateHappensAfter (const char *f, int l, void *addr);
 void __tsan_func_entry   (void *);
@@ -2005,7 +2003,6 @@ void __tsan_write8       (void *location);
   AnnotateHappensAfter (__FILE__, __LINE__, (void*)0);
   __tsan_func_entry   ((void*)0);
   __tsan_write8       ((void*)0);
-
       ]])],
       [ocaml_cv_tsan_builtins=yes],
       [ocaml_cv_tsan_builtins=no])
@@ -2021,23 +2018,23 @@ void __tsan_write8       (void *location);
     # We need warning flags as using the wrong builtins is often a warning
     LDFLAGS="$LDFLAGS -fsanitize=thread $warn_error_flag"
     AC_LINK_IFELSE([AC_LANG_PROGRAM(
-        [[void __tsan_func_exit(void *);]],
-        [[__tsan_func_exit((void*)0);]])],
-      [ocaml_cv_func_which___tsan_func_exit=void_void_p],
+        [[void __tsan_func_exit(void);]],
+        [[__tsan_func_exit();]])],
+      [ocaml_cv_func_which___tsan_func_exit=void_void],
       # Else branch if the first program fails to link
       [AC_LINK_IFELSE([AC_LANG_PROGRAM(
-          [[void __tsan_func_exit(void);]],
-          [[__tsan_func_exit();]])],
-        [ocaml_cv_func_which___tsan_func_exit=void_void],
+          [[void __tsan_func_exit(void *);]],
+          [[__tsan_func_exit((void *)0);]])],
+        [ocaml_cv_func_which___tsan_func_exit=void_void_p],
         [ocaml_cv_func_which___tsan_func_exit=no])])
     LDFLAGS="$saved_LDFLAGS"])
 
   # Define a C macro based on the detected __tsan_func_exit signature
   AS_CASE([$ocaml_cv_func_which___tsan_func_exit],
     [void_void_p], [AC_DEFINE([HAVE___TSAN_FUNC_EXIT_VOID_VOID_P], [1],
-                    [ThreadSanitizer exit function signature: void (void*)])],
+                  [ThreadSanitizer exit function signature: void (*)(void*)])],
     [void_void], [AC_DEFINE([HAVE___TSAN_FUNC_EXIT_VOID_VOID], [1],
-                    [ThreadSanitizer exit function signature: void (void)])],
+                  [ThreadSanitizer exit function signature: void (*)(void)])],
     [AC_MSG_ERROR([libtsan uses an unexpected signature for __tsan_func_exit])])
 
   AS_CASE([$ocaml_cc_vendor],

--- a/configure.ac
+++ b/configure.ac
@@ -1981,12 +1981,17 @@ AS_IF([$tsan],
                    Try installing it on your system.])])
   LDFLAGS="$SAVED_LDFLAGS"
 
-  # We use tsan builtins which are internal functions and might not be backwards compatible.
+  # We use tsan builtins which are internal functions
+  # and might not be backwards compatible.
   # We explicitly check if the compiler uses the same declarations we expect
 
-  # Some tsan builtins like __tsan_func_exit have either of 2 signatures void(void) or void(void *) (PR #14082)
-  # We first do a single check for all builtins for which we expect only one signature
-  # Then check builtins for which we expect one of multiple signatures and set a #define according to which one is found
+  # Some tsan builtins like __tsan_func_exit have either of
+  # 2 signatures void(void) or void(void *) (PR #14082)
+  # We first do a single check for all builtins
+  # for which we expect only one signature
+
+  # Then check builtins for which we expect one of multiple signatures
+  # and set a preprocessor definition according to which one is found
 
   SAVED_LDFLAGS="$LDFLAGS"
   AC_MSG_CHECKING([for ThreadSanitizer builtins])
@@ -2057,7 +2062,8 @@ AS_IF([$tsan],
     [VOID_VOID],
       [AC_DEFINE([TSAN_FUNC_EXIT_SIGNATURE], [2],
                  [ThreadSanitizer exit function signature: void(void)])],
-    [AC_MSG_ERROR([libtsan provided uses unexpected type of builtin __tsan_func_exit])])
+    [AC_MSG_ERROR([libtsan provided uses
+                        unexpected type of builtin __tsan_func_exit])])
 
   AS_CASE([$ocaml_cc_vendor],
     [gcc-[[0123456789]]-*|gcc-10-*|clang-*],

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -250,14 +250,13 @@ G(name):
         /* arg 1: pc of raise */                                \
         movq    STACK_RETADDR_OFFSET(%rsp, offset), C_ARG_1;    \
         SWITCH_OCAML_TO_C;                                      \
-        C_call  (GCALL(__tsan_func_entry));                     \
+        C_call  (GCALL(caml_tsan_func_entry_asm));              \
         SWITCH_C_TO_OCAML;
 
 /* Calls __tsan_func_exit. May clobber all caller-saved registers. */
 #define TSAN_EXIT_FUNCTION                                      \
         SWITCH_OCAML_TO_C;                                      \
-        movq    $0, C_ARG_1;                                    \
-        C_call  (GCALL(__tsan_func_exit));                      \
+        C_call  (GCALL(caml_tsan_func_exit_asm));               \
         SWITCH_C_TO_OCAML;
 #else
 #define TSAN_ENTER_FUNCTION(offset)
@@ -801,7 +800,7 @@ CFI_STARTPROC
         pushq   C_ARG_1; CFI_ADJUST(8)
         /* Read return address */
         movq    (8 + CALLEE_SAVE_REGS_SIZE)(%rsp), C_ARG_1
-        C_call  (GCALL(__tsan_func_entry))
+        C_call  (GCALL(caml_tsan_func_entry_asm))
         popq    C_ARG_1; CFI_ADJUST(-8)
 #endif
     /* Load Caml_state into r14 (was passed as an argument from C) */
@@ -881,8 +880,7 @@ LBL(108):
        and we are on a C stack. */
         /* Save %rax before C call */
         pushq   %rax; CFI_ADJUST(8)
-        movq    $0, C_ARG_1
-        C_call  (GCALL(__tsan_func_exit))
+        C_call  (GCALL(caml_tsan_func_exit_asm))
         popq    %rax; CFI_ADJUST(-8)
 #endif
     /* Restore callee-save registers. */
@@ -1002,7 +1000,7 @@ CFI_STARTPROC
         pushq   C_ARG_2; CFI_ADJUST(8)
         pushq   C_ARG_3; CFI_ADJUST(8)
         movq    24(%rsp), C_ARG_1 /* Read return address */
-        C_call  (GCALL(__tsan_func_entry))
+        C_call  (GCALL(caml_tsan_func_entry_asm))
         popq    C_ARG_3; CFI_ADJUST(-8)
         popq    C_ARG_2; CFI_ADJUST(-8)
         popq    C_ARG_1; CFI_ADJUST(-8)
@@ -1029,7 +1027,7 @@ CFI_STARTPROC
         pushq   C_ARG_2; CFI_ADJUST(8)
         pushq   C_ARG_3; CFI_ADJUST(8)
         movq    24(%rsp), C_ARG_1 /* Read return address */
-        C_call  (GCALL(__tsan_func_entry))
+        C_call  (GCALL(caml_tsan_func_entry_asm))
         popq    C_ARG_3; CFI_ADJUST(-8)
         popq    C_ARG_2; CFI_ADJUST(-8)
         popq    C_ARG_1; CFI_ADJUST(-8)
@@ -1056,7 +1054,7 @@ CFI_STARTPROC
         pushq   C_ARG_2; CFI_ADJUST(8)
         pushq   C_ARG_3; CFI_ADJUST(8)
         movq    24(%rsp), C_ARG_1 /* Read return address */
-        C_call  (GCALL(__tsan_func_entry))
+        C_call  (GCALL(caml_tsan_func_entry_asm))
         popq    C_ARG_3; CFI_ADJUST(-8)
         popq    C_ARG_2; CFI_ADJUST(-8)
         popq    C_ARG_1; CFI_ADJUST(-8)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -236,14 +236,14 @@ G(name):
 
 
 /* When ThreadSanitizer instrumentation is enabled, the code must call
-   the C functions __tsan_func_entry and __tsan_func_exit to signal
-   function entries and exits. They follow the x86_64 calling
-   convention of the platform. For efficiency reasons, we don't always
-   save all caller-saved registers before calling them, but only the
-   registers in use. */
+   the C functions caml_tsan_func_entry_asm and caml_tsan_func_exit_asm to
+   signal function entries and exits. They follow the x86_64 calling convention
+   of the platform. For efficiency reasons, we don't always save all
+   caller-saved registers before calling them, but only the registers in use.
+ */
 
-/* Calls __tsan_func_entry on the current return address. [offset] is the
-   distance from the current stack pointer to the saved return address, in
+/* Calls caml_tsan_func_entry_asm on the current return address. [offset] is
+   the distance from the current stack pointer to the saved return address, in
    bytes. May clobber all caller-saved registers. */
 #if defined(WITH_THREAD_SANITIZER)
 #define TSAN_ENTER_FUNCTION(offset)                             \
@@ -253,7 +253,7 @@ G(name):
         C_call  (GCALL(caml_tsan_func_entry_asm));              \
         SWITCH_C_TO_OCAML;
 
-/* Calls __tsan_func_exit. May clobber all caller-saved registers. */
+/* Calls caml_tsan_func_exit_asm. May clobber all caller-saved registers. */
 #define TSAN_EXIT_FUNCTION                                      \
         SWITCH_OCAML_TO_C;                                      \
         C_call  (GCALL(caml_tsan_func_exit_asm));               \

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -364,13 +364,13 @@ G(name):
         SWITCH_C_TO_OCAML
 .endm
 
-/* Invoke __tsan_func_entry(return address in the caller) */
+/* Invoke caml_tsan_func_entry_asm (return address in the caller) */
 .macro TSAN_ENTER_FUNCTION
         mov     x0, x30        /* arg1: return address in caller */
         TSAN_C_CALL G(caml_tsan_func_entry_asm)
 .endm
 
-/* Invoke __tsan_func_exit(0) */
+/* Invoke caml_tsan_func_exit_asm */
 .macro TSAN_EXIT_FUNCTION
         TSAN_C_CALL G(caml_tsan_func_exit_asm)
 .endm

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -367,13 +367,12 @@ G(name):
 /* Invoke __tsan_func_entry(return address in the caller) */
 .macro TSAN_ENTER_FUNCTION
         mov     x0, x30        /* arg1: return address in caller */
-        TSAN_C_CALL G(__tsan_func_entry)
+        TSAN_C_CALL G(caml_tsan_func_entry_asm)
 .endm
 
 /* Invoke __tsan_func_exit(0) */
 .macro TSAN_EXIT_FUNCTION
-        mov     x0, xzr
-        TSAN_C_CALL G(__tsan_func_exit)
+        TSAN_C_CALL G(caml_tsan_func_exit_asm)
 .endm
 
 /* This is similar to SAVE_ALL_REGS, but only saving the caller-saved
@@ -680,7 +679,7 @@ FUNCTION(caml_start_program)
        OCaml stack, and we are still on a C stack at this point. */
         mov     x0, x30        /* arg1: return address in caller */
         TSAN_SETUP_C_CALL
-        bl      G(__tsan_func_entry)
+        bl      G(caml_tsan_func_entry_asm)
         TSAN_CLEANUP_AFTER_C_CALL
         ldr     x0, [sp], 16
         CFI_ADJUST(-16)
@@ -782,9 +781,8 @@ L(return_result):
        OCaml stack, and we are back to a C stack at this point. */
         str     x0, [sp, -16]!
         CFI_ADJUST(16)
-        mov     x0, xzr
         TSAN_SETUP_C_CALL
-        bl      G(__tsan_func_exit)
+        bl      G(caml_tsan_func_exit_asm)
         TSAN_CLEANUP_AFTER_C_CALL
         ldr     x0, [sp], 16
         CFI_ADJUST(-16)
@@ -930,7 +928,7 @@ FUNCTION(caml_callback_asm)
         stp     x2, x30, [sp, -16]!
         CFI_ADJUST(16)
         mov     x0, x30 /* return address */
-        bl      G(__tsan_func_entry)
+        bl      G(caml_tsan_func_entry_asm)
         ldp     x2, x30, [sp], 16
         CFI_ADJUST(-16)
         ldp     x0, x1, [sp], 16
@@ -955,7 +953,7 @@ FUNCTION(caml_callback2_asm)
         stp     x2, x30, [sp, -16]!
         CFI_ADJUST(16)
         mov     x0, x30 /* return address */
-        bl      G(__tsan_func_entry)
+        bl      G(caml_tsan_func_entry_asm)
         ldp     x2, x30, [sp], 16
         CFI_ADJUST(-16)
         ldp     x0, x1, [sp], 16
@@ -981,7 +979,7 @@ FUNCTION(caml_callback3_asm)
         stp     x2, x30, [sp, -16]!
         CFI_ADJUST(16)
         mov     x0, x30 /* return address */
-        bl      G(__tsan_func_entry)
+        bl      G(caml_tsan_func_entry_asm)
         ldp     x2, x30, [sp], 16
         CFI_ADJUST(-16)
         ldp     x0, x1, [sp], 16

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -324,4 +324,6 @@
 
 #undef HAVE_LABELS_AS_VALUES
 
+#undef TSAN_FUNC_EXIT_SIGNATURE
+
 /* Define if the C compiler supports the labels as values extension. */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -324,6 +324,7 @@
 
 #undef HAVE_LABELS_AS_VALUES
 
-#undef TSAN_FUNC_EXIT_SIGNATURE
+#undef HAVE___TSAN_FUNC_EXIT_VOID_VOID_P
+#undef HAVE___TSAN_FUNC_EXIT_VOID_VOID
 
 /* Define if the C compiler supports the labels as values extension. */

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -93,9 +93,38 @@ CAMLextern void caml_tsan_exit_on_perform(uintnat pc, char* sp);
 CAMLextern void caml_tsan_entry_on_resume(uintnat pc, char* sp,
     struct stack_info const* stack);
 
+
+#if defined(WITH_THREAD_SANITIZER)
+
+// __tsan* functions are not to be used directly, but rather through the caml_tsan_* wrappers
+
+// __tsan_func_exit can have either of the 2 signatures (#14082)
+#if TSAN_FUNC_EXIT_SIGNATURE == 1 // void(void)
 extern void __tsan_func_exit(void*);
+#elif TSAN_FUNC_EXIT_SIGNATURE == 2 // void(void*)
+extern void __tsan_func_exit(void);
+#endif
+
 extern void __tsan_func_entry(void*);
 void __tsan_write8(void *location);
+
+Caml_inline void caml_tsan_func_exit(void) {
+  #if TSAN_FUNC_EXIT_SIGNATURE == 1 // void(void)
+    __tsan_func_exit(NULL);
+  #elif TSAN_FUNC_EXIT_SIGNATURE == 2 // void(void*)
+    __tsan_func_exit();
+  #endif
+}
+
+Caml_inline void caml_tsan_func_entry(void *retaddr) {
+  __tsan_func_entry(retaddr);
+}
+
+Caml_inline void caml_tsan_write8(void *location) {
+  __tsan_write8(location);
+}
+
+#endif /* WITH_THREAD_SANITIZER */
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -96,8 +96,6 @@ CAMLextern void caml_tsan_entry_on_resume(uintnat pc, char* sp,
 
 #if defined(WITH_THREAD_SANITIZER)
 
-// __tsan* functions are not to be used directly, but rather through the caml_tsan_* wrappers
-
 // __tsan_func_exit can have either of the 2 signatures (#14082)
 #if TSAN_FUNC_EXIT_SIGNATURE == 1 // void(void)
 extern void __tsan_func_exit(void*);

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -97,9 +97,9 @@ CAMLextern void caml_tsan_entry_on_resume(uintnat pc, char* sp,
 #if defined(WITH_THREAD_SANITIZER)
 
 // __tsan_func_exit can have either of the 2 signatures (#14082)
-#if TSAN_FUNC_EXIT_SIGNATURE == 1 // void(void)
+#if defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID_P)
 extern void __tsan_func_exit(void*);
-#elif TSAN_FUNC_EXIT_SIGNATURE == 2 // void(void*)
+#elif defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID)
 extern void __tsan_func_exit(void);
 #endif
 
@@ -107,9 +107,9 @@ extern void __tsan_func_entry(void*);
 void __tsan_write8(void *location);
 
 Caml_inline void caml_tsan_func_exit(void) {
-  #if TSAN_FUNC_EXIT_SIGNATURE == 1 // void(void)
+#if defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID_P)
     __tsan_func_exit(NULL);
-  #elif TSAN_FUNC_EXIT_SIGNATURE == 2 // void(void*)
+#elif defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID)
     __tsan_func_exit();
   #endif
 }

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -106,19 +106,19 @@ extern void __tsan_func_exit(void);
 extern void __tsan_func_entry(void*);
 void __tsan_write8(void *location);
 
-Caml_inline void caml_tsan_func_exit(void) {
+CAMLno_tsan Caml_inline void caml_tsan_func_exit(void) {
 #if defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID_P)
-    __tsan_func_exit(NULL);
+  __tsan_func_exit(NULL);
 #elif defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID)
-    __tsan_func_exit();
+  __tsan_func_exit();
   #endif
 }
 
-Caml_inline void caml_tsan_func_entry(void *retaddr) {
+CAMLno_tsan Caml_inline void caml_tsan_func_entry(void *retaddr) {
   __tsan_func_entry(retaddr);
 }
 
-Caml_inline void caml_tsan_write8(void *location) {
+CAMLno_tsan Caml_inline void caml_tsan_write8(void *location) {
   __tsan_write8(location);
 }
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -209,7 +209,7 @@ CAMLno_tsan /* We remove the ThreadSanitizer instrumentation of memory accesses
 CAMLexport CAMLweakdef void caml_modify (volatile value *fp, value val)
 {
 #if defined(WITH_THREAD_SANITIZER) && defined(NATIVE_CODE)
-  __tsan_func_entry(__builtin_return_address(0));
+  caml_tsan_func_entry(__builtin_return_address(0));
 #endif
 
   write_barrier((value)fp, 0, *fp, val);
@@ -222,8 +222,8 @@ CAMLexport CAMLweakdef void caml_modify (volatile value *fp, value val)
    * CAMLno_tsan. We signal it to ThreadSanitizer as a plain store (see
    * ocaml-multicore/ocaml-tsan/pull/22#issuecomment-1377439074 on Github).
    */
-  __tsan_write8((void *)fp);
-  __tsan_func_exit(NULL);
+  caml_tsan_write8((void *)fp);
+  caml_tsan_func_exit();
 #endif
 
   atomic_store_release(&Op_atomic_val((value)fp)[0], val);

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -1157,7 +1157,6 @@ FUNCTION caml_runstack
         mr      SP, 27 /* OCaml stack */
 #if defined(WITH_THREAD_SANITIZER)
     /* Signal to TSan that we exit caml_runstack (no registers to save here) */
-        li      3, 0
         SWITCH_OCAML_TO_C
         TSAN_SETUP_C_CALL 0
         Far_call(caml_tsan_func_exit_asm)

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -301,7 +301,7 @@ caml_hot$code_end:
         SWITCH_OCAML_TO_C
         TSAN_SETUP_C_CALL 0
         mr      3, 0            /* arg1: return address in caller */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         TSAN_CLEANUP_AFTER_C_CALL 0
         SWITCH_C_TO_OCAML
 .endm
@@ -439,8 +439,7 @@ FUNCTION caml_call_gc
         Far_call(caml_garbage_collection)
 #if defined(WITH_THREAD_SANITIZER)
         TSAN_SETUP_C_CALL 0
-        li      3, 0
-        Far_call(__tsan_func_exit)
+        Far_call(caml_tsan_func_exit_asm)
         TSAN_CLEANUP_AFTER_C_CALL 0
 #endif
         SWITCH_C_TO_OCAML
@@ -492,8 +491,7 @@ FUNCTION caml_c_call
        it may have returned its result (if any) either in r3 or f1. */
         std     3,  (RESERVED_STACK + 0)(SP)
         stfd    1,  (RESERVED_STACK + 8)(SP)
-        li      3, 0
-        Far_call(__tsan_func_exit)
+        Far_call(caml_tsan_func_exit_asm)
         lfd     1,  (RESERVED_STACK + 8)(SP)
         ld      3,  (RESERVED_STACK + 0)(SP)
         TSAN_CLEANUP_AFTER_C_CALL 16
@@ -653,7 +651,7 @@ FUNCTION caml_start_program
         TSAN_SETUP_C_CALL 16
         std     3, (RESERVED_STACK + 0)(SP)
         mr      3, 0            /* arg1: return address in caller */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         ld      3, (RESERVED_STACK + 0)(SP)
         TSAN_CLEANUP_AFTER_C_CALL 16
 #endif
@@ -812,8 +810,7 @@ FUNCTION caml_start_program
 #if defined(WITH_THREAD_SANITIZER)
         TSAN_SETUP_C_CALL 16
         std     3, (RESERVED_STACK + 0)(SP)
-        li      3, 0
-        Far_call(__tsan_func_exit)
+        Far_call(caml_tsan_func_exit_asm)
         ld      3, (RESERVED_STACK + 0)(SP)
         TSAN_CLEANUP_AFTER_C_CALL 16
 #endif
@@ -841,7 +838,7 @@ FUNCTION caml_callback_asm
         std     4, (RESERVED_STACK + 8)(SP)
         std     5, (RESERVED_STACK + 16)(SP)
         mr      3, 0 /* return address */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         ld      5, (RESERVED_STACK + 16)(SP)
         ld      4, (RESERVED_STACK + 8)(SP)
         ld      3, (RESERVED_STACK + 0)(SP)
@@ -864,7 +861,7 @@ FUNCTION caml_callback2_asm
         std     4, (RESERVED_STACK + 8)(SP)
         std     5, (RESERVED_STACK + 16)(SP)
         mr      3, 0 /* return address */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         ld      5, (RESERVED_STACK + 16)(SP)
         ld      4, (RESERVED_STACK + 8)(SP)
         ld      3, (RESERVED_STACK + 0)(SP)
@@ -889,7 +886,7 @@ FUNCTION caml_callback3_asm
         std     4, (RESERVED_STACK + 8)(SP)
         std     5, (RESERVED_STACK + 16)(SP)
         mr      3, 0 /* return address */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         ld      5, (RESERVED_STACK + 16)(SP)
         ld      4, (RESERVED_STACK + 8)(SP)
         ld      3, (RESERVED_STACK + 0)(SP)
@@ -971,8 +968,7 @@ FUNCTION caml_perform
         std     7, (RESERVED_STACK + 32)(SP)
         std     8, (RESERVED_STACK + 40)(SP)
     /* Match the TSan-enter made from caml_runstack */
-        li      3, 0
-        Far_call(__tsan_func_exit)
+        Far_call(caml_tsan_func_exit_asm)
         ld      8, (RESERVED_STACK + 40)(SP)
         ld      7, (RESERVED_STACK + 32)(SP)
         ld      6, (RESERVED_STACK + 24)(SP)
@@ -1017,7 +1013,7 @@ FUNCTION caml_perform
         Far_call(caml_tsan_entry_on_resume)
         /* invoke __tsan_func_entry without shuffling stacks */
         ld      3, LR_SAVE(SP)
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         TSAN_CLEANUP_AFTER_C_CALL 0
         SWITCH_C_TO_OCAML
         TSAN_RESTORE_CALLER_REGS
@@ -1056,7 +1052,7 @@ FUNCTION caml_resume
         std     3, (RESERVED_STACK + 0)(SP)
     /* Necessary to include the caller of caml_resume in the TSan backtrace */
         mr      3, 0            /* arg1: return address in caller */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
     /* Signal to TSan all stack frames exited by the perform. */
         ld      3, (RESERVED_STACK + 0)(SP)
         mr      5, 3            /* arg3: fiber */
@@ -1096,7 +1092,7 @@ FUNCTION caml_runstack
         std     5, (RESERVED_STACK + 16)(SP)
     /* Necessary to include the caller of caml_runstack in the TSan backtrace */
         mr      3, 0            /* arg1: return address in caller */
-        Far_call(__tsan_func_entry)
+        Far_call(caml_tsan_func_entry_asm)
         ld      5, (RESERVED_STACK + 16)(SP)
         ld      4, (RESERVED_STACK + 8)(SP)
         ld      3, (RESERVED_STACK + 0)(SP)
@@ -1164,7 +1160,7 @@ FUNCTION caml_runstack
         li      3, 0
         SWITCH_OCAML_TO_C
         TSAN_SETUP_C_CALL 0
-        Far_call(__tsan_func_exit)
+        Far_call(caml_tsan_func_exit_asm)
         TSAN_CLEANUP_AFTER_C_CALL 0
         SWITCH_C_TO_OCAML
 #endif

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -301,13 +301,12 @@ name:
 /* Invoke __tsan_func_entry(return address in the caller) */
 .macro TSAN_ENTER_FUNCTION
         mv      a0, ra  /* arg1: return address in caller */
-        TSAN_C_CALL __tsan_func_entry
+        TSAN_C_CALL caml_tsan_func_entry_asm
 .endm
 
 /* Invoke __tsan_func_exit(0) */
 .macro TSAN_EXIT_FUNCTION
-        mv      a0, x0
-        TSAN_C_CALL __tsan_func_exit
+        TSAN_C_CALL caml_tsan_func_exit_asm
 .endm
 
 /* This is similar to SAVE_ALL_REGS, but only saving the caller-saved
@@ -607,7 +606,7 @@ FUNCTION(caml_start_program)
        on an OCaml stack, yet we are still on a C stack at this point. */
         mv      a0, ra
         ENTER_FUNCTION
-        call    PLT(__tsan_func_entry)
+        call    PLT(caml_tsan_func_entry_asm)
         LEAVE_FUNCTION
         ld      a0, 0(sp)
         addi    sp, sp, 16
@@ -731,9 +730,8 @@ L(return_result):
         addi    sp, sp, -16
         CFI_ADJUST(16)
         sd      a0, 0(sp)
-        mv      a0, x0
         ENTER_FUNCTION
-        call    PLT(__tsan_func_exit)
+        call    PLT(caml_tsan_func_exit_asm)
         LEAVE_FUNCTION
         ld      a0, 0(sp)
         addi    sp, sp, 16
@@ -893,7 +891,7 @@ FUNCTION(caml_callback_asm)
         sd      a2, 16(sp)
         sd      ra, 24(sp)
         mv      a0, ra
-        call    PLT(__tsan_func_entry)
+        call    PLT(caml_tsan_func_entry_asm)
         ld      ra, 24(sp)
         ld      a2, 16(sp)
         ld      a1, 8(sp)
@@ -920,7 +918,7 @@ FUNCTION(caml_callback2_asm)
         sd      a2, 16(sp)
         sd      ra, 24(sp)
         mv      a0, ra
-        call    PLT(__tsan_func_entry)
+        call    PLT(caml_tsan_func_entry_asm)
         ld      ra, 24(sp)
         ld      a2, 16(sp)
         ld      a1, 8(sp)
@@ -949,7 +947,7 @@ FUNCTION(caml_callback3_asm)
         sd      a2, 16(sp)
         sd      ra, 24(sp)
         mv      a0, ra
-        call    PLT(__tsan_func_entry)
+        call    PLT(caml_tsan_func_entry_asm)
         ld      ra, 24(sp)
         ld      a2, 16(sp)
         ld      a1, 8(sp)

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -298,13 +298,13 @@ name:
         SWITCH_C_TO_OCAML
 .endm
 
-/* Invoke __tsan_func_entry(return address in the caller) */
+/* Invoke caml_tsan_func_entry_asm (return address in the caller) */
 .macro TSAN_ENTER_FUNCTION
         mv      a0, ra  /* arg1: return address in caller */
         TSAN_C_CALL caml_tsan_func_entry_asm
 .endm
 
-/* Invoke __tsan_func_exit(0) */
+/* Invoke caml_tsan_func_exit_asm */
 .macro TSAN_EXIT_FUNCTION
         TSAN_C_CALL caml_tsan_func_exit_asm
 .endm

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -312,12 +312,12 @@ caml_system__code_begin:
         TSAN_CLEANUP_AFTER_C_CALL;                     \
         SWITCH_C_TO_OCAML
 
-/* Invoke __tsan_func_entry(return address in the caller) */
+/* Invoke caml_tsan_func_entry_asm (return address in the caller) */
 #define TSAN_ENTER_FUNCTION                            \
         lgr     C_ARG_1, %r14; /* arg1: return address in caller */ \
         TSAN_C_CALL(caml_tsan_func_entry_asm)
 
-/* Invoke __tsan_func_exit(0) */
+/* Invoke caml_tsan_func_exit_asm */
 #define TSAN_EXIT_FUNCTION                             \
         TSAN_C_CALL(caml_tsan_func_exit_asm)
 

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -315,12 +315,11 @@ caml_system__code_begin:
 /* Invoke __tsan_func_entry(return address in the caller) */
 #define TSAN_ENTER_FUNCTION                            \
         lgr     C_ARG_1, %r14; /* arg1: return address in caller */ \
-        TSAN_C_CALL(__tsan_func_entry)
+        TSAN_C_CALL(caml_tsan_func_entry_asm)
 
 /* Invoke __tsan_func_exit(0) */
 #define TSAN_EXIT_FUNCTION                             \
-        lgfi    C_ARG_1, 0;                            \
-        TSAN_C_CALL(__tsan_func_exit)
+        TSAN_C_CALL(caml_tsan_func_exit_asm)
 
 /* This is similar to SAVE_ALL_REGS, but only saving the caller-saved
    registers. */
@@ -594,7 +593,7 @@ CFI_STARTPROC
        OCaml stack, yet we are still on a C stack at this point. */
         lgr     C_ARG_1, %r14
         TSAN_SETUP_C_CALL
-        brasl   %r14, GCALL(__tsan_func_entry)
+        brasl   %r14, GCALL(caml_tsan_func_entry_asm)
         TSAN_CLEANUP_AFTER_C_CALL
         lg      C_ARG_1, 0(%r15)
         la      %r15, 8(%r15)
@@ -691,9 +690,8 @@ LBL(return_result):  /* restore GC regs */
         lay     %r15, -8(%r15)
         CFI_ADJUST(8)
         stg     C_ARG_1, 0(%r15)
-        lgfi    C_ARG_1, 0
         TSAN_SETUP_C_CALL
-        brasl   %r14, GCALL(__tsan_func_exit)
+        brasl   %r14, GCALL(caml_tsan_func_exit_asm)
         TSAN_CLEANUP_AFTER_C_CALL
         lg      C_ARG_1, 0(%r15)
         la      %r15, 8(%r15)
@@ -844,7 +842,7 @@ CFI_STARTPROC
         stg     C_ARG_3, (RESERVED_STACK+16)(%r15)
         stg     %r14, (RESERVED_STACK+24)(%r15)
         lgr     C_ARG_1, %r14
-        brasl   %r14, GCALL(__tsan_func_entry)
+        brasl   %r14, GCALL(caml_tsan_func_entry_asm)
         lg      %r14, (RESERVED_STACK+24)(%r15)
         lg      C_ARG_3, (RESERVED_STACK+16)(%r15)
         lg      C_ARG_2, (RESERVED_STACK+8)(%r15)
@@ -873,7 +871,7 @@ CFI_STARTPROC
         stg     C_ARG_3, (RESERVED_STACK+16)(%r15)
         stg     %r14, (RESERVED_STACK+24)(%r15)
         lgr     C_ARG_1, %r14
-        brasl   %r14, GCALL(__tsan_func_entry)
+        brasl   %r14, GCALL(caml_tsan_func_entry_asm)
         lg      %r14, (RESERVED_STACK+24)(%r15)
         lg      C_ARG_3, (RESERVED_STACK+16)(%r15)
         lg      C_ARG_2, (RESERVED_STACK+8)(%r15)
@@ -904,7 +902,7 @@ CFI_STARTPROC
         stg     C_ARG_3, (RESERVED_STACK+16)(%r15)
         stg     %r14, (RESERVED_STACK+24)(%r15)
         lgr     C_ARG_1, %r14
-        brasl   %r14, GCALL(__tsan_func_entry)
+        brasl   %r14, GCALL(caml_tsan_func_entry_asm)
         lg      %r14, (RESERVED_STACK+24)(%r15)
         lg      C_ARG_3, (RESERVED_STACK+16)(%r15)
         lg      C_ARG_2, (RESERVED_STACK+8)(%r15)

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -467,3 +467,17 @@ CAMLno_tsan void __tsan_unaligned_volatile_write16(void *ptr)
 {
   __tsan_write16(ptr);
 }
+
+CAMLno_tsan void caml_tsan_func_exit_asm(void) {
+#if defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID_P)
+  __tsan_func_exit(NULL);
+#elif defined(HAVE___TSAN_FUNC_EXIT_VOID_VOID)
+  __tsan_func_exit();
+  #endif
+}
+
+CAMLno_tsan void caml_tsan_func_entry_asm(void *retaddr) {
+  __tsan_func_entry(retaddr);
+}
+
+// caml_tsan_write8 is never used in .S files

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -243,7 +243,7 @@ void caml_tsan_exit_on_raise(uintnat pc, char* sp, char* trapsp)
     }
 
     caml_tsan_debug_log_pc("forced__tsan_func_exit for", pc);
-    __tsan_func_exit(NULL);
+    caml_tsan_func_exit();
     pc = next_pc;
   }
 }
@@ -292,7 +292,7 @@ void caml_tsan_exit_on_raise_c(char* limit)
 #ifdef TSAN_DEBUG
     caml_tsan_debug_log_pc("forced__tsan_func_exit for", prev_pc);
 #endif
-    __tsan_func_exit(NULL);
+    caml_tsan_func_exit();
 
     if ((char*)sp >= limit) {
       break;
@@ -326,7 +326,7 @@ void caml_tsan_exit_on_perform(uintnat pc, char* sp)
     }
 
     caml_tsan_debug_log_pc("forced__tsan_func_exit for", pc);
-    __tsan_func_exit(NULL);
+    caml_tsan_func_exit();
 
     pc = next_pc;
   }
@@ -368,7 +368,7 @@ CAMLno_tsan void caml_tsan_entry_on_resume(uintnat pc, char* sp,
 
   caml_tsan_entry_on_resume(next_pc, sp, stack);
   caml_tsan_debug_log_pc("forced__tsan_func_entry for", pc);
-  __tsan_func_entry((void*)next_pc);
+  caml_tsan_func_entry((void*)next_pc);
 }
 
 #endif // NATIVE_CODE


### PR DESCRIPTION
#14065 
`__tsan_func_exit()` has a function signature of `void(void)`, but we declare it as `void(void *)` in [tsan.h](https://github.com/ocaml/ocaml/blob/d0a28652ba2967759445958fd256f89c4ecd9913/runtime/caml/tsan.h#L96)

This leads to the following warning in GCC15 (and error as we have `-Werror` enabled)
```
<source>:1:13: error: conflicting types for built-in function '__tsan_func_exit'; expected 'void(void)' [-Werror=builtin-declaration-mismatch]
    1 | extern void __tsan_func_exit(void*);
      |             ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
Compiler returned: 1
```

It also conflicts with Clang's definition over [here](https://github.com/llvm/llvm-project/blob/17d956588a2cc508acf98574f913eaef6d0e1af3/compiler-rt/lib/tsan/rtl/tsan_interface.h#L86), but no warnings have been observed.

[Godbolt link](https://godbolt.org/z/5vT3h4749)

This also causes a test failure in `polling_insertion.ml` in GCC15 
```
failed (The file <test output file> was expected to be empty because there is no reference file <expected reference file> but it is not:
<compilation warning related to tsan_func_exit>
```

This PR fixes this inconsistency

Requesting review in particular on the changes made to `.S` files

~This change only matters when tsan is enabled and I would like to test it on CI
Hence, I have attempted to force tsan to be always be enabled 
This change will be reverted before merge~
