### PR TITLE
CI: attempt to silence a MSVC warning

### DIFF
--- a/testsuite/tests/lib-bigarray-2/bigarrcstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrcstub.c
@@ -42,7 +42,8 @@ void printtab(double tab[DIMX][DIMY])
 value c_filltab(value unit)
 {
   filltab();
-  return caml_ba_alloc_dims(CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
+  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
+  return caml_ba_alloc_dims((int)CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
                             2, ctab, (intnat)DIMX, (intnat)DIMY);
 }
 

--- a/testsuite/tests/lib-bigarray-2/bigarrfstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrfstub.c
@@ -24,7 +24,8 @@ extern float ftab_[];
 value fortran_filltab(value unit)
 {
   filltab_();
-  return caml_ba_alloc_dims(CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
+  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
+  return caml_ba_alloc_dims((int)CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
                             2, ftab_, (intnat)8, (intnat)6);
 }
 

--- a/testsuite/tests/statmemprof/bigarray_stubs.c
+++ b/testsuite/tests/statmemprof/bigarray_stubs.c
@@ -5,20 +5,21 @@ static char buf[10000];
 value static_bigstring(value unit)
 {
   intnat dim[] = { sizeof(buf) };
-  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
+  // the (int) cast is intended to silence a MSVC warning (C5287)
+  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
                        1, buf, dim);
 }
 
 value new_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
+  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
                        1, NULL, dim);
 }
 
 value malloc_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
+  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
                        1, malloc(dim[0]), dim);
 }


### PR DESCRIPTION
Our msvc CI target fails on trunk and all PRs currently, due to an apparently-new warning regarding or-ing values of different enums together. See my preliminary investigation at https://github.com/ocaml/ocaml/pull/14059#issuecomment-2985738799

The present PR is an attempt to silence this warning to make the CI go back to green.
(I haven't actually tested this on MSVC so this is pure hope at this point.)

cc @MisterDA 