### PR TITLE
Use a strong type for Proxies in Out_type

### DIFF
--- a/Changes
+++ b/Changes
@@ -185,6 +185,10 @@ Working version
 - #14654: Fix non-exhaustive directive rule in lexer.
   (Antonin Décimo, review by Martin Jambon and Gabriel Scherer)
 
+- #14156: Introduce a new type for type proxies that are used in printing
+  types.
+  (Stefan Muenzel, review by ????)
+
 ### Build system:
 
 ### Bug fixes:

--- a/Changes
+++ b/Changes
@@ -187,7 +187,7 @@ Working version
 
 - #14156: Introduce a new type for type proxies that are used in printing
   types.
-  (Stefan Muenzel, review by ????)
+  (Stefan Muenzel, review by Samuel Vivien)
 
 ### Build system:
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -20,8 +20,10 @@ open Types
 
 (**** Sets, maps and hashtables of types ****)
 
+module TransientTypeSet : Set.S with type elt = transient_expr
 module TypeSet : sig
   include Set.S with type elt = transient_expr
+                 and type t = TransientTypeSet.t
   val add: type_expr -> t -> t
   val mem: type_expr -> t -> bool
   val singleton: type_expr -> t

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -355,7 +355,7 @@ and print_simple_out_type ppf =
         (print_object_fields row) fields
   | Otyp_stuff s -> pp_print_string ppf s
   | Otyp_var (non_gen, s) -> ty_var ~non_gen ppf s
-  | Otyp_variant (row_fields, closed, tags) ->
+  | Otyp_variant { fields = row_fields; closed; tags } ->
       let print_present ppf =
         function
           None | Some [] -> ()

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1221,7 +1221,6 @@ let rec tree_of_typexp mode ty =
    Otyp_var (non_gen, name) else
 
   let pr_typ () =
-    let tty = Transient_expr.repr ty in
     match printer_get_desc ty with
     | Tvar _ ->
         let non_gen = is_non_gen mode px in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -929,6 +929,7 @@ end = struct
     if name_is_already_used name then new_name () else name
 
   let rec new_weak_name ty () =
+    let ty = Proxy.type_expr (Proxy.make ty) in
     let name = "weak" ^ Int.to_string !weak_counter in
     incr weak_counter;
     if name_is_already_used name then new_weak_name ty ()

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -665,8 +665,6 @@ module Proxy : sig
 
   val is_non_gen : type_or_scheme -> t -> bool
 
-  val id : t -> int
-
   val refresh : t -> t
 
   module Set : Stdlib.Set.S with type elt = t
@@ -683,7 +681,6 @@ end = struct
   let type_expr = Transient_expr.type_expr
 
   let desc t = t.desc
-  let id t = t.id
 
   let refresh t =
     make (type_expr t)
@@ -699,8 +696,6 @@ end = struct
     result
 
 end
-
-let _ = Proxy.id
 
 let proxy = Proxy.make
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -851,7 +851,7 @@ module Variable_names : sig
   val add_subst : (type_expr * type_expr) list -> unit
 
   val new_name : unit -> string
-  val new_var_name : non_gen:bool -> type_expr -> unit -> string
+  val new_var_name : non_gen:bool -> Proxy.t -> unit -> string
 
   val name_of_type : (unit -> string) -> Proxy.t -> string
   val check_name_of_type : non_gen:bool -> Proxy.t -> unit
@@ -946,13 +946,10 @@ end = struct
         name
       end
 
-  let new_var_name ~non_gen ty () =
+  let new_var_name ~non_gen px () =
+    let ty = Proxy.type_expr px in
     if non_gen then new_weak_name ty ()
     else new_name ()
-
-  let new_var_name ~non_gen ty () =
-    let ty = Proxy.type_expr (Proxy.make ty) in
-    new_var_name ~non_gen ty ()
 
   let name_of_type name_generator (px : Proxy.t) =
     (* We've already been through repr at this stage, so t is our representative
@@ -986,7 +983,7 @@ end = struct
       name
 
   let check_name_of_type ~non_gen (px : Proxy.t) =
-    let name_gen = new_var_name ~non_gen (Proxy.type_expr px) in
+    let name_gen = new_var_name ~non_gen px in
     ignore(name_of_type name_gen px)
 
   let remove_name (px : Proxy.t) =
@@ -1219,7 +1216,7 @@ let rec tree_of_typexp mode ty =
   let px = proxy ty in
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
    let non_gen = is_non_gen mode px in
-   let name = Variable_names.(name_of_type (new_var_name ~non_gen ty))
+   let name = Variable_names.(name_of_type (new_var_name ~non_gen px))
                 px in
    Otyp_var (non_gen, name) else
 
@@ -1228,7 +1225,7 @@ let rec tree_of_typexp mode ty =
     match printer_get_desc ty with
     | Tvar _ ->
         let non_gen = is_non_gen mode px in
-        let name_gen = Variable_names.new_var_name ~non_gen ty in
+        let name_gen = Variable_names.new_var_name ~non_gen px in
         Otyp_var (non_gen, Variable_names.name_of_type name_gen (Proxy.make ty))
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
@@ -1348,7 +1345,7 @@ let rec tree_of_typexp mode ty =
     Aliases.add_printed_proxy ~non_gen px;
     (* add_printed_proxy chose a name, thus the name generator
        doesn't matter.*)
-    let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
+    let alias = Variable_names.(name_of_type (new_var_name ~non_gen px)) px in
     Otyp_alias {non_gen;  aliased = pr_typ (); alias } end
   else pr_typ ()
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -832,35 +832,37 @@ end = struct
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
      be one-shot. *)
-  let names = ref ([] : (transient_expr * string) list)
-  let name_subst = ref ([] : (transient_expr * transient_expr) list)
+  let names = ref (TransientTypeMap.empty : string TransientTypeMap.t)
+  let names_set = ref String.Set.empty
+  let name_subst = ref (TransientTypeMap.empty : (transient_expr TransientTypeMap.t))
   let name_counter = ref 0
-  let named_vars = ref ([] : string list)
-  let visited_for_named_vars = ref ([] : transient_expr list)
+  let named_vars = ref String.Set.empty
+  let visited_for_named_vars = ref TransientTypeSet.empty
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
   let named_weak_vars = ref String.Set.empty
 
   let reset_names () =
-    names := [];
-    name_subst := [];
+    names := TransientTypeMap.empty;
+    names_set := String.Set.empty;
+    name_subst := TransientTypeMap.empty;
     name_counter := 0;
-    named_vars := [];
-    visited_for_named_vars := []
+    named_vars := String.Set.empty;
+    visited_for_named_vars := TransientTypeSet.empty
 
   let add_named_var tty =
     match tty.desc with
       Tvar (Some name) | Tunivar (Some name) ->
-        if List.mem name !named_vars then () else
-        named_vars := name :: !named_vars
+        if String.Set.mem name !named_vars then () else
+        named_vars := String.Set.add name !named_vars
     | _ -> ()
 
   let rec add_named_vars ty =
     let tty = Transient_expr.repr ty in
     let px = proxy ty in
-    if not (List.memq px !visited_for_named_vars) then begin
-      visited_for_named_vars := px :: !visited_for_named_vars;
+    if not (TransientTypeSet.mem px !visited_for_named_vars) then begin
+      visited_for_named_vars := TransientTypeSet.add px !visited_for_named_vars;
       match tty.desc with
       | Tvar _ | Tunivar _ ->
           add_named_var tty
@@ -869,19 +871,20 @@ end = struct
     end
 
   let substitute ty =
-    match List.assq ty !name_subst with
+    match TransientTypeMap.find ty !name_subst with
     | ty' -> ty'
     | exception Not_found -> ty
 
   let add_subst subst =
     name_subst :=
-      List.map (fun (t1,t2) -> Transient_expr.repr t1, Transient_expr.repr t2)
+      List.fold_left
+        (fun m (t1,t2) -> TypeMap.add t1 (Transient_expr.repr t2) m)
+        !name_subst
         subst
-      @ !name_subst
 
   let name_is_already_used name =
-    List.mem name !named_vars
-    || List.exists (fun (_, name') -> name = name') !names
+    String.Set.mem name !named_vars
+    || String.Set.mem name !names_set
     || String.Set.mem name !named_weak_vars
 
   let rec new_name () =
@@ -907,7 +910,7 @@ end = struct
     (* We've already been through repr at this stage, so t is our representative
        of the union-find class. *)
     let t = substitute t in
-    try List.assq t !names with Not_found ->
+    try TransientTypeMap.find t !names with Not_found ->
       try TransientTypeMap.find t !weak_var_map with Not_found ->
       let name =
         match t.desc with
@@ -916,9 +919,7 @@ end = struct
              * unification variable to that name. We want to keep the name, so
              * try adding a number until we find a name that's not taken. *)
             let available name =
-              List.for_all
-                (fun (_, name') -> name <> name')
-                !names
+              not (String.Set.mem name !names_set)
             in
             if available name then name
             else
@@ -930,25 +931,38 @@ end = struct
             name_generator ()
       in
       (* Exception for type declarations *)
-      if name <> "_" then names := (t, name) :: !names;
+      if name <> "_" then begin
+        names := TransientTypeMap.add t name !names;
+        names_set := String.Set.add name !names_set
+      end;
       name
 
   let check_name_of_type ~non_gen px =
     let name_gen = new_var_name ~non_gen (Transient_expr.type_expr px) in
     ignore(name_of_type name_gen px : string)
 
+  let remove_name t =
+    let t = substitute t in
+    match TransientTypeMap.find t !names with
+    | name ->
+        names_set := String.Set.remove name !names_set;
+        names := TransientTypeMap.remove t !names
+    | exception Not_found -> ()
+
   let remove_names tyl =
-    let tyl = List.map substitute tyl in
-    names := List.filter (fun (ty,_) -> not (List.memq ty tyl)) !names
+    List.iter remove_name tyl
 
   let with_local_names f =
     let old_names = !names in
+    let old_names_set = !names_set in
     let old_subst = !name_subst in
-    names      := [];
-    name_subst := [];
+    names      := TransientTypeMap.empty;
+    names_set  := String.Set.empty;
+    name_subst := TransientTypeMap.empty;
     try_finally
       ~always:(fun () ->
         names      := old_names;
+        names_set  := old_names_set;
         name_subst := old_subst)
       f
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -673,15 +673,10 @@ module Proxy : sig
   module Map : Stdlib.Map.S with type key = t
 
 end = struct
-  module T = struct
-    type t = transient_expr
+  type t = transient_expr
 
-    let compare = TransientTypeOps.compare
-  end
-  include T
-
-  module Set = Stdlib.Set.Make(T)
-  module Map = Stdlib.Map.Make(T)
+  module Set = TransientTypeSet
+  module Map = TransientTypeMap
 
   let make ty = Transient_expr.repr (proxy ty)
 
@@ -925,13 +920,13 @@ end = struct
 
   let add_subst subst =
     name_subst :=
-      List.fold_left
-        (fun m (t1,t2) ->
+      List.fold_right
+        (fun (t1,t2) m ->
            let t1 = Proxy.make t1 in
            let t2 = Proxy.make t2 in
            Proxy.Map.add t1 t2 m)
-        !name_subst
         subst
+        !name_subst
 
   let name_is_already_used name =
     String.Set.mem name !named_vars

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1029,7 +1029,8 @@ end = struct
         m, s
     in
     let m, s =
-      Proxy.Map.fold refresh !weak_var_map (Proxy.Map.empty ,String.Set.empty) in
+      Proxy.Map.fold refresh !weak_var_map
+        (Proxy.Map.empty ,String.Set.empty) in
     named_weak_vars := s;
     weak_var_map := m
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -641,6 +641,10 @@ let tree_of_type_path p =
   let p'' = if (s = Id) then p' else p in
   tree_of_best_type_path p p''
 
+(* When printing a type scheme, we print weak names.  When printing a plain
+   type, we do not.  This type controls that behavior *)
+type type_or_scheme = Type | Type_scheme
+
 (* Print a type expression *)
 
 (* We use proxies to find shared parts of type expressions/name variables.
@@ -661,6 +665,8 @@ module Proxy : sig
   val transient_expr_REMOVE : t -> transient_expr
 
   val desc : t -> type_desc
+
+  val is_non_gen : type_or_scheme -> t -> bool
 
   module Set : Stdlib.Set.S with type elt = t
   module Map : Stdlib.Map.S with type key = t
@@ -683,18 +689,18 @@ end = struct
 
   let desc t = t.desc
 
+  let is_non_gen mode t =
+    match mode with
+    | Type_scheme ->
+        let ty = type_expr t in
+        is_Tvar ty && get_level ty <> generic_level
+    | Type        -> false
+
 end
 
 let proxy = Proxy.make
 
-(* When printing a type scheme, we print weak names.  When printing a plain
-   type, we do not.  This type controls that behavior *)
-type type_or_scheme = Type | Type_scheme
-
-let is_non_gen mode ty =
-  match mode with
-  | Type_scheme -> is_Tvar ty && get_level ty <> generic_level
-  | Type        -> false
+let is_non_gen = Proxy.is_non_gen
 
 let nameable_row row =
   row_name row <> None &&
@@ -873,7 +879,7 @@ end = struct
   let visited_for_named_vars = ref Proxy.Set.empty
 
   let weak_counter = ref 1
-  let weak_var_map = ref TypeMap.empty
+  let weak_var_map = ref (TypeMap.empty : string TypeMap.t)
   let named_weak_vars = ref String.Set.empty
 
   let reset_names () =
@@ -929,7 +935,8 @@ end = struct
     if name_is_already_used name then new_name () else name
 
   let rec new_weak_name ty () =
-    let ty = Proxy.type_expr (Proxy.make ty) in
+    let px = Proxy.make ty in
+    let ty = Proxy.type_expr px in
     let name = "weak" ^ Int.to_string !weak_counter in
     incr weak_counter;
     if name_is_already_used name then new_weak_name ty ()
@@ -1009,7 +1016,7 @@ end = struct
 
   let refresh_weak () =
     let refresh t name (m,s) =
-      if is_non_gen Type_scheme t then
+      if is_non_gen Type_scheme (Proxy.make t) then
         begin
           TypeMap.add t name m,
           String.Set.add name s
@@ -1204,14 +1211,14 @@ let with_labels b f = Misc.protect_refs [R (print_labels,b)] f
 let alias_nongen_row mode (px : Proxy.t) ty =
     match printer_get_desc ty with
     | Tvariant _ | Tobject _ ->
-        if is_non_gen mode (Proxy.type_expr px) then
+        if is_non_gen mode px then
           Aliases.add_proxy px
     | _ -> ()
 
 let rec tree_of_typexp mode ty =
   let px = proxy ty in
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
-   let non_gen = is_non_gen mode (Proxy.type_expr px) in
+   let non_gen = is_non_gen mode px in
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty))
                 px in
    Otyp_var (non_gen, name) else
@@ -1220,7 +1227,7 @@ let rec tree_of_typexp mode ty =
     let tty = Transient_expr.repr ty in
     match printer_get_desc ty with
     | Tvar _ ->
-        let non_gen = is_non_gen mode ty in
+        let non_gen = is_non_gen mode px in
         let name_gen = Variable_names.new_var_name ~non_gen ty in
         Otyp_var (non_gen, Variable_names.name_of_type name_gen (Proxy.make ty))
     | Tarrow(l, ty1, ty2, _) ->
@@ -1337,7 +1344,7 @@ let rec tree_of_typexp mode ty =
   Aliases.remove_delay px;
   alias_nongen_row mode px ty;
   if Aliases.(is_aliased_proxy px && aliasable ty) then begin
-    let non_gen = is_non_gen mode (Proxy.type_expr px) in
+    let non_gen = is_non_gen mode px in
     Aliases.add_printed_proxy ~non_gen px;
     (* add_printed_proxy chose a name, thus the name generator
        doesn't matter.*)

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -842,6 +842,7 @@ module Variable_names : sig
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
   val name_of_type : (unit -> string) -> transient_expr -> string
+  val name_of_type_proxy_TEMPORARY : (unit -> string) -> transient_expr -> string
   val check_name_of_type : non_gen:bool -> Proxy.t -> unit
 
 
@@ -963,6 +964,9 @@ end = struct
         names_set := String.Set.add name !names_set
       end;
       name
+
+  let name_of_type_proxy_TEMPORARY name_generator t =
+    name_of_type name_generator (Proxy.transient_expr_REMOVE (proxy (Transient_expr.type_expr t)))
 
   let check_name_of_type ~non_gen (px : Proxy.t) =
     let name_gen = new_var_name ~non_gen (Proxy.type_expr px) in
@@ -1208,7 +1212,7 @@ let rec tree_of_typexp mode ty =
     | Tvar _ ->
         let non_gen = is_non_gen mode ty in
         let name_gen = Variable_names.new_var_name ~non_gen ty in
-        Otyp_var (non_gen, Variable_names.name_of_type name_gen tty)
+        Otyp_var (non_gen, Variable_names.name_of_type_proxy_TEMPORARY name_gen tty)
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
           if !print_labels || is_optional l then l else Nolabel
@@ -1308,7 +1312,7 @@ let rec tree_of_typexp mode ty =
               (* Make the names delayed, so that the real type is
                  printed once when used as proxy *)
               List.iter Aliases.add_delayed pxl;
-              let tl = List.map Variable_names.(name_of_type new_name) tyl in
+              let tl = List.map Variable_names.(name_of_type_proxy_TEMPORARY new_name) tyl in
               let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
               (* Forget names when we leave scope *)
               Variable_names.remove_names tyl;
@@ -1316,7 +1320,7 @@ let rec tree_of_typexp mode ty =
             )
         end
     | Tunivar _ ->
-        Otyp_var (false, Variable_names.(name_of_type new_name) tty)
+        Otyp_var (false, Variable_names.(name_of_type_proxy_TEMPORARY new_name) tty)
     | Tpackage pack ->
         let pack = tree_of_package mode pack in
         Otyp_module pack

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -942,6 +942,10 @@ end = struct
     if non_gen then new_weak_name ty ()
     else new_name ()
 
+  let new_var_name ~non_gen ty () =
+    let ty = Proxy.type_expr (Proxy.make ty) in
+    new_var_name ~non_gen ty ()
+
   let name_of_type name_generator (px : Proxy.t) =
     (* We've already been through repr at this stage, so t is our representative
        of the union-find class. *)

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1013,9 +1013,10 @@ end = struct
 
   let refresh_weak () =
     let refresh t name (m,s) =
-      if is_non_gen Type_scheme (Proxy.make t) then
+      let px = Proxy.make t in
+      if is_non_gen Type_scheme px then
         begin
-          TypeMap.add t name m,
+          TypeMap.add (Proxy.type_expr px) name m,
           String.Set.add name s
         end
       else m, s in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -970,37 +970,72 @@ end = struct
     add_named_vars ty
 end
 
-module Aliases = struct
-  let visited_objects = ref ([] : transient_expr list)
-  let aliased = ref ([] : transient_expr list)
-  let delayed = ref ([] : transient_expr list)
-  let printed_aliases = ref ([] : transient_expr list)
+module Aliases : sig
+
+  val aliasable : type_expr -> bool
+
+  val mark_loops : type_expr -> unit
+
+  val add : type_expr -> unit
+  val add_proxy : transient_expr -> unit
+  val is_aliased_proxy : transient_expr -> bool
+
+  val add_printed : type_expr -> non_gen:bool -> unit
+  val add_printed_proxy : non_gen:bool -> transient_expr -> unit
+  val is_printed_proxy : transient_expr -> bool
+  val mark_as_printed : transient_expr -> unit
+
+  val add_visited_object_proxy : transient_expr -> unit
+  val is_visited_object_proxy : transient_expr -> bool
+
+  val add_delayed : transient_expr -> unit
+  val remove_delay : transient_expr -> unit
+  val is_delayed : transient_expr -> bool
+  val with_temporary_delay : (unit -> 'a) -> 'a
+
+  val reset : unit -> unit
+end = struct
+  let visited_objects = ref (TransientTypeSet.empty)
+  let aliased = ref (TransientTypeSet.empty)
+  let delayed = ref (TransientTypeSet.empty)
+  let printed_aliases = ref (TransientTypeSet.empty)
+
+  let with_temporary_delay f =
+    let old_delayed = !delayed in
+    let res = f () in
+    delayed := old_delayed;
+    res
 
 (* [printed_aliases] is a subset of [aliased] that records only those aliased
    types that have actually been printed; this allows us to avoid naming loops
    that the user will never see. *)
 
-  let is_delayed t = List.memq t !delayed
+  let is_delayed t = TransientTypeSet.mem t !delayed
+
+  let is_visited_object_proxy t = TransientTypeSet.mem t !visited_objects
 
   let remove_delay t =
     if is_delayed t then
-      delayed := List.filter ((!=) t) !delayed
+      delayed := TransientTypeSet.remove t !delayed
 
   let add_delayed t =
-    if not (is_delayed t) then delayed := t :: !delayed
+    if not (is_delayed t) then delayed := TransientTypeSet.add t !delayed
 
-  let is_aliased_proxy px = List.memq px !aliased
-  let is_printed_proxy px = List.memq px !printed_aliases
+  let is_aliased_proxy px = TransientTypeSet.mem px !aliased
+  let is_printed_proxy px = TransientTypeSet.mem px !printed_aliases
 
   let add_proxy px =
     if not (is_aliased_proxy px) then
-      aliased := px :: !aliased
+      aliased := TransientTypeSet.add px !aliased
 
   let add ty = add_proxy (proxy ty)
 
   let add_printed_proxy ~non_gen px =
     Variable_names.check_name_of_type ~non_gen px;
-    printed_aliases := px :: !printed_aliases
+    printed_aliases := TransientTypeSet.add px !printed_aliases
+
+  let add_visited_object_proxy px =
+    visited_objects := TransientTypeSet.add px !visited_objects
 
   let mark_as_printed px =
      if is_aliased_proxy px then (add_printed_proxy ~non_gen:false) px
@@ -1026,9 +1061,9 @@ module Aliases = struct
       let visited = px :: visited in
       match printer_get_desc ty with
       | Tvariant _ | Tobject _ ->
-          if List.memq px !visited_objects then add_proxy px else begin
+          if TransientTypeSet.mem px !visited_objects then add_proxy px else begin
             if should_visit_object ty then
-              visited_objects := px :: !visited_objects;
+              visited_objects := TransientTypeSet.add px !visited_objects;
             printer_iter_type_expr (mark_loops_rec visited) ty
           end
       | Tpoly(ty, tyl) ->
@@ -1053,7 +1088,10 @@ module Aliases = struct
     mark_loops_rec [] ty
 
   let reset () =
-    visited_objects := []; aliased := []; delayed := []; printed_aliases := []
+    visited_objects := TransientTypeSet.empty;
+    aliased := TransientTypeSet.empty;
+    delayed := TransientTypeSet.empty;
+    printed_aliases := TransientTypeSet.empty
 
 end
 
@@ -1223,15 +1261,16 @@ let rec tree_of_typexp mode ty =
           prerr_string "; " in *)
         if tyl = [] then tree_of_typexp mode ty else begin
           let tyl = List.map Transient_expr.repr tyl in
-          let old_delayed = !Aliases.delayed in
-          (* Make the names delayed, so that the real type is
-             printed once when used as proxy *)
-          List.iter Aliases.add_delayed tyl;
-          let tl = List.map Variable_names.(name_of_type new_name) tyl in
-          let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
-          (* Forget names when we leave scope *)
-          Variable_names.remove_names tyl;
-          Aliases.delayed := old_delayed; tr
+          Aliases.with_temporary_delay (fun () ->
+              (* Make the names delayed, so that the real type is
+                 printed once when used as proxy *)
+              List.iter Aliases.add_delayed tyl;
+              let tl = List.map Variable_names.(name_of_type new_name) tyl in
+              let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
+              (* Forget names when we leave scope *)
+              Variable_names.remove_names tyl;
+              tr
+            )
         end
     | Tunivar _ ->
         Otyp_var (false, Variable_names.(name_of_type new_name) tty)
@@ -1731,7 +1770,7 @@ let tree_of_method mode (lab, priv, virt, ty) =
 let rec prepare_class_type params = function
   | Cty_constr (_p, tyl, cty) ->
       let row = Btype.self_type_row cty in
-      if List.memq (proxy row) !Aliases.visited_objects
+      if Aliases.is_visited_object_proxy (proxy row)
       || not (List.for_all is_Tvar params)
       || deep_occur_list row tyl
       then prepare_class_type params cty
@@ -1739,8 +1778,8 @@ let rec prepare_class_type params = function
   | Cty_signature sign ->
       (* Self may have a name *)
       let px = proxy sign.csig_self_row in
-      if List.memq px !Aliases.visited_objects then Aliases.add_proxy px
-      else Aliases.(visited_objects := px :: !visited_objects);
+      if Aliases.is_visited_object_proxy px then Aliases.add_proxy px
+      else Aliases.add_visited_object_proxy px;
       Vars.iter (fun _ (_, _, ty) -> prepare_type ty) sign.csig_vars;
       Meths.iter prepare_method sign.csig_meths
   | Cty_arrow (_, ty, cty) ->
@@ -1751,7 +1790,7 @@ let rec tree_of_class_type mode params =
   function
   | Cty_constr (p', tyl, cty) ->
       let row = Btype.self_type_row cty in
-      if List.memq (proxy row) !Aliases.visited_objects
+      if Aliases.is_visited_object_proxy (proxy row)
       || not (List.for_all is_Tvar params)
       then
         tree_of_class_type mode params cty

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -660,7 +660,10 @@ module Proxy : sig
   val type_expr : t -> type_expr
   val transient_expr_REMOVE : t -> transient_expr
 
+  val desc : t -> type_desc
+
   module Set : Stdlib.Set.S with type elt = t
+  module Map : Stdlib.Map.S with type key = t
 
 end = struct
   module T = struct
@@ -671,11 +674,14 @@ end = struct
   include T
 
   module Set = Stdlib.Set.Make(T)
+  module Map = Stdlib.Map.Make(T)
 
   let make ty = Transient_expr.repr (proxy ty)
 
   let type_expr = Transient_expr.type_expr
   let transient_expr_REMOVE px = px
+
+  let desc t = t.desc
 
 end
 
@@ -841,14 +847,13 @@ module Variable_names : sig
   val new_name : unit -> string
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
-  val name_of_type : (unit -> string) -> transient_expr -> string
-  val name_of_type_proxy_TEMPORARY : (unit -> string) -> transient_expr -> string
+  val name_of_type : (unit -> string) -> Proxy.t -> string
   val check_name_of_type : non_gen:bool -> Proxy.t -> unit
 
 
   val reserve: type_expr -> unit
 
-  val remove_names : transient_expr list -> unit
+  val remove_names : Proxy.t list -> unit
 
   val with_local_names : (unit -> 'a) -> 'a
 
@@ -860,9 +865,9 @@ end = struct
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
      be one-shot. *)
-  let names = ref (TransientTypeMap.empty : string TransientTypeMap.t)
+  let names = ref (Proxy.Map.empty : string Proxy.Map.t)
   let names_set = ref String.Set.empty
-  let name_subst = ref (TransientTypeMap.empty : (transient_expr TransientTypeMap.t))
+  let name_subst = ref (Proxy.Map.empty : (Proxy.t Proxy.Map.t))
   let name_counter = ref 0
   let named_vars = ref String.Set.empty
   let visited_for_named_vars = ref Proxy.Set.empty
@@ -872,9 +877,9 @@ end = struct
   let named_weak_vars = ref String.Set.empty
 
   let reset_names () =
-    names := TransientTypeMap.empty;
+    names := Proxy.Map.empty;
     names_set := String.Set.empty;
-    name_subst := TransientTypeMap.empty;
+    name_subst := Proxy.Map.empty;
     name_counter := 0;
     named_vars := String.Set.empty;
     visited_for_named_vars := Proxy.Set.empty
@@ -898,18 +903,18 @@ end = struct
           printer_iter_type_expr add_named_vars ty
     end
 
-  let substitute ty =
-    match TransientTypeMap.find ty !name_subst with
-    | ty' -> ty'
-    | exception Not_found -> ty
+  let substitute (px : Proxy.t) : Proxy.t =
+    match Proxy.Map.find px !name_subst with
+    | px' -> px'
+    | exception Not_found -> px
 
   let add_subst subst =
     name_subst :=
       List.fold_left
         (fun m (t1,t2) ->
-           let t1 = Transient_expr.type_expr (Proxy.transient_expr_REMOVE (Proxy.make t1)) in
-           let t2 = Proxy.transient_expr_REMOVE (Proxy.make t2) in
-           TypeMap.add t1 t2 m)
+           let t1 = Proxy.make t1 in
+           let t2 = Proxy.make t2 in
+           Proxy.Map.add t1 t2 m)
         !name_subst
         subst
 
@@ -937,14 +942,14 @@ end = struct
     if non_gen then new_weak_name ty ()
     else new_name ()
 
-  let name_of_type name_generator t =
+  let name_of_type name_generator (px : Proxy.t) =
     (* We've already been through repr at this stage, so t is our representative
        of the union-find class. *)
-    let t = substitute t in
-    try TransientTypeMap.find t !names with Not_found ->
-      try TransientTypeMap.find t !weak_var_map with Not_found ->
+    let px = substitute px in
+    try Proxy.Map.find px !names with Not_found ->
+      try TransientTypeMap.find (Proxy.transient_expr_REMOVE px) !weak_var_map with Not_found ->
       let name =
-        match t.desc with
+        match Proxy.desc px with
           Tvar (Some name) | Tunivar (Some name) ->
             (* Some part of the type we've already printed has assigned another
              * unification variable to that name. We want to keep the name, so
@@ -963,24 +968,21 @@ end = struct
       in
       (* Exception for type declarations *)
       if name <> "_" then begin
-        names := TransientTypeMap.add t name !names;
+        names := Proxy.Map.add px name !names;
         names_set := String.Set.add name !names_set
       end;
       name
 
-  let name_of_type_proxy_TEMPORARY name_generator t =
-    name_of_type name_generator (Proxy.transient_expr_REMOVE (proxy (Transient_expr.type_expr t)))
-
   let check_name_of_type ~non_gen (px : Proxy.t) =
     let name_gen = new_var_name ~non_gen (Proxy.type_expr px) in
-    ignore(name_of_type name_gen (Proxy.transient_expr_REMOVE px))
+    ignore(name_of_type name_gen px)
 
-  let remove_name t =
-    let t = substitute t in
-    match TransientTypeMap.find t !names with
+  let remove_name (px : Proxy.t) =
+    let px = substitute px in
+    match Proxy.Map.find px !names with
     | name ->
         names_set := String.Set.remove name !names_set;
-        names := TransientTypeMap.remove t !names
+        names := Proxy.Map.remove px !names
     | exception Not_found -> ()
 
   let remove_names tyl =
@@ -990,9 +992,9 @@ end = struct
     let old_names = !names in
     let old_names_set = !names_set in
     let old_subst = !name_subst in
-    names      := TransientTypeMap.empty;
+    names      := Proxy.Map.empty;
     names_set  := String.Set.empty;
-    name_subst := TransientTypeMap.empty;
+    name_subst := Proxy.Map.empty;
     try_finally
       ~always:(fun () ->
         names      := old_names;
@@ -1206,7 +1208,7 @@ let rec tree_of_typexp mode ty =
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
    let non_gen = is_non_gen mode (Proxy.type_expr px) in
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty))
-                (Proxy.transient_expr_REMOVE px) in
+                px in
    Otyp_var (non_gen, name) else
 
   let pr_typ () =
@@ -1215,7 +1217,7 @@ let rec tree_of_typexp mode ty =
     | Tvar _ ->
         let non_gen = is_non_gen mode ty in
         let name_gen = Variable_names.new_var_name ~non_gen ty in
-        Otyp_var (non_gen, Variable_names.name_of_type_proxy_TEMPORARY name_gen tty)
+        Otyp_var (non_gen, Variable_names.name_of_type name_gen (Proxy.make ty))
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
           if !print_labels || is_optional l then l else Nolabel
@@ -1310,20 +1312,19 @@ let rec tree_of_typexp mode ty =
           prerr_string "; " in *)
         if tyl = [] then tree_of_typexp mode ty else begin
           let pxl = List.map Proxy.make tyl in
-          let tyl = List.map Transient_expr.repr tyl in
           Aliases.with_temporary_delay (fun () ->
               (* Make the names delayed, so that the real type is
                  printed once when used as proxy *)
               List.iter Aliases.add_delayed pxl;
-              let tl = List.map Variable_names.(name_of_type_proxy_TEMPORARY new_name) tyl in
+              let tl = List.map Variable_names.(name_of_type new_name) pxl in
               let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
               (* Forget names when we leave scope *)
-              Variable_names.remove_names tyl;
+              Variable_names.remove_names pxl;
               tr
             )
         end
     | Tunivar _ ->
-        Otyp_var (false, Variable_names.(name_of_type_proxy_TEMPORARY new_name) tty)
+        Otyp_var (false, Variable_names.(name_of_type new_name) px)
     | Tpackage pack ->
         let pack = tree_of_package mode pack in
         Otyp_module pack
@@ -1335,7 +1336,7 @@ let rec tree_of_typexp mode ty =
     Aliases.add_printed_proxy ~non_gen px;
     (* add_printed_proxy chose a name, thus the name generator
        doesn't matter.*)
-    let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) (Proxy.transient_expr_REMOVE px) in
+    let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
     Otyp_alias {non_gen;  aliased = pr_typ (); alias } end
   else pr_typ ()
 
@@ -1812,7 +1813,7 @@ let prepare_method _lab (priv, _virt, ty) =
 let tree_of_method mode (lab, priv, virt, ty) =
   let (ty, tyl) = method_type priv ty in
   let tty = tree_of_typexp mode ty in
-  Variable_names.remove_names (List.map Transient_expr.repr tyl);
+  Variable_names.remove_names (List.map proxy tyl);
   let priv = priv <> Mpublic in
   let virt = virt = Virtual in
   Ocsg_method (lab, priv, virt, tty)
@@ -1852,7 +1853,7 @@ let rec tree_of_class_type mode params =
       let self_ty =
         if Aliases.is_aliased_proxy px then
           Some
-            (Otyp_var (false, Variable_names.(name_of_type new_name) (Proxy.transient_expr_REMOVE px)))
+            (Otyp_var (false, Variable_names.(name_of_type new_name) px))
         else None
       in
       let csil = [] in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -906,7 +906,10 @@ end = struct
   let add_subst subst =
     name_subst :=
       List.fold_left
-        (fun m (t1,t2) -> TypeMap.add t1 (Transient_expr.repr t2) m)
+        (fun m (t1,t2) ->
+           let t1 = Transient_expr.type_expr (Proxy.transient_expr_REMOVE (Proxy.make t1)) in
+           let t2 = Proxy.transient_expr_REMOVE (Proxy.make t2) in
+           TypeMap.add t1 t2 m)
         !name_subst
         subst
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -652,7 +652,38 @@ let tree_of_type_path p =
    we maintain the invariant that the row variable uniquely identifies the type.
    This, however, means, we can no longer distinguish between the row variable
    and the type containing the row variable. *)
-let proxy ty = Transient_expr.repr (proxy ty)
+module Proxy : sig
+  type t
+
+  val make : type_expr -> t
+
+  val make_unnormalized_REMOVE : transient_expr -> t
+
+  val type_expr : t -> type_expr
+  val transient_expr_REMOVE : t -> transient_expr
+
+  module Set : Stdlib.Set.S with type elt = t
+
+end = struct
+  module T = struct
+    type t = transient_expr
+
+    let compare = TransientTypeOps.compare
+  end
+  include T
+
+  module Set = Stdlib.Set.Make(T)
+
+  let make ty = Transient_expr.repr (proxy ty)
+
+  let make_unnormalized_REMOVE ty = ty
+
+  let type_expr = Transient_expr.type_expr
+  let transient_expr_REMOVE px = px
+
+end
+
+let proxy = Proxy.make
 
 (* When printing a type scheme, we print weak names.  When printing a plain
    type, we do not.  This type controls that behavior *)
@@ -815,7 +846,7 @@ module Variable_names : sig
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
   val name_of_type : (unit -> string) -> transient_expr -> string
-  val check_name_of_type : non_gen:bool -> transient_expr -> unit
+  val check_name_of_type : non_gen:bool -> Proxy.t -> unit
 
 
   val reserve: type_expr -> unit
@@ -837,7 +868,7 @@ end = struct
   let name_subst = ref (TransientTypeMap.empty : (transient_expr TransientTypeMap.t))
   let name_counter = ref 0
   let named_vars = ref String.Set.empty
-  let visited_for_named_vars = ref TransientTypeSet.empty
+  let visited_for_named_vars = ref Proxy.Set.empty
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
@@ -849,7 +880,7 @@ end = struct
     name_subst := TransientTypeMap.empty;
     name_counter := 0;
     named_vars := String.Set.empty;
-    visited_for_named_vars := TransientTypeSet.empty
+    visited_for_named_vars := Proxy.Set.empty
 
   let add_named_var tty =
     match tty.desc with
@@ -861,8 +892,8 @@ end = struct
   let rec add_named_vars ty =
     let tty = Transient_expr.repr ty in
     let px = proxy ty in
-    if not (TransientTypeSet.mem px !visited_for_named_vars) then begin
-      visited_for_named_vars := TransientTypeSet.add px !visited_for_named_vars;
+    if not (Proxy.Set.mem px !visited_for_named_vars) then begin
+      visited_for_named_vars := Proxy.Set.add px !visited_for_named_vars;
       match tty.desc with
       | Tvar _ | Tunivar _ ->
           add_named_var tty
@@ -937,9 +968,9 @@ end = struct
       end;
       name
 
-  let check_name_of_type ~non_gen px =
-    let name_gen = new_var_name ~non_gen (Transient_expr.type_expr px) in
-    ignore(name_of_type name_gen px : string)
+  let check_name_of_type ~non_gen (px : Proxy.t) =
+    let name_gen = new_var_name ~non_gen (Proxy.type_expr px) in
+    ignore(name_of_type name_gen (Proxy.transient_expr_REMOVE px))
 
   let remove_name t =
     let t = substitute t in
@@ -991,28 +1022,29 @@ module Aliases : sig
   val mark_loops : type_expr -> unit
 
   val add : type_expr -> unit
-  val add_proxy : transient_expr -> unit
-  val is_aliased_proxy : transient_expr -> bool
+  val add_proxy : Proxy.t -> unit
+  val is_aliased_proxy : Proxy.t -> bool
 
   val add_printed : type_expr -> non_gen:bool -> unit
-  val add_printed_proxy : non_gen:bool -> transient_expr -> unit
-  val is_printed_proxy : transient_expr -> bool
-  val mark_as_printed : transient_expr -> unit
+  val add_printed_proxy : non_gen:bool -> Proxy.t -> unit
+  val is_printed_proxy : Proxy.t -> bool
+  val mark_as_printed : Proxy.t -> unit
 
-  val add_visited_object_proxy : transient_expr -> unit
-  val is_visited_object_proxy : transient_expr -> bool
+  val add_visited_object_proxy : Proxy.t -> unit
+  val is_visited_object_proxy : Proxy.t -> bool
 
-  val add_delayed : transient_expr -> unit
-  val remove_delay : transient_expr -> unit
-  val is_delayed : transient_expr -> bool
+  val add_delayed : Proxy.t -> unit
+  val add_delayed_transient_REMOVE : transient_expr -> unit
+  val remove_delay : Proxy.t -> unit
+  val is_delayed : Proxy.t -> bool
   val with_temporary_delay : (unit -> 'a) -> 'a
 
   val reset : unit -> unit
 end = struct
-  let visited_objects = ref (TransientTypeSet.empty)
-  let aliased = ref (TransientTypeSet.empty)
-  let delayed = ref (TransientTypeSet.empty)
-  let printed_aliases = ref (TransientTypeSet.empty)
+  let visited_objects = ref (Proxy.Set.empty)
+  let aliased = ref (Proxy.Set.empty)
+  let delayed = ref (Proxy.Set.empty)
+  let printed_aliases = ref (Proxy.Set.empty)
 
   let with_temporary_delay f =
     let old_delayed = !delayed in
@@ -1024,32 +1056,35 @@ end = struct
    types that have actually been printed; this allows us to avoid naming loops
    that the user will never see. *)
 
-  let is_delayed t = TransientTypeSet.mem t !delayed
+  let is_delayed t = Proxy.Set.mem t !delayed
 
-  let is_visited_object_proxy t = TransientTypeSet.mem t !visited_objects
+  let is_visited_object_proxy t = Proxy.Set.mem t !visited_objects
 
   let remove_delay t =
     if is_delayed t then
-      delayed := TransientTypeSet.remove t !delayed
+      delayed := Proxy.Set.remove t !delayed
 
   let add_delayed t =
-    if not (is_delayed t) then delayed := TransientTypeSet.add t !delayed
+    if not (is_delayed t) then delayed := Proxy.Set.add t !delayed
 
-  let is_aliased_proxy px = TransientTypeSet.mem px !aliased
-  let is_printed_proxy px = TransientTypeSet.mem px !printed_aliases
+  let add_delayed_transient_REMOVE t =
+    add_delayed (Proxy.make_unnormalized_REMOVE t)
+
+  let is_aliased_proxy px = Proxy.Set.mem px !aliased
+  let is_printed_proxy px = Proxy.Set.mem px !printed_aliases
 
   let add_proxy px =
     if not (is_aliased_proxy px) then
-      aliased := TransientTypeSet.add px !aliased
+      aliased := Proxy.Set.add px !aliased
 
   let add ty = add_proxy (proxy ty)
 
-  let add_printed_proxy ~non_gen px =
+  let add_printed_proxy ~non_gen (px : Proxy.t) =
     Variable_names.check_name_of_type ~non_gen px;
-    printed_aliases := TransientTypeSet.add px !printed_aliases
+    printed_aliases := Proxy.Set.add px !printed_aliases
 
   let add_visited_object_proxy px =
-    visited_objects := TransientTypeSet.add px !visited_objects
+    visited_objects := Proxy.Set.add px !visited_objects
 
   let mark_as_printed px =
      if is_aliased_proxy px then (add_printed_proxy ~non_gen:false) px
@@ -1075,9 +1110,9 @@ end = struct
       let visited = px :: visited in
       match printer_get_desc ty with
       | Tvariant _ | Tobject _ ->
-          if TransientTypeSet.mem px !visited_objects then add_proxy px else begin
+          if Proxy.Set.mem px !visited_objects then add_proxy px else begin
             if should_visit_object ty then
-              visited_objects := TransientTypeSet.add px !visited_objects;
+              visited_objects := Proxy.Set.add px !visited_objects;
             printer_iter_type_expr (mark_loops_rec visited) ty
           end
       | Tpoly(ty, tyl) ->
@@ -1102,10 +1137,10 @@ end = struct
     mark_loops_rec [] ty
 
   let reset () =
-    visited_objects := TransientTypeSet.empty;
-    aliased := TransientTypeSet.empty;
-    delayed := TransientTypeSet.empty;
-    printed_aliases := TransientTypeSet.empty
+    visited_objects := Proxy.Set.empty;
+    aliased := Proxy.Set.empty;
+    delayed := Proxy.Set.empty;
+    printed_aliases := Proxy.Set.empty
 
 end
 
@@ -1160,18 +1195,19 @@ let wrap_env ?(keep_short_paths = false) fenv ftree arg =
 let print_labels = ref true
 let with_labels b f = Misc.protect_refs [R (print_labels,b)] f
 
-let alias_nongen_row mode px ty =
+let alias_nongen_row mode (px : Proxy.t) ty =
     match printer_get_desc ty with
     | Tvariant _ | Tobject _ ->
-        if is_non_gen mode (Transient_expr.type_expr px) then
+        if is_non_gen mode (Proxy.type_expr px) then
           Aliases.add_proxy px
     | _ -> ()
 
 let rec tree_of_typexp mode ty =
   let px = proxy ty in
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
-   let non_gen = is_non_gen mode (Transient_expr.type_expr px) in
-   let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
+   let non_gen = is_non_gen mode (Proxy.type_expr px) in
+   let name = Variable_names.(name_of_type (new_var_name ~non_gen ty))
+                (Proxy.transient_expr_REMOVE px) in
    Otyp_var (non_gen, name) else
 
   let pr_typ () =
@@ -1278,7 +1314,7 @@ let rec tree_of_typexp mode ty =
           Aliases.with_temporary_delay (fun () ->
               (* Make the names delayed, so that the real type is
                  printed once when used as proxy *)
-              List.iter Aliases.add_delayed tyl;
+              List.iter Aliases.add_delayed_transient_REMOVE tyl;
               let tl = List.map Variable_names.(name_of_type new_name) tyl in
               let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
               (* Forget names when we leave scope *)
@@ -1295,11 +1331,11 @@ let rec tree_of_typexp mode ty =
   Aliases.remove_delay px;
   alias_nongen_row mode px ty;
   if Aliases.(is_aliased_proxy px && aliasable ty) then begin
-    let non_gen = is_non_gen mode (Transient_expr.type_expr px) in
+    let non_gen = is_non_gen mode (Proxy.type_expr px) in
     Aliases.add_printed_proxy ~non_gen px;
     (* add_printed_proxy chose a name, thus the name generator
        doesn't matter.*)
-    let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
+    let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) (Proxy.transient_expr_REMOVE px) in
     Otyp_alias {non_gen;  aliased = pr_typ (); alias } end
   else pr_typ ()
 
@@ -1816,7 +1852,7 @@ let rec tree_of_class_type mode params =
       let self_ty =
         if Aliases.is_aliased_proxy px then
           Some
-            (Otyp_var (false, Variable_names.(name_of_type new_name) px))
+            (Otyp_var (false, Variable_names.(name_of_type new_name) (Proxy.transient_expr_REMOVE px)))
         else None
       in
       let csil = [] in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -657,8 +657,6 @@ module Proxy : sig
 
   val make : type_expr -> t
 
-  val make_unnormalized_REMOVE : transient_expr -> t
-
   val type_expr : t -> type_expr
   val transient_expr_REMOVE : t -> transient_expr
 
@@ -675,8 +673,6 @@ end = struct
   module Set = Stdlib.Set.Make(T)
 
   let make ty = Transient_expr.repr (proxy ty)
-
-  let make_unnormalized_REMOVE ty = ty
 
   let type_expr = Transient_expr.type_expr
   let transient_expr_REMOVE px = px
@@ -1034,7 +1030,6 @@ module Aliases : sig
   val is_visited_object_proxy : Proxy.t -> bool
 
   val add_delayed : Proxy.t -> unit
-  val add_delayed_transient_REMOVE : transient_expr -> unit
   val remove_delay : Proxy.t -> unit
   val is_delayed : Proxy.t -> bool
   val with_temporary_delay : (unit -> 'a) -> 'a
@@ -1066,9 +1061,6 @@ end = struct
 
   let add_delayed t =
     if not (is_delayed t) then delayed := Proxy.Set.add t !delayed
-
-  let add_delayed_transient_REMOVE t =
-    add_delayed (Proxy.make_unnormalized_REMOVE t)
 
   let is_aliased_proxy px = Proxy.Set.mem px !aliased
   let is_printed_proxy px = Proxy.Set.mem px !printed_aliases
@@ -1310,11 +1302,12 @@ let rec tree_of_typexp mode ty =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
           prerr_string "; " in *)
         if tyl = [] then tree_of_typexp mode ty else begin
+          let pxl = List.map Proxy.make tyl in
           let tyl = List.map Transient_expr.repr tyl in
           Aliases.with_temporary_delay (fun () ->
               (* Make the names delayed, so that the real type is
                  printed once when used as proxy *)
-              List.iter Aliases.add_delayed_transient_REMOVE tyl;
+              List.iter Aliases.add_delayed pxl;
               let tl = List.map Variable_names.(name_of_type new_name) tyl in
               let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
               (* Forget names when we leave scope *)

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1306,12 +1306,12 @@ let rec tree_of_typexp mode ty =
               if is_nth s then List.hd args else Otyp_constr (id, args) in
             let tags =
               if all_present then None else Some (List.map fst present) in
-            Otyp_variant (Ovar_typ out_variant, closed, tags)
+            Otyp_variant { fields = Ovar_typ out_variant; closed; tags }
         | _ ->
             let fields = List.map (tree_of_row_field mode) fields in
             let tags =
               if all_present then None else Some (List.map fst present) in
-            Otyp_variant (Ovar_fields fields, closed, tags)
+            Otyp_variant { fields = Ovar_fields fields; closed; tags }
         end
     | Tobject (fi, nm) ->
         tree_of_typobject mode fi !nm

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -661,12 +661,13 @@ module Proxy : sig
 
   val make : type_expr -> t
 
-  val type_expr : t -> type_expr
-  val transient_expr_REMOVE : t -> transient_expr
-
   val desc : t -> type_desc
 
   val is_non_gen : type_or_scheme -> t -> bool
+
+  val id : t -> int
+
+  val refresh : t -> t
 
   module Set : Stdlib.Set.S with type elt = t
   module Map : Stdlib.Map.S with type key = t
@@ -685,18 +686,26 @@ end = struct
   let make ty = Transient_expr.repr (proxy ty)
 
   let type_expr = Transient_expr.type_expr
-  let transient_expr_REMOVE px = px
 
   let desc t = t.desc
+  let id t = t.id
+
+  let refresh t =
+    make (type_expr t)
 
   let is_non_gen mode t =
+    let result =
     match mode with
     | Type_scheme ->
         let ty = type_expr t in
         is_Tvar ty && get_level ty <> generic_level
     | Type        -> false
+    in
+    result
 
 end
+
+let _ = Proxy.id
 
 let proxy = Proxy.make
 
@@ -879,7 +888,7 @@ end = struct
   let visited_for_named_vars = ref Proxy.Set.empty
 
   let weak_counter = ref 1
-  let weak_var_map = ref (TypeMap.empty : string TypeMap.t)
+  let weak_var_map = ref (Proxy.Map.empty : string Proxy.Map.t)
   let named_weak_vars = ref String.Set.empty
 
   let reset_names () =
@@ -934,29 +943,26 @@ end = struct
     incr name_counter;
     if name_is_already_used name then new_name () else name
 
-  let rec new_weak_name ty () =
-    let px = Proxy.make ty in
-    let ty = Proxy.type_expr px in
+  let rec new_weak_name px () =
     let name = "weak" ^ Int.to_string !weak_counter in
     incr weak_counter;
-    if name_is_already_used name then new_weak_name ty ()
+    if name_is_already_used name then new_weak_name px ()
     else begin
-        named_weak_vars := String.Set.add name !named_weak_vars;
-        weak_var_map := TypeMap.add ty name !weak_var_map;
-        name
-      end
+      named_weak_vars := String.Set.add name !named_weak_vars;
+      weak_var_map := Proxy.Map.add px name !weak_var_map;
+      name
+    end
 
   let new_var_name ~non_gen px () =
-    let ty = Proxy.type_expr px in
-    if non_gen then new_weak_name ty ()
+    if non_gen then new_weak_name px ()
     else new_name ()
 
-  let name_of_type name_generator (px : Proxy.t) =
+  let name_of_type name_generator (px' : Proxy.t) =
     (* We've already been through repr at this stage, so t is our representative
        of the union-find class. *)
-    let px = substitute px in
+    let px = substitute px' in
     try Proxy.Map.find px !names with Not_found ->
-      try TransientTypeMap.find (Proxy.transient_expr_REMOVE px) !weak_var_map with Not_found ->
+      try Proxy.Map.find px !weak_var_map with Not_found ->
       let name =
         match Proxy.desc px with
           Tvar (Some name) | Tunivar (Some name) ->
@@ -1012,16 +1018,18 @@ end = struct
       f
 
   let refresh_weak () =
-    let refresh t name (m,s) =
-      let px = Proxy.make t in
+    let refresh px name (m,s) =
       if is_non_gen Type_scheme px then
         begin
-          TypeMap.add (Proxy.type_expr px) name m,
+          let px = Proxy.refresh px in
+          Proxy.Map.add px name m,
           String.Set.add name s
         end
-      else m, s in
+      else
+        m, s
+    in
     let m, s =
-      TypeMap.fold refresh !weak_var_map (TypeMap.empty ,String.Set.empty) in
+      Proxy.Map.fold refresh !weak_var_map (Proxy.Map.empty ,String.Set.empty) in
     named_weak_vars := s;
     weak_var_map := m
 

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -78,7 +78,9 @@ type out_type =
   | Otyp_sum of out_constructor list
   | Otyp_tuple of (string option * out_type) list
   | Otyp_var of bool * string
-  | Otyp_variant of out_variant * bool * (string list) option
+  | Otyp_variant of { fields : out_variant;
+                      closed : bool;
+                      tags : (string list) option; }
   | Otyp_poly of string list * out_type
   | Otyp_module of out_package
   | Otyp_attribute of out_type * out_attribute

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -103,6 +103,9 @@ let rec split_last = function
       (hd :: lst, last)
 
 module Stdlib = struct
+  module Set = Stdlib.Set
+  module Map = Stdlib.Map
+
   module List = struct
     include Stdlib.List
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -111,6 +111,8 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
 (** {1 Extensions to the standard library} *)
 
 module Stdlib : sig
+  module Set = Stdlib.Set
+  module Map = Stdlib.Map
 
 (** {2 Extensions to the List module} *)
   module List : sig


### PR DESCRIPTION
When trying to understand how printing of types works when I looked at https://github.com/ocaml/ocaml/pull/14147, I ended up refactoring `Out_type` a little bit to gain a cleaner understanding.

I'm putting this up here in case this is useful.

Specifically, this PR:
- Introduces `Proxy.t` to manage type proxies in `Out_type`. We remove any mixing of proxied and unproxied types
- Uses `Proxy.Set.t` and `Proxy.Map.t` instead of lists for managing collections
- Wraps the `Alias` interface with a signature