### PR TITLE
Add `-Wno-cast-function-type-mismatch` more clangily

### DIFF
--- a/configure
+++ b/configure
@@ -15113,8 +15113,7 @@ case $ocaml_cc_vendor in #(
   msvc-*) :
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
--Wno-cast-function-type-mismatch"
+    cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
          warn_error_flag='-WX' ;; #(
   *) :
     cc_warnings='-W2'
@@ -15124,6 +15123,52 @@ esac ;; #(
     warn_error_flag='-Werror'
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
 -Wold-style-definition -Wundef" ;;
+esac
+
+case $ocaml_cc_vendor in #(
+  msvc-*-clang-*) :
+    as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-Wno-cast-function-type-mismatch" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -Wno-cast-function-type-mismatch" >&5
+printf %s "checking whether the C compiler accepts -Wno-cast-function-type-mismatch... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag -Wno-cast-function-type-mismatch"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  cc_warnings="$cc_warnings -Wno-cast-function-type-mismatch"
+else $as_nop
+  :
+fi
+ ;; #(
+  *) :
+     ;;
 esac
 
 # Use -Wold-style-declaration if supported

--- a/configure.ac
+++ b/configure.ac
@@ -921,14 +921,19 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [AS_CASE([$ocaml_cc_vendor],
       [msvc-*-clang-*],
-        [cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
--Wno-cast-function-type-mismatch"
+        [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
          warn_error_flag='-WX'],
       [cc_warnings='-W2'
        warn_error_flag='-WX -options:strict'])],
   [warn_error_flag='-Werror'
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
 -Wold-style-definition -Wundef"])
+
+AS_CASE([$ocaml_cc_vendor],
+  [msvc-*-clang-*],
+    [AX_CHECK_COMPILE_FLAG([-Wno-cast-function-type-mismatch],
+      [cc_warnings="$cc_warnings -Wno-cast-function-type-mismatch"], [],
+      [$warn_error_flag])])
 
 # Use -Wold-style-declaration if supported
 AX_CHECK_COMPILE_FLAG([-Wold-style-declaration],


### PR DESCRIPTION
#14102 added `-Wno-cast-function-type-mismatch` to deal with build failures in 20250617. I forgot that clang and gcc differ on how they handle `-Wno-` warnings so on my fork, which for reasons known only to GitHub is building the clang jobs with the 20250602 image, I get:

```
clang-cl -nologo -O2 -Gy- -MD -W4 -Wno-unused-parameter -Wno-sign-compare -Wundef -Wno-cast-function-type-mismatch -Wimplicit-fallthrough -WX  -I ./runtime -I ./flexdll -I ./winpthreads/include -D_CRT_SECURE_NO_DEPRECATE -DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME  runtime/sak.c /link /out:runtime/sak.exe /ENTRY:wmainCRTStartup  
error: unknown warning option '-Wno-cast-function-type-mismatch'; did you mean '-Wno-cast-function-type-strict'? [-Werror,-Wunknown-warning-option]
```

This PR instead tests for the `-Wno-cast-function-type-mismatch` flag and adds it only then. In https://github.com/dra27/ocaml/pull/211 on my fork, https://github.com/dra27/ocaml/actions/runs/15906003270/job/44861034627?pr=211 is building with runner image 20250602.1.0 and we get this in `configure`:

```
checking whether the C compiler accepts -Wno-cast-function-type-mismatch... no
```

Hopefully on ocaml/ocaml it'll use the newer image and we'll it working 🤞