### PR TITLE
Integral type hygiene in compaction

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,9 @@ Working version
   to reduce latent-garbage delay and therefore improve GC performance.
   (Stephen Dolan and Nick Barnes, review by KC Sivaramakrishnan)
 
+- #14123: Fix integer-overflow problems in heap compaction.
+  (Nick Barnes, review by Antonin Décimo).
+
 - #14035: Fix the alignment of _Atomic long long unsigned int fields
   before GCC 11.1 on i686. Silence GCC note on newer versions.
   (Antonin Décimo, review by Sadiq Jaffer)

--- a/runtime/caml/sizeclasses.h
+++ b/runtime/caml/sizeclasses.h
@@ -4,6 +4,9 @@
 #define SIZECLASS_MAX 128
 #define NUM_SIZECLASSES 32
 
+typedef unsigned char sizeclass;
+static_assert(NUM_SIZECLASSES < (1 << (CHAR_BIT * sizeof(sizeclass))), "");
+
 /* The largest size for this size class.
    (A gap is left after smaller objects) */
 static const unsigned int wsize_sizeclass[NUM_SIZECLASSES] =
@@ -27,7 +30,7 @@ static const unsigned char wastage_sizeclass[NUM_SIZECLASSES] =
   /* 30:*/ 80, 124 };
 
 /* Map from (positive) object sizes to size classes. */
-static const unsigned char sizeclass_wsize[SIZECLASS_MAX + 1] =
+static const sizeclass sizeclass_wsize[SIZECLASS_MAX + 1] =
 { /*  0:*/ 255, 0, 1, 2, 3,
   /*  5:*/ 4, 5, 6, 7, 8,
   /* 10:*/ 8, 9, 9, 10, 10,

--- a/tools/gen_sizeclasses.ml
+++ b/tools/gen_sizeclasses.ml
@@ -94,6 +94,9 @@ let _ =
   printf "#define SIZECLASS_MAX %d\n" max_slot;
   printf "#define NUM_SIZECLASSES %d\n" (List.length sizes);
   printf {|
+typedef unsigned char sizeclass;
+static_assert(NUM_SIZECLASSES < (1 << (CHAR_BIT * sizeof(sizeclass))), "");
+
 /* The largest size for this size class.
    (A gap is left after smaller objects) */
 static const unsigned int wsize_sizeclass[NUM_SIZECLASSES] =@[<2>{ %a };@]
@@ -107,6 +110,6 @@ static const unsigned char wastage_sizeclass[NUM_SIZECLASSES] =@[<2>{ %a };@]
     print_list wastage;
   printf {|
 /* Map from (positive) object sizes to size classes. */
-static const unsigned char sizeclass_wsize[SIZECLASS_MAX + 1] =@[<2>{ %a };@]
+static const sizeclass sizeclass_wsize[SIZECLASS_MAX + 1] =@[<2>{ %a };@]
 |}
     print_list (255 :: size_slots 1);


### PR DESCRIPTION
In OxCaml we have found integer-overflow bugs in compaction; I'll get a PR up tomorrow but thought I'd offer one here as well: integral type hygiene throughout the compaction code here. While I was here I thought I'd consistently define and use a type for size classes, which were previously in parts of `shared_heap.c` as `sizeclass`, here defined in `sizeclasses.h` as `sizeclass_t`.
