### PR TITLE
Add debugger flags for sanitizer script

### DIFF
--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -23,7 +23,12 @@
 
 export OCAMLTEST_SKIP_TESTS="tests/afl-instrumentation/afltest.ml \
 tests/afl-instrumentation/afl-fuzz-test.ml \
-tests/runtime-errors/stackoverflow.ml"
+tests/runtime-errors/stackoverflow.ml \
+tests/native-debugger/linux-gdb-amd64.ml \
+tests/native-debugger/linux-lldb-amd64.ml \
+tests/native-debugger/linux-gdb-arm64.ml \
+tests/native-debugger/linux-lldb-arm64.ml \
+tests/native-debugger/linux-gdb-riscv.ml"
 
 jobs=-j8
 make=make
@@ -86,7 +91,7 @@ export UBSAN_OPTIONS="print_stacktrace=1"
 # Don't optimize too much to get better backtraces of errors
 CFLAGS="-Og -g -fno-omit-frame-pointer $sanitizers"
 LDFLAGS="$sanitizers -Og -g"
-CC=$clang
+CC="$clang -Og -g"
 
 # Test that UBSAN works
 cat >ubsan.c <<EOF


### PR DESCRIPTION
Fix for https://github.com/ocaml/ocaml/issues/14058

We set the `-g -O0` flags to enable generating debug information and disable optimised C for the test suite, which is required by the native-debug tests. 

I suspect that the `-fno-omit-frame-pointer` flag is not required here either, the unwinding should be using CFI. But I haven't found a good way to test that. 

cc @OlivierNicole 