### PR TITLE
Fix a possible hang in Pprintast

### DIFF
--- a/Changes
+++ b/Changes
@@ -195,6 +195,10 @@ Working version
   macros to define OCaml integers.
   (Antonin Décimo, review by Nick Barnes)
 
+- #14105: Fix a loop in Pprintast that could result in a hang when printing
+  constructor `(::)` in isolation.
+  (Ulysse Gérard, review by Nicolás Ojeda Bär and Florian Angeletti)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -567,7 +567,8 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
         simple_pattern ctxt f x
     | Ppat_construct ({txt=Lident("::");_}, Some ([],
         {ppat_desc = Ppat_tuple([None, pat1; None, pat2], Closed);_})) ->
-        pp f "%a::%a" (simple_pattern ctxt) pat1 (pattern1 ctxt) pat2 (*RA*)
+        (* Right associative*)
+        pp f "%a::%a" (simple_pattern ctxt) pat1 (pattern1 ctxt) pat2
     | Ppat_construct (li, po) ->
         (* FIXME The third field always false *)
         (match po with

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -559,38 +559,28 @@ and pattern_or ctxt f x =
       pp f "@[<hov0>%a@]" (list ~sep:"@ | " (pattern1 ctxt)) orpats
 
 and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
-  let rec pattern_list_helper f = function
-    | {ppat_desc =
-         Ppat_construct
-           ({ txt = Lident("::") ;_},
-            Some ([], {ppat_desc = Ppat_tuple([None, pat1; None, pat2],
-                                              Closed);_}));
-       ppat_attributes = []}
-
-      ->
-        pp f "%a::%a" (simple_pattern ctxt) pat1 pattern_list_helper pat2 (*RA*)
-    | p -> pattern1 ctxt f p
-  in
   if x.ppat_attributes <> [] then pattern ctxt f x
   else match x.ppat_desc with
     | Ppat_variant (l, Some p) ->
         pp f "@[<2>`%a@;%a@]" ident_of_name l (simple_pattern ctxt) p
     | Ppat_construct (({txt=Lident("()"|"[]"|"true"|"false");_}), _) ->
         simple_pattern ctxt f x
-    | Ppat_construct (({txt;_} as li), po) ->
+    | Ppat_construct (
+        {txt=Lident("::");_},
+        Some ([], {ppat_desc = Ppat_tuple([None, pat1; None, pat2], Closed);_}))
+      when x.ppat_attributes = [] ->
+        pp f "%a::%a" (simple_pattern ctxt) pat1 (pattern1 ctxt) pat2 (*RA*)
+    | Ppat_construct (li, po) ->
         (* FIXME The third field always false *)
-        if txt = Lident "::" then
-          pp f "%a" pattern_list_helper x
-        else
-          (match po with
-           | Some ([], x) ->
-               (* [true] and [false] are handled above *)
-               pp f "%a@;%a"  value_longident_loc li (simple_pattern ctxt) x
-           | Some (vl, x) ->
-               pp f "%a@ (type %a)@;%a" value_longident_loc li
-                 (list ~sep:"@ " ident_of_name_loc) vl
-                 (simple_pattern ctxt) x
-           | None -> pp f "%a" value_longident_loc li)
+        (match po with
+          | Some ([], x) ->
+              (* [true] and [false] are handled above *)
+              pp f "%a@;%a"  value_longident_loc li (simple_pattern ctxt) x
+          | Some (vl, x) ->
+              pp f "%a@ (type %a)@;%a" value_longident_loc li
+                (list ~sep:"@ " ident_of_name_loc) vl
+                (simple_pattern ctxt) x
+          | None -> pp f "%a" value_longident_loc li)
     | _ -> simple_pattern ctxt f x
 
 and tuple_pattern_component ctxt (f:Format.formatter) (label, x) : unit =

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -565,10 +565,8 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
         pp f "@[<2>`%a@;%a@]" ident_of_name l (simple_pattern ctxt) p
     | Ppat_construct (({txt=Lident("()"|"[]"|"true"|"false");_}), _) ->
         simple_pattern ctxt f x
-    | Ppat_construct (
-        {txt=Lident("::");_},
-        Some ([], {ppat_desc = Ppat_tuple([None, pat1; None, pat2], Closed);_}))
-      when x.ppat_attributes = [] ->
+    | Ppat_construct ({txt=Lident("::");_}, Some ([],
+        {ppat_desc = Ppat_tuple([None, pat1; None, pat2], Closed);_})) ->
         pp f "%a::%a" (simple_pattern ctxt) pat1 (pattern1 ctxt) pat2 (*RA*)
     | Ppat_construct (li, po) ->
         (* FIXME The third field always false *)

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -66,3 +66,25 @@ run {| let foo : type a . a -> a = fun x -> x in foo |}
 let foo : 'a . 'a -> 'a = fun (type a) -> (fun x -> x : a -> a) in foo
 - : unit = ()
 |}]
+
+
+let run s =
+  let pe = Parse.implementation (Lexing.from_string s) in
+  let te,_,_,_,_ = Typemod.type_structure Env.initial pe in
+  let ute = Untypeast.untype_structure te in
+  Format.printf "%a@." Pprintast.structure ute
+;;
+
+[%%expect{|
+val run : string -> unit = <fun>
+|}];;
+
+(* That test would hang before ocaml/ocaml#14105 *)
+run {|type t = (::);; let f (x : t) = match x with (::) -> 4|}
+
+[%%expect{|
+type t =
+  | (::)
+let f (x : t) = match x with | (::) -> 4
+- : unit = ()
+|}]


### PR DESCRIPTION
This issue impacted Merlin: https://github.com/ocaml/merlin/pull/1944

The fallback case of `pattern_list_helper`, `pattern1 ctxt f p`, made it loop infinitely when printing the `(::)` type constructor in isolation.