### PR TITLE
document that char compare uses ASCII order

### DIFF
--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -51,7 +51,9 @@ val compare: t -> t -> int
 (** The comparison function for characters, with the same specification as
     {!Stdlib.compare}.  Along with the type [t], this function [compare]
     allows the module [Char] to be passed as argument to the functors
-    {!Set.Make} and {!Map.Make}. *)
+    {!Set.Make} and {!Map.Make}.
+    The order used for comparison is the order of the underlying bytes,
+    that is, ASCII order extended to the range \[[0x00];[0xFF]\]. *)
 
 val equal: t -> t -> bool
 (** The equal function for chars.

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -52,8 +52,7 @@ val compare: t -> t -> int
 (** The comparison function for characters, with the same specification as
     {!Stdlib.compare}.  Along with the type [t], this function [compare]
     allows the module [Char] to be passed as argument to the functors
-    {!Set.Make} and {!Map.Make}. The comparison order is compatible with
-    {!Char.code}. *)
+    {!Set.Make} and {!Map.Make}. The order is compatible with {!Char.code}. *)
 
 val equal: t -> t -> bool
 (** The equal function for chars.

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -29,7 +29,8 @@ type t = char
 (** An alias for the type of characters. *)
 
 external code : char -> int = "%identity"
-(** Return the integer code of the argument. *)
+(** Return the integer code of the argument. The integer code coincides with
+    the ASCII encoding for character literals in the ASCII character set. *)
 
 val chr : int -> char
 (** Return the character with the given integer code.
@@ -51,8 +52,8 @@ val compare: t -> t -> int
 (** The comparison function for characters, with the same specification as
     {!Stdlib.compare}.  Along with the type [t], this function [compare]
     allows the module [Char] to be passed as argument to the functors
-    {!Set.Make} and {!Map.Make}.
-    The comparison order is compatible with ASCII. *)
+    {!Set.Make} and {!Map.Make}. The comparison order is compatible with
+    {!Char.code}. *)
 
 val equal: t -> t -> bool
 (** The equal function for chars.

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -52,8 +52,7 @@ val compare: t -> t -> int
     {!Stdlib.compare}.  Along with the type [t], this function [compare]
     allows the module [Char] to be passed as argument to the functors
     {!Set.Make} and {!Map.Make}.
-    The order used for comparison is the order of the underlying bytes,
-    that is, ASCII order extended to the range \[[0x00];[0xFF]\]. *)
+    The comparison order is compatible with ASCII. *)
 
 val equal: t -> t -> bool
 (** The equal function for chars.

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -29,8 +29,8 @@ type t = char
 (** An alias for the type of characters. *)
 
 external code : char -> int = "%identity"
-(** Return the integer code of the argument. The integer code coincides with
-    the ASCII encoding for character literals in the ASCII character set. *)
+(** [code c] is the byte corresponding to [c]. If [c] is an ASCII character
+    this corresponds to its encoding in ASCII or UTF-8. *)
 
 val chr : int -> char
 (** Return the character with the given integer code.


### PR DESCRIPTION
Not sure this is very useful.
The question popped in my mind when looking at https://ocaml.org/manual/5.3/api/Char.html
Anyway, there are many ways to compare characters (using locale or not, etc) so here it is.