### PR TITLE
Fix missing expectations in expect tests, add auditing

### DIFF
--- a/Changes
+++ b/Changes
@@ -232,6 +232,10 @@ Working version
   external
   (Keryan Didier, review by Vincent Laviron and Gabriel Scherer)
 
+- #14155: Audit unexecuted phrases in compiler expect tests and
+  fix all occurences
+  (Stefan Muenzel, review by ????)
+
 
 OCaml 5.4.0
 ---------------

--- a/Changes
+++ b/Changes
@@ -234,7 +234,7 @@ Working version
 
 - #14155: Audit unexecuted phrases in compiler expect tests and
   fix all occurences
-  (Stefan Muenzel, review by ????)
+  (Stefan Muenzel, review by Gabriel Scherer)
 
 
 OCaml 5.4.0

--- a/testsuite/tests/letrec-check/float_unboxing.ml
+++ b/testsuite/tests/letrec-check/float_unboxing.ml
@@ -34,4 +34,5 @@ Line 4, characters 16-28:
 4 |     let rec x = (f <- y; ()) and y = 2.0 in f
                     ^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of "let rec"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;

--- a/testsuite/tests/letrec-check/float_unboxing.ml
+++ b/testsuite/tests/letrec-check/float_unboxing.ml
@@ -23,16 +23,17 @@ Error: This kind of expression is not allowed as right-hand side of "let rec"
 
 (* same example, with object instance variables
    instead of record fields *)
-class c = object
-  val mutable f = 0.0
-  method m =
-    let rec x = (f <- y; ()) and y = 2.0 in f
-end;;
-let _ = print_float (new c)#m;;
+module S = struct
+  class c = object
+    val mutable f = 0.0
+    method m =
+      let rec x = (f <- y; ()) and y = 2.0 in f
+  end
+  let _ = print_float (new c)#m
+end
 [%%expect{|
-Line 4, characters 16-28:
-4 |     let rec x = (f <- y; ()) and y = 2.0 in f
-                    ^^^^^^^^^^^^
+Line 5, characters 18-30:
+5 |       let rec x = (f <- y; ()) and y = 2.0 in f
+                      ^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of "let rec"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;

--- a/testsuite/tests/letrec-check/records.ml
+++ b/testsuite/tests/letrec-check/records.ml
@@ -6,27 +6,28 @@ type t = { x : int; self : t };;
 type t = { x : int; self : t; }
 |}];;
 
-let rec x = 1
-and u = Some { t with x = 2 }
-and t = { x; self = t }
-(* We have carefully placed `u` before `t` here,
-   so that the copy { t with .. }, if accepted,
-   is evaluated before 't' is initialized -- making
-   the assertion below fail, typically aborting
-   with a segmentation fault.
+module S = struct
+  let rec x = 1
+  and u = Some { t with x = 2 }
+  and t = { x; self = t }
+  (* We have carefully placed `u` before `t` here,
+     so that the copy { t with .. }, if accepted,
+     is evaluated before 't' is initialized -- making
+     the assertion below fail, typically aborting
+     with a segmentation fault.
 
-   If you exchange the declaration orders of `u` and `t`,
-   and the static check accepts this example, then `t`
-   is initialized first and the assertion succeeds. *)
+     If you exchange the declaration orders of `u` and `t`,
+     and the static check accepts this example, then `t`
+     is initialized first and the assertion succeeds. *)
 
 
-let () = match u with
-  | None -> assert false
-  | Some {x = _; self} -> assert (self.x = t.x)
+  let () = match u with
+    | None -> assert false
+    | Some {x = _; self} -> assert (self.x = t.x)
+end;;
 [%%expect {|
-Line 2, characters 8-29:
-2 | and u = Some { t with x = 2 }
-            ^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 10-31:
+3 |   and u = Some { t with x = 2 }
+              ^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of "let rec"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;

--- a/testsuite/tests/letrec-check/records.ml
+++ b/testsuite/tests/letrec-check/records.ml
@@ -28,4 +28,5 @@ Line 2, characters 8-29:
 2 | and u = Some { t with x = 2 }
             ^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of "let rec"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -23,11 +23,13 @@ let _ = Array.fill a 3 6 None;;
 a;;
 [%%expect{|
 Exception: Invalid_argument "Array.fill".
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 let _ = Array.fill a (-1) 2 None;;
 a;;
 [%%expect{|
 Exception: Invalid_argument "Array.fill".
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 let _ = Gc.compact ();;
 let _ = Array.fill a 5 1 (Some (if Random.int 2 < 0 then 1 else 2));;

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -20,16 +20,12 @@ a;;
 [|None; None; Some 42; Some 0; Some 42; None; None; None|]
 |}]
 let _ = Array.fill a 3 6 None;;
-a;;
 [%%expect{|
 Exception: Invalid_argument "Array.fill".
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 let _ = Array.fill a (-1) 2 None;;
-a;;
 [%%expect{|
 Exception: Invalid_argument "Array.fill".
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 let _ = Gc.compact ();;
 let _ = Array.fill a 5 1 (Some (if Random.int 2 < 0 then 1 else 2));;

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -232,6 +232,7 @@ Error: Signature mismatch:
        The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 module M = struct
@@ -267,4 +268,5 @@ Error: Signature mismatch:
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -204,22 +204,24 @@ module M = struct
   let r = ref []
 end
 
-let foo p (e : (T.t, T.u) eq) (x : T.t) (y : T.u) =
-  match e with
-  | Refl ->
-    let z = if p then x else y in
-    let module N = struct
-      module type S = module type of struct let r = ref [z] end
-    end in
-    let module O : N.S = M in
-    ()
+module S = struct
+  let foo p (e : (T.t, T.u) eq) (x : T.t) (y : T.u) =
+    match e with
+    | Refl ->
+        let z = if p then x else y in
+        let module N = struct
+          module type S = module type of struct let r = ref [z] end
+        end in
+        let module O : N.S = M in
+        ()
 
-module type S = module type of M ;;
+  module type S = module type of M
+end;;
 [%%expect{|
 module M : sig val r : '_weak1 list ref end
-Line 12, characters 25-26:
-12 |     let module O : N.S = M in
-                              ^
+Line 13, characters 29-30:
+13 |         let module O : N.S = M in
+                                  ^
 Error: Signature mismatch:
        Modules do not match:
          sig val r : '_weak1 list ref end
@@ -232,29 +234,30 @@ Error: Signature mismatch:
        The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 module M = struct
   let r = ref []
 end
 
-let foo p (e : (T.u, T.t) eq) (x : T.t) (y : T.u) =
-  match e with
-  | Refl ->
-    let z = if p then x else y in
-    let module N = struct
-      module type S = module type of struct let r = ref [z] end
-    end in
-    let module O : N.S = M in
-    ()
+module S = struct
+  let foo p (e : (T.u, T.t) eq) (x : T.t) (y : T.u) =
+    match e with
+    | Refl ->
+        let z = if p then x else y in
+        let module N = struct
+          module type S = module type of struct let r = ref [z] end
+        end in
+        let module O : N.S = M in
+        ()
 
-module type S = module type of M ;;
+  module type S = module type of M
+end;;
 [%%expect{|
 module M : sig val r : '_weak2 list ref end
-Line 12, characters 25-26:
-12 |     let module O : N.S = M in
-                              ^
+Line 13, characters 29-30:
+13 |         let module O : N.S = M in
+                                  ^
 Error: Signature mismatch:
        Modules do not match:
          sig val r : '_weak2 list ref end
@@ -268,5 +271,4 @@ Error: Signature mismatch:
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-gadts/gadthead.ml
+++ b/testsuite/tests/typing-gadts/gadthead.ml
@@ -18,14 +18,15 @@ module M : sig type t val x : t val print : t -> unit end
 type _ g = I : int g
 |}]
 
-let g (x : M.t) =
-  match x with I -> M.print I
-let () = g M.x
+module S = struct
+  let g (x : M.t) =
+    match x with I -> M.print I
+  let () = g M.x
+end
 [%%expect{|
-Line 2, characters 15-16:
-2 |   match x with I -> M.print I
-                   ^
+Line 3, characters 17-18:
+3 |     match x with I -> M.print I
+                     ^
 Error: This pattern matches values of type "'a g"
        but a pattern was expected which matches values of type "M.t"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-gadts/gadthead.ml
+++ b/testsuite/tests/typing-gadts/gadthead.ml
@@ -27,4 +27,5 @@ Line 2, characters 15-16:
                    ^
 Error: This pattern matches values of type "'a g"
        but a pattern was expected which matches values of type "M.t"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -119,14 +119,15 @@ type 'a u = U : 'b M.t -> 'b M.t u;;
 module M : sig type _ t val wrap : 'a -> 'a t val unwrap : 'a t -> 'a end
 type 'a u = U : 'b M.t -> 'b M.t u
 |}]
-let f : type a b. a M.t u -> b M.t = fun (U x) -> x;;
-let g x = M.unwrap (f (U (M.wrap x)));;
+module S = struct
+  let f : type a b. a M.t u -> b M.t = fun (U x) -> x
+  let g x = M.unwrap (f (U (M.wrap x)))
+end;;
 [%%expect{|
-Line 1, characters 50-51:
-1 | let f : type a b. a M.t u -> b M.t = fun (U x) -> x;;
-                                                      ^
+Line 2, characters 52-53:
+2 |   let f : type a b. a M.t u -> b M.t = fun (U x) -> x
+                                                        ^
 Error: The value "x" has type "$0 M.t" but an expression was expected of type
          "b M.t"
        Type "$0" is not compatible with type "b"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -128,4 +128,5 @@ Line 1, characters 50-51:
 Error: The value "x" has type "$0 M.t" but an expression was expected of type
          "b M.t"
        Type "$0" is not compatible with type "b"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -59,6 +59,7 @@ Line 1, characters 0-49:
 Error: In the definition
          "type 'b t = A of 'a constraint 'b = [< `X of 'a ]"
        the type variable "'a" cannot be deduced from the type parameters.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -48,18 +48,19 @@ Error: In the definition
 
 (* Another (more direct) instance using polymorphic variants *)
 (* PR#6275 *)
-type 'x t = A of 'a constraint 'x = [< `X of 'a ] ;; (* fail *)
-let magic (x : int) : bool  =
-  let A x = A x in
-  x;; (* fail *)
+module S = struct
+  type 'x t = A of 'a constraint 'x = [< `X of 'a ] (* fail *)
+  let magic (x : int) : bool  =
+    let A x = A x in
+    x (* fail *)
+end;;
 [%%expect{|
-Line 1, characters 0-49:
-1 | type 'x t = A of 'a constraint 'x = [< `X of 'a ] ;; (* fail *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 2-51:
+2 |   type 'x t = A of 'a constraint 'x = [< `X of 'a ] (* fail *)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the definition
          "type 'b t = A of 'a constraint 'b = [< `X of 'a ]"
        the type variable "'a" cannot be deduced from the type parameters.
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)

--- a/testsuite/tests/typing-gadts/pr6158.ml
+++ b/testsuite/tests/typing-gadts/pr6158.ml
@@ -8,9 +8,6 @@ type 'a s = S of 'a
 type (_, _) eq = Refl : ('a, 'a) eq;;
 
 let f : (int s, int t) eq -> unit = function Refl -> ();;
-
-module M (S : sig type 'a t = T of 'a type 'a s = T of 'a end) =
-struct let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> () end;;
 [%%expect{|
 type 'a t = T of 'a
 type 'a s = S of 'a
@@ -22,5 +19,16 @@ Error: This pattern matches values of type "(int s, int s) eq"
        but a pattern was expected which matches values of type
          "(int s, int t) eq"
        Type "int s" is not compatible with type "int t"
-Unexecuted phrases: 1 phrases did not execute due to an error
+|}];;
+
+module M (S : sig type 'a t = T of 'a type 'a s = T of 'a end) =
+struct let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> () end;;
+[%%expect{|
+Line 2, characters 54-58:
+2 | struct let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> () end;;
+                                                          ^^^^
+Error: This pattern matches values of type "($'a S.s, $'a S.s) eq"
+       but a pattern was expected which matches values of type
+         "($'a S.s, $'a S.t) eq"
+       The type constructor "$'a" would escape its scope
 |}];;

--- a/testsuite/tests/typing-gadts/pr6158.ml
+++ b/testsuite/tests/typing-gadts/pr6158.ml
@@ -22,4 +22,5 @@ Error: This pattern matches values of type "(int s, int s) eq"
        but a pattern was expected which matches values of type
          "(int s, int t) eq"
        Type "int s" is not compatible with type "int t"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -44,6 +44,7 @@ Line 4, characters 13-16:
 4 | module Bad = Fix(Id)
                  ^^^
 Error: Unbound module "Fix"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 (* addendum: ensure that hidden paths are checked too *)

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -12,39 +12,70 @@ type ('a, 'b) eq = Refl : ('a, 'a) eq
 module type S = sig type 'a t constraint 'a = [ `Rec of 'b ] end
 |}]
 
-module Fix (X : S) : sig
+module type Fix = sig
+  module X : S
   type t
   val uniq : ('a, [`Rec of 'a] X.t) eq -> ('a, t) eq
-end = struct
+end
+
+module Fix (X : S) : Fix with module X = X = struct
+  module X = X
   type t = [`Rec of 'a] X.t as 'a
   let uniq : type a . (a, [`Rec of a] X.t) eq -> (a, t) eq =
     fun Refl -> Refl
 end;; (* should fail *)
 [%%expect{|
-Line 7, characters 16-20:
-7 |     fun Refl -> Refl
-                    ^^^^
+module type Fix =
+  sig
+    module X : S
+    type t
+    val uniq : ('a, [ `Rec of 'a ] X.t) eq -> ('a, t) eq
+  end
+Line 11, characters 16-20:
+11 |     fun Refl -> Refl
+                     ^^^^
 Error: The constructor "Refl" has type "(a, a) eq"
        but an expression was expected of type "(a, t) eq"
-       Type "a" is not compatible with type "t" = "[ `Rec of 'a ] X.t as 'a"
+       Type "a" is not compatible with type
+         "t" = "([ `Rec of 'a X.t ] as 'a) X/2.t"
+       Line 8, characters 2-14:
+         Definition of module "X"
+       Line 7, characters 12-13:
+         Definition of module "X/2"
 |}]
 
 (* Trigger the unsoundness if Fix were definable *)
-module Id = struct
-  type 'a t = 'b constraint 'a = [ `Rec of 'b ]
-end
-module Bad = Fix(Id)
-let magic : type a b. a -> b =
-  fun x ->
+module Make(Fix : functor (X : S) -> Fix with module X = X) = struct
+  module Id = struct
+    type 'a t = 'b constraint 'a = [ `Rec of 'b ]
+  end
+  module Bad = Fix(Id)
+  let magic : type a b. a -> b =
+    fun x ->
     let Refl = (Bad.uniq Refl : (a,Bad.t) eq) in
     let Refl = (Bad.uniq Refl : (b,Bad.t) eq) in x
+end
 [%%expect{|
-module Id : sig type 'a t = 'b constraint 'a = [ `Rec of 'b ] end
-Line 4, characters 13-16:
-4 | module Bad = Fix(Id)
-                 ^^^
-Error: Unbound module "Fix"
-Unexecuted phrases: 1 phrases did not execute due to an error
+module Make :
+  (Fix : (X : S) ->
+           sig
+             module X :
+               sig type 'a t = 'a X.t constraint 'a = [ `Rec of 'b ] end
+             type t
+             val uniq : ('a, [ `Rec of 'a ] X.t) eq -> ('a, t) eq
+           end)
+    ->
+    sig
+      module Id : sig type 'a t = 'b constraint 'a = [ `Rec of 'b ] end
+      module Bad :
+        sig
+          module X :
+            sig type 'a t = 'a Id.t constraint 'a = [ `Rec of 'b ] end
+          type t = Fix(Id).t
+          val uniq : ('a, [ `Rec of 'a ] X.t) eq -> ('a, t) eq
+        end
+      val magic : 'a -> 'b
+    end
 |}]
 
 (* addendum: ensure that hidden paths are checked too *)

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -45,6 +45,7 @@ Error: In this GADT constructor definition, the variance of the 2nd parameter
        in other parameters.
        In GADTS, covariant or contravariant type parameters must not depend
        on other parameters.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 type (_, +_) eq2 = Neq : ('a, 'b) eq2 | Refl : ('a, 'a) eq2

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -26,26 +26,26 @@ Error: Type "a" is not a subtype of "b"
 
 (* Variance and subtyping *)
 
-type (_, +_) eq = Refl : ('a, 'a) eq
+module S = struct
+  type (_, +_) eq = Refl : ('a, 'a) eq
 
-let magic : 'a 'b. 'a -> 'b =
-  fun (type a) (type b) (x : a) ->
+  let magic : 'a 'b. 'a -> 'b =
+    fun (type a) (type b) (x : a) ->
     let bad_proof (type a) =
       (Refl : (< m : a>, <m : a>) eq :> (<m : a>, < >) eq) in
     let downcast : type a. (a, < >) eq -> < > -> a =
       fun (type a) (Refl : (a, < >) eq) (s : < >) -> (s :> a) in
     (downcast bad_proof ((object method m = x end) :> < >)) # m
-;;
+end;;
 [%%expect{|
-Line 1, characters 18-36:
-1 | type (_, +_) eq = Refl : ('a, 'a) eq
-                      ^^^^^^^^^^^^^^^^^^
+Line 2, characters 20-38:
+2 |   type (_, +_) eq = Refl : ('a, 'a) eq
+                        ^^^^^^^^^^^^^^^^^^
 Error: In this GADT constructor definition, the variance of the 2nd parameter
        cannot be checked, because the type variable "'a" appears
        in other parameters.
        In GADTS, covariant or contravariant type parameters must not depend
        on other parameters.
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 type (_, +_) eq2 = Neq : ('a, 'b) eq2 | Refl : ('a, 'a) eq2

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -167,6 +167,7 @@ Error: Signature mismatch:
        is not included in
          type t [@@immediate]
        The first is not an immediate type.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -155,7 +155,6 @@ Error: Signature mismatch:
 
 (* Same as above but with explicit signature *)
 module M_invalid : S = struct type t = string end;;
-module FM_invalid = F (struct type t = string end);;
 [%%expect{|
 Line 1, characters 23-49:
 1 | module M_invalid : S = struct type t = string end;;
@@ -167,7 +166,19 @@ Error: Signature mismatch:
        is not included in
          type t [@@immediate]
        The first is not an immediate type.
-Unexecuted phrases: 1 phrases did not execute due to an error
+|}];;
+module FM_invalid = F (struct type t = string end);;
+[%%expect{|
+Line 1, characters 20-50:
+1 | module FM_invalid = F (struct type t = string end);;
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Modules do not match: sig type t = string end is not included in
+       S
+     Type declarations do not match:
+       type t = string
+     is not included in
+       type t [@@immediate]
+     The first is not an immediate type.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -191,6 +191,7 @@ Line 1, characters 0-58:
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be injective invariant,
        but it is unrestricted.
+Unexecuted phrases: 2 phrases did not execute due to an error
 |}]
 
 (* Injective bivariance in a signature is respected in its structures *)
@@ -231,6 +232,7 @@ Line 3, characters 2-29:
 Error: In the GADT constructor
          "G : 'a X.t -> 'a X.t u x"
        the type variable "'a" cannot be deduced from the type parameters.
+Unexecuted phrases: 2 phrases did not execute due to an error
 |}]
 
 (* Try to be clever *)
@@ -460,6 +462,7 @@ Line 1, characters 18-19:
 1 | let x_eq_y : (int R.t, string R.t) eql = Refl
                       ^
 Error: Unbound module "R"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 (* #10028 by Stephen Dolan *)
@@ -494,6 +497,7 @@ Line 3, characters 2-35:
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be injective invariant,
        but it is invariant.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 module Priv2 :
@@ -515,4 +519,5 @@ Line 3, characters 2-31:
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be injective invariant,
        but it is invariant.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -119,14 +119,20 @@ val f : 'a -> [< `Foo ] -> 'a = <fun>
 
 (* PR#6124 *)
 let f : ([`A | `B ] as 'a) -> [> 'a] -> unit = fun x (y : [> 'a]) -> ();;
-let f (x : [`A | `B] as 'a) (y : [> 'a]) = ();;
 [%%expect{|
 Line 1, characters 61-63:
 1 | let f : ([`A | `B ] as 'a) -> [> 'a] -> unit = fun x (y : [> 'a]) -> ();;
                                                                  ^^
 Error:    The type "'a" does not expand to a polymorphic variant type
 Hint: Did you mean "`a"?
-Unexecuted phrases: 1 phrases did not execute due to an error
+|}]
+let f (x : [`A | `B] as 'a) (y : [> 'a]) = ();;
+[%%expect{|
+Line 1, characters 36-38:
+1 | let f (x : [`A | `B] as 'a) (y : [> 'a]) = ();;
+                                        ^^
+Error:    The type "'a" does not expand to a polymorphic variant type
+Hint: Did you mean "`a"?
 |}]
 
 (* PR#5927 *)

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -126,6 +126,7 @@ Line 1, characters 61-63:
                                                                  ^^
 Error:    The type "'a" does not expand to a polymorphic variant type
 Hint: Did you mean "`a"?
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 (* PR#5927 *)

--- a/testsuite/tests/typing-misc/variance.ml
+++ b/testsuite/tests/typing-misc/variance.ml
@@ -147,4 +147,5 @@ Line 6, characters 2-23:
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be covariant,
        but it is invariant.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-misc/variance.ml
+++ b/testsuite/tests/typing-misc/variance.ml
@@ -131,21 +131,22 @@ Error: In this definition, expected parameter variances are not satisfied.
        but it is invariant.
 |}]
 
-module Make_covariant(M: sig type 'a t end): sig
-  type 'a i = 'a
-  type +'a t = 'a i M.t
-end = struct
-  type 'a i = 'a
-  type +'a t = 'a i M.t
-end
+module S = struct
+  module Make_covariant(M: sig type 'a t end): sig
+    type 'a i = 'a
+    type +'a t = 'a i M.t
+  end = struct
+    type 'a i = 'a
+    type +'a t = 'a i M.t
+  end
 
-module Positive_ref = Make_covariant(struct type 'a t = 'a ref end)
+  module Positive_ref = Make_covariant(struct type 'a t = 'a ref end)
+end;;
 [%%expect {|
-Line 6, characters 2-23:
-6 |   type +'a t = 'a i M.t
-      ^^^^^^^^^^^^^^^^^^^^^
+Line 7, characters 4-25:
+7 |     type +'a t = 'a i M.t
+        ^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be covariant,
        but it is invariant.
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -714,17 +714,18 @@ module type S' = sig module M : sig type t = H.t = A val x : t end end
 (* PR#6376 *)
 module type Alias = sig module N : sig end module M = N end;;
 module F (X : sig end) = struct type t end;;
-module type A = Alias with module N := F(List);;
-module rec Bad : A = Bad;;
+module S = struct
+  module type A = Alias with module N := F(List)
+  module rec Bad : A = Bad
+end;;
 [%%expect{|
 module type Alias = sig module N : sig end module M = N end
 module F : (X : sig end) -> sig type t end
-Line 3, characters 16-46:
-3 | module type A = Alias with module N := F(List);;
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 4, characters 18-48:
+4 |   module type A = Alias with module N := F(List)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this "with" constraint, replacing "N" by "F(Stdlib.List)" would
        introduce an invalid alias at "M"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 (* Shinwell 2014-04-23 *)

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -724,6 +724,7 @@ Line 3, characters 16-46:
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this "with" constraint, replacing "N" by "F(Stdlib.List)" would
        introduce an invalid alias at "M"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 (* Shinwell 2014-04-23 *)

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -22,8 +22,6 @@ let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'));;
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a));;
 let f2 (x : (module S2 with type t = 'a and type u = 'b)) =
   (x : (module S'));; (* fail *)
-let k (x : (module S2 with type t = 'a)) =
-  (x : (module S with type t = 'a));; (* fail *)
 [%%expect{|
 module type S2 = sig type u type t type w end
 val g2 : (module S2 with type t = int and type u = bool) -> (module S') =
@@ -39,7 +37,17 @@ Error: The value "x" has type "(module S2 with type t = int and type u = bool)"
        is not included in
          sig type u = bool type t = int type w end
        The type "w" is required but not provided
-Unexecuted phrases: 1 phrases did not execute due to an error
+|}];;
+let k (x : (module S2 with type t = 'a)) =
+  (x : (module S with type t = 'a));; (* fail *)
+[%%expect{|
+Line 2, characters 3-4:
+2 |   (x : (module S with type t = 'a));; (* fail *)
+       ^
+Error: The value "x" has type "(module S2 with type t = 'a)"
+       but an expression was expected of type "(module S with type t = 'a)"
+       Modules do not match: S is not included in S2
+       The type "w" is required but not provided
 |}];;
 
 (* but you cannot forget values (no physical coercions) *)

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -39,6 +39,7 @@ Error: The value "x" has type "(module S2 with type t = int and type u = bool)"
        is not included in
          sig type u = bool type t = int type w end
        The type "w" is required but not provided
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 
 (* but you cannot forget values (no physical coercions) *)

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -212,9 +212,6 @@ module M' = F(M);;
 module type S' = module type of M';;
 module Asc = struct type t = int let compare x y = x - y end;;
 module Desc = struct type t = int let compare x y = y - x end;;
-module rec M1 : S' with module Term0 := Asc and module T := Desc = M1;;
-(* And now we have a witness of MkT(Asc).t = MkT(Desc).t ... *)
-let (E eq : M1.u) = (E Eq : M1.t);;
 [%%expect{|
 type (_, _) eq = Eq : ('a, 'a) eq
 module MkT :
@@ -305,9 +302,16 @@ module type S' =
   end
 module Asc : sig type t = int val compare : int -> int -> int end
 module Desc : sig type t = int val compare : int -> int -> int end
-Line 15, characters 0-69:
-15 | module rec M1 : S' with module Term0 := Asc and module T := Desc = M1;;
-     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+|}]
+module S = struct
+  module rec M1 : S' with module Term0 := Asc and module T := Desc = M1
+  (* And now we have a witness of MkT(Asc).t = MkT(Desc).t ... *)
+  let (E eq : M1.u) = (E Eq : M1.t)
+end
+[%%expect{|
+Line 2, characters 2-71:
+2 |   module rec M1 : S' with module Term0 := Asc and module T := Desc = M1
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type "M.t"
        Constructors do not match:
          "E of (MkT(M.T).t, MkT(M.T).t) eq"
@@ -317,5 +321,4 @@ Error: This variant or record definition does not match that of type "M.t"
          "(MkT(Desc).t, MkT(Desc).t) eq"
        Type "MkT(M.T).t" = "Set.Make(M.Term0).t" is not equal to type
          "MkT(Desc).t" = "Set.Make(Desc).t"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -317,4 +317,5 @@ Error: This variant or record definition does not match that of type "M.t"
          "(MkT(Desc).t, MkT(Desc).t) eq"
        Type "MkT(M.T).t" = "Set.Make(M.Term0).t" is not equal to type
          "MkT(Desc).t" = "Set.Make(Desc).t"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -21,30 +21,25 @@ module M : sig type x type y type t = E of x type u = t = E of y end
 module type S = sig type x type y type t = E of x type u = t = E of y end
 |}]
 
-module rec M1 : S with type x = int and type y = bool = M1;;
+module S = struct
+  module rec M1 : S with type x = int and type y = bool = M1
+
+  let bool_of_int x =
+    let (E y : M1.u) = (E x : M1.t) in
+    y
+
+      bool_of_int 3
+end
 [%%expect{|
-Line 1, characters 0-58:
-1 | module rec M1 : S with type x = int and type y = bool = M1;;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 2-60:
+2 |   module rec M1 : S with type x = int and type y = bool = M1
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type "M1.t"
        Constructors do not match:
          "E of M1.x"
        is not the same as:
          "E of M1.y"
        The type "M1.x" = "int" is not equal to the type "M1.y" = "bool"
-|}]
-
-let bool_of_int x =
-  let (E y : M1.u) = (E x : M1.t) in
-  y;;
-
-bool_of_int 3;;
-[%%expect{|
-Line 2, characters 28-30:
-2 |   let (E y : M1.u) = (E x : M1.t) in
-                                ^^
-Error: Unbound module "M1"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 (* Also check the original version *)
@@ -71,14 +66,17 @@ module M :
 module type S =
   sig type x and y type t = E of (x, x) eq type u = t = E of (x, y) eq end
 |}]
-module rec M1 : S with type x = int and type y = bool = M1;;
-let (E eq : M1.u) = (E Eq : M1.t);;
-let cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x;;
-cast eq 3;;
+
+module S = struct
+  module rec M1 : S with type x = int and type y = bool = M1
+  let (E eq : M1.u) = (E Eq : M1.t)
+  let cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x
+      cast eq 3
+end
 [%%expect{|
-Line 1, characters 0-58:
-1 | module rec M1 : S with type x = int and type y = bool = M1;;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 2-60:
+2 |   module rec M1 : S with type x = int and type y = bool = M1
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type "M1.t"
        Constructors do not match:
          "E of (M1.x, M1.x) eq"
@@ -86,5 +84,4 @@ Error: This variant or record definition does not match that of type "M1.t"
          "E of (M1.x, M1.y) eq"
        The type "(M1.x, M1.x) eq" is not equal to the type "(M1.x, M1.y) eq"
        Type "M1.x" = "int" is not equal to type "M1.y" = "bool"
-Unexecuted phrases: 3 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -44,6 +44,7 @@ Line 2, characters 28-30:
 2 |   let (E y : M1.u) = (E x : M1.t) in
                                 ^^
 Error: Unbound module "M1"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}]
 
 (* Also check the original version *)
@@ -85,4 +86,5 @@ Error: This variant or record definition does not match that of type "M1.t"
          "E of (M1.x, M1.y) eq"
        The type "(M1.x, M1.x) eq" is not equal to the type "(M1.x, M1.y) eq"
        Type "M1.x" = "int" is not equal to type "M1.y" = "bool"
+Unexecuted phrases: 3 phrases did not execute due to an error
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -581,8 +581,6 @@ let f2 f = (f : id)#id 1, (f : id)#id true
 ;;
 let f3 f = f#id 1, f#id true
 ;;
-let f4 f = ignore(f : id); f#id 1, f#id true
-;;
 [%%expect {|
 val f1 : id -> int * bool = <fun>
 val f2 : id -> int * bool = <fun>
@@ -591,6 +589,25 @@ Line 5, characters 24-28:
                             ^^^^
 Error: This expression should not be a boolean literal, the expected type is
        "int"
+|}];;
+let f4 f = ignore(f : id); f#id 1, f#id true
+;;
+[%%expect {|
+val f4 : id -> int * bool = <fun>
+|}, Principal{|
+Line 1, characters 27-31:
+1 | let f4 f = ignore(f : id); f#id 1, f#id true
+                               ^^^^
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
+
+Line 1, characters 35-39:
+1 | let f4 f = ignore(f : id); f#id 1, f#id true
+                                       ^^^^
+Warning 18 [not-principal]: this use of a polymorphic method is not
+  principal.
+
+val f4 : id -> int * bool = <fun>
 |}];;
 
 class c = object
@@ -823,9 +840,6 @@ class node : object method as_variant : [> `Node of node_type ] end
 
 type bad = {bad : 'a. 'a option ref};;
 let bad = {bad = ref None};;
-type bad2 = {mutable bad2 : 'a. 'a option ref option};;
-let bad2 = {bad2 = None};;
-bad2.bad2 <- Some (ref None);;
 [%%expect {|
 type bad = { bad : 'a. 'a option ref; }
 Line 2, characters 17-25:
@@ -833,6 +847,18 @@ Line 2, characters 17-25:
                      ^^^^^^^^
 Error: This field value has type "'b option ref" which is less general than
          "'a. 'a option ref"
+|}];;
+type bad2 = {mutable bad2 : 'a. 'a option ref option};;
+let bad2 = {bad2 = None};;
+bad2.bad2 <- Some (ref None);;
+[%%expect {|
+type bad2 = { mutable bad2 : 'a. 'a option ref option; }
+val bad2 : bad2 = {bad2 = None}
+Line 3, characters 13-28:
+3 | bad2.bad2 <- Some (ref None);;
+                 ^^^^^^^^^^^^^^^
+Error: This field value has type "'b option ref option"
+       which is less general than "'a. 'a option ref option"
 |}];;
 
 (* Type variable scope *)
@@ -946,7 +972,6 @@ and u = int t
 (* Loose polymorphism if we expand *)
 type 'a t constraint 'a = int;;
 type 'a u = 'a and 'a v = 'a u t;;
-type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
 type 'a t constraint 'a = int
 Line 2, characters 26-32:
@@ -955,12 +980,16 @@ Line 2, characters 26-32:
 Error: Constraints are not satisfied in this type.
        Type "'a u t" should be an instance of "int t"
 |}];;
+type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
+[%%expect {|
+type 'a u = 'a
+and 'a v = 'a u t constraint 'a = int
+|}];;
 
 (* Behaviour is unstable *)
 type g = int;;
 type 'a t = unit constraint 'a = g;;
 type 'a u = 'a and 'a v = 'a u t;;
-type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
 type g = int
 type 'a t = unit constraint 'a = g
@@ -969,6 +998,14 @@ Line 3, characters 26-32:
                               ^^^^^^
 Error: Constraints are not satisfied in this type.
        Type "'a u t" should be an instance of "g t"
+|}];;
+type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
+[%%expect {|
+type 'a u = 'a
+and 'a v = 'a u t constraint 'a = int u
+|}, Principal{|
+type 'a u = 'a
+and 'a v = 'a u t constraint 'a = int
 |}];;
 
 (* Full unification trace reported for "Constraints are not satisfied in this type" *)
@@ -1091,17 +1128,6 @@ let f () = object (self:c) method m = 1 end;;
 let f () = object (self:c) method private n = 1 method m = self#n end;;
 let f () = object method private n = 1 method m = {<>}#n end;;
 let f () = object (self:c) method n = 1 method m = 2 end;;
-let f () = object (_:'s) constraint 's = < n : int > method m = 1 end;;
-class c = object (_ : 's)
-  method x = 1
-  method private m =
-    object (self: 's) method x = 3 method private m = self end
-end;;
-let o = object (_ : 's)
-  method x = 1
-  method private m =
-    object (self: 's) method x = 3 method private m = self end
-end;;
 [%%expect {|
 class c : object method m : int end
 val f : unit -> c = <fun>
@@ -1119,16 +1145,40 @@ Line 5, characters 27-39:
 Error: This object is expected to have type : "c"
        This type does not have a method "n".
 |}];;
+let f () = object (_:'s) constraint 's = < n : int > method m = 1 end;;
+[%%expect {|
+Line 1, characters 53-65:
+1 | let f () = object (_:'s) constraint 's = < n : int > method m = 1 end;;
+                                                         ^^^^^^^^^^^^
+Error: This object is expected to have type : "< n : int >"
+       This type does not have a method "m".
+|}];;
+class c = object (_ : 's)
+  method x = 1
+  method private m =
+    object (self: 's) method x = 3 method private m = self end
+end;;
+[%%expect {|
+Line 4, characters 4-62:
+4 |     object (self: 's) method x = 3 method private m = self end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot close type of object literal: "< x : int; .. > as '_weak1"
+       it has been unified with the self type of a class that is not yet
+       completely defined.
+|}];;
+let o = object (_ : 's)
+  method x = 1
+  method private m =
+    object (self: 's) method x = 3 method private m = self end
+end;;
+[%%expect {|
+val o : < x : int > = <obj>
+|}];;
 
 
 (* Unsound! *)
 fun (x : <m : 'a. 'a * <m: 'b. 'a * 'foo> > as 'foo) ->
   (x : <m : 'a. 'a * (<m:'b. 'a * <m:'c. 'c * 'bar> > as 'bar) >);;
-type 'a foo = <m: 'b. 'a * 'a foo>
-type foo' =   <m: 'a. 'a * 'a foo>
-type 'a bar = <m: 'b. 'a * <m: 'c. 'c * 'a bar> >
-type bar' =   <m: 'a. 'a * 'a bar >
-let f (x : foo') = (x : bar');;
 [%%expect {|
 Line 2, characters 3-4:
 2 |   (x : <m : 'a. 'a * (<m:'b. 'a * <m:'c. 'c * 'bar> > as 'bar) >);;
@@ -1142,16 +1192,34 @@ Error: The value "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        "'c. 'c * < m : 'a * < m : 'c. 'e > > as 'e"
        The universal variable "'a" would escape its scope
 |}];;
+type 'a foo = <m: 'b. 'a * 'a foo>
+type foo' =   <m: 'a. 'a * 'a foo>
+type 'a bar = <m: 'b. 'a * <m: 'c. 'c * 'a bar> >
+type bar' =   <m: 'a. 'a * 'a bar >
+let f (x : foo') = (x : bar');;
+[%%expect {|
+type 'a foo = < m : 'a * 'a foo >
+type foo' = < m : 'a. 'a * 'a foo >
+type 'a bar = < m : 'a * < m : 'c. 'c * 'a bar > >
+type bar' = < m : 'a. 'a * 'a bar >
+Line 5, characters 20-21:
+5 | let f (x : foo') = (x : bar');;
+                        ^
+Error: The value "x" has type "foo'" = "< m : 'a. 'a * 'a foo >"
+       but an expression was expected of type "bar'" = "< m : 'a. 'a * 'a bar >"
+       Type "'a foo" = "< m : 'a * 'a foo >" is not compatible with type
+         "'a bar" = "< m : 'a * < m : 'c. 'c * 'a bar > >"
+       Type "'a foo" = "< m : 'a * 'a foo >" is not compatible with type
+         "< m : 'c. 'c * 'a bar >"
+       The method "m" has type "'a * < m : 'c. 'c * 'a bar >",
+       but the expected method type was "'c. 'c * 'a bar"
+       The universal variables "'a" and "'c" are distinct.
+       The first type variable "'a" was introduced in an earlier universal
+       quantification.
+|}];;
 
 fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->
   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('c * 'bar)>)> as 'bar);;
-fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->
-  (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('b * 'bar)>)> as 'bar);;
-fun (x : <m : 'a. 'a * ('a * 'foo)> as 'foo) ->
-  (x : <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>);;
-let f x =
-    (x : <m : 'a. 'a -> ('a * <m:'c. 'c -> 'bar> as 'bar)>
-       :> <m : 'a. 'a -> ('a * 'foo)> as 'foo);;
 [%%expect {|
 Line 2, characters 3-4:
 2 |   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('c * 'bar)>)> as 'bar);;
@@ -1165,6 +1233,47 @@ Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The universal variables "'b" and "'c" are distinct.
        The first type variable "'b" was introduced in an earlier universal
        quantification.
+|}];;
+fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->
+  (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('b * 'bar)>)> as 'bar);;
+[%%expect {|
+Line 2, characters 3-4:
+2 |   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('b * 'bar)>)> as 'bar);;
+       ^
+Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
+       but an expression was expected of type
+         "< m : 'b. 'b * ('b * < m : 'c. 'c * ('b * 'd) >) > as 'd"
+       The method "m" has type
+       "'c. 'c * ('b * < m : 'b. 'b * ('b * < m : 'c. 'e >) >) as 'e",
+       but the expected method type was
+       "'b. 'b * ('b * < m : 'c. 'c * ('b * < m : 'b. 'f >) >) as 'f"
+       The universal variable "'b" would escape its scope
+|}];;
+fun (x : <m : 'a. 'a * ('a * 'foo)> as 'foo) ->
+  (x : <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>);;
+[%%expect {|
+Line 2, characters 3-4:
+2 |   (x : <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>);;
+       ^
+Error: The value "x" has type "< m : 'b. 'b * ('b * 'a) > as 'a"
+       but an expression was expected of type
+         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'd > as 'd) >"
+       The method "m" has type "'b. 'b * ('b * < m : 'c. 'c * 'd > as 'd)",
+       but the expected method type was "'c. 'c * ('b * < m : 'c. 'e >) as 'e"
+       The universal variable "'b" would escape its scope
+|}];;
+let f x =
+    (x : <m : 'a. 'a -> ('a * <m:'c. 'c -> 'bar> as 'bar)>
+       :> <m : 'a. 'a -> ('a * 'foo)> as 'foo);;
+[%%expect {|
+Lines 2-3, characters 4-46:
+2 | ....(x : <m : 'a. 'a -> ('a * <m:'c. 'c -> 'bar> as 'bar)>
+3 |        :> <m : 'a. 'a -> ('a * 'foo)> as 'foo)..
+Error: Type "< m : 'a. 'a -> ('a * < m : 'c. 'c -> 'b > as 'b) >"
+       is not a subtype of "< m : 'a. 'a -> 'a * 'd > as 'd"
+       Type "'c. 'c -> 'a * < m : 'c. 'e > as 'e" is not a subtype of
+         "'a. 'a -> 'a * < m : 'a. 'f > as 'f"
+       The universal variable "'a" would escape its scope
 |}];;
 
 let f (x: <x: 'a 'b 'c. 'a * 'b * 'b * 'c >) =
@@ -1212,9 +1321,6 @@ Error: The value "o" has type "< x : 'a 'b. ('a * 'a) * 'b >"
 module M
 : sig val f : (<m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>) -> unit end
 = struct let f (x : <m : 'a. 'a * ('a * 'foo)> as 'foo) = () end;;
-module M
-: sig type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)> end
-= struct type t = <m : 'a. 'a * ('a * 'foo)> as 'foo end;;
 [%%expect {|
 Line 3, characters 2-64:
 3 | = struct let f (x : <m : 'a. 'a * ('a * 'foo)> as 'foo) = () end;;
@@ -1233,6 +1339,28 @@ Error: Signature mismatch:
        The type "(< m : 'a. 'a * ('a * 'd) > as 'd) -> unit"
        is not compatible with the type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) > -> unit"
+       The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
+       but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
+       The universal variable "'b" would escape its scope
+|}];;
+module M
+: sig type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)> end
+= struct type t = <m : 'a. 'a * ('a * 'foo)> as 'foo end;;
+[%%expect {|
+Line 3, characters 2-56:
+3 | = struct type t = <m : 'a. 'a * ('a * 'foo)> as 'foo end;;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < m : 'a. 'a * ('a * 'b) > as 'b end
+       is not included in
+         sig type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) > end
+       Type declarations do not match:
+         type t = < m : 'a. 'a * ('a * 'b) > as 'b
+       is not included in
+         type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
+       The type "< m : 'a. 'a * ('a * 'd) > as 'd" is not equal to the type
+         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) >"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
@@ -1270,12 +1398,6 @@ fun x -> (x : t :> v);;
 type u = private [< t];;
 fun x -> (x : u :> v);;
 fun x -> (x : v :> u);;
-type v = private [< t];;
-fun x -> (x : u :> v);;
-type p = <x:p>;;
-type q = private <x:p; ..>;;
-fun x -> (x : q :> p);;
-fun x -> (x : p :> q);;
 [%%expect {|
 type t = [ `A | `B ]
 type v = private [> t ]
@@ -1287,21 +1409,33 @@ Line 6, characters 9-21:
              ^^^^^^^^^^^^
 Error: Type "v" = "[> `A | `B ]" is not a subtype of "u" = "[< `A | `B ]"
 |}];;
+type v = private [< t];;
+fun x -> (x : u :> v);;
+[%%expect {|
+type v = private [< t ]
+Line 2, characters 9-21:
+2 | fun x -> (x : u :> v);;
+             ^^^^^^^^^^^^
+Error: Type "u" = "[< `A | `B ]" is not a subtype of "v" = "[< `A | `B ]"
+|}];;
+type p = <x:p>;;
+type q = private <x:p; ..>;;
+fun x -> (x : q :> p);;
+fun x -> (x : p :> q);;
+[%%expect {|
+type p = < x : p >
+type q = private < x : p; .. >
+- : q -> p = <fun>
+Line 4, characters 9-21:
+4 | fun x -> (x : p :> q);;
+             ^^^^^^^^^^^^
+Error: Type "p" = "< x : p >" is not a subtype of "q" = "< x : p; .. >"
+       The second object type has an abstract row, it cannot be closed
+|}];;
 
 let f1 x =
   (x : <m:'a. (<p:int;..> as 'a) -> int>
     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>);;
-let f2 x =
-  (x : <m:'a. (<p:<a:int>;..> as 'a) -> int>
-    :> <m:'b. (<p:<a:int;b:int>;..> as 'b) -> int>);;
-let f3 x =
-  (x : <m:'a. (<p:<a:int;b:int>;..> as 'a) -> int>
-    :> <m:'b. (<p:<a:int>;..> as 'b) -> int>);;
-let f4 x = (x : <p:<a:int;b:int>;..> :> <p:<a:int>;..>);;
-let f5 x =
-  (x : <m:'a. [< `A of <p:int> ] as 'a> :> <m:'a. [< `A of < > ] as 'a>);;
-let f6 x =
-  (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
 [%%expect {|
 Lines 2-3, characters 2-47:
 2 | ..(x : <m:'a. (<p:int;..> as 'a) -> int>
@@ -1309,6 +1443,53 @@ Lines 2-3, characters 2-47:
 Error: Type "< m : 'a. (< p : int; .. > as 'a) -> int >" is not a subtype of
          "< m : 'b. (< p : int; q : int; .. > as 'b) -> int >"
        Type "< p : int; q : int; .. >" is not a subtype of "< p : int; .. >"
+|}];;
+let f2 x =
+  (x : <m:'a. (<p:<a:int>;..> as 'a) -> int>
+    :> <m:'b. (<p:<a:int;b:int>;..> as 'b) -> int>);;
+[%%expect {|
+val f2 :
+  < m : 'a. (< p : < a : int >; .. > as 'a) -> int > ->
+  < m : 'b. (< p : < a : int; b : int >; .. > as 'b) -> int > = <fun>
+|}];;
+let f3 x =
+  (x : <m:'a. (<p:<a:int;b:int>;..> as 'a) -> int>
+    :> <m:'b. (<p:<a:int>;..> as 'b) -> int>);;
+[%%expect {|
+Lines 2-3, characters 2-45:
+2 | ..(x : <m:'a. (<p:<a:int;b:int>;..> as 'a) -> int>
+3 |     :> <m:'b. (<p:<a:int>;..> as 'b) -> int>)..
+Error: Type "< m : 'a. (< p : < a : int; b : int >; .. > as 'a) -> int >"
+       is not a subtype of "< m : 'b. (< p : < a : int >; .. > as 'b) -> int >"
+       Type "< a : int >" is not a subtype of "< a : int; b : int >"
+       The first object type has no method "b"
+|}];;
+let f4 x = (x : <p:<a:int;b:int>;..> :> <p:<a:int>;..>);;
+[%%expect {|
+Line 1, characters 11-55:
+1 | let f4 x = (x : <p:<a:int;b:int>;..> :> <p:<a:int>;..>);;
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "< p : < a : int; b : int >; .. >" is not a subtype of
+         "< p : < a : int >; .. >"
+       The second object type has no method "b"
+|}];;
+let f5 x =
+  (x : <m:'a. [< `A of <p:int> ] as 'a> :> <m:'a. [< `A of < > ] as 'a>);;
+[%%expect {|
+val f5 :
+  < m : 'a. [< `A of < p : int > ] as 'a > ->
+  < m : 'b. [< `A of <  > ] as 'b > = <fun>
+|}];;
+let f6 x =
+  (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
+[%%expect {|
+Line 2, characters 2-72:
+2 |   (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "< m : 'a. [< `A of <  > ] as 'a >" is not a subtype of
+         "< m : 'b. [< `A of < p : int > ] as 'b >"
+       Type "<  >" is not a subtype of "< p : int >"
+       The first object type has no method "p"
 |}];;
 
 (* Keep sharing the epsilons *)
@@ -1553,11 +1734,19 @@ module Polux :
 (* PR#5560 *)
 
 let (a, b) = (raise Exit : int * int);;
+[%%expect {|
+Exception: Stdlib.Exit.
+|}];;
 type t = { foo : int }
 let {foo} = (raise Exit : t);;
+[%%expect {|
+type t = { foo : int; }
+Exception: Stdlib.Exit.
+|}];;
 type s = A of int
 let (A x) = (raise Exit : s);;
 [%%expect {|
+type s = A of int
 Exception: Stdlib.Exit.
 |}];;
 
@@ -1710,7 +1899,7 @@ let x = f 3;;
 [%%expect{|
 type (+'a, -'b) foo = private int
 val f : int -> ('a, 'a) foo = <fun>
-val x : ('_weak1, '_weak1) foo = 3
+val x : ('_weak2, '_weak2) foo = 3
 |}]
 
 
@@ -1887,8 +2076,8 @@ Line 1, characters 0-63:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type of this class,
        "class ['a] r :
-         object constraint 'a = '_weak2 list ref method get : 'a end",
-       contains the non-generalizable type variable(s): "'_weak2".
+         object constraint 'a = '_weak3 list ref method get : 'a end",
+       contains the non-generalizable type variable(s): "'_weak3".
        (see manual section 6.1.2)
 |}]
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -589,7 +589,6 @@ Line 5, characters 24-28:
                             ^^^^
 Error: This expression should not be a boolean literal, the expected type is
        "int"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 let f4 f = ignore(f : id); f#id 1, f#id true
 ;;
@@ -848,7 +847,6 @@ Line 2, characters 17-25:
                      ^^^^^^^^
 Error: This field value has type "'b option ref" which is less general than
          "'a. 'a option ref"
-Unexecuted phrases: 3 phrases did not execute due to an error
 |}];;
 type bad2 = {mutable bad2 : 'a. 'a option ref option};;
 let bad2 = {bad2 = None};;
@@ -981,7 +979,6 @@ Line 2, characters 26-32:
                               ^^^^^^
 Error: Constraints are not satisfied in this type.
        Type "'a u t" should be an instance of "int t"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
@@ -1001,7 +998,6 @@ Line 3, characters 26-32:
                               ^^^^^^
 Error: Constraints are not satisfied in this type.
        Type "'a u t" should be an instance of "g t"
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
@@ -1148,7 +1144,6 @@ Line 5, characters 27-39:
                                ^^^^^^^^^^^^
 Error: This object is expected to have type : "c"
        This type does not have a method "n".
-Unexecuted phrases: 3 phrases did not execute due to an error
 |}];;
 let f () = object (_:'s) constraint 's = < n : int > method m = 1 end;;
 [%%expect {|
@@ -1196,7 +1191,6 @@ Error: The value "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        but the expected method type was
        "'c. 'c * < m : 'a * < m : 'c. 'e > > as 'e"
        The universal variable "'a" would escape its scope
-Unexecuted phrases: 5 phrases did not execute due to an error
 |}];;
 type 'a foo = <m: 'b. 'a * 'a foo>
 type foo' =   <m: 'a. 'a * 'a foo>
@@ -1239,7 +1233,6 @@ Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The universal variables "'b" and "'c" are distinct.
        The first type variable "'b" was introduced in an earlier universal
        quantification.
-Unexecuted phrases: 3 phrases did not execute due to an error
 |}];;
 fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->
   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('b * 'bar)>)> as 'bar);;
@@ -1349,7 +1342,6 @@ Error: Signature mismatch:
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
-Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 module M
 : sig type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)> end
@@ -1416,7 +1408,6 @@ Line 6, characters 9-21:
 6 | fun x -> (x : v :> u);;
              ^^^^^^^^^^^^
 Error: Type "v" = "[> `A | `B ]" is not a subtype of "u" = "[< `A | `B ]"
-Unexecuted phrases: 6 phrases did not execute due to an error
 |}];;
 type v = private [< t];;
 fun x -> (x : u :> v);;
@@ -1452,7 +1443,6 @@ Lines 2-3, characters 2-47:
 Error: Type "< m : 'a. (< p : int; .. > as 'a) -> int >" is not a subtype of
          "< m : 'b. (< p : int; q : int; .. > as 'b) -> int >"
        Type "< p : int; q : int; .. >" is not a subtype of "< p : int; .. >"
-Unexecuted phrases: 5 phrases did not execute due to an error
 |}];;
 let f2 x =
   (x : <m:'a. (<p:<a:int>;..> as 'a) -> int>
@@ -1758,7 +1748,6 @@ let (A x) = (raise Exit : s);;
 [%%expect {|
 type s = A of int
 Exception: Stdlib.Exit.
-Unexecuted phrases: 4 phrases did not execute due to an error
 |}];;
 
 (* PR#5224 *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -589,6 +589,7 @@ Line 5, characters 24-28:
                             ^^^^
 Error: This expression should not be a boolean literal, the expected type is
        "int"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 let f4 f = ignore(f : id); f#id 1, f#id true
 ;;
@@ -847,6 +848,7 @@ Line 2, characters 17-25:
                      ^^^^^^^^
 Error: This field value has type "'b option ref" which is less general than
          "'a. 'a option ref"
+Unexecuted phrases: 3 phrases did not execute due to an error
 |}];;
 type bad2 = {mutable bad2 : 'a. 'a option ref option};;
 let bad2 = {bad2 = None};;
@@ -979,6 +981,7 @@ Line 2, characters 26-32:
                               ^^^^^^
 Error: Constraints are not satisfied in this type.
        Type "'a u t" should be an instance of "int t"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
@@ -998,6 +1001,7 @@ Line 3, characters 26-32:
                               ^^^^^^
 Error: Constraints are not satisfied in this type.
        Type "'a u t" should be an instance of "g t"
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
@@ -1144,6 +1148,7 @@ Line 5, characters 27-39:
                                ^^^^^^^^^^^^
 Error: This object is expected to have type : "c"
        This type does not have a method "n".
+Unexecuted phrases: 3 phrases did not execute due to an error
 |}];;
 let f () = object (_:'s) constraint 's = < n : int > method m = 1 end;;
 [%%expect {|
@@ -1191,6 +1196,7 @@ Error: The value "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        but the expected method type was
        "'c. 'c * < m : 'a * < m : 'c. 'e > > as 'e"
        The universal variable "'a" would escape its scope
+Unexecuted phrases: 5 phrases did not execute due to an error
 |}];;
 type 'a foo = <m: 'b. 'a * 'a foo>
 type foo' =   <m: 'a. 'a * 'a foo>
@@ -1233,6 +1239,7 @@ Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The universal variables "'b" and "'c" are distinct.
        The first type variable "'b" was introduced in an earlier universal
        quantification.
+Unexecuted phrases: 3 phrases did not execute due to an error
 |}];;
 fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->
   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('b * 'bar)>)> as 'bar);;
@@ -1342,6 +1349,7 @@ Error: Signature mismatch:
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 module M
 : sig type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)> end
@@ -1408,6 +1416,7 @@ Line 6, characters 9-21:
 6 | fun x -> (x : v :> u);;
              ^^^^^^^^^^^^
 Error: Type "v" = "[> `A | `B ]" is not a subtype of "u" = "[< `A | `B ]"
+Unexecuted phrases: 6 phrases did not execute due to an error
 |}];;
 type v = private [< t];;
 fun x -> (x : u :> v);;
@@ -1443,6 +1452,7 @@ Lines 2-3, characters 2-47:
 Error: Type "< m : 'a. (< p : int; .. > as 'a) -> int >" is not a subtype of
          "< m : 'b. (< p : int; q : int; .. > as 'b) -> int >"
        Type "< p : int; q : int; .. >" is not a subtype of "< p : int; .. >"
+Unexecuted phrases: 5 phrases did not execute due to an error
 |}];;
 let f2 x =
   (x : <m:'a. (<p:<a:int>;..> as 'a) -> int>
@@ -1748,6 +1758,7 @@ let (A x) = (raise Exit : s);;
 [%%expect {|
 type s = A of int
 Exception: Stdlib.Exit.
+Unexecuted phrases: 4 phrases did not execute due to an error
 |}];;
 
 (* PR#5224 *)

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -47,6 +47,7 @@ Error: This class type is recursive. This use of the class type "Foo.c"
        makes the module type of "Bar" depend on the module type of "Foo".
        Such recursive definitions of class types within recursive modules
        are not allowed.
+Unexecuted phrases: 3 phrases did not execute due to an error
 |}]
 
 (* #12480 *)

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -30,24 +30,25 @@ Error: This class type is recursive. This use of the class type "Foo.c"
        are not allowed.
 |}]
 
-module rec Foo : sig class type c = object method x : int end end = Foo
-and Bar : sig class type c = Foo.c end = Bar
-and Baz : sig class type c = Bar.c end = Baz
+module S = struct
+  module rec Foo : sig class type c = object method x : int end end = Foo
+  and Bar : sig class type c = Foo.c end = Bar
+  and Baz : sig class type c = Bar.c end = Baz
 
-let foo (x : Foo.c) = x#x
-let bar (x : Bar.c) = x#x
-let baz (x : Baz.c) = x#x;;
+  let foo (x : Foo.c) = x#x
+  let bar (x : Bar.c) = x#x
+  let baz (x : Baz.c) = x#x
+end;;
 [%%expect{|
-Line 2, characters 29-32:
-2 | and Bar : sig class type c = Foo.c end = Bar
-                                 ^^^
+Line 3, characters 31-34:
+3 |   and Bar : sig class type c = Foo.c end = Bar
+                                   ^^^
 Error: This class type is recursive. This use of the class type "Foo.c"
        from the recursive module "Foo" within the definition of
        the class type "c" in the recursive module "Bar"
        makes the module type of "Bar" depend on the module type of "Foo".
        Such recursive definitions of class types within recursive modules
        are not allowed.
-Unexecuted phrases: 3 phrases did not execute due to an error
 |}]
 
 (* #12480 *)

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -81,6 +81,7 @@ Line 1, characters 0-51:
 1 | type t7 = I of string | J of bool [@@ocaml.unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because it has more than one constructor.
+Unexecuted phrases: 1 phrases did not execute due to an error
 |}];;
 type t9 = K of { j : string; l : int } [@@ocaml.unboxed];;
 [%%expect{|

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -74,14 +74,18 @@ Line 1, characters 0-40:
 Error: This type cannot be unboxed because it has more than one constructor.
 |}];;
 type t7 = I of string | J of bool [@@ocaml.unboxed];;
-
-type t8 = { h : bool; i : int } [@@ocaml.unboxed];;  (* more than one field *)
 [%%expect{|
 Line 1, characters 0-51:
 1 | type t7 = I of string | J of bool [@@ocaml.unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because it has more than one constructor.
-Unexecuted phrases: 1 phrases did not execute due to an error
+|}];;
+type t8 = { h : bool; i : int } [@@ocaml.unboxed];;  (* more than one field *)
+[%%expect{|
+Line 1, characters 0-49:
+1 | type t8 = { h : bool; i : int } [@@ocaml.unboxed];;  (* more than one field *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because it has more than one field.
 |}];;
 type t9 = K of { j : string; l : int } [@@ocaml.unboxed];;
 [%%expect{|


### PR DESCRIPTION
Expect tests terminate the expectation at the first error -- each error should have a separate `[%%expect` clause