### PR TITLE
Fix bug in non-destructive `with type` with type constraint

### DIFF
--- a/Changes
+++ b/Changes
@@ -160,11 +160,12 @@ Working version
   (Nicolás Ojeda Bär, review by Gabriel Scherer, Samuel Vivien, Ulysse Gérard
   and Vincent Laviron)
 
-- #13911: Refactor the merging of signature constraints, by splitting the
-  monolithic merge function into separate, specialized functions (for merging
-  types, modules and module types) - sharing only the recursive part for
+- #13911, #14117: Refactor the merging of signature constraints, by splitting
+  the monolithic merge function into separate, specialized functions (for
+  merging types, modules and module types) - sharing only the recursive part for
   handling deep constraints.
-  (Clement Blaudeau, review by Florian Angeletti and Samuel Vivien)
+  (Clement Blaudeau, review by Florian Angeletti and Samuel Vivien, fix by Ryan
+  Tjoa)
 
 - #13980 Refactor `type-approx` and improve some errors' locations.
   (Leo White, Ulysse Gérard, review by Samuel Vivien and Florian Angeletti)

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -628,10 +628,5 @@ module type S2 = S with type ('a, _) t = 'a t2
 [%%expect{|
 module type S = sig type ('a, 'b) t constraint 'a = 'l * 'r end
 type 'a t2 constraint 'a = 'l * 'r
-Line 7, characters 17-46:
-7 | module type S2 = S with type ('a, _) t = 'a t2
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Destructive substitutions are not supported for constrained
-       types (other than when replacing a type constructor with
-       a type constructor with the same arguments).
+module type S2 = sig type ('a, _) t = 'a t2 constraint 'a = 'b * 'c end
 |}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -618,15 +618,100 @@ Error: In this "with" constraint, replacing "X0" by "F(X)" would
        introduce an invalid alias at "X1"
 |}]
 
-module type S = sig
-  type ('a, 'b) t constraint 'a = 'l * 'r
+(*** [with type] with type constraints ***)
+
+(* This first test is a regression test for #14117. *)
+module type Non_destructive_with_type_with_constraint = sig
+  module type S = sig
+    type ('a, 'b) t constraint 'a = 'l * 'r
+  end
+  type 'a t2 constraint 'a = 'l * 'r
+  module type S2 = S with type ('a, _) t = 'a t2
 end
-
-type 'a t2 constraint 'a = 'l * 'r
-
-module type S2 = S with type ('a, _) t = 'a t2
 [%%expect{|
-module type S = sig type ('a, 'b) t constraint 'a = 'l * 'r end
-type 'a t2 constraint 'a = 'l * 'r
-module type S2 = sig type ('a, _) t = 'a t2 constraint 'a = 'b * 'c end
+module type Non_destructive_with_type_with_constraint =
+  sig
+    module type S = sig type ('a, 'b) t constraint 'a = 'l * 'r end
+    type 'a t2 constraint 'a = 'l * 'r
+    module type S2 = sig type ('a, _) t = 'a t2 constraint 'a = 'b * 'c end
+  end
+|}]
+
+module type Non_destructive_with_type_alias_with_constraint = sig
+  module type S = sig
+    type ('a, 'b) t constraint 'a = 'l * 'r
+  end
+  type ('a, 'b) t2 constraint 'a = 'l * 'r
+  module type S2 = S with type ('a, 'b) t = ('a, 'b) t2
+end
+[%%expect{|
+module type Non_destructive_with_type_alias_with_constraint =
+  sig
+    module type S = sig type ('a, 'b) t constraint 'a = 'l * 'r end
+    type ('a, 'b) t2 constraint 'a = 'l * 'r
+    module type S2 =
+      sig type ('a, 'b) t = ('a, 'b) t2 constraint 'a = 'c * 'd end
+  end
+|}]
+
+module type Non_destructive_with_type_alias_with_inconsistent_constraint = sig
+  module type S = sig
+    type ('a, 'b) t constraint 'a = 'l * 'r
+  end
+  type ('a, 'b) t2 constraint 'a = 'l * 'r * 's
+  module type S2 = S with type ('a, 'b) t = ('a, 'b) t2
+end
+[%%expect{|
+Line 6, characters 32-34:
+6 |   module type S2 = S with type ('a, 'b) t = ('a, 'b) t2
+                                    ^^
+Error: The type constraints are not consistent.
+       Type "'a * 'b * 'c" is not compatible with type "'d * 'e"
+|}]
+
+module type Destructive_with_type_with_constraint = sig
+  module type S = sig
+    type ('a, 'b) t constraint 'a = 'l * 'r
+  end
+  type 'a t2 constraint 'a = 'l * 'r
+  module type S2 = S with type ('a, _) t := 'a t2
+end
+[%%expect{|
+Line 6, characters 19-49:
+6 |   module type S2 = S with type ('a, _) t := 'a t2
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Destructive substitutions are not supported for constrained
+       types (other than when replacing a type constructor with
+       a type constructor with the same arguments).
+|}]
+
+module type Destructive_with_type_alias_with_constraint = sig
+  module type S = sig
+    type ('a, 'b) t constraint 'a = 'l * 'r
+  end
+  type ('a, 'b) t2 constraint 'a = 'l * 'r
+  module type S2 = S with type ('a, 'b) t := ('a, 'b) t2
+end
+[%%expect{|
+module type Destructive_with_type_alias_with_constraint =
+  sig
+    module type S = sig type ('a, 'b) t constraint 'a = 'l * 'r end
+    type ('a, 'b) t2 constraint 'a = 'l * 'r
+    module type S2 = sig end
+  end
+|}]
+
+module type Destructive_with_type_alias_with_inconsistent_constraint = sig
+  module type S = sig
+    type ('a, 'b) t constraint 'a = 'l * 'r
+  end
+  type ('a, 'b) t2 constraint 'a = 'l * 'r * 's
+  module type S2 = S with type ('a, 'b) t := ('a, 'b) t2
+end
+[%%expect{|
+Line 6, characters 32-34:
+6 |   module type S2 = S with type ('a, 'b) t := ('a, 'b) t2
+                                    ^^
+Error: The type constraints are not consistent.
+       Type "'a * 'b * 'c" is not compatible with type "'d * 'e"
 |}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -617,3 +617,21 @@ Lines 4-8, characters 18-26:
 Error: In this "with" constraint, replacing "X0" by "F(X)" would
        introduce an invalid alias at "X1"
 |}]
+
+module type S = sig
+  type ('a, 'b) t constraint 'a = 'l * 'r
+end
+
+type 'a t2 constraint 'a = 'l * 'r
+
+module type S2 = S with type ('a, _) t = 'a t2
+[%%expect{|
+module type S = sig type ('a, 'b) t constraint 'a = 'l * 'r end
+type 'a t2 constraint 'a = 'l * 'r
+Line 7, characters 17-46:
+7 | module type S2 = S with type ('a, _) t = 'a t2
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Destructive substitutions are not supported for constrained
+       types (other than when replacing a type constructor with
+       a type constructor with the same arguments).
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -716,22 +716,25 @@ module Merge = struct
     let path, paths, tdecl, sg = merge ~patch ~destructive env sg loc lid in
     (* Post processing *)
     let replace =
-      match type_decl_is_alias sdecl with
-      | Some lid ->
-          (* if the type is an alias of [lid], replace by the definition *)
-          let replacement, _ =
-            try Env.find_type_by_name lid.txt env
-            with Not_found -> assert false
-          in
-          fun s path -> Subst.Unsafe.add_type_path path replacement s
-      | None ->
-          (* if the type is not an alias, try to inline it *)
-          let body = Option.get tdecl.typ_type.type_manifest in
-          let params = tdecl.typ_type.type_params in
-          if params_are_constrained params then
-            raise(Error(loc, env, With_cannot_remove_constrained_type));
-          fun s path ->
-            Subst.Unsafe.add_type_function path ~params ~body s
+      if destructive then
+        match type_decl_is_alias sdecl with
+        | Some lid ->
+            (* if the type is an alias of [lid], replace by the definition *)
+            let replacement, _ =
+              try Env.find_type_by_name lid.txt env
+              with Not_found -> assert false
+            in
+            fun s path -> Subst.Unsafe.add_type_path path replacement s
+        | None ->
+            (* if the type is not an alias, try to inline it *)
+            let body = Option.get tdecl.typ_type.type_manifest in
+            let params = tdecl.typ_type.type_params in
+            if params_are_constrained params then
+              raise(Error(loc, env, With_cannot_remove_constrained_type));
+            fun s path ->
+              Subst.Unsafe.add_type_function path ~params ~body s
+      else
+        fun s _ -> s
     in
     let sg = post_process ~destructive loc lid env paths sg replace in
     (tdecl, (path, lid, sg))


### PR DESCRIPTION
Non-destructive `with type` constraints can fail when a type constraint is present (when this should only happen for destructive substitution):
```ocaml
module type S = sig
  type ('a, 'b) t constraint 'a = 'l * 'r
end

type 'a t2 constraint 'a = 'l * 'r

module type S2 = S with type ('a, _) t = 'a t2
```
```
7 | module type S2 = S with type ('a, _) t = 'a t2
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Destructive substitutions are not supported for constrained
       types (other than when replacing a type constructor with
       a type constructor with the same arguments).
```

This appears to have been introduced in https://github.com/ocaml/ocaml/pull/13911.

cc @clementblaudeau @Octachron