### PR TITLE
Add `Domain.running_domain_count`

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,7 +53,7 @@ Working version
    Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
 
 - #14086: Add Domain.running_domain_count.
-  (Nicolás Ojeda Bär)
+  (Nicolás Ojeda Bär, review by David Allsopp and Gabriel Scherer)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -52,6 +52,9 @@ Working version
   (Kate Deplaix, review by Daniel Bünzli, Gabriel Scherer,
    Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
 
+- #14086: Add Domain.running_domain_count.
+  (Nicolás Ojeda Bär)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2325,6 +2325,11 @@ CAMLprim value caml_domain_dls_compare_and_set(value old, value new)
   }
 }
 
+CAMLprim value caml_running_domain_count(value unused)
+{
+  return Val_long(atomic_load_relaxed(&caml_num_domains_running));
+}
+
 CAMLprim value caml_recommended_domain_count(value unused)
 {
   intnat n = -1;

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -40,6 +40,8 @@ module Raw = struct
     = "caml_ml_domain_id" [@@noalloc]
   external cpu_relax : unit -> unit
     = "caml_ml_domain_cpu_relax"
+  external get_running_domain_count: unit -> int
+    = "caml_running_domain_count" [@@noalloc]
   external get_recommended_domain_count: unit -> int
     = "caml_recommended_domain_count" [@@noalloc]
 end
@@ -298,4 +300,5 @@ let join { term_sync ; _ } =
   | Ok x -> x
   | Error ex -> raise ex
 
+let running_domain_count = Raw.get_running_domain_count
 let recommended_domain_count = Raw.get_recommended_domain_count

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -85,6 +85,11 @@ val cpu_relax : unit -> unit
 val is_main_domain : unit -> bool
 (** [is_main_domain ()] returns true if called from the initial domain. *)
 
+val running_domain_count : unit -> int
+(** The number of currently running domains.
+
+    @since 5.5 *)
+
 val recommended_domain_count : unit -> int
 (** The recommended maximum number of domains which should be running
     simultaneously (including domains already running).


### PR DESCRIPTION
Adds a function to retrieve the number of running domains.