### PR TITLE
matching: fix some non-deterministic code generation

### DIFF
--- a/Changes
+++ b/Changes
@@ -890,11 +890,16 @@ OCaml 5.4.0
 - #14025: fix data race between compaction and domain termination
   (Gabriel Scherer, review by Jan Midtgaard,
    report by Jan Midtgaard)
+
 - #13956 Fix a regression introduced in #13308 triggering wrong unused warnings.
   (Ulysse Gérard, review by Florian Angeletti)
 
 - #14070: also point to label mismatches in error messages for labelled tuples
   (Florian Angeletti, review by Gabriel Scherer)
+
+- #14088, #14091: fix non-deterministic code generation in
+  matching.ml (backport of rescript-lang/rescript#7557)
+  (Christiano Calgano, review by Gabriel Scherer and Vincent Laviron)
 
 - #14105: Fix a loop in Pprintast that could result in a hang when printing
   constructor `(::)` in isolation.

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2751,15 +2751,21 @@ let reintroduce_fail sw =
       in
       List.iter seen sw.sw_consts;
       List.iter seen sw.sw_blocks;
-      let i_max = ref (-1) and max = ref (-1) in
+      let c_max = ref (-1) in
+      let i_max = ref max_int in
       Hashtbl.iter
         (fun i c ->
-          if c > !max then (
+          if c > !c_max then (
             i_max := i;
-            max := c
+            c_max := c
+          ) else if c = !c_max then (
+           (* Pick the miminal [i] which has maximal [c], and not just
+              the first [i], as the Hashtbl iteration order is not
+              deterministic: see #14088. *)
+            i_max := min i !i_max;
           ))
         t;
-      if !max >= 3 then
+      if !c_max >= 3 then
         let default = !i_max in
         let remove =
           List.filter (fun (_, lam) ->


### PR DESCRIPTION
fixes #14088 , following the rescript fix by @cristianoc