### PR TITLE
Add String.[r]{take,drop,span}

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,9 @@ Working version
 
 ### Standard library:
 
+- #XXXXX: Add String.[r]{drop,take,span}.
+  (Daniel Bünzli, review by ZZZZ)
+
 - #13728: Add Sys.runtime_executable containing the full path (if available) to
   the currently executing runtime.
   (David Allsopp, review by Nicolás Ojeda Bär and Daniel Bünzli)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -227,6 +227,24 @@ let ends_with ~suffix s =
 external seeded_hash : int -> string -> int = "caml_string_hash" [@@noalloc]
 let hash x = seeded_hash 0 x
 
+(* Breaking with magnitudes *)
+
+let subrange ?(first = 0) ?last s =
+  let max = length s - 1 in
+  let first = if first < 0 then 0 else first in
+  let last = match last with None -> max | Some last -> last in
+  let last = if last > max then max else last in
+  if first > last then "" else sub s first (last - first + 1)
+
+let take n s = subrange ~last:(n - 1) s
+let drop n s = subrange ~first:n s
+let span n s = (take n s, drop n s)
+let rtake n s = subrange ~first:(length s - n) s
+let rdrop n s = subrange ~last:(length s - n - 1) s
+let rspan n s = (rdrop n s, rtake n s)
+
+(* Breaking with separators *)
+
 (* duplicated in bytes.ml *)
 let split_on_char sep s =
   let r = ref [] in

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -192,6 +192,46 @@ val sub : string -> int -> int -> string
     @raise Invalid_argument if [pos] and [len] do not designate a valid
     substring of [s]. *)
 
+(** {1:breaking Breaking strings} *)
+
+(** {2:breaking_mag Breaking with magnitudes} *)
+
+val take : int -> string -> string
+(** [take n s] are the first [n] bytes of [s]. This is [s] if
+    [n >= length s] and [""] if [n <= 0].
+
+    @since 5.5 *)
+
+val rtake : int -> string -> string
+(** [rtake n s] are the last [n] bytes of [s].  This is [s] if
+    [n >= length s] and [""] if [n <= 0].
+
+    @since 5.5 *)
+
+val drop : int -> string -> string
+(** [drop n s] is [s] without the first [n] bytes of [s]. This is [""]
+    if [n >= length s] and [s] if [n <= 0].
+
+    @since 5.5 *)
+
+val rdrop : int -> string -> string
+(** [rdrop n s] is [s] without the last [n] bytes of [s]. This is [""]
+    if [n >= length s] and [s] if [n <= 0].
+
+    @since 5.5 *)
+
+val span : int -> string -> string * string
+(** [span n v] is [(take n v, drop n v)].
+
+    @since 5.5 *)
+
+val rspan : int -> string -> string * string
+(** [rspan n v] is [(rdrop n v, rtake n v)].
+
+    @since 5.5 *)
+
+(** {2:breaking_sep Breaking with separators} *)
+
 val split_on_char : char -> string -> string list
 (** [split_on_char sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -192,6 +192,46 @@ val sub : string -> pos:int -> len:int -> string
     @raise Invalid_argument if [pos] and [len] do not designate a valid
     substring of [s]. *)
 
+(** {1:breaking Breaking strings} *)
+
+(** {2:breaking_mag Breaking with magnitudes} *)
+
+val take : int -> string -> string
+(** [take n s] are the first [n] bytes of [s]. This is [s] if
+    [n >= length s] and [""] if [n <= 0].
+
+    @since 5.5 *)
+
+val rtake : int -> string -> string
+(** [rtake n s] are the last [n] bytes of [s].  This is [s] if
+    [n >= length s] and [""] if [n <= 0].
+
+    @since 5.5 *)
+
+val drop : int -> string -> string
+(** [drop n s] is [s] without the first [n] bytes of [s]. This is [""]
+    if [n >= length s] and [s] if [n <= 0].
+
+    @since 5.5 *)
+
+val rdrop : int -> string -> string
+(** [rdrop n s] is [s] without the last [n] bytes of [s]. This is [""]
+    if [n >= length s] and [s] if [n <= 0].
+
+    @since 5.5 *)
+
+val span : int -> string -> string * string
+(** [span n v] is [(take n v, drop n v)].
+
+    @since 5.5 *)
+
+val rspan : int -> string -> string * string
+(** [rspan n v] is [(rdrop n v, rtake n v)].
+
+    @since 5.5 *)
+
+(** {2:breaking_sep Breaking with separators} *)
+
 val split_on_char : sep:char -> string -> string list
 (** [split_on_char ~sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -132,3 +132,84 @@ let () =
   test ~max_dist ["abc"] "a" [];
   test ~max_dist ["abc"; "ab"; "b"] "a" ["ab"; "b"];
   ()
+
+let () =
+  (* String.take *)
+  assert (String.take (-1) "" = "");
+  assert (String.take (-1) "a" = "");
+  assert (String.take (-1) "ab" = "");
+  assert (String.take 0 "" = "");
+  assert (String.take 0 "a" = "");
+  assert (String.take 0 "ab" = "");
+  assert (String.take 1 "" = "");
+  assert (String.take 1 "a" = "a");
+  assert (String.take 1 "ab" = "a");
+  assert (String.take 2 "" = "");
+  assert (String.take 2 "a" = "a");
+  assert (String.take 2 "ab" = "ab");
+  (* String.rtake *)
+  assert (String.rtake (-1) "" = "");
+  assert (String.rtake (-1) "a" = "");
+  assert (String.rtake (-1) "ab" = "");
+  assert (String.rtake 0 "" = "");
+  assert (String.rtake 0 "a" = "");
+  assert (String.rtake 0 "ab" = "");
+  assert (String.rtake 1 "" = "");
+  assert (String.rtake 1 "a" = "a");
+  assert (String.rtake 1 "ab" = "b");
+  assert (String.rtake 2 "" = "");
+  assert (String.rtake 2 "a" = "a");
+  assert (String.rtake 2 "ab" = "ab");
+  (* String.drop *)
+  assert (String.drop (-1) "" = "");
+  assert (String.drop (-1) "a" = "a");
+  assert (String.drop (-1) "ab" = "ab");
+  assert (String.drop 0 "" = "");
+  assert (String.drop 0 "a" = "a");
+  assert (String.drop 0 "ab" = "ab");
+  assert (String.drop 1 "" = "");
+  assert (String.drop 1 "a" = "");
+  assert (String.drop 1 "ab" = "b");
+  assert (String.drop 2 "" = "");
+  assert (String.drop 2 "a" = "");
+  assert (String.drop 2 "ab" = "");
+  (* String.rdrop *)
+  assert (String.rdrop (-1) "" = "");
+  assert (String.rdrop (-1) "a" = "a");
+  assert (String.rdrop (-1) "ab" = "ab");
+  assert (String.rdrop 0 "" = "");
+  assert (String.rdrop 0 "a" = "a");
+  assert (String.rdrop 0 "ab" = "ab");
+  assert (String.rdrop 1 "" = "");
+  assert (String.rdrop 1 "a" = "");;
+  assert (String.rdrop 1 "ab" = "a");
+  assert (String.rdrop 2 "" = "");
+  assert (String.rdrop 2 "a" = "");
+  assert (String.rdrop 2 "ab" = "");
+  (* String.span *)
+  assert (String.span (-1) "" = ("", ""));
+  assert (String.span (-1) "a" = ("", "a"));
+  assert (String.span (-1) "ab" = ("", "ab"));
+  assert (String.span 0 "" = ("", ""));
+  assert (String.span 0 "a" = ("", "a"));
+  assert (String.span 0 "ab" = ("", "ab"));
+  assert (String.span 1 "" = ("", ""));
+  assert (String.span 1 "a" = ("a", ""));
+  assert (String.span 1 "ab" = ("a", "b"));
+  assert (String.span 2 "" = ("", ""));
+  assert (String.span 2 "a" = ("a", ""));
+  assert (String.span 2 "ab" = ("ab", ""));
+  (* String.rspan *)
+  assert (String.rspan (-1) "" = ("", ""));
+  assert (String.rspan (-1) "a" = ("a", ""));
+  assert (String.rspan (-1) "ab" = ("ab", ""));
+  assert (String.rspan 0 "" = ("", ""));
+  assert (String.rspan 0 "a" = ("a", ""));
+  assert (String.rspan 0 "ab" = ("ab", ""));
+  assert (String.rspan 1 "" = ("", ""));
+  assert (String.rspan 1 "a" = ("", "a"));
+  assert (String.rspan 1 "ab" = ("a", "b"));
+  assert (String.rspan 2 "" = ("", ""));
+  assert (String.rspan 2 "a" = ("", "a"));
+  assert (String.rspan 2 "ab" = ("", "ab"));
+  ()


### PR DESCRIPTION
This PR adds the classical combinators for breaking sequences with magnitudes to the `String` module along with `r*` variants that act in reverse as is usual in the `String` module.

If that goes well, a follow up PR will add the combinators that break with predicates (`String.[r]{drop,take,span}_while`).

## On the `String.span` name

The `String.span` function proposed in this PR is called [`splitAt`] in Haskell. I think the latter name is confusing on indexed sequences at it rather evokes splitting at a given index rather than with a magnitude. This becomes even more confusing once we factor in the reverse version which would be `rsplit_at` (does not exist in Haskell).
  
Now in Haskell the [`span`] function is the one that pairs the results of `takeWhile`, `dropWhile`.  I propose to use `span_while` for this. This means we get a consistent naming scheme for OCaml:
  
* `take`, `drop`, `span` for breaking with magnitudes.
* `take_while`, `drop_while`, `span_while` for breaking with predicates.
  
Another idea would be to call this function `break` and keep `span` for `span_while`. But personally I prefer the consistent naming scheme despite the Haskell discrepancy, after all they can also be wrong sometimes :-)

[`splitAt`]: https://hackage.haskell.org/package/base-4.21.0.0/docs/Prelude.html#v:splitAt
[`span`]: https://hackage.haskell.org/package/base-4.21.0.0/docs/Prelude.html#v:span

---
P.S. For now I don't see a strong need to add these to `Bytes`. If we want them there they can be added in another PR, once the APIs have been bikesheded it's an easier task.