### PR TITLE
c++ support: move basic atomic type definitions to misc.h

### DIFF
--- a/Changes
+++ b/Changes
@@ -935,6 +935,10 @@ OCaml 5.4.0
   (Stephen Dolan, report by Jan Midtgaard, investigation by Nick Roberts,
    review by Antonin Décimo and Miod Vallat)
 
+- #14101, #14139: define atomic helper types inside `caml/misc.h` to improve
+  header compatibility with C++
+  (Florian Angeletti, report by Kate Deplaix, review by Gabriel Scherer)
+
 - #14135: Fix a rare internal typechecker error when combining recursive
   modules, polymorphic fields or methods, and constrained type parameters.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -25,24 +25,13 @@
  */
 
 #ifdef __cplusplus
-
 extern "C++" {
-#include <atomic>
-typedef std::atomic<uintnat> atomic_uintnat;
-typedef std::atomic<intnat> atomic_intnat;
 using std::memory_order_relaxed;
 using std::memory_order_acquire;
 using std::memory_order_release;
 using std::memory_order_acq_rel;
 using std::memory_order_seq_cst;
 }
-
-#else
-
-#include <stdatomic.h>
-typedef _Atomic uintnat atomic_uintnat;
-typedef _Atomic intnat atomic_intnat;
-
 #endif
 
 #ifdef CAML_INTERNALS

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -77,6 +77,17 @@
 /* Basic types and constants */
 
 typedef size_t asize_t;
+#ifdef __cplusplus
+extern "C++" {
+#include <atomic>
+typedef std::atomic<uintnat> atomic_uintnat;
+typedef std::atomic<intnat> atomic_intnat;
+}
+#else
+#include <stdatomic.h>
+typedef _Atomic uintnat atomic_uintnat;
+typedef _Atomic intnat atomic_intnat;
+#endif
 
 #ifndef NULL
 #define NULL 0
@@ -619,7 +630,7 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 /* runtime message flags. Settable with v= in OCAMLRUNPARAM */
 
-extern _Atomic uintnat caml_verb_gc;
+extern atomic_uintnat caml_verb_gc;
 
 /* Bits which may be set in caml_verb_gc. The quotations are from the
  * OCaml manual. */


### PR DESCRIPTION
This PR fixes #14101 by moving the definitions of `atomic_uintnat` and `atomic_intnat` in `misc.h`.

Note that this only fixes the C++ uses of `misc.h` when `CAML_INTERNALS` is defined which is not really supported.
