### PR TITLE
Add {Set,Map}.S.is_singleton

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,6 +57,10 @@ Working version
 - #12877: Dynarray.rev_iter, Dynarray.rev_iteri
   (Gabriel Scherer, review by Léo Andrès, Jeremy Yallop and Nicolás Ojeda Bär)
 
+- #14118: Add {Set,Map}.S.is_singleton
+  (Kate Deplaix, review by Daniel Bünzli, Vincent Laviron, Nicolás Ojeda Bär
+   and Stephen Dolan)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -56,6 +56,7 @@ module type S =
     val partition: (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     val is_empty: 'a t -> bool
+    val is_singleton: 'a t -> bool
     val mem: key -> 'a t -> bool
     val equal: ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
     val compare: ('a -> 'a -> int) -> 'a t -> 'a t -> int
@@ -121,6 +122,10 @@ module Make(Ord: OrderedType) = struct
     let empty = Empty
 
     let is_empty = function Empty -> true | _ -> false
+
+    let is_singleton = function
+      | Node{l=Empty; r=Empty} -> true
+      | Empty | Node _ -> false
 
     let rec add x data = function
         Empty ->

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -304,6 +304,11 @@ module type S =
     val is_empty: 'a t -> bool
     (** Test whether a map is empty or not. *)
 
+    val is_singleton: 'a t -> bool
+    (** Test whether a map has exactly one element or not.
+
+        @since 5.5 *)
+
     val mem: key -> 'a t -> bool
     (** [mem x m] returns [true] if [m] contains a binding for [x],
         and [false] otherwise. *)

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -955,6 +955,11 @@ module Map : sig
       val is_empty: 'a t -> bool
       (** Test whether a map is empty or not. *)
 
+      val is_singleton: 'a t -> bool
+      (** Test whether a map has exactly one element or not.
+
+          @since 5.5 *)
+
       val mem: key -> 'a t -> bool
       (** [mem x m] returns [true] if [m] contains a binding for [x],
           and [false] otherwise. *)
@@ -1266,6 +1271,11 @@ module Set : sig
 
       val is_empty: t -> bool
       (** Test whether a set is empty or not. *)
+
+      val is_singleton: t -> bool
+      (** Test whether a set has exactly one element or not.
+
+          @since 5.5 *)
 
       val mem: elt -> t -> bool
       (** [mem x s] tests whether [x] belongs to the set [s]. *)

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -55,6 +55,7 @@ module type S =
     val partition: (elt -> bool) -> t -> t * t
     val split: elt -> t -> t * bool * t
     val is_empty: t -> bool
+    val is_singleton: t -> bool
     val mem: elt -> t -> bool
     val equal: t -> t -> bool
     val compare: t -> t -> int
@@ -243,6 +244,10 @@ module Make(Ord: OrderedType) =
     let empty = Empty
 
     let is_empty = function Empty -> true | _ -> false
+
+    let is_singleton = function
+      | Node{l=Empty; r=Empty} -> true
+      | Empty | Node _ -> false
 
     let rec mem x = function
         Empty -> false

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -260,6 +260,11 @@ module type S =
     val is_empty: t -> bool
     (** Test whether a set is empty or not. *)
 
+    val is_singleton: t -> bool
+    (** Test whether a set has exactly one element or not.
+
+        @since 5.5 *)
+
     val mem: elt -> t -> bool
     (** [mem x s] tests whether [x] belongs to the set [s]. *)
 

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -304,6 +304,11 @@ module type S =
     val is_empty: 'a t -> bool
     (** Test whether a map is empty or not. *)
 
+    val is_singleton: 'a t -> bool
+    (** Test whether a map has exactly one element or not.
+
+        @since 5.5 *)
+
     val mem: key -> 'a t -> bool
     (** [mem x m] returns [true] if [m] contains a binding for [x],
         and [false] otherwise. *)

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -260,6 +260,11 @@ module type S =
     val is_empty: t -> bool
     (** Test whether a set is empty or not. *)
 
+    val is_singleton: t -> bool
+    (** Test whether a set has exactly one element or not.
+
+        @since 5.5 *)
+
     val mem: elt -> t -> bool
     (** [mem x s] tests whether [x] belongs to the set [s]. *)
 

--- a/testsuite/tests/generalized-open/accepted_expect.ml
+++ b/testsuite/tests/generalized-open/accepted_expect.ml
@@ -36,6 +36,7 @@ val filter_map : (elt -> elt option) -> t -> t = <fun>
 val partition : (elt -> bool) -> t -> t * t = <fun>
 val split : elt -> t -> t * bool * t = <fun>
 val is_empty : t -> bool = <fun>
+val is_singleton : t -> bool = <fun>
 val mem : elt -> t -> bool = <fun>
 val equal : t -> t -> bool = <fun>
 val compare : t -> t -> int = <fun>

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -137,6 +137,7 @@ module Without_constraint :
     val partition : (elt -> bool) -> t -> t * t
     val split : elt -> t -> t * bool * t
     val is_empty : t -> bool
+    val is_singleton : t -> bool
     val mem : elt -> t -> bool
     val equal : t -> t -> bool
     val compare : t -> t -> int

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -336,6 +336,7 @@ module type MapT =
     val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
     val split : key -> 'a t -> 'a t * 'a option * 'a t
     val is_empty : 'a t -> bool
+    val is_singleton : 'a t -> bool
     val mem : key -> 'a t -> bool
     val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
     val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
@@ -392,6 +393,7 @@ module SSMap :
     val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
     val split : key -> 'a t -> 'a t * 'a option * 'a t
     val is_empty : 'a t -> bool
+    val is_singleton : 'a t -> bool
     val mem : key -> 'a t -> bool
     val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
     val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -335,6 +335,7 @@ module StringSet :
     val partition : (elt -> bool) -> t -> t * t
     val split : elt -> t -> t * bool * t
     val is_empty : t -> bool
+    val is_singleton : t -> bool
     val mem : elt -> t -> bool
     val equal : t -> t -> bool
     val compare : t -> t -> int
@@ -383,6 +384,7 @@ module SSet :
     val partition : (elt -> bool) -> t -> t * t
     val split : elt -> t -> t * bool * t
     val is_empty : t -> bool
+    val is_singleton : t -> bool
     val mem : elt -> t -> bool
     val equal : t -> t -> bool
     val compare : t -> t -> int
@@ -463,6 +465,7 @@ module A :
         val partition : (elt -> bool) -> t -> t * t
         val split : elt -> t -> t * bool * t
         val is_empty : t -> bool
+        val is_singleton : t -> bool
         val mem : elt -> t -> bool
         val equal : t -> t -> bool
         val compare : t -> t -> int
@@ -595,6 +598,7 @@ module SInt :
     val partition : (elt -> bool) -> t -> t * t
     val split : elt -> t -> t * bool * t
     val is_empty : t -> bool
+    val is_singleton : t -> bool
     val mem : elt -> t -> bool
     val equal : t -> t -> bool
     val compare : t -> t -> int

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -252,6 +252,7 @@ module MkT :
       val partition : (elt -> bool) -> t -> t * t
       val split : elt -> t -> t * bool * t
       val is_empty : t -> bool
+      val is_singleton : t -> bool
       val mem : elt -> t -> bool
       val equal : t -> t -> bool
       val compare : t -> t -> int

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -49,6 +49,7 @@ module Core :
             val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
             val split : key -> 'a t -> 'a t * 'a option * 'a t
             val is_empty : 'a t -> bool
+            val is_singleton : 'a t -> bool
             val mem : key -> 'a t -> bool
             val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
             val compare : ('a -> 'a -> key) -> 'a t -> 'a t -> key


### PR DESCRIPTION
We have that function in opam (OpamStd.Set.is_singleton) but it isn't really efficient without knowing the internal representation of `Set.t`. I think it's a generally useful function to have.