### PR TITLE
Add a variant of discontinue with effects

### DIFF
--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -62,6 +62,9 @@ module Deep = struct
   let discontinue k e =
     resume (take_cont_noexc k) (fun e -> raise e) e (cont_last_fiber k)
 
+  let discontinue_with_effect k e = 
+    resume (take_cont_noexc k) (fun e -> perform e) e (cont_last_fiber k)
+
   let discontinue_with_backtrace k e bt =
     resume (take_cont_noexc k) (fun e -> Printexc.raise_with_backtrace e bt)
       e (cont_last_fiber k)

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -59,6 +59,11 @@ module Deep : sig
       resumed. *)
 
   val discontinue_with_effect: ('a, 'b) continuation -> 'a t -> 'b
+ (** [discontinue_with_effect k e] resumes the continuation [k] by performing the
+      effect [e] in [k].
+
+      @raise Continuation_already_resumed if the continuation has already been
+      resumed. *)
 
   val discontinue_with_backtrace:
     ('a, 'b) continuation -> exn -> Printexc.raw_backtrace -> 'b

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -58,6 +58,8 @@ module Deep : sig
       @raise Continuation_already_resumed if the continuation has already been
       resumed. *)
 
+  val discontinue_with_effect: ('a, 'b) continuation -> 'a t -> 'b
+
   val discontinue_with_backtrace:
     ('a, 'b) continuation -> exn -> Printexc.raw_backtrace -> 'b
   (** [discontinue_with_backtrace k e bt] resumes the continuation [k] by

--- a/testsuite/tests/effects/discontinue_with_effect.ml
+++ b/testsuite/tests/effects/discontinue_with_effect.ml
@@ -11,3 +11,19 @@ let x = try perform (E ()) with
                     | effect F x, k -> x + 2;;
 
 assert (x = 3)
+
+let y = try 
+          try 
+            perform (E ()) 
+          with effect F x, k -> x + 2
+        with effect E x, k -> discontinue_with_effect k (F 1);;
+        
+assert (y = 3)
+
+let z = try 
+          try 
+            perform (E ()) 
+          with effect E x, k -> discontinue_with_effect k (F 1)
+        with effect F x, k -> x + 2;;
+        
+assert (z = 3)

--- a/testsuite/tests/effects/discontinue_with_effect.ml
+++ b/testsuite/tests/effects/discontinue_with_effect.ml
@@ -1,0 +1,13 @@
+(* TEST *)
+
+open Effect
+open Deep
+
+type _ t += E : unit -> int t
+type _ t += F : int -> int t
+
+let x = try perform (E ()) with 
+        effect E x, k -> discontinue_with_effect k (F 1)
+                    | effect F x, k -> x + 2;;
+
+assert (x = 3)


### PR DESCRIPTION
It seems strange to me that we can `match` an expression with:

1. A value 
2. An exception
3. An effect

But we can resume a continuation only by `continue`-ing with a value or `discontinue`-ing with an exception. 

This seems to me a strange asymmetry, though perhaps it has been previously discussed and rejected for some reason that I'm missing. 

I've implemented the feature as `discontinue_with_effect`. This is, in my opinion, not the optimal name, since the meaning of `with` is different to the meaning of `with` in `discontinue_with_backtrace`. I'm happy to hear alternative proposals. Some other I considered include:

1. `reperform`
2. `discontinue_using_effect`