### PR TITLE
ocamldoc: no paragraphes in the table of modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -783,6 +783,10 @@ OCaml 5.4.0
   (Gabriel Scherer, review by Jan Midtgaard and Miod Vallat,
    report by Jan Midtgaard)
 
+- #13896, #?????: ocamldoc, do not wrap module description in a paragraph tag
+  inside the table of modules
+  (Florian Angeletti, review by ????)
+
 - #13703: wrong explanation for some polymorphic-variant subtyping errors
   (Gabriel Scherer, review by Jacques Garrigue,
    report by Wiktor Kuchta and Richard Eisenberg)

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -552,7 +552,7 @@ class virtual text =
              let (html, _) = Naming.html_files m.m_name in
              bp b "<a href=\"%s\">%s</a></td>" html m.m_name;
              bs b "<td>";
-             self#html_of_info_first_sentence b m.m_info;
+             self#html_of_info_first_sentence ~with_p:false b m.m_info;
            with
              Not_found ->
                Odoc_global.pwarning (Odoc_messages.cross_module_not_found name);
@@ -786,7 +786,7 @@ class virtual info =
 
     (** Print html code for the first sentence of a description.
        The titles and lists in this first sentence has been removed.*)
-    method html_of_info_first_sentence b info_opt =
+    method html_of_info_first_sentence ~with_p b info_opt =
       match info_opt with
         None -> ()
       | Some info ->
@@ -799,7 +799,7 @@ class virtual info =
              None -> ()
            | Some d when d = [Odoc_info.Raw ""] -> ()
            | Some d ->
-               self#html_of_text ~with_p:true b
+               self#html_of_text ~with_p b
                  (Odoc_info.text_no_title_no_list
                     (Odoc_info.first_sentence_of_text d));
                bs b "\n"
@@ -2081,7 +2081,7 @@ class html =
          if complete then
            self#html_of_info ~cls: "module top" ~indent: true
          else
-           self#html_of_info_first_sentence
+           self#html_of_info_first_sentence ~with_p:true
         ) b m.m_info
       else
         ()
@@ -2112,7 +2112,7 @@ class html =
          if complete then
            self#html_of_info ~cls: "modtype top" ~indent: true
          else
-           self#html_of_info_first_sentence
+           self#html_of_info_first_sentence ~with_p:true
         ) b mt.mt_info
       else
         ()
@@ -2267,7 +2267,7 @@ class html =
        if complete then
          self#html_of_info ~cls: "class top" ~indent: true
        else
-         self#html_of_info_first_sentence
+         self#html_of_info_first_sentence ~with_p:true
       ) b c.cl_info
 
     (** Print html code for a class type. *)
@@ -2310,7 +2310,7 @@ class html =
        if complete then
          self#html_of_info ~cls: "classtype top" ~indent: true
        else
-         self#html_of_info_first_sentence
+         self#html_of_info_first_sentence ~with_p:true
       ) b ct.clt_info
 
     (** Return html code to represent a dag, represented as in Odoc_dag2html. *)
@@ -2444,7 +2444,7 @@ class html =
           if simple_name <> father_name && father_name <> "" then
             bp b "[<a href=\"%s\">%s</a>]" (fst (Naming.html_files father_name)) father_name;
           bs b "</td>\n<td>";
-          self#html_of_info_first_sentence b (info e);
+          self#html_of_info_first_sentence ~with_p:false b (info e);
           bs b "</td></tr>\n"
         end
         in

--- a/ocamldoc/odoc_html.mli
+++ b/ocamldoc/odoc_html.mli
@@ -258,7 +258,7 @@ module Generator :
           ?cls:string ->
           ?indent:bool -> Buffer.t -> Odoc_types.info option -> unit
         method html_of_info_first_sentence :
-          Buffer.t -> Odoc_info.info option -> unit
+          with_p:bool -> Buffer.t -> Odoc_info.info option -> unit
         method html_of_method : Buffer.t -> Odoc_info.Value.t_method -> unit
         method html_of_modtype :
           Buffer.t ->
@@ -555,7 +555,7 @@ module type Html_generator =
           ?cls:string ->
           ?indent:bool -> Buffer.t -> Odoc_types.info option -> unit
         method html_of_info_first_sentence :
-          Buffer.t -> Odoc_info.info option -> unit
+          with_p:bool -> Buffer.t -> Odoc_info.info option -> unit
         method html_of_method : Buffer.t -> Odoc_info.Value.t_method -> unit
         method html_of_modtype :
           Buffer.t ->

--- a/testsuite/tests/tool-ocamldoc/Paragraph.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Paragraph.html.reference
@@ -60,8 +60,7 @@
    
 <table class="indextable module-list">
 <tr><td class="module"><a href="Paragraph.html">Paragraph</a></td><td><div class="info">
-<p>This file tests the generation of paragraph within module comments.</p>
-
+This file tests the generation of paragraph within module comments.
 </div>
 </td></tr>
 </table></p>


### PR DESCRIPTION
This PR fixes #13896 by avoiding to wrap in a `<p>` tag the short module description inside the index table of modules.