### PR TITLE
minor gc: more consistent memprof logging

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -867,7 +867,7 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
   }
 
   CAML_EV_BEGIN(EV_MINOR_MEMPROF_CLEAN);
-  CAML_GC_MESSAGE(MINOR, "Updating memprof.\n");
+  caml_gc_log("updating memprof");
   caml_memprof_after_minor_gc(domain);
   CAML_EV_END(EV_MINOR_MEMPROF_CLEAN);
 


### PR DESCRIPTION
In
  https://github.com/ocaml/ocaml/pull/13580#issuecomment-3092253963
@jmid reports that he needed to tweak the GC verbosity setting to avoid getting spammed by minor-gc messages when debugging an assertion failure.

The other sub-phases of the GC minor all uses `caml_gc_log` rather than CAML_GC_MESSAGE, and do not seem to cause similar spamming issues. Fixing the code to be consistent will avoid inconsistent verbosity levels in end-user scripts.