### PR TITLE
typechecker: fix an internal error due to a wrong exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -935,6 +935,9 @@ OCaml 5.4.0
   (Stephen Dolan, report by Jan Midtgaard, investigation by Nick Roberts,
    review by Antonin Décimo and Miod Vallat)
 
+- #14135: Fix a rare internal typechecker error when combining recursive
+  modules, polymorphic fields or methods, and constrained type parameters.
+  (Florian Angeletti, review by Gabriel Scherer)
 
 OCaml 5.3.0 (8 January 2025)
 ----------------------------

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -171,3 +171,36 @@ Line 7, characters 33-34:
 Error: This match case could not be refuted.
        Here is an example of a value that would reach it: "A"
 |}]
+
+module rec M: sig
+  type x
+  type 'a t = A constraint 'a = <x: 'a. 'a -> x >
+end = struct
+  type x
+  type 'a t = A constraint 'a = <x:'a. 'a -> 'a >
+end
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type x
+6 |   type 'a t = A constraint 'a = <x:'a. 'a -> 'a >
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type x = M.x
+           type 'b t = 'b M.t = A constraint 'b = < x : 'a. 'a -> 'a >
+         end
+       is not included in
+         sig type x type 'b t = A constraint 'b = < x : 'a. 'a -> x > end
+       Type declarations do not match:
+         type 'b t = 'b M.t = A constraint 'b = < x : 'a. 'a -> 'a >
+       is not included in
+         type 'b t = A constraint 'b = < x : 'a. 'a -> x >
+       Their parameters differ
+       The type "< x : 'a. 'a -> 'a >" is not equal to the type
+         "< x : 'a. 'a -> x >"
+       Type "'a" is not equal to type "x" = "M.x"
+       The method "x" has type "'a. 'a -> 'a", but the expected method type was
+       "'a. 'a -> x"
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2400,9 +2400,9 @@ let rec mcomp type_pairs env t1 t2 =
         | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _)) ->
             mcomp_type_decl type_pairs env p1 p2 tl1 tl2
         | (Tconstr (_, [], _), _) when has_injective_univars env t2' ->
-            raise_unexplained_for Unify
+            raise Incompatible
         | (_, Tconstr (_, [], _)) when has_injective_univars env t1' ->
-            raise_unexplained_for Unify
+            raise Incompatible
         | (Tconstr (p, _, _), _) | (_, Tconstr (p, _, _)) ->
             begin try
               let decl = Env.find_type p env in


### PR DESCRIPTION
This PR fixes an exotic internal error in the typechecker. Currently,
```ocaml
module rec M: sig
  type x
  type 'a t = A constraint 'a = <x: 'a. 'a -> x >
end = struct
  type x
  type 'a t = A constraint 'a = <x:'a. 'a -> 'a >
end
```
yields
```
Fatal error: exception Ctype.Unify_trace(0)
```
because the function `Ctype.mcomp` is unexpectedly raising an unification errortrace.

What happens here is that `Ctype.mcomp` is expected to raise an `Incompatible` exception whenever two types are incompatible.  However, when comparing zero-arity type constructor to a type expression with free universal variables in injective positions, the function was raising an unification errortrace instead. 

Raising an errortrace is fine for internal uses of `mcomp` within `Ctype`, because calls to `mcomp` in `Ctype` goes through `mcomp_for` which transforms the `Incompatible` exception into an errortrace. This unexpected errortrace leads to potential internal errors for the lone external user of `Ctype.mcomp` .

This two lines PR (not counting the test) fixes this issue by replacing the two raises of errortrace by raise of `Incompatible` in `Ctype.mcomp`.