### PR TITLE
Rename Domain.running_domain_count => Domain.count

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,7 +47,8 @@ Working version
    Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
 
 - #14086: Add Domain.count.
-  (Nicolás Ojeda Bär, review by David Allsopp and Gabriel Scherer)
+  (Nicolás Ojeda Bär, review by David Allsopp, Gabriel Scherer, Daniel Bünzli
+  and KC Sivaramakrishnan)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -46,7 +46,7 @@ Working version
   (Kate Deplaix, review by Daniel Bünzli, Gabriel Scherer,
    Nicolás Ojeda Bär, Florian Angeletti and Josh Berdine)
 
-- #14086: Add Domain.running_domain_count.
+- #14086: Add Domain.count.
   (Nicolás Ojeda Bär, review by David Allsopp and Gabriel Scherer)
 
 ### Type system:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2325,7 +2325,7 @@ CAMLprim value caml_domain_dls_compare_and_set(value old, value new)
   }
 }
 
-CAMLprim value caml_running_domain_count(value unused)
+CAMLprim value caml_domain_count(value unused)
 {
   return Val_long(atomic_load_relaxed(&caml_num_domains_running));
 }

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -40,8 +40,8 @@ module Raw = struct
     = "caml_ml_domain_id" [@@noalloc]
   external cpu_relax : unit -> unit
     = "caml_ml_domain_cpu_relax"
-  external get_running_domain_count: unit -> int
-    = "caml_running_domain_count" [@@noalloc]
+  external get_domain_count: unit -> int
+    = "caml_domain_count" [@@noalloc]
   external get_recommended_domain_count: unit -> int
     = "caml_recommended_domain_count" [@@noalloc]
 end
@@ -300,5 +300,5 @@ let join { term_sync ; _ } =
   | Ok x -> x
   | Error ex -> raise ex
 
-let running_domain_count = Raw.get_running_domain_count
+let count = Raw.get_domain_count
 let recommended_domain_count = Raw.get_recommended_domain_count

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -85,8 +85,8 @@ val cpu_relax : unit -> unit
 val is_main_domain : unit -> bool
 (** [is_main_domain ()] returns true if called from the initial domain. *)
 
-val running_domain_count : unit -> int
-(** The number of currently running domains.
+val count : unit -> int
+(** The current number of domains.
 
     @since 5.5 *)
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -86,7 +86,8 @@ val is_main_domain : unit -> bool
 (** [is_main_domain ()] returns true if called from the initial domain. *)
 
 val count : unit -> int
-(** The current number of domains.
+(** The number of domains that have been spawned (including the initial domain)
+    and have not yet terminated.
 
     @since 5.5 *)
 


### PR DESCRIPTION
As discussed in https://github.com/ocaml/ocaml/pull/14086#issuecomment-2985498083:

- "running" is misleading because it implies that there is another state for domains,
- `Domain.domain_count` would needlessly repeat "domain"

So we are left with `Domain.count`.