### PR TITLE
Use an opaque abstract type for Dynarray.Dummy.with_dummy

### DIFF
--- a/Changes
+++ b/Changes
@@ -142,6 +142,9 @@ Working version
   (Émile Trotignon, review by Nicolás Ojeda Bär, Jan Midtgaard and
    Damien Doligez)
 
+- #14084: Future-proof Dynarray implementation against a smarter compiler
+  (Basile Clément, review by Gabriel Scherer)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion


### PR DESCRIPTION
The internal `('a, 'stamp) with_dummy` type used by the Dynarray module since #12885 is currently defined as a type alias to the internal `'a` type. While convenient, this is a lie, as the `('a, 'stamp) with_dummy` type can also contain dummies.

In particular, this is telling (through types) the compiler that an `(int, 'stamp) with_dummy array` can only contain immediates. This could in theory allow the compiler to perform optimisations such as:

 - Remove the `is_dummy` checks for these arrays (since we also know through types that dummies are never immediates) ;

 - Remove calls to `caml_modify` when writing to these arrays

While I don't think these optimisations can currently happen, this patch uses an abstract type for `with_dummy` so as to prevent issues if they ever start happening in the future.

It also fixes an issue in `unsafe_nocopy_to_array` for floats where we call `unsafe_get` before checking for the dummy.