### PR TITLE
typechecker error messages: explain quantifier mismatches

### DIFF
--- a/Changes
+++ b/Changes
@@ -176,8 +176,8 @@ Working version
   recursive modules.
   (Shivam Acharya, review by Gabriel Scherer and Florian Angeletti)
 
-- #14076: error messages, add a short explanation for mismatched universal
-  variables.
+- #14076, 14111: error messages, add a short explanation for mismatched
+  universal variables and universal quantifications.
   (Florian Angeletti, review by Gabriel Scherer)
 
 - #14146: add an error message for external declaration with
@@ -191,6 +191,8 @@ Working version
 - #14147: print row types in error messages when they are a type constructor,
   e.g. `< foo : int; .. as $0>` when $0 is introduced by a GADT constructor
   (Stefan Muenzel, review by Jacques Garrigue and Florian Angeletti)
+
+
 
 ### Internal/compiler-libs changes:
 

--- a/testsuite/tests/typing-gadts/pr10907.ml
+++ b/testsuite/tests/typing-gadts/pr10907.ml
@@ -48,6 +48,8 @@ let unsound_cast : 'a 'b. 'a -> 'b = fun x ->
 Lines 1-2, characters 37-36:
 1 | .....................................fun x ->
 2 |   match t with Iso (g, h) -> h (g x)
-Error: This definition has type "'c. 'c -> 'c" which is less general than
+Error: This definition has type "'b. 'b -> 'b" which is less general than
          "'a 'b. 'a -> 'b"
+       The universal type variable "'b" in the first type matches multiple
+       distinct variables in the second type.
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -806,11 +806,13 @@ Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
 Error: This definition has type
-         "'c 'd. ('d, 'd) eq -> ([< `A of 'd | `B ] as 'c) -> 'c"
+         "'c 'b. ('b, 'b) eq -> ([< `A of 'b | `B ] as 'c) -> 'c"
        which is less general than
-         "'e 'f 'a 'b.
+         "'d 'e 'a 'b.
            ('a, 'b) eq ->
-           ([< `A of 'a | `B ] as 'f) -> ([< `A of 'b | `B ] as 'e)"
+           ([< `A of 'a | `B ] as 'e) -> ([< `A of 'b | `B ] as 'd)"
+       The universal type variable "'b" in the first type matches multiple
+       distinct variables in the second type.
 |}];;
 
 let f : type a b. (a,b) eq -> [`A of a | `B] -> [`A of b | `B] =

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -519,7 +519,10 @@ end
 Line 3, characters 12-17:
 3 |   method id x = x
                 ^^^^^
-Error: This method has type "'a -> 'a" which is less general than "'b. 'b -> 'a"
+Error: This method has type "'b -> 'b" which is less general than
+         "'b0. 'b0 -> 'b"
+       The type variable "'b" is not generalizable to an universal
+       type variable.
 |}];;
 
 class id2 (x : 'a) = object
@@ -531,7 +534,10 @@ end
 Line 3, characters 12-17:
 3 |   method id x = x
                 ^^^^^
-Error: This method has type "'a -> 'a" which is less general than "'b. 'b -> 'a"
+Error: This method has type "'b -> 'b" which is less general than
+         "'b0. 'b0 -> 'b"
+       The type variable "'b" is not generalizable to an universal
+       type variable.
 |}];;
 
 class id3 x = object
@@ -544,7 +550,10 @@ end
 Line 4, characters 12-17:
 4 |   method id _ = x
                 ^^^^^
-Error: This method has type "'b -> 'b" which is less general than "'a. 'a -> 'a"
+Error: This method has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a0"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 class id4 () = object
@@ -562,7 +571,10 @@ Lines 4-7, characters 12-17:
 5 |     match r with
 6 |       None -> r <- Some x; x
 7 |     | Some y -> y
-Error: This method has type "'b -> 'b" which is less general than "'a. 'a -> 'a"
+Error: This method has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a0"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 class c = object
@@ -845,8 +857,10 @@ type bad = { bad : 'a. 'a option ref; }
 Line 2, characters 17-25:
 2 | let bad = {bad = ref None};;
                      ^^^^^^^^
-Error: This field value has type "'b option ref" which is less general than
-         "'a. 'a option ref"
+Error: This field value has type "'a option ref" which is less general than
+         "'a0. 'a0 option ref"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 type bad2 = {mutable bad2 : 'a. 'a option ref option};;
 let bad2 = {bad2 = None};;
@@ -857,8 +871,10 @@ val bad2 : bad2 = {bad2 = None}
 Line 3, characters 13-28:
 3 | bad2.bad2 <- Some (ref None);;
                  ^^^^^^^^^^^^^^^
-Error: This field value has type "'b option ref option"
-       which is less general than "'a. 'a option ref option"
+Error: This field value has type "'a option ref option"
+       which is less general than "'a0. 'a0 option ref option"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 (* Type variable scope *)
@@ -1607,6 +1623,7 @@ Line 2, characters 2-46:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type "int t -> int" which is less general than
          "'a. 'a t -> int"
+       The type "int" is not a type variable.
 |}];;
 let rec depth : 'a. 'a t -> _ =
   function Leaf x -> x | Node x -> depth x;; (* fails *)
@@ -1614,8 +1631,10 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'b t -> 'b" which is less general than
-         "'a. 'a t -> 'c"
+Error: This definition has type "'a t -> 'a" which is less general than
+         "'a0. 'a0 t -> 'b"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 let rec depth : 'a 'b. 'a t -> 'b =
   function Leaf x -> x | Node x -> depth x;; (* fails *)
@@ -1623,8 +1642,10 @@ let rec depth : 'a 'b. 'a t -> 'b =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'c. 'c t -> 'c" which is less general than
+Error: This definition has type "'b. 'b t -> 'b" which is less general than
          "'a 'b. 'a t -> 'b"
+       The universal type variable "'b" in the first type matches multiple
+       distinct variables in the second type.
 |}];;
 let rec r : 'a. 'a list * 'b list ref = [], ref []
 and q () = r;;
@@ -1712,6 +1733,7 @@ Line 3, characters 19-20:
                        ^
 Error: This field value has type "unit -> unit" which is less general than
          "'a. 'a -> unit"
+       The type "unit" is not a type variable.
 |}];;
 
 (* Polux Moon caml-list 2011-07-26 *)
@@ -2116,8 +2138,10 @@ let rec foo : 'a . 'a -> 'd = fun x -> x
 Line 1, characters 30-40:
 1 | let rec foo : 'a . 'a -> 'd = fun x -> x
                                   ^^^^^^^^^^
-Error: This definition has type "'b -> 'b" which is less general than
-         "'a. 'a -> 'c"
+Error: This definition has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'b"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}]
 
 (* #7741 *)
@@ -2193,6 +2217,8 @@ Line 2, characters 6-44:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type "'a option ref" which is less general than
          "'a0. 'a0 option ref"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}]
 
 type pr = { foo : 'a. 'a option ref }
@@ -2202,8 +2228,10 @@ type pr = { foo : 'a. 'a option ref; }
 Line 2, characters 16-24:
 2 | let x = { foo = ref None }
                     ^^^^^^^^
-Error: This field value has type "'b option ref" which is less general than
-         "'a. 'a option ref"
+Error: This field value has type "'a option ref" which is less general than
+         "'a0. 'a0 option ref"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}]
 
 
@@ -2279,8 +2307,9 @@ let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y ()
 Line 1, characters 65-85:
 1 | let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y (); o#x
                                                                      ^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'b. < x : 'b; y : unit -> 'c; .. > -> 'b"
-       which is less general than "'a 'd. (< x : 'a; .. > as 'd) -> 'a"
+Error: This definition has type "'a. < x : 'a; y : unit -> 'b; .. > -> 'a"
+       which is less general than "'a 'c. (< x : 'a; .. > as 'c) -> 'a"
+       The type "< y : unit -> 'd; .. >" is not a type variable.
 |}]
 
 

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -19,6 +19,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This argument has type "int -> int" which is less general than
          "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 let id x = x
@@ -33,8 +34,10 @@ let _ = poly1 (id (fun x -> x))
 Line 1, characters 14-31:
 1 | let _ = poly1 (id (fun x -> x))
                   ^^^^^^^^^^^^^^^^^
-Error: This argument has type "'b -> 'b" which is less general than
-         "'a. 'a -> 'a"
+Error: This argument has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a0"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 let _ = poly1 (let r = ref None in fun x -> r := Some x; x)
@@ -42,8 +45,10 @@ let _ = poly1 (let r = ref None in fun x -> r := Some x; x)
 Line 1, characters 14-59:
 1 | let _ = poly1 (let r = ref None in fun x -> r := Some x; x)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This argument has type "'b -> 'b" which is less general than
-         "'a. 'a -> 'a"
+Error: This argument has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a0"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 let escape f = poly1 (fun x -> f x; x)
@@ -51,8 +56,10 @@ let escape f = poly1 (fun x -> f x; x)
 Line 1, characters 21-38:
 1 | let escape f = poly1 (fun x -> f x; x)
                          ^^^^^^^^^^^^^^^^^
-Error: This argument has type "'b -> 'b" which is less general than
-         "'a. 'a -> 'a"
+Error: This argument has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a0"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 let poly2 : ('a. 'a -> 'a) -> int * string =
@@ -73,6 +80,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This argument has type "int -> int" which is less general than
          "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 let poly3 : 'b. ('a. 'a -> 'a) -> 'b -> 'b * 'b option =
@@ -93,6 +101,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This argument has type "int -> int" which is less general than
          "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 let rec poly4 p (id : 'a. 'a -> 'a) =
@@ -113,6 +122,7 @@ Line 1, characters 19-35:
                        ^^^^^^^^^^^^^^^^
 Error: This argument has type "int -> int" which is less general than
          "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 let rec poly5 : bool -> ('a. 'a -> 'a) -> int * string =
@@ -134,6 +144,7 @@ Line 1, characters 19-35:
                        ^^^^^^^^^^^^^^^^
 Error: This argument has type "int -> int" which is less general than
          "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 
@@ -156,6 +167,7 @@ Line 1, characters 19-35:
                        ^^^^^^^^^^^^^^^^
 Error: This argument has type "int -> int" which is less general than
          "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 let needs_magic (magic : 'a 'b. 'a -> 'b) = (magic 5 : string)
@@ -165,8 +177,10 @@ val needs_magic : ('a 'b. 'a -> 'b) -> string = <fun>
 Line 2, characters 20-32:
 2 | let _ = needs_magic (fun x -> x)
                         ^^^^^^^^^^^^
-Error: This argument has type "'c. 'c -> 'c" which is less general than
+Error: This argument has type "'b. 'b -> 'b" which is less general than
          "'a 'b. 'a -> 'b"
+       The universal type variable "'b" in the first type matches multiple
+       distinct variables in the second type.
 |}];;
 
 let with_id (f : ('a. 'a -> 'a) -> 'b) = f (fun x -> x)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -220,7 +220,7 @@ val instance_poly_fixed:
         (* Take an instance of a type scheme containing free univars for
            checking that an expression matches this scheme. *)
 
-val polyfy: Env.t -> type_expr -> type_expr list -> type_expr * bool
+val polyfy: Env.t -> type_expr -> type_expr list -> type_expr * type_expr list
 
 val instance_label:
   fixed:bool ->

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -92,6 +92,10 @@ type first_class_module =
     | Package_inclusion of Format_doc.doc
     | Package_coercion of Format_doc.doc
 
+type univar =
+  | Var_mismatch of { order:order; diff:type_expr diff }
+  | Quantification_mismatch of type_expr list
+
 type ('a, 'variety) elt =
   (* Common *)
   | Diff : 'a diff -> ('a, _) elt
@@ -102,7 +106,7 @@ type ('a, 'variety) elt =
   | Tuple_label_mismatch of string option diff
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   | First_class_module: first_class_module -> ('a,_) elt
-  | Univar_mismatch of { order:order; diff:type_expr diff }
+  | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) elt
 


### PR DESCRIPTION
This PR complements the explanation for mismatched universal type variables added in #14076 with a short explanation for mismatch at the quantifier level. For intance, this PR, we explain now that the type variable `'a` is not generisable in

```ocaml
type x = { o: 'a.  'a option ref }
let x = { o = ref None }
```

>```
>Error: This definition has type "'a option ref" which is less general than
>         "'a0. 'a0 option ref"
>       The type variable "'a" is not generalizable to an universal
>       type variable.
>```
and thus we cannot lift it at the quantifier level.

Similarly, whenever the number of bound universal variables in the actual type is less than the expected number of variables, this PR adds a line pointing to actual variables that match multiple expected variables:

```ocaml
type f = { f: 'a 'b. 'a -> 'a -> 'b -> 'b }
type g = { f : 'a 'b 'c 'd. 'a -> 'b -> 'c -> 'd }
let fail {f} = {g=f}
```

>```
>Error: This field value has type 'b 'd. 'b -> 'b -> 'd -> 'd
>       which is less general than 'a 'b 'c 'd. 'a -> 'b -> 'c -> 'd
>       The universal type variable 'b in the first type matches multiple
>       distinct variables in the second type.
>       The universal type variable 'd in the first type matches multiple
>       distinct variables in the second type.
>```

It is probably better to avoid merging this PR before #13806 to avoid conflicts on the error messages.