### PR TITLE
Fix use of `time_t` on i686 mingw-w64

### DIFF
--- a/Changes
+++ b/Changes
@@ -175,7 +175,7 @@ Working version
 - #14094: toplevel, simplify check on installed printer types
   (Florian Angeletti, review by Gabriel Scherer)
 
-- #13656: Use C99 stdint.h/inttypes.h fixed-width integer types and
+- #13656, #14114: Use C99 stdint.h/inttypes.h fixed-width integer types and
   macros to define OCaml integers.
   (Antonin Décimo, review by Nick Barnes)
 

--- a/configure
+++ b/configure
@@ -15368,9 +15368,13 @@ fi
 esac
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
+# Enable 64-bit time_t in time.h
 case $target in #(
   i686-w64-mingw32*) :
-    internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
+    internal_cflags="$internal_cflags -mfpmath=sse -msse2"
+    # This instructs _mingw.h to adopt the switch in Visual Studio 8 (2005) to
+    # make time_t a 64-bit value.
+    internal_cppflags="$internal_cppflags -D__MINGW_USE_VC2005_COMPAT" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1012,9 +1012,13 @@ AS_CASE([$ocaml_cc_vendor],
   [common_cflags="-O"])
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
+# Enable 64-bit time_t in time.h
 AS_CASE([$target],
   [i686-w64-mingw32*],
-    [internal_cflags="$internal_cflags -mfpmath=sse -msse2"])
+    [internal_cflags="$internal_cflags -mfpmath=sse -msse2"
+    # This instructs _mingw.h to adopt the switch in Visual Studio 8 (2005) to
+    # make time_t a 64-bit value.
+    internal_cppflags="$internal_cppflags -D__MINGW_USE_VC2005_COMPAT"])
 
 # Use 64-bit file offset if possible
 # See also AC_SYS_LARGEFILE


### PR DESCRIPTION
Follow-on to #13656, we need to set `__MINGW_USE_VC2005_COMPAT` in order to make `time_t` 64-bit. Manifesting in two test failures on Jenkins.