### PR TITLE
toplevel: refactor simple printer match

### DIFF
--- a/Changes
+++ b/Changes
@@ -188,6 +188,9 @@ Working version
 - #14024: Fix unterminated-string-initialization warnings from the C compiler.
   (Antonin Décimo, review by David Allsopp and Miod Vallat)
 
+- #14094: toplevel, simplify check on installed printer types
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/testsuite/tests/tool-toplevel/install_printer.compilers.reference
+++ b/testsuite/tests/tool-toplevel/install_printer.compilers.reference
@@ -11,6 +11,12 @@ type ('a, 'b) v = D of 'a * 'b
 type 'a printer = Format.formatter -> 'a -> unit
 val print_generic : 'a printer -> 'b printer -> ('a, 'b) v printer = <fun>
 - : (int, t) v list = [D<0, ~A>; D<42, ~B>]
+val pp_option_ref : Format.formatter -> '_weak1 option ref -> unit = <fun>
+- : int option ref = {contents = Some 0}
+- : Format.formatter -> '_weak1 option ref -> unit = <fun>
+- : Format.formatter -> int option ref -> unit = <fun>
+- : int option ref = Something
+val x : '_weak2 option ref = {contents = None}
 Unbound value name_that_does_not_exist.
 List.map has the wrong type for a printing function.
 Unbound value name_that_does_not_exist.

--- a/testsuite/tests/tool-toplevel/install_printer.ml
+++ b/testsuite/tests/tool-toplevel/install_printer.ml
@@ -45,7 +45,19 @@ let print_generic (type a b) (pa : a printer) (pb : b printer) : (a, b) v printe
 
 #install_printer print_generic;;
 [D (0, A); D (42, B)];;
+(* Simple printer witn non_generic variable *)
 
+let pp_option_ref = Fun.id @@ fun ppf x ->
+    match !x with
+    | None -> Format.fprintf ppf "Nothing"
+    | Some _ -> Format.fprintf ppf "Something"
+;;
+#install_printer pp_option_ref;;
+ref (Some 0);;
+pp_option_ref;;
+let _ = (pp_option_ref: _ -> int option ref -> _);;
+ref (Some 0);;
+let x = ref None;;
 
 (* error cases *)
 #install_printer name_that_does_not_exist;;

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -673,7 +673,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       | [] -> raise Not_found
       | (_name, User_printer.Simple (sch, printer)) :: remainder ->
           if not (Ctype.contains_nongen_variables sch) &&
-             Ctype.is_moregeneral env true sch ty
+             Ctype.is_moregeneral env sch ty
           then printer
           else find remainder
       | (_name, User_printer.Generic (path, fn)) :: remainder ->

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -672,7 +672,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       let rec find = function
       | [] -> raise Not_found
       | (_name, User_printer.Simple (sch, printer)) :: remainder ->
-          if Ctype.is_moregeneral env false sch ty
+          if not (Ctype.contains_nongen_variables sch) &&
+             Ctype.is_moregeneral env true sch ty
           then printer
           else find remainder
       | (_name, User_printer.Generic (path, fn)) :: remainder ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -645,6 +645,10 @@ let free_variables_list ?env tyl =
     List.fold_left (fun acc ty -> free_vars ~init:acc ~add_one ?env mark ty)
       [] tyl)
 
+let contains_nongen_variables ?env ty =
+  let add_one ty _kind acc = acc || (get_level ty < generic_level) in
+  with_type_mark (fun mark -> free_vars ~init:false ~add_one ?env mark ty)
+
 let closed_type ?env mark ty =
   let add_one ty kind _acc = raise (Non_closed (ty, kind)) in
   free_vars ~init:() ~add_one ?env mark ty

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3833,17 +3833,14 @@ let moregen_occur env level ty =
   occur_univar_for Moregen env ty;
   update_level_for Moregen env level ty
 
-let may_instantiate inst_nongen t1 =
-  let level = get_level t1 in
-  if inst_nongen then level <> subject_level
-                 else level =  generic_level
+let may_instantiate t1 = get_level t1 <> subject_level
 
-let rec moregen inst_nongen type_pairs env t1 t2 =
+let rec moregen type_pairs env t1 t2 =
   if eq_type t1 t2 then () else
 
   try
     match (get_desc t1, get_desc t2) with
-      (Tvar _, _) when may_instantiate inst_nongen t1 ->
+      (Tvar _, _) when may_instantiate t1 ->
         moregen_occur env (get_level t1) t2;
         update_scope_for Moregen (get_scope t1) t2;
         occur_for Moregen (Expression {env; in_subst = false}) t1 t2;
@@ -3858,38 +3855,37 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
         if not (TypePairs.mem type_pairs (t1', t2')) then begin
           TypePairs.add type_pairs (t1', t2');
           match (get_desc t1', get_desc t2') with
-            (Tvar _, _) when may_instantiate inst_nongen t1' ->
+            (Tvar _, _) when may_instantiate t1' ->
               moregen_occur env (get_level t1') t2;
               update_scope_for Moregen (get_scope t1') t2;
               link_type t1' t2
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) ->
               eq_labels Moregen ~in_pattern_mode:false l1 l2;
-              moregen inst_nongen type_pairs env t1 t2;
-              moregen inst_nongen type_pairs env u1 u2
+              moregen type_pairs env t1 t2;
+              moregen type_pairs env u1 u2
           | (Ttuple tl1, Ttuple tl2) ->
-              moregen_labeled_list inst_nongen type_pairs env tl1 tl2
+              moregen_labeled_list type_pairs env tl1 tl2
           | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _))
                 when Path.same p1 p2 ->
-              moregen_list inst_nongen type_pairs env tl1 tl2
+              moregen_list type_pairs env tl1 tl2
           | (Tpackage pack1, Tpackage pack2) ->
-              moregen_package inst_nongen type_pairs env (get_level t1') pack1
+              moregen_package type_pairs env (get_level t1') pack1
                 (get_level t2') pack2
           | (Tnil,  Tconstr _ ) -> raise_for Moregen (Obj (Abstract_row Second))
           | (Tconstr _,  Tnil ) -> raise_for Moregen (Obj (Abstract_row First))
           | (Tvariant row1, Tvariant row2) ->
-              moregen_row inst_nongen type_pairs env row1 row2
+              moregen_row type_pairs env row1 row2
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
-              moregen_fields inst_nongen type_pairs env fi1 fi2
+              moregen_fields type_pairs env fi1 fi2
           | (Tfield _, Tfield _) ->           (* Actually unused *)
-              moregen_fields inst_nongen type_pairs env
-                t1' t2'
+              moregen_fields type_pairs env t1' t2'
           | (Tnil, Tnil) ->
               ()
           | (Tpoly (t1, []), Tpoly (t2, [])) ->
-              moregen inst_nongen type_pairs env t1 t2
+              moregen type_pairs env t1 t2
           | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
               enter_poly_for Moregen env t1 tl1 t2 tl2
-                (moregen inst_nongen type_pairs env)
+                (moregen type_pairs env)
           | (Tunivar _, Tunivar _) ->
               unify_univar_for Moregen t1' t2' !univar_pairs
           | (_, _) ->
@@ -3899,12 +3895,12 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
     raise_trace_for Moregen (Diff {got = t1; expected = t2} :: trace)
 
 
-and moregen_list inst_nongen type_pairs env tl1 tl2 =
+and moregen_list type_pairs env tl1 tl2 =
   if List.length tl1 <> List.length tl2 then
     raise_unexplained_for Moregen;
-  List.iter2 (moregen inst_nongen type_pairs env) tl1 tl2
+  List.iter2 (moregen type_pairs env) tl1 tl2
 
-and moregen_labeled_list inst_nongen type_pairs env labeled_tl1
+and moregen_labeled_list type_pairs env labeled_tl1
     labeled_tl2 =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
     raise_unexplained_for Moregen;
@@ -3912,19 +3908,19 @@ and moregen_labeled_list inst_nongen type_pairs env labeled_tl1
     (fun (label1, ty1) (label2, ty2) ->
       if not (Option.equal String.equal label1 label2) then
         raise_unexplained_for Moregen;
-      moregen inst_nongen type_pairs env ty1 ty2)
+      moregen type_pairs env ty1 ty2)
     labeled_tl1 labeled_tl2
 
-and moregen_package inst_nongen type_pairs env lvl1 pack1 lvl2 pack2 =
+and moregen_package type_pairs env lvl1 pack1 lvl2 pack2 =
   match
-    compare_package env (moregen_list inst_nongen type_pairs env)
+    compare_package env (moregen_list type_pairs env)
       lvl1 pack1 lvl2 pack2
   with
   | Ok () -> ()
   | Error fme -> raise_for Moregen (First_class_module fme)
   | exception Not_found -> raise_unexplained_for Moregen
 
-and moregen_fields inst_nongen type_pairs env ty1 ty2 =
+and moregen_fields type_pairs env ty1 ty2 =
   let (fields1, rest1) = flatten_fields ty1
   and (fields2, rest2) = flatten_fields ty2 in
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
@@ -3933,13 +3929,13 @@ and moregen_fields inst_nongen type_pairs env ty1 ty2 =
     | (n, _, _) :: _ -> raise_for Moregen (Obj (Missing_field (Second, n)))
     | [] -> ()
   end;
-  moregen inst_nongen type_pairs env rest1
+  moregen type_pairs env rest1
     (build_fields (get_level ty2) miss2 rest2);
   List.iter
     (fun (name, k1, t1, k2, t2) ->
        (* The below call should never throw [Public_method_to_private_method] *)
        moregen_kind k1 k2;
-       try moregen inst_nongen type_pairs env t1 t2 with Moregen_trace trace ->
+       try moregen type_pairs env t1 t2 with Moregen_trace trace ->
          raise_trace_for Moregen
            (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
     )
@@ -3952,14 +3948,14 @@ and moregen_kind k1 k2 =
   | (Fpublic, Fprivate)              -> raise Public_method_to_private_method
   | (Fabsent, _) | (_, Fabsent)      -> assert false
 
-and moregen_row inst_nongen type_pairs env row1 row2 =
+and moregen_row type_pairs env row1 row2 =
   let Row {fields = row1_fields; more = rm1; closed = row1_closed} =
     row_repr row1 in
   let Row {fields = row2_fields; more = rm2; closed = row2_closed;
            fixed = row2_fixed} = row_repr row2 in
   if eq_type rm1 rm2 then () else
   let may_inst =
-    is_Tvar rm1 && may_instantiate inst_nongen rm1 || get_desc rm1 = Tnil in
+    is_Tvar rm1 && may_instantiate rm1 || get_desc rm1 = Tnil in
   let r1, r2, pairs = merge_row_fields row1_fields row2_fields in
   let r1, r2 =
     if row2_closed then
@@ -3993,7 +3989,7 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
       (* This [link_type] has to be undone if the rest of the function fails *)
       link_type rm1 ext
   | Tconstr _, Tconstr _ ->
-      moregen inst_nongen type_pairs env rm1 rm2
+      moregen type_pairs env rm1 rm2
   | _ -> raise_unexplained_for Moregen
   end;
   try
@@ -4004,7 +4000,7 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
          (* Both matching [Rpresent]s *)
          | Rpresent(Some t1), Rpresent(Some t2) -> begin
              try
-               moregen inst_nongen type_pairs env t1 t2
+               moregen type_pairs env t1 t2
              with Moregen_trace trace ->
                raise_trace_for Moregen
                  (Variant (Incompatible_types_for l) :: trace)
@@ -4019,11 +4015,11 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
                    rf_either [] ~use_ext_of:f2 ~no_arg:c2 ~matched:m2 in
                  link_row_field_ext ~inside:f1 f2';
                  if List.length tl1 = List.length tl2 then
-                   List.iter2 (moregen inst_nongen type_pairs env) tl1 tl2
+                   List.iter2 (moregen type_pairs env) tl1 tl2
                  else match tl2 with
                    | t2 :: _ ->
                      List.iter
-                       (fun t1 -> moregen inst_nongen type_pairs env t1 t2)
+                       (fun t1 -> moregen type_pairs env t1 t2)
                        tl1
                    | [] -> if tl1 <> [] then raise_unexplained_for Moregen
                end
@@ -4036,7 +4032,7 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
              try
                link_row_field_ext ~inside:f1 f2;
                List.iter
-                 (fun t1 -> moregen inst_nongen type_pairs env t1 t2)
+                 (fun t1 -> moregen type_pairs env t1 t2)
                  tl1
              with Moregen_trace trace ->
                raise_trace_for Moregen
@@ -4070,9 +4066,9 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
     set_type_desc rm1 md1; raise exn
 
 (* Must empty univar_pairs first *)
-let moregen inst_nongen type_pairs env patt subj =
+let moregen type_pairs env patt subj =
   with_univar_pairs [] (fun () ->
-    moregen inst_nongen type_pairs env patt subj)
+    moregen type_pairs env patt subj)
 
 (*
    Non-generic variable can be instantiated only if [inst_nongen] is
@@ -4082,7 +4078,7 @@ let moregen inst_nongen type_pairs env patt subj =
    Usually, the subject is given by the user, and the pattern
    is unimportant.  So, no need to propagate abbreviations.
 *)
-let moregeneral env inst_nongen pat_sch subj_sch =
+let moregeneral env pat_sch subj_sch =
   (* Moregen splits the generic level into two finer levels:
      [generic_level] and [subject_level = generic_level - 1].
      In order to properly detect and print weak variables when
@@ -4108,15 +4104,15 @@ let moregeneral env inst_nongen pat_sch subj_sch =
       let subj = duplicate_type subj_inst in
       (* Duplicate generic variables *)
       let patt = generic_instance pat_sch in
-      try Ok (moregen inst_nongen (TypePairs.create 13) env patt subj)
+      try Ok (moregen (TypePairs.create 13) env patt subj)
       with Moregen_trace trace -> Error trace
     end with
     | Ok () -> ()
     | Error trace -> raise (Moregen (expand_to_moregen_error env trace))
   end
 
-let is_moregeneral env inst_nongen pat_sch subj_sch =
-  match moregeneral env inst_nongen pat_sch subj_sch with
+let is_moregeneral env pat_sch subj_sch =
+  match moregeneral env pat_sch subj_sch with
   | () -> true
   | exception Moregen _ -> false
 
@@ -4547,7 +4543,7 @@ let rec moregen_clty ~arrow_index trace type_pairs env cty1 cty2 =
     | Cty_arrow (l1, ty1, cty1'), Cty_arrow (l2, ty2, cty2') when l1 = l2 ->
         let arrow_index = arrow_index + 1 in
         begin
-          try moregen true type_pairs env ty1 ty2 with Moregen_trace trace ->
+          try moregen type_pairs env ty1 ty2 with Moregen_trace trace ->
             raise (Failure [
                 CM_Parameter_mismatch
                   (arrow_index, env, expand_to_moregen_error env trace)])
@@ -4562,7 +4558,7 @@ let rec moregen_clty ~arrow_index trace type_pairs env cty1 cty2 =
                   all methods in sign2 are present in sign1. *)
                assert false
              | (_, _, ty') ->
-                 match moregen true type_pairs env ty' ty with
+                 match moregen type_pairs env ty' ty with
                  | () -> ()
                  | exception Moregen_trace trace ->
                      raise (Failure [
@@ -4580,7 +4576,7 @@ let rec moregen_clty ~arrow_index trace type_pairs env cty1 cty2 =
                   all instance variables in sign2 are present in sign1. *)
                assert false
              | (_, _, ty') ->
-                 match moregen true type_pairs env ty' ty with
+                 match moregen type_pairs env ty' ty with
                  | () -> ()
                  | exception Moregen_trace trace ->
                      raise (Failure [
@@ -4641,7 +4637,7 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
           let row2 = sign2.csig_self_row in
           TypePairs.add type_pairs (self1, self2);
           (* Always succeeds *)
-          moregen true type_pairs env row1 row2;
+          moregen type_pairs env row1 row2;
           (* May fail *)
           try moregen_clty trace type_pairs env patt subj; []
           with Failure res -> res

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -292,9 +292,9 @@ val filter_method: Env.t -> string -> type_expr -> type_expr
 val occur_in: Env.t -> type_expr -> type_expr -> bool
 val deep_occur: type_expr -> type_expr -> bool
 val deep_occur_list: type_expr -> type_expr list -> bool
-val moregeneral: Env.t -> bool -> type_expr -> type_expr -> unit
+val moregeneral: Env.t -> type_expr -> type_expr -> unit
         (* Check if the first type scheme is more general than the second. *)
-val is_moregeneral: Env.t -> bool -> type_expr -> type_expr -> bool
+val is_moregeneral: Env.t -> type_expr -> type_expr -> bool
 val rigidify: type_expr -> type_expr list
         (* "Rigidify" a type and return its type variable *)
 val all_distinct_vars: Env.t -> type_expr list -> bool

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -457,6 +457,7 @@ type closed_class_failure = {
 val free_variables: ?env:Env.t -> type_expr -> type_expr list
 val free_variables_list: ?env:Env.t -> type_expr list -> type_expr list
         (* If env present, then check for incomplete definitions too *)
+val contains_nongen_variables: ?env:Env.t -> type_expr -> bool
 val closed_type_expr: ?env:Env.t -> type_expr -> bool
 val closed_type_decl: type_declaration -> type_expr option
 val closed_extension_constructor: extension_constructor -> type_expr option

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -99,7 +99,7 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  match Ctype.moregeneral env true vd1.val_type vd2.val_type with
+  match Ctype.moregeneral env vd1.val_type vd2.val_type with
   | exception Ctype.Moregen err -> raise (Dont_match (Type err))
   | () -> value_descriptions_consistency env vd1 vd2
 


### PR DESCRIPTION
This small PR refactors the code in `Toplevel.genprintval` which checks if  simple printer's type scheme matches a given value type.

Currently, this code is using a special mode of `Ctype.is_moregeneral` to recognize printer type scheme which may match the type of a value. This special mode of `Ctype.is_moregeneral` is here to ensure that printing a value does not change the type scheme of an installed printer. Consider for instance
 
```ocaml
let pp_option_ref = Fun.id @@ fun ppf x ->
    match !x with
    | None -> Format.fprintf ppf "Nothing"
    | Some _ -> Format.fprintf ppf "Something"
;;
#install_printer pp_option_ref;;
ref (Some 0);;
```
In this situation, the toplevel trying to print `ref (Some 0)` should not instantiate the type of `pp_option_ref` to a `int option ref printer`.

This PR proposes to achieve the same behaviour by explicitly excluding printers whose type schemes still contain non-generic type variables when searching for printers in the toplevel in commit 91dd1fbc6ef3c11c7cb6168a87993de5ca70097b .

This makes it then possible to remove a boolean flag in the `Ctype.moregen` family of functions that was only used in the toplevel in 16abf9dd4af21109f9b44f07dc2aec61f040d3cf .