### PR TITLE
Missing case in {Stdlib,Float}.frexp documentation

### DIFF
--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -424,8 +424,7 @@ external frexp : float -> float * int = "caml_frexp_float"
     and the exponent of [f].  When [f] is zero, the
     significant [x] and the exponent [n] of [f] are equal to
     zero.  When [f] is non-zero, they are defined by
-    [f = x *. 2 ** n] and with [0.5 <= x < 1.0] for a positive [f]
-    and [-1.0 < x <= -0.5] for a negative [f]. *)
+    [f = x *. 2 ** n] and [0.5 <= abs x < 1.0]. *)
 
 external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =
   "caml_ldexp_float" "caml_ldexp_float_unboxed" [@@noalloc]

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -424,7 +424,8 @@ external frexp : float -> float * int = "caml_frexp_float"
     and the exponent of [f].  When [f] is zero, the
     significant [x] and the exponent [n] of [f] are equal to
     zero.  When [f] is non-zero, they are defined by
-    [f = x *. 2 ** n] and [0.5 <= x < 1.0]. *)
+    [f = x *. 2 ** n] and with [0.5 <= x < 1.0] for a positive [f]
+    and [-1.0 < x <= -0.5] for a negative [f]. *)
 
 external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =
   "caml_ldexp_float" "caml_ldexp_float_unboxed" [@@noalloc]

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -584,7 +584,8 @@ external frexp : float -> float * int = "caml_frexp_float"
    and the exponent of [f].  When [f] is zero, the
    significant [x] and the exponent [n] of [f] are equal to
    zero.  When [f] is non-zero, they are defined by
-   [f = x *. 2 ** n] and [0.5 <= x < 1.0]. *)
+   [f = x *. 2 ** n] and with [0.5 <= x < 1.0] for a positive [f]
+   and [-1.0 < x <= -0.5] for a negative [f]. *)
 
 
 external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -584,8 +584,7 @@ external frexp : float -> float * int = "caml_frexp_float"
    and the exponent of [f].  When [f] is zero, the
    significant [x] and the exponent [n] of [f] are equal to
    zero.  When [f] is non-zero, they are defined by
-   [f = x *. 2 ** n] and with [0.5 <= x < 1.0] for a positive [f]
-   and [-1.0 < x <= -0.5] for a negative [f]. *)
+   [f = x *. 2 ** n] and [0.5 <= abs x < 1.0]. *)
 
 
 external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =

--- a/stdlib/templates/float.template.mli
+++ b/stdlib/templates/float.template.mli
@@ -424,7 +424,7 @@ external frexp : float -> float * int = "caml_frexp_float"
     and the exponent of [f].  When [f] is zero, the
     significant [x] and the exponent [n] of [f] are equal to
     zero.  When [f] is non-zero, they are defined by
-    [f = x *. 2 ** n] and [0.5 <= x < 1.0]. *)
+    [f = x *. 2 ** n] and [0.5 <= abs x < 1.0]. *)
 
 external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =
   "caml_ldexp_float" "caml_ldexp_float_unboxed" [@@noalloc]


### PR DESCRIPTION
While playing with floating point number weirdness I stumbled upon a case of a negative significant missing from the documentation:
```ocaml
frexp (-3.);;
- : float * int = (-0.75, 2)
```

(no changes entry needed)