### PR TITLE
Address CI failures coming from recent GitHub Actions image updates

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -83,6 +83,7 @@ jobs:
 
     strategy:
       matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
+      fail-fast: true
 
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
             name: extra (debug)
           - id: debug-s4096
             name: extra (debug-s4096)
+      fail-fast: true
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -212,6 +213,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(needs.config.outputs.jobs) }}
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/configure
+++ b/configure
@@ -15113,7 +15113,8 @@ case $ocaml_cc_vendor in #(
   msvc-*) :
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+    cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
+-Wno-cast-function-type-mismatch"
          warn_error_flag='-WX' ;; #(
   *) :
     cc_warnings='-W2'

--- a/configure.ac
+++ b/configure.ac
@@ -921,7 +921,8 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [AS_CASE([$ocaml_cc_vendor],
       [msvc-*-clang-*],
-        [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+        [cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
+-Wno-cast-function-type-mismatch"
          warn_error_flag='-WX'],
       [cc_warnings='-W2'
        warn_error_flag='-WX -options:strict'])],

--- a/testsuite/tests/lib-bigarray-2/bigarrcstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrcstub.c
@@ -42,9 +42,15 @@ void printtab(double tab[DIMX][DIMY])
 value c_filltab(value unit)
 {
   filltab();
-  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
-  return caml_ba_alloc_dims((int)CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc_dims(CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
                             2, ctab, (intnat)DIMX, (intnat)DIMY);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value c_printtab(value ba)

--- a/testsuite/tests/lib-bigarray-2/bigarrfstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrfstub.c
@@ -24,9 +24,15 @@ extern float ftab_[];
 value fortran_filltab(value unit)
 {
   filltab_();
-  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
-  return caml_ba_alloc_dims((int)CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc_dims(CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
                             2, ftab_, (intnat)8, (intnat)6);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value fortran_printtab(value ba)

--- a/testsuite/tests/statmemprof/bigarray_stubs.c
+++ b/testsuite/tests/statmemprof/bigarray_stubs.c
@@ -5,21 +5,41 @@ static char buf[10000];
 value static_bigstring(value unit)
 {
   intnat dim[] = { sizeof(buf) };
-  // the (int) cast is intended to silence a MSVC warning (C5287)
-  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
                        1, buf, dim);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value new_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
                        1, NULL, dim);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value malloc_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
                        1, malloc(dim[0]), dim);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }


### PR DESCRIPTION
At present, with [Runner Image 20250617.1.0](https://github.com/actions/runner-images/blob/win22/20250617.1/images/windows/Windows2022-Readme.md), we can see [MSVC x86_64](https://github.com/ocaml/ocaml/actions/runs/15833559199/job/44631809853?pr=14102) and [MSVC i686](https://github.com/ocaml/ocaml/actions/runs/15833559199/job/44631809855?pr=14102) both failing `tests/lib-bigarray-2/bigarrcml.ml` and `tests/statmemprof/bigarray.ml`. Unfortunately, the change in #14097 ran through CI using the older [Runner Image 20250609.2.0](https://github.com/actions/runner-images/blob/win22/20250609.2/images/windows/Windows2022-Readme.md). That issue has already been [reported to Microsoft](https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942#T-N10914938) and is supposed to be fixed, but there isn't a release with which to verify this. Assuming that the next release addresses this, it seems better to suppress the warning temporarily.

Additionally, the same runner image change moves from clang 18.1 to clang 19.1 and causes the [clang-cl x86_64](https://github.com/ocaml/ocaml/actions/runs/15833559199/job/44631809877?pr=14102) failure also being seen. I had formed the impression that https://github.com/llvm/llvm-project/pull/77178 might address this, but experimenting both with a released copy clang-cl from LLVM 20.x and compiling LLVM 21.x in Visual Studio (turns out my 3990X still has its uses...) that this still triggers. In the interests of getting CI back to green a.s.a.p., I've pushed to disable this warning, with the intention that #13841, as and when merged, should re-enable it.