### PR TITLE
error messages: external with non-syntactic arity

### DIFF
--- a/Changes
+++ b/Changes
@@ -172,6 +172,14 @@ Working version
   variables.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14146: add an error message for external declaration with
+  a non-syntactic arity
+  ```
+   external fail: (int -> int as 'a) -> 'a = "%identity"
+  ```
+  rather than failing with an internal error.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/testsuite/tests/typing-external/non_syntactic_arity.ml
+++ b/testsuite/tests/typing-external/non_syntactic_arity.ml
@@ -1,0 +1,12 @@
+(* TEST
+ expect;
+*)
+external fail: (int -> int as 'a) -> 'a = "%identity"
+
+[%%expect{|
+Line 1, characters 37-39:
+1 | external fail: (int -> int as 'a) -> 'a = "%identity"
+                                         ^^
+Error: This external declaration has a non-syntactic arity,
+       its arity is greater than its syntatic arity.
+|}]

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -107,6 +107,7 @@ type error =
   | Nonrec_gadt
   | Invalid_private_row_declaration of type_expr
   | Atomic_field_must_be_mutable of string
+  | External_with_non_syntactic_arity
 
 exception Error of Location.t * error
 


### PR DESCRIPTION
Currently, declaring an external with a non-syntactic arity:
```ocaml
external x: (int -> int as 'a) -> 'a = "%identity"
```
triggers an `assert false` in `Typedecl`. This PR proposes to emit a normal error message:


>```
>Error: This external declaration has a non-syntactic arity,
>        its arity is greater than its syntatic arity.
>```