### PR TITLE
Revert "Temporarily disable warning C5387 on MSVC"

### DIFF
--- a/testsuite/tests/lib-bigarray-2/bigarrcstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrcstub.c
@@ -42,15 +42,9 @@ void printtab(double tab[DIMX][DIMY])
 value c_filltab(value unit)
 {
   filltab();
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 5287)
-#endif
-  return caml_ba_alloc_dims(CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
+  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
+  return caml_ba_alloc_dims((int)CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
                             2, ctab, (intnat)DIMX, (intnat)DIMY);
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 }
 
 value c_printtab(value ba)

--- a/testsuite/tests/lib-bigarray-2/bigarrfstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrfstub.c
@@ -24,15 +24,9 @@ extern float ftab_[];
 value fortran_filltab(value unit)
 {
   filltab_();
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 5287)
-#endif
-  return caml_ba_alloc_dims(CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
+  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
+  return caml_ba_alloc_dims((int)CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
                             2, ftab_, (intnat)8, (intnat)6);
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 }
 
 value fortran_printtab(value ba)

--- a/testsuite/tests/statmemprof/bigarray_stubs.c
+++ b/testsuite/tests/statmemprof/bigarray_stubs.c
@@ -5,41 +5,21 @@ static char buf[10000];
 value static_bigstring(value unit)
 {
   intnat dim[] = { sizeof(buf) };
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 5287)
-#endif
-  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
+  // the (int) cast is intended to silence a MSVC warning (C5287)
+  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
                        1, buf, dim);
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 }
 
 value new_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 5287)
-#endif
-  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
+  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
                        1, NULL, dim);
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 }
 
 value malloc_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 5287)
-#endif
-  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
+  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
                        1, malloc(dim[0]), dim);
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 }


### PR DESCRIPTION
TODO item following up #14102 to be merged as-and-when:
1. https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942#T-N10914938 is released and renders the disabling of C5387 unnecessary
2. GitHub Actions runners are updated to use that release