### PR TITLE
Fix ignored signature constraints in approximation of recursive modules signatures

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,9 +87,11 @@ Working version
   module rec X : ((sig module A : sig end end) with module A := X0)
   and Y : sig type t = X.A.t end (* Unbound type constructor X.A.t *)
   ```
-  Now, type and module constraints are properly merged during approximation
-  (still disabling any wellformedness check).
-  (Clement Blaudeau, review by ???)
+
+  Now, type and module constraints are properly merged during approximation ,
+  reusing the infrastructure for normal merging of constraints, but disabling
+  any wellformedness check.
+  (Clement Blaudeau, review by Florian Angeletti)
 
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -78,6 +78,20 @@ Working version
   explaining that `X1` would keep an invalid alias to `F(X)`
   (Clement Blaudeau, review by Florian Angeletti)
 
+* #14100: Do not ignore type-constraints and module-constraints when building
+  the approximated signature of recursive modules. Ignoring those constraints
+  resulted in incorrect (wrong set of fields, wrong shadowing between fields)
+  approximated signatures, failing to typecheck, as in:
+  ```ocaml
+  module X0 : sig type t end
+  module rec X : ((sig module A : sig end end) with module A := X0)
+  and Y : sig type t = X.A.t end (* Unbound type constructor X.A.t *)
+  ```
+  Now, type and module constraints are properly merged during approximation
+  (still disabling any wellformedness check).
+  (Clement Blaudeau, review by ???)
+
+
 ### Other libraries:
 
 * #14046: On Windows, `Unix.kill pid Sys.sigkill` causes the receiving process

--- a/Changes
+++ b/Changes
@@ -87,11 +87,10 @@ Working version
   module rec X : ((sig module A : sig end end) with module A := X0)
   and Y : sig type t = X.A.t end (* Unbound type constructor X.A.t *)
   ```
-
   Now, type and module constraints are properly merged during approximation ,
   reusing the infrastructure for normal merging of constraints, but disabling
   any wellformedness check.
-  (Clement Blaudeau, review by Florian Angeletti)
+  (Clement Blaudeau and Ryan Tjoa, review by Florian Angeletti)
 
 
 ### Other libraries:

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -715,3 +715,213 @@ Line 6, characters 32-34:
 Error: The type constraints are not consistent.
        Type "'a * 'b * 'c" is not compatible with type "'d * 'e"
 |}]
+
+(** Merging and approximation ***)
+(* The test are made inside module types, as they only focus on approximation
+   and typechecking of signatures of recursive modules, hence the
+   implementations are irrelevant. The tests for module type constraints can be
+   found in [module_type_substitution.ml] *)
+
+(** Module constraints during approximation **)
+
+(*  Merging modules constraints during the approximation phase of typechecking
+    recursive modules should result in the right approximated signature, with
+    the right set of visible fields. Concrete constraints (where a module that
+    is already an alias is replaced by an equivalent alias) are not tested as it
+    is unsupported (issue #13897) *)
+
+(* Approximating a signature with a module constraint should merge the module
+   (abstract, shallow, non destructive case) *)
+module type Module_Abstract_Shallow = sig
+  module X0 : sig type t end
+  module rec X : (sig module X1 : sig end end with module X1 = X0)
+     and Y : sig type u = X.X1.t end
+end
+[%%expect {|
+module type Module_Abstract_Shallow =
+  sig
+    module X0 : sig type t end
+    module rec X : sig module X1 : sig type t = X0.t end end
+    and Y : sig type u = X.X1.t end
+  end
+|}]
+
+(* Approximating a signature with a module constraint should merge the module
+   (abstract, shallow, destructive case). We use shadowing to test that the
+   destructed item has indeed been removed *)
+module type Module_Abstract_Shallow_Destructive = sig
+  module X0 : sig end
+  module type S = sig module X1 : sig end end
+  module rec X : (sig
+                   module X1 : sig type t end
+                   include (S with module X1 := X0)
+                 end)
+     and Y : sig type u = X.X1.t end
+end
+[%%expect {|
+module type Module_Abstract_Shallow_Destructive =
+  sig
+    module X0 : sig end
+    module type S = sig module X1 : sig end end
+    module rec X : sig module X1 : sig type t end end
+    and Y : sig type u = X.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a module constraint should merge the module
+   (abstract, shallow, non destructive case) *)
+module type Module_Abstract_Deep = sig
+  module X0 : sig type t end
+  module rec X : (sig
+                   module X1 : sig module X2 : sig end end
+                 end with module X1.X2 = X0)
+     and Y : sig type u = X.X1.X2.t end
+end
+[%%expect {|
+module type Module_Abstract_Deep =
+  sig
+    module X0 : sig type t end
+    module rec X :
+      sig module X1 : sig module X2 : sig type t = X0.t end end end
+    and Y : sig type u = X.X1.X2.t end
+  end
+|}]
+
+(* There is no test for (abstract, deep, destructive case). The shallow test
+   cannot be adapted, as the root module (X1) would still be shadowed *)
+
+(* Ill-formed module constraints (when the field does not exist) should be
+   caught during approximation.  *)
+module type IllFormed_Module_No_Field = sig
+  module X0 : sig end
+  module rec X : (sig
+                   module X1 : sig end
+
+                   (* invalid, but the error should not be here *)
+                   type 'a t
+                   type u = (int, bool) t
+                 end) with module X2 = X0
+end
+[%%expect {|
+Line 9, characters 39-41:
+9 |                  end) with module X2 = X0
+                                           ^^
+Error: The signature constrained by "with" has no component named "X2"
+|}]
+
+
+(* Ill-formed module constraints (when the field does not exist) should be
+   caught during approximation (destructive case).  *)
+module type IllFormed_Module_No_Field_Destructive = sig
+  module X0 : sig end
+  module rec X : (sig
+                   module X1 : sig module X1' : sig end end
+
+                   (* invalid, but the error should not be here *)
+                   type 'a t
+                   type u = (int, bool) t
+                 end) with module X1.X2 = X0
+end
+[%%expect {|
+Line 9, characters 42-44:
+9 |                  end) with module X1.X2 = X0
+                                              ^^
+Error: The signature constrained by "with" has no component named "X1.X2"
+|}]
+
+(* Other forms of ill-formed module constraints (when the field exists) should
+   be caught after approximation.  *)
+module type IllFormed_Module_Other = sig
+  module X0 : sig end
+  module rec X : (sig
+                   module X1 : sig type t end
+                 end) with module X1 = X0
+end
+[%%expect {|
+Lines 3-5, characters 17-41:
+3 | .................(sig
+4 |                    module X1 : sig type t end
+5 |                  end) with module X1 = X0
+Error: In this "with" constraint, the new definition of "X1"
+       does not match its original definition in the constrained signature:
+       Modules do not match: sig end is not included in sig type t end
+       The type "t" is required but not provided
+|}]
+
+(** Type constraints during approximation **)
+
+(*  Merging type constraints during the approximation phase of typechecking
+    recursive modules should result in the right approximated signature, with
+    the right set of visible fields. There is not much to check for non
+    destructive cases, as approximated constraints are abstract anyway *)
+
+(* Approximation a signature with a type constraint should merge the type
+   (abstract, shallow, destructive case). We use shadowing to test that the
+   type has indeed been removed *)
+module type Type_Abstract_Shallow_Destructive = sig
+  module rec X : (sig
+                   type 'a t
+                   include (sig type t end) with type t := int
+                 end)
+     and Y : sig type u = int X.t end
+end
+[%%expect {|
+module type Type_Abstract_Shallow_Destructive =
+  sig module rec X : sig type 'a t end and Y : sig type u = int X.t end end
+|}]
+
+
+(* Ill-formed type constraints (when the field does not exist) should be
+   caught during approximation.  *)
+module type IllFormed_Type_No_Field = sig
+  module rec X : (sig
+                   type t
+                   (* invalid, but the error should not be here *)
+                   type u = int t
+                 end) with type v = int
+end
+[%%expect {|
+Line 6, characters 27-39:
+6 |                  end) with type v = int
+                               ^^^^^^^^^^^^
+Error: The signature constrained by "with" has no component named "v"
+|}]
+
+
+(* Ill-formed type constraints (when the field does not exist) should be
+   caught during approximation (destructive case).  *)
+module type IllFormed_Type_No_Field_Destructive = sig
+  module rec X : (sig
+                   type t
+                   (* invalid, but the error should not be here *)
+                   type u = int t
+                 end) with type v := int
+end
+[%%expect {|
+Line 6, characters 27-40:
+6 |                  end) with type v := int
+                               ^^^^^^^^^^^^^
+Error: The signature constrained by "with" has no component named "v"
+|}]
+
+(* Other forms of ill-formed type constraints (when the field exists) should
+   be caught after approximation.  *)
+module type IllFormed_Module_Other = sig
+  module rec X : (sig
+                   type 'a t
+                 end) with type t = int
+end
+[%%expect {|
+Lines 2-4, characters 17-39:
+2 | .................(sig
+3 |                    type 'a t
+4 |                  end) with type t = int
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = int
+       is not included in
+         type 'a t
+       They have different arities.
+|}]

--- a/testsuite/tests/typing-recmod/regression_destructive_subst.ml
+++ b/testsuite/tests/typing-recmod/regression_destructive_subst.ml
@@ -1,0 +1,96 @@
+(* TEST
+ expect;
+*)
+
+(* Regression test for https://github.com/oxcaml/oxcaml/pull/4121 *)
+
+module type Destructive_module_subst = sig
+  module type S = sig
+    module A : sig end
+  end
+
+  module rec M : sig
+    module A : sig type t end
+    include S with module A := A
+  end
+
+  and N : sig
+    type alias_MAt = M.A.t
+  end
+end
+[%%expect{|
+module type Destructive_module_subst =
+  sig
+    module type S = sig module A : sig end end
+    module rec M : sig module A : sig type t end end
+    and N : sig type alias_MAt = M.A.t end
+  end
+|}]
+
+module type Destructive_type_subst = sig
+  module type S = sig
+    type a
+  end
+
+  module rec M : sig
+    type a
+    include S with type a := a
+  end
+
+  and N : sig
+    type 'a require_value
+    type require_Ma_value = M.a require_value
+  end
+end
+[%%expect{|
+module type Destructive_type_subst =
+  sig
+    module type S = sig type a end
+    module rec M : sig type a end
+    and N :
+      sig type 'a require_value type require_Ma_value = M.a require_value end
+  end
+|}]
+
+(* Destructive module type substitution *)
+module type P = sig
+  module type T
+  module A:T
+end
+
+module rec X: P with module type T := sig type t end = struct
+  module A = struct type t end
+end
+and Y : sig type t = X.A.t end = struct
+   type t = X.A.t
+end
+[%%expect{|
+module type P = sig module type T module A : T end
+module rec X : sig module A : sig type t end end
+and Y : sig type t = X.A.t end
+|}]
+
+module type No_false_dangling_reference = sig
+  module type S = sig
+    module A : sig type t end
+    module C = A
+  end
+
+  module A2 : sig type t end
+
+  module rec M : sig
+    include S with module A := A2
+  end
+  and N : sig
+    type t = M.C.t
+  end
+end
+[%%expect{|
+module type No_false_dangling_reference =
+  sig
+    module type S = sig module A : sig type t end module C = A end
+    module A2 : sig type t end
+    module rec M : sig module C = A2 end
+    and N : sig type t = M.C.t end
+  end
+|}]


### PR DESCRIPTION
# Overview 
Both module constraints and type constraints are ignored during the approximation phase (when typing recursive modules), resulting in wrong approximated signatures:

```ocaml
module type Test = sig
  module Empty : sig end

  module rec X : sig
           module A : sig type t end
           include (sig module A : sig end end) (* could shadow A *)
                   with module A := Empty (* actually, no shadowing, as A is removed (destructive substitution) *)
           type u = A.t
         end
     and Y : sig type u = X.A.t end
end
```
fails with
```ocaml
Line 11, characters 26-31:
11 |      and Y : sig type u = X.A.t end
                               ^^^^^
Error: Unbound type constructor X.A.t
```
This comes from the fact that the destructive constraint on the included signature is not properly computed in the approximation phase, leaving the `module A : sig end` field inside, which in turns shadows the original `module A : sig type t end`, making `X.A.t` undefined.  

# Context
This PR fixes the same problem as [this PR in Oxcaml](https://github.com/oxcaml/oxcaml/pull/4121). While the fix proposed there seems fine, it does not benefit from the refactoring of #13911 (as OxCaml was based on 5.2). The added test-file was borrowed from there. The case of module-type constraints was already fixed by #13829.

# Fix 

Merging module constraints in approximation mode now uses an `~approx` flag, similarly to module type constraints: it disable equivalence and wellformedness checks, but performs the merging. For type constraints, a special `merge_type_approx` function with a simplified logic is defined. It still uses the normal merging infrastructure. 
Overall, a better skeleton for the approximated signature is build, as the destructive substitutions are correctly removing the fields. 

# Notes 

* This PR changes the `lookup_module_path ~load:false` for `lookup_module`, where the load flag is not set to false. It should not have much impact for well-typed programs, as the loading would happen after the approximation phase anyway.
* Ill formed substitutions where the field is not present are caught at approximation phase, while other forms of ill-formedness are caught at typechecking (when the equivalence and wellformedness checks are not disabled)

# ~~Missing:~~ 
- [x] Add similar support for type constraints
- [x] Add more tests
- [x] Update changelog entry with reviewer