### PR TITLE
Removed unused field in package_type

### DIFF
--- a/Changes
+++ b/Changes
@@ -207,6 +207,9 @@ Working version
   macros to define OCaml integers.
   (Antonin Décimo, review by Nick Barnes)
 
+- #14148: Remove an unused field from package_type in typedtree
+  (Samuel Vivien, review by Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -493,7 +493,6 @@ and core_type_desc =
 and package_type = {
   tpt_path : Path.t;
   tpt_cstrs : (Longident.t loc * core_type) list;
-  tpt_type : Types.module_type;
   tpt_txt : Longident.t loc;
 }
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -686,7 +686,6 @@ and core_type_desc =
 and package_type = {
   tpt_path : Path.t;
   tpt_cstrs : (Longident.t loc * core_type) list;
-  tpt_type : Types.module_type;
   tpt_txt : Longident.t loc;
 }
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -899,14 +899,10 @@ module Merge = struct
 
   let check_package_with_type_constraints loc env mty constraints =
     let sg = extract_sig env loc mty in
-    let sg =
-      List.fold_left
-        (fun sg (lid, cty) ->
-           merge_package env loc sg lid cty)
-        sg constraints
-    in
-    let scope = Ctype.create_scope () in
-    Mtype.freshen ~scope (Mty_signature sg)
+    ignore (List.fold_left
+                (fun sg (lid, cty) ->
+                  merge_package env loc sg lid cty)
+                sg constraints)
 
   let () =
     Typetexp.check_package_with_type_constraints :=

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -689,7 +689,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       unify_var env (newvar()) ty';
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package ptyp ->
-      let path, mty, ptys = transl_package env ~policy ~row_context ptyp in
+      let path, ptys = transl_package env ~policy ~row_context ptyp in
       let ty = newty (Tpackage {
           pack_path = path;
           pack_cstrs = List.map (fun (s, cty) ->
@@ -697,7 +697,6 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       in
       ctyp (Ttyp_package {
             tpt_path = path;
-            tpt_type = mty;
             tpt_cstrs = ptys;
             tpt_txt = ptyp.ppt_path;
            }) ty
@@ -784,13 +783,10 @@ and transl_package env ~policy ~row_context ptyp =
   let ptys =
     List.map (fun (s, pty) -> s, transl_type env ~policy ~row_context pty) l
   in
-  let mty =
-    if ptys <> [] then
-      !check_package_with_type_constraints loc env mty.mty_type ptys
-    else mty.mty_type
-  in
+  if ptys <> [] then
+    !check_package_with_type_constraints loc env mty.mty_type ptys;
   let path = !transl_modtype_longident loc env ptyp.ppt_path.txt in
-  path, mty, ptys
+  path, ptys
 
 (* Make the rows "fixed" in this type, to make universal check easier *)
 let rec make_fixed_univars mark ty =

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -104,4 +104,4 @@ val transl_modtype: (* from Typemod *)
 val check_package_with_type_constraints: (* from Typemod *)
     (Location.t -> Env.t -> Types.module_type ->
      (Longident.t Asttypes.loc * Typedtree.core_type) list ->
-     Types.module_type) ref
+     unit) ref


### PR DESCRIPTION
The type `package_type` contains a field called `tpt_type` that is never read.

It has been introduced in https://github.com/ocaml/ocaml/commit/d39d43e55fab716fbe05cec3c89233f0dd208835 13 years ago under the name `pack_type` and was already never read at the time.

Thus I propose to clean the code from this field. This allow removing a small computation in `typemod.ml` as we don't need to compute the value to put in that slot anymore.