### PR TITLE
symbol names: keep using `.` on non-Apple unix systems

### DIFF
--- a/Changes
+++ b/Changes
@@ -484,7 +484,7 @@ OCaml 5.4.0
   Vallat, Vincent Laviron and Xavier Leroy)
 
 * #13050, #14104, #?????: Use '$' instead of '.' to separate module names
-  in symbol names on non Apple and non-unix operating systems.
+  in symbol names on Apple and non-unix operating systems.
   This changes mangling of OCaml identifiers on those operating systems from
   `camlModule.name_NNN` to `camlModule$name_NNN`. Additionally it
   changes the encoding of special characters from $xx (two hex digits)

--- a/Changes
+++ b/Changes
@@ -483,12 +483,12 @@ OCaml 5.4.0
   Xavier Leroy, Miod Vallat, Gabriel Scherer and Stephen Dolan, review by Miod
   Vallat, Vincent Laviron and Xavier Leroy)
 
-* #13050: Use '$' instead of '.' to separate module names in symbol names.
-  This changes mangling of OCaml identifiers from
+* #13050, #14104, #?????: Use '$' instead of '.' to separate module names
+  in symbol names on non Apple and non-unix operating systems.
+  This changes mangling of OCaml identifiers on those operating systems from
   `camlModule.name_NNN` to `camlModule$name_NNN`. Additionally it
   changes the encoding of special characters from $xx (two hex digits)
   to $$xx (two dollar signs followed by two hex digits).
-  Mangled names are now consistent across all platforms.
   (Tim McGilchrist, with contributions from Xavier Leroy,
    reviewed by Xavier Leroy, Miod Vallat, Gabriel Scherer,
    Nick Barnes and Hugo Heuzard)

--- a/Changes
+++ b/Changes
@@ -483,8 +483,8 @@ OCaml 5.4.0
   Xavier Leroy, Miod Vallat, Gabriel Scherer and Stephen Dolan, review by Miod
   Vallat, Vincent Laviron and Xavier Leroy)
 
-* #13050, #14104, #?????: Use '$' instead of '.' to separate module names
-  in symbol names on Apple and non-unix operating systems.
+* #13050, #14104, #14143: Use '$' instead of '.' to separate module names
+  in symbol names on macOS and Windows (including the Cygwin backend).
   This changes mangling of OCaml identifiers on those operating systems from
   `camlModule.name_NNN` to `camlModule$name_NNN`. Additionally it
   changes the encoding of special characters from $xx (two hex digits)

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -48,7 +48,8 @@ let emit_symbol s =
       if c = Compilenv.symbol_separator then
         output_char !output_channel c
       else
-        Printf.fprintf !output_channel "$$%02x" (Char.code c)
+        Printf.fprintf !output_channel "%s%02x" Compilenv.escape_prefix
+          (Char.code c)
   done
 
 let emit_string_literal s =

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -83,7 +83,7 @@ let string_of_symbol prefix s =
     String.iter
       (fun c ->
        if is_special_char c then
-         Printf.bprintf b "$$%02x" (Char.code c)
+         Printf.bprintf b "%s%02x" Compilenv.escape_prefix (Char.code c)
        else
          Buffer.add_char b c
       )

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -92,7 +92,7 @@ let current_unit =
 
 let linuxlike_mangling = match Config.system with
   | "macosx"
-  | "mingw" | "cygwin" | "win32" | "win64" -> false
+  | "mingw" | "mingw64" | "cygwin" | "win32" | "win64" -> false
   | _ -> true
 
 let symbol_separator = if linuxlike_mangling then '.' else '$'

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -90,7 +90,13 @@ let current_unit =
     ui_export_info = default_ui_export_info;
     ui_for_pack = None }
 
-let symbol_separator = '$'
+let linuxlike_mangling = match Config.system with
+  | "macosx"
+  | "mingw" | "cygwin" | "win32" | "win64" -> false
+  | _ -> true
+
+let symbol_separator = if linuxlike_mangling then '.' else '$'
+let escape_prefix = if linuxlike_mangling then "$" else "$$"
 
 let concat_symbol unitname id =
   Printf.sprintf "%s%c%s" unitname symbol_separator id

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -56,6 +56,9 @@ val current_unit_symbol: unit -> Symbol.t
 val symbol_separator: char
         (* Return the module separator used when building symbol names. *)
 
+val escape_prefix: string
+        (* Return the escape prefix for hexadecimal escape sequence. *)
+
 val make_symbol: ?unitname:string -> string option -> string
         (* [make_symbol ~unitname:u None] returns the asm symbol that
            corresponds to the compilation unit [u] (default: the current unit).

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -57,7 +57,8 @@ val symbol_separator: char
         (* Return the module separator used when building symbol names. *)
 
 val escape_prefix: string
-        (* Return the escape prefix for hexadecimal escape sequence. *)
+        (* Return the escape prefix for hexadecimal escape sequences
+           in symbol names. *)
 
 val make_symbol: ?unitname:string -> string option -> string
         (* [make_symbol ~unitname:u None] returns the asm symbol that

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -23,6 +23,7 @@
 
 #if defined(SYS_macosx)
 
+#define CAMLSEP(x,y) caml_##x##$##y
 #define LBL(x) L##x
 #define G(r) _##r
 #define GREL(r) _##r@GOTPCREL
@@ -38,6 +39,7 @@ G(name):
 
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)
 
+#define CAMLSEP(x,y) caml_##x##$##y
 #define LBL(x) .L##x
 #define G(r) r
 #undef  GREL
@@ -54,6 +56,7 @@ G(name):
 
 #else /* Unix-like operating systems using ELF binaries */
 
+#define CAMLSEP(x,y) caml_##x##.##y
 #define LBL(x) .L##x
 #define G(r) r
 #define GREL(r) r@GOTPCREL
@@ -404,13 +407,13 @@ G(name):
         .text
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(caml_hot$code_begin)
-        .globl  G(caml_hot$code_begin)
-G(caml_hot$code_begin):
+        TEXT_SECTION(CAMLSEP(hot,code_begin))
+        .globl  G(CAMLSEP(hot,code_begin))
+G(CAMLSEP(hot,code_begin)):
 
-        TEXT_SECTION(caml_hot$code_end)
-        .globl  G(caml_hot$code_end)
-G(caml_hot$code_end):
+        TEXT_SECTION(CAMLSEP(hot,code_end))
+        .globl  G(CAMLSEP(hot,code_end))
+G(CAMLSEP(hot,code_end)):
 #endif
 
 /******************************************************************************/
@@ -1342,7 +1345,7 @@ G(caml_system__code_end):
 /* Frametable - GC roots for callback */
 /* Uses the same naming convention as ocamlopt generated modules. */
         .data
-OBJECT(caml_system$frametable)
+OBJECT(CAMLSEP(system,frametable))
         .quad   2           /* two descriptors */
         .quad   LBL(108)    /* return address into callback */
         .value  -1          /* negative frame size => use callback link */
@@ -1351,7 +1354,7 @@ OBJECT(caml_system$frametable)
         .quad   LBL(frame_runstack) /* return address into fiber_val_handler */
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
-END_OBJECT(caml_system$frametable)
+END_OBJECT(CAMLSEP(system,frametable))
 
 #if defined(SYS_macosx)
         .literal16

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -71,9 +71,11 @@
 
 /* Globals and labels */
 #if defined(SYS_macosx)
+#define CAMLSEP(x,y) caml_##x##$##y
 #define G(sym) _##sym
 #define L(lbl) L##lbl
 #else
+#define CAMLSEP(x,y) caml_##x##.##y
 #define G(sym) sym
 #define L(lbl) .L##lbl
 #endif
@@ -104,13 +106,13 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(caml_hot$code_begin)
-        .globl  G(caml_hot$code_begin)
-G(caml_hot$code_begin):
+        TEXT_SECTION(CAMLSEP(hot,code_begin))
+        .globl  G(CAMLSEP(hot,code_begin))
+G(CAMLSEP(hot,code_begin)):
 
-        TEXT_SECTION(caml_hot$code_end)
-        .globl  G(caml_hot$code_end)
-G(caml_hot$code_end):
+        TEXT_SECTION(CAMLSEP(hot,code_end))
+        .globl  G(CAMLSEP(hot,code_end))
+G(CAMLSEP(hot,code_end)):
 #endif
 
 #if defined(SYS_macosx)
@@ -1285,7 +1287,7 @@ G(caml_system__code_end):
 
 /* Frametable - GC roots for callback */
 /* Uses the same naming convention as ocamlopt generated modules. */
-OBJECT(caml_system$frametable)
+OBJECT(CAMLSEP(system,frametable))
         .quad   2               /* two descriptors */
         .quad   L(caml_retaddr) /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
@@ -1295,6 +1297,6 @@ OBJECT(caml_system$frametable)
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots here */
         .align 3
-        END_OBJECT(caml_system$frametable)
+        END_OBJECT(CAMLSEP(system,frametable))
 
         NONEXECSTACK_NOTE

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -39,7 +39,11 @@ CAMLexport void (*caml_natdynlink_hook)(void* handle, const char* unit) = NULL;
 #include <string.h>
 #include <limits.h>
 
-#define CAML_SYM_SEPARATOR "$"
+#if defined (_WIN32) || defined (__CYGWIN__) || defined (__APPLE__)
+ #define CAML_SYM_SEPARATOR "$"
+#else
+ #define CAML_SYM_SEPARATOR "."
+#endif
 
 #define Handle_val(v) (*((void **) Data_abstract_val(v)))
 static value Val_handle(void* handle) {

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -77,13 +77,13 @@
 .endm
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION caml_hot$code_begin
-        .globl caml_hot$code_begin
-caml_hot$code_begin:
+        TEXT_SECTION caml_hot.code_begin
+        .globl caml_hot.code_begin
+caml_hot.code_begin:
 
-        TEXT_SECTION caml_hot$code_end
-        .globl caml_hot$code_end
-caml_hot$code_end:
+        TEXT_SECTION caml_hot.code_end
+        .globl caml_hot.code_end
+caml_hot.code_end:
 #endif
 
 .macro FUNCTION name
@@ -1190,7 +1190,7 @@ caml_system__code_end:
 /* Frametable - GC roots for callback */
 /* Uses the same naming convention as ocamlopt generated modules. */
         .section ".data"
-OBJECT caml_system$frametable
+OBJECT caml_system.frametable
         .quad   2               /* two descriptors */
         .quad   .Lcaml_retaddr + 4  /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
@@ -1200,7 +1200,7 @@ OBJECT caml_system$frametable
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots here */
         .align 3
-ENDOBJECT caml_system$frametable
+ENDOBJECT caml_system.frametable
 
 /* TOC entries */
 

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -64,13 +64,13 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(caml_hot$code_begin)
-        .globl caml_hot$code_begin
-caml_hot$code_begin:
+        TEXT_SECTION(caml_hot.code_begin)
+        .globl caml_hot.code_begin
+caml_hot.code_begin:
 
-        TEXT_SECTION(caml_hot$code_end)
-        .globl caml_hot$code_end
-caml_hot$code_end:
+        TEXT_SECTION(caml_hot.code_end)
+        .globl caml_hot.code_end
+caml_hot.code_end:
 #endif
 
 /* Globals and labels */
@@ -1244,7 +1244,7 @@ caml_system__code_end:
 
 /* Frametable - GC roots for callback */
 /* Uses the same naming convention as ocamlopt generated modules. */
-OBJECT(caml_system$frametable)
+OBJECT(caml_system.frametable)
         .quad   2                 /* two descriptors */
         .quad   L(caml_retaddr)   /* return address into callback */
         .short  -1                /* negative frame size => use callback link */
@@ -1254,6 +1254,6 @@ OBJECT(caml_system$frametable)
         .short  -1                /* negative frame size => use callback link */
         .short  0                 /* no roots */
         .align  3
-END_OBJECT(caml_system$frametable)
+END_OBJECT(caml_system.frametable)
 
         NONEXECSTACK_NOTE

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -48,13 +48,13 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(caml_hot$code_begin)
-        .globl caml_hot$code_begin
-caml_hot$code_begin:
+        TEXT_SECTION(caml_hot.code_begin)
+        .globl caml_hot.code_begin
+caml_hot.code_begin:
 
-        TEXT_SECTION(caml_hot$code_end)
-        .globl caml_hot$code_end
-caml_hot$code_end:
+        TEXT_SECTION(caml_hot.code_end)
+        .globl caml_hot.code_end
+caml_hot.code_end:
 #endif
 
 #define FUNCTION(name) \
@@ -1204,7 +1204,7 @@ caml_system__code_end:
 /* Frametable - GC roots for callback */
 /* Uses the same naming convention as ocamlopt generated modules. */
         .section ".data"
-OBJECT(caml_system$frametable)
+OBJECT(caml_system.frametable)
         .quad   2               /* two descriptors */
         .quad   LBL(caml_retaddr)  /* return address into callback */
         .short  -1              /* negative size count => use callback link */
@@ -1214,6 +1214,6 @@ OBJECT(caml_system$frametable)
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
         .align  8
-ENDOBJECT(caml_system$frametable)
+ENDOBJECT(caml_system.frametable)
 
         NONEXECSTACK_NOTE

--- a/testsuite/tests/asmcomp/func_sections.run
+++ b/testsuite/tests/asmcomp/func_sections.run
@@ -7,4 +7,4 @@ ${program}
 
 # now check the assembly file produced during compilation
 asm=${test_build_directory}/func_sections.s
-grep "\.section \.text\.caml\.camlFunc_sections." "$asm" | wc -l | tr -d ' ' | sed '/^$/d'
+grep "\.section \.text\.caml\.camlFunc_sections[.$]" "$asm" | wc -l | tr -d ' ' | sed '/^$/d'

--- a/testsuite/tests/asmcomp/func_sections.run
+++ b/testsuite/tests/asmcomp/func_sections.run
@@ -7,4 +7,4 @@ ${program}
 
 # now check the assembly file produced during compilation
 asm=${test_build_directory}/func_sections.s
-grep "\.section \.text\.caml\.camlFunc_sections\\$" "$asm" | wc -l | tr -d ' ' | sed '/^$/d'
+grep "\.section \.text\.caml\.camlFunc_sections." "$asm" | wc -l | tr -d ' ' | sed '/^$/d'

--- a/testsuite/tests/atomic-locs/cmm.compilers.reference
+++ b/testsuite/tests/atomic-locs/cmm.compilers.reference
@@ -3,53 +3,53 @@ cmm:
 (data)
 (data
  int 3063
- "camlCmm$5":
- addr "camlCmm$standard_atomic_get_274"
+ "camlCmm.5":
+ addr "camlCmm.standard_atomic_get_274"
  int 72057594037927941)
 (data
  int 4087
- "camlCmm$4":
+ "camlCmm.4":
  addr "caml_curry3"
  int 216172782113783815
- addr "camlCmm$standard_atomic_cas_299")
-(data int 3063 "camlCmm$3": addr "camlCmm$get_307" int 72057594037927941)
+ addr "camlCmm.standard_atomic_cas_299")
+(data int 3063 "camlCmm.3": addr "camlCmm.get_307" int 72057594037927941)
 (data
  int 4087
- "camlCmm$2":
+ "camlCmm.2":
  addr "caml_curry2"
  int 144115188075855879
- addr "camlCmm$set_310")
+ addr "camlCmm.set_310")
 (data
  int 4087
- "camlCmm$1":
+ "camlCmm.1":
  addr "caml_curry3"
  int 216172782113783815
- addr "camlCmm$cas_314")
+ addr "camlCmm.cas_314")
 (data int 5888 global "camlCmm" "camlCmm": int 1 int 1 int 1 int 1 int 1)
-(data global "camlCmm$gc_roots" "camlCmm$gc_roots": addr "camlCmm" int 0)
-(function camlCmm$standard_atomic_get_274 (r: val) (load_mut_atomic val r))
+(data global "camlCmm.gc_roots" "camlCmm.gc_roots": addr "camlCmm" int 0)
+(function camlCmm.standard_atomic_get_274 (r: val) (load_mut_atomic val r))
 
-(function camlCmm$standard_atomic_cas_299 (r: val oldv: val newv: val)
+(function camlCmm.standard_atomic_cas_299 (r: val oldv: val newv: val)
  (extcall "caml_atomic_cas_field" r 1 oldv newv int,int,int,int->val))
 
-(function camlCmm$get_307 (r: val) (load_mut_atomic val (+a r 8)))
+(function camlCmm.get_307 (r: val) (load_mut_atomic val (+a r 8)))
 
-(function camlCmm$set_310 (r: val v: val)
+(function camlCmm.set_310 (r: val v: val)
  (extcall "caml_atomic_exchange_field" r 3 v int,int,int->unit) 1)
 
-(function camlCmm$cas_314 (r: val oldv: val newv: val)
+(function camlCmm.cas_314 (r: val oldv: val newv: val)
  (extcall "caml_atomic_cas_field" r 3 oldv newv int,int,int,int->val))
 
-(function camlCmm$entry ()
- (let standard_atomic_get "camlCmm$5"
+(function camlCmm.entry ()
+ (let standard_atomic_get "camlCmm.5"
    (extcall "caml_initialize" "camlCmm" standard_atomic_get ->unit))
- (let standard_atomic_cas "camlCmm$4"
+ (let standard_atomic_cas "camlCmm.4"
    (extcall "caml_initialize" (+a "camlCmm" 8) standard_atomic_cas ->unit))
- (let get "camlCmm$3"
+ (let get "camlCmm.3"
    (extcall "caml_initialize" (+a "camlCmm" 16) get ->unit))
- (let set "camlCmm$2"
+ (let set "camlCmm.2"
    (extcall "caml_initialize" (+a "camlCmm" 24) set ->unit))
- (let cas "camlCmm$1"
+ (let cas "camlCmm.1"
    (extcall "caml_initialize" (+a "camlCmm" 32) cas ->unit))
  1)
 

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.reference
@@ -23,8 +23,8 @@ Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
 frame 1: caml_c_call
-frame 2: camlMeander$omain
-frame 3: camlMeander$entry
+frame 2: camlMeander.omain
+frame 3: camlMeander.entry
 frame 4: caml_program
 frame 5: caml_start_program
 frame 6: caml_startup_common
@@ -33,16 +33,16 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-Breakpoint 4, camlMeander$c_to_ocaml () at meander.ml:5
+Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander$c_to_ocaml
+frame 0: camlMeander.c_to_ocaml
 frame 1: caml_start_program
 frame 2: caml_callback_exn
 frame 3: caml_callback
 frame 4: ocaml_to_c
 frame 5: caml_c_call
-frame 6: camlMeander$omain
-frame 7: camlMeander$entry
+frame 6: camlMeander.omain
+frame 7: camlMeander.entry
 frame 8: caml_program
 frame 9: caml_start_program
 frame 10: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.reference
@@ -23,8 +23,8 @@ Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
 frame 1: caml_c_call
-frame 2: camlMeander$omain
-frame 3: camlMeander$entry
+frame 2: camlMeander.omain
+frame 3: camlMeander.entry
 frame 4: caml_program
 frame 5: caml_start_program
 frame 6: caml_startup_common
@@ -33,16 +33,16 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-Breakpoint 4, camlMeander$c_to_ocaml () at meander.ml:5
+Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander$c_to_ocaml
+frame 0: camlMeander.c_to_ocaml
 frame 1: caml_start_program
 frame 2: caml_callback_exn
 frame 3: caml_callback
 frame 4: ocaml_to_c
 frame 5: caml_c_call
-frame 6: camlMeander$omain
-frame 7: camlMeander$entry
+frame 6: camlMeander.omain
+frame 7: camlMeander.entry
 frame 8: caml_program
 frame 9: caml_start_program
 frame 10: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.reference
@@ -23,8 +23,8 @@ Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
 frame 1: caml_c_call
-frame 2: camlMeander$omain
-frame 3: camlMeander$entry
+frame 2: camlMeander.omain
+frame 3: camlMeander.entry
 frame 4: caml_program
 frame 5: caml_start_program
 frame 6: caml_startup_common
@@ -33,16 +33,16 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-Breakpoint 4, camlMeander$c_to_ocaml () at meander.ml:5
+Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander$c_to_ocaml
+frame 0: camlMeander.c_to_ocaml
 frame 1: caml_start_program
 frame 2: caml_callback_exn
 frame 3: caml_callback
 frame 4: ocaml_to_c
 frame 5: caml_c_call
-frame 6: camlMeander$omain
-frame 7: camlMeander$entry
+frame 6: camlMeander.omain
+frame 7: camlMeander.entry
 frame 8: caml_program
 frame 9: caml_start_program
 frame 10: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander\$c_to_ocaml*
-Breakpoint created for regex camlMeander\$c_to_ocaml*.
+(lldb) create camlMeander.c_to_ocaml*
+Breakpoint created for regex camlMeander.c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
@@ -62,8 +62,8 @@ Process XXXX stopped
 (lldb) backtrace
 frame 0: meander`ocaml_to_c
 frame 1: meander`caml_c_call
-frame 2: meander`camlMeander$omain
-frame 3: meander`camlMeander$entry
+frame 2: meander`camlMeander.omain
+frame 3: meander`camlMeander.entry
 frame 4: meander`caml_program
 frame 5: meander`caml_start_program
 frame 6: meander`caml_startup_common
@@ -79,7 +79,7 @@ frame 14: meander`_start
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 3.1
-    frame #0: 0x00000000000000 meander`camlMeander$c_to_ocaml at meander.ml:5:20
+    frame #0: 0x00000000000000 meander`camlMeander.c_to_ocaml at meander.ml:5:20
    2   	         : unit -> int = "ocaml_to_c"
    3   	exception E1
    4   	exception E2
@@ -89,14 +89,14 @@ Process XXXX stopped
    7   	          "c_to_ocaml" c_to_ocaml
    8   	let omain () =
 (lldb) backtrace
-frame 0: meander`camlMeander$c_to_ocaml
+frame 0: meander`camlMeander.c_to_ocaml
 frame 1: meander`caml_start_program
 frame 2: meander`caml_callback_exn
 frame 3: meander`caml_callback
 frame 4: meander`ocaml_to_c
 frame 5: meander`caml_c_call
-frame 6: meander`camlMeander$omain
-frame 7: meander`camlMeander$entry
+frame 6: meander`camlMeander.omain
+frame 7: meander`camlMeander.entry
 frame 8: meander`caml_program
 frame 9: meander`caml_start_program
 frame 10: meander`caml_startup_common

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander.c_to_ocaml*
-Breakpoint created for regex camlMeander.c_to_ocaml*.
+(lldb) create camlMeander[.$]c_to_ocaml*
+Breakpoint created for regex camlMeander[.$]c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander\$c_to_ocaml*
-Breakpoint created for regex camlMeander\$c_to_ocaml*.
+(lldb) create camlMeander.c_to_ocaml*
+Breakpoint created for regex camlMeander.c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
@@ -62,8 +62,8 @@ Process XXXX stopped
 (lldb) backtrace
 frame 0: meander`ocaml_to_c
 frame 1: meander`caml_c_call
-frame 2: meander`camlMeander$omain
-frame 3: meander`camlMeander$entry
+frame 2: meander`camlMeander.omain
+frame 3: meander`camlMeander.entry
 frame 4: meander`caml_program
 frame 5: meander`caml_start_program
 frame 6: meander`caml_startup_common
@@ -95,8 +95,8 @@ frame 2: meander`caml_callback_exn
 frame 3: meander`caml_callback
 frame 4: meander`ocaml_to_c
 frame 5: meander`caml_c_call
-frame 6: meander`camlMeander$omain
-frame 7: meander`camlMeander$entry
+frame 6: meander`camlMeander.omain
+frame 7: meander`camlMeander.entry
 frame 8: meander`caml_program
 frame 9: meander`caml_start_program
 frame 10: meander`caml_startup_common

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander.c_to_ocaml*
-Breakpoint created for regex camlMeander.c_to_ocaml*.
+(lldb) create camlMeander[.$]c_to_ocaml*
+Breakpoint created for regex camlMeander[.$]c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run

--- a/testsuite/tests/native-debugger/lldb-script
+++ b/testsuite/tests/native-debugger/lldb-script
@@ -3,7 +3,7 @@ settings set stop-disassembly-display never
 command script import ./lldb_test.py
 create caml_start_program
 create caml_program
-create camlMeander\$c_to_ocaml*
+create camlMeander[.$]c_to_ocaml*
 create ocaml_to_c
 run
 backtrace

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander\$c_to_ocaml*
-Breakpoint created for regex camlMeander\$c_to_ocaml*.
+(lldb) create camlMeander[.$]c_to_ocaml*
+Breakpoint created for regex camlMeander[.$]c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander\$c_to_ocaml*
-Breakpoint created for regex camlMeander\$c_to_ocaml*.
+(lldb) create camlMeander[.$]c_to_ocaml*
+Breakpoint created for regex camlMeander[.$]c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run


### PR DESCRIPTION
As discussed in #14104, this PR proposes to revert to using `.` as module separator for symbol names on non-Apple unix systems — at the very least for OCaml 5.4.
 
This should restore the support of OCaml symbol name mangling in perf for OCaml 5.4, while keeping the lldb fix on Apple systems . Moreover, it seems likely to me that any tools analyzing symbol names already needs to have OS specific paths, thus we are hopefully not exporting a noticeable amount of complexity to those external tools.

cc @tmcgilchrist 