### PR TITLE
Make List.{take,drop} total

### DIFF
--- a/Changes
+++ b/Changes
@@ -234,6 +234,9 @@ OCaml 5.4.0
 
 ### Standard library:
 
+* #14124: Do not raise Invalid_argument on negative List.{drop,take}.
+  (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+
 - #13696: Add Result.product and Result.Syntax:
   `let open Result.Syntax in let* x = ... in ...`
   (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -297,16 +297,14 @@ let take n l =
     | 0, _ | _, [] -> []
     | n, x::l -> x::aux (n - 1) l
   in
-  if n < 0 then invalid_arg "List.take";
-  aux n l
+  if n <= 0 then [] else aux n l
 
 let drop n l =
   let rec aux i = function
     | _x::l when i < n -> aux (i + 1) l
     | rest -> rest
   in
-  if n < 0 then invalid_arg "List.drop";
-  aux 0 l
+  if n <= 0 then l else aux 0 l
 
 let take_while p l =
   let[@tail_mod_cons] rec aux = function

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -370,21 +370,22 @@ val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
 
 val take : int -> 'a list -> 'a list
 (** [take n l] returns the prefix of [l] of length [n],
-    or a copy of [l] if [n > length l].
+    or a copy of [l] if [n > length l]. This is the empty
+    list if [n] is negative.
 
-    [n] must be nonnegative.
+    {b Warning.} In version 5.3 only, this function raises
+    [Invalid_argument] for negative [n] values.
 
-    @raise Invalid_argument if [n] is negative.
     @since 5.3
 *)
 
 val drop : int -> 'a list -> 'a list
 (** [drop n l] returns the suffix of [l] after [n] elements,
-    or [[]] if [n > length l].
+    or [[]] if [n > length l]. This is [l] if [n] is negative.
 
-    [n] must be nonnegative.
+    {b Warning.} In version 5.3 only, this function raises
+    [Invalid_argument] for negative [n] values.
 
-    @raise Invalid_argument if [n] is negative.
     @since 5.3
 *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -370,21 +370,22 @@ val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
 
 val take : int -> 'a list -> 'a list
 (** [take n l] returns the prefix of [l] of length [n],
-    or a copy of [l] if [n > length l].
+    or a copy of [l] if [n > length l]. This is the empty
+    list if [n] is negative.
 
-    [n] must be nonnegative.
+    {b Warning.} In version 5.3 only, this function raises
+    [Invalid_argument] for negative [n] values.
 
-    @raise Invalid_argument if [n] is negative.
     @since 5.3
 *)
 
 val drop : int -> 'a list -> 'a list
 (** [drop n l] returns the suffix of [l] after [n] elements,
-    or [[]] if [n > length l].
+    or [[]] if [n > length l]. This is [l] if [n] is negative.
 
-    [n] must be nonnegative.
+    {b Warning.} In version 5.3 only, this function raises
+    [Invalid_argument] for negative [n] values.
 
-    @raise Invalid_argument if [n] is negative.
     @since 5.3
 *)
 

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -68,13 +68,13 @@ let () =
   assert (List.take 3 [1; 2; 3; 4; 5] = [1; 2; 3]);
   assert (List.take 3 [1; 2] = [1; 2]);
   assert (List.take 3 [] = []);
-  assert ((try List.take (-1) [1; 2] with Invalid_argument _ -> [999]) = [999]);
+  assert (List.take (-1) [1; 2] = []);
   assert (List.take 0 [1; 2] = []);
   assert (List.drop 6 hello_world = world);
   assert (List.drop 3 [1; 2; 3; 4; 5] = [4; 5]);
   assert (List.drop 3 [1; 2] = []);
   assert (List.drop 3 [] = []);
-  assert ((try List.drop (-1) [1; 2] with Invalid_argument _ -> [999]) = [999]);
+  assert (List.drop (-1) [1; 2] = [1; 2]);
   assert (List.drop 0 [1; 2] = [1; 2]);
   assert (List.take_while (fun x -> x < 3) [1; 2; 3; 4; 1; 2; 3; 4]
           = [1; 2]);


### PR DESCRIPTION
See [discussion](https://github.com/ocaml/ocaml/pull/12869#issuecomment-3026730119). 

Raising is highly non-standard across languages and libraries and the functions have only been there in 5.3 so far. 

I think this should go in 5.4 too.