### PR TITLE
Make finalizer processing in major slice independent of budget.

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,10 @@ Working version
 
 ### Runtime system:
 
+- #14145: Make the finaliser processing in major slice independent of the
+  budget. Fixes live locks in phase transition.
+  (KC Sivaramakrishnan, review by )
+
 - #14035: Fix the alignment of _Atomic long long unsigned int fields
   before GCC 11.1 on i686. Silence GCC note on newer versions.
   (Antonin Décimo, review by Sadiq Jaffer)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1874,7 +1874,6 @@ mark_again:
   if (mode != Slice_opportunistic) {
     /* Finalisers */
     if (caml_gc_phase == Phase_mark_final &&
-        get_major_slice_work(mode) > 0 &&
         caml_final_update_first(domain_state)) {
       /* This domain has updated finalise first values */
       (void)caml_atomic_counter_decr(&num_domains_to_final_update_first);
@@ -1884,7 +1883,6 @@ mark_again:
     }
 
     if (caml_gc_phase == Phase_sweep_ephe &&
-        get_major_slice_work(mode) > 0 &&
         caml_final_update_last(domain_state)) {
       /* This domain has updated finalise last values */
       (void)caml_atomic_counter_decr(&num_domains_to_final_update_last);


### PR DESCRIPTION
When a domain becomes idle (no allocation activity), `get_major_slice_work(mode)` returns 0, preventing the domain from participating in phase transitions. This is particularly problematic for finaliser updates, which are coupled to allocation pressure. Even if the domain is idle, its finalisers should be processed. This commit removes the necessity for a positive budget to process finalisers.

This is intended to fix a test failure observed in #13580, but could also potentially occur without #13580. See the comment https://github.com/ocaml/ocaml/pull/13580#issuecomment-3034700018.

Finaliser processing is not incremental. Hence, any non-zero budget would process the entire list of finalisers in that domain. So, removing this check should make the runtime to behave as if the budget was a very small non-zero number. 

A future PR may address other issues:

1. A similar issue exists with weak arrays / ephemeron processing.
2. Make the budget calculation aware of per-domain finaliser and ephemeron work.
3. Make the finaliser processing incremental.