### PR TITLE
explain the syntax change for variance (by #13820)

### DIFF
--- a/Changes
+++ b/Changes
@@ -212,6 +212,10 @@ Working version
   universal variables and universal quantifications.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14126: Document the `-i-variance` option and `+-`, `-+` variance indicators
+  in the reference manual.
+  (Takafumi Saikawa, review by Florian Angeletti)
+
 - #14146: add an error message for external declaration with
   a non-syntactic arity
   ```

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -278,6 +278,11 @@ just redirect the standard output of the compiler to a ".mli" file,
 and edit that file to remove all declarations of unexported names.
 }%notop
 
+\item["-i-variance"]
+Cause the compiler to print the computed variance of type parameters for
+every type declaration.  Without this option, variance is printed only for
+private types or types without a manifest (e.g., abstract types).
+
 \item["-I" \var{directory}]
 Add the given directory to the list of directories searched for
 \nat{compiled interface files (".cmi"), compiled object code files (".cmx"),

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -201,8 +201,10 @@ original type constructor.
 The type variables appearing as type parameters can optionally be prefixed by
 "+", "-", "+-", or "-+" to indicate that the type constructor has a specific
 variance with respect this parameter.
-A parameter with "+" is covariant, "-" contravariant,
-and "+-" (or "-+") bivariant.
+A parameter prefixed with "+" is covariant,
+one prefixed with "-" is contravariant.
+A parameter can be both covariant and contravariant,
+also known as bivariant, with either a "+-" or "-+" prefix.
 This variance information is used to decide subtyping relations when
 checking the validity of @":>"@ coercions
 (see section \ref{ss:expr-coercions}).

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -45,8 +45,8 @@ ext-variance:
 variance:
           '+'
         | '-'
-	| '+-'
-	| '-+'
+        | '+-'
+        | '-+'
 ;
 injectivity: '!'
 ;

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -200,7 +200,7 @@ original type constructor.
 
 The type variables appearing as type parameters can optionally be prefixed by
 "+", "-", "+-", or "-+" to indicate that the type constructor has a specific
-variance with respect this parameter.
+variance with respect to this parameter.
 A parameter prefixed with "+" is covariant,
 one prefixed with "-" is contravariant.
 A parameter can be both covariant and contravariant,

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -45,6 +45,8 @@ ext-variance:
 variance:
           '+'
         | '-'
+	| '+-'
+	| '-+'
 ;
 injectivity: '!'
 ;
@@ -196,10 +198,12 @@ constructor must have the same arity and the same type constraints as the
 original type constructor.
 \end{description}
 
-The type variables appearing as type parameters can optionally be
-prefixed by "+" or "-" to indicate that the type constructor is
-covariant or contravariant with respect to this parameter.  This
-variance information is used to decide subtyping relations when
+The type variables appearing as type parameters can optionally be prefixed by
+"+", "-", "+-", or "-+" to indicate that the type constructor has a specific
+variance with respect this parameter.
+A parameter with "+" is covariant, "-" contravariant,
+and "+-" (or "-+") bivariant.
+This variance information is used to decide subtyping relations when
 checking the validity of @":>"@ coercions
 (see section \ref{ss:expr-coercions}).
 


### PR DESCRIPTION
#13820 introduced the bivariance indicators (`+-`, `-+`) in the syntax.
This PR documents them.