### PR TITLE
Print row types when they are a type constructor

### DIFF
--- a/Changes
+++ b/Changes
@@ -188,6 +188,10 @@ Working version
   rather than failing with an internal error.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14147: print row types in error messages when they are a type constructor,
+  e.g. `< foo : int; .. as $0>` when $0 is introduced by a GADT constructor
+  (Stefan Muenzel, review by Jacques Garrigue and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1067,9 +1067,9 @@ type _ int_bar = IB_constr : < bar : int; .. > int_bar
 Line 10, characters 3-4:
 10 |   (x:<foo:int>)
         ^
-Error: The value "x" has type "t" = "< foo : int; .. >"
+Error: The value "x" has type "t" = "< foo : int; .. as $0 >"
        but an expression was expected of type "< foo : int >"
-       Type "$0" = "< bar : int; .. >" is not compatible with type "<  >"
+       Type "$0" = "< bar : int; .. as $1 >" is not compatible with type "<  >"
        The second object type has no method "bar"
 |}];;
 
@@ -1081,9 +1081,10 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 Line 3, characters 3-4:
 3 |   (x:<foo:int;bar:int>)
        ^
-Error: The value "x" has type "t" = "< foo : int; .. >"
+Error: The value "x" has type "t" = "< foo : int; .. as $0 >"
        but an expression was expected of type "< bar : int; foo : int >"
-       Type "$0" = "< bar : int; .. >" is not compatible with type "< bar : int >"
+       Type "$0" = "< bar : int; .. as $1 >" is not compatible with type
+         "< bar : int >"
        The first object type has an abstract row, it cannot be closed
 |}];;
 
@@ -1095,14 +1096,14 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 Line 3, characters 2-26:
 3 |   (x:<foo:int;bar:int;..>)
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< bar : int; foo : int; .. >"
+Error: This expression has type "< bar : int; foo : int; .. as $1 >"
        but an expression was expected of type "'a"
        The type constructor "$1" would escape its scope
 |}, Principal{|
 Line 3, characters 2-26:
 3 |   (x:<foo:int;bar:int;..>)
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< bar : int; foo : int; .. >"
+Error: This expression has type "< bar : int; foo : int; .. as $1 >"
        but an expression was expected of type "'a"
        This instance of "$1" is ambiguous:
        it would escape the scope of its equation

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -283,7 +283,7 @@ let is_row_name s =
   let l = String.length s in
   (* PR#10661: when l=4 and s is "#row", this is not a row name
      but the valid #-type name of a class named "row". *)
-  l > 4 && String.sub s (l-4) 4 = "#row"
+  l > 4 && String.ends_with ~suffix:"#row" s
 
 let is_constr_row ~allow_ident t =
   match get_desc t with

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -72,7 +72,7 @@ type out_type =
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
-  | Otyp_object of { fields: (string * out_type) list; open_row:bool}
+  | Otyp_object of { fields: (string * out_type) list; row: out_row}
   | Otyp_record of out_label list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
@@ -83,6 +83,11 @@ type out_type =
   | Otyp_module of out_package
   | Otyp_attribute of out_type * out_attribute
   | Otyp_external of string
+
+and out_row =
+  | Orow_closed
+  | Orow_open_anonymous
+  | Orow_open of out_type
 
 and out_label = {
   olab_name: string;


### PR DESCRIPTION
This improves error messages, by not hiding types that are necessary to interpret the error:
```
Error: This expression has type "< bar : int; foo : int; .. >"
       but an expression was expected of type "'a"
       The type constructor "$1" would escape its scope
```

becomes

```
Error: This expression has type "< bar : int; foo : int; .. as $1>"
       but an expression was expected of type "'a"
       The type constructor "$1" would escape its scope
```