### PR TITLE
Fix dependency generation when things are disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2068,7 +2068,7 @@ partialclean::
 ocamltest/ocamltest_config.ml ocamltest/ocamltest_unix.ml: config.status
 	./$< $@
 
-beforedepend:: ocamltest/ocamltest_unix.ml
+beforedepend:: ocamltest/ocamltest_config.ml ocamltest/ocamltest_unix.ml
 
 # Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -2100,7 +2100,7 @@ partialclean::
 .PHONY: ocamltest-manual
 ocamltest-manual: ocamltest/ocamltest.html
 
-ocamltest/ocamltest.html: ocamltest/ocamltest.org
+ocamltest/ocamltest.html: ocamltest/OCAMLTEST.org
 	pandoc -s --toc -N -f org -t html -o $@ $<
 
 # The extra libraries

--- a/configure
+++ b/configure
@@ -3571,8 +3571,6 @@ ac_config_files="$ac_config_files manual/src/version.tex"
 
 ac_config_files="$ac_config_files manual/src/html_processing/src/common.ml"
 
-ac_config_files="$ac_config_files ocamltest/ocamltest_config.ml"
-
 ac_config_files="$ac_config_files otherlibs/dynlink/dynlink_config.ml"
 
 ac_config_files="$ac_config_files utils/config.common.ml"
@@ -23424,6 +23422,8 @@ ocamltest_unix_mod="ocamltest/ocamltest_unix_${ocamltest_unix_impl}.ml"
 if $build_ocamltest
 then :
   optional_libraries="$optional_libraries testsuite/lib/testing"
+  ac_config_files="$ac_config_files ocamltest/ocamltest_config.ml"
+
   ac_config_links="$ac_config_links ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}"
 
   for ac_prog in patdiff diff
@@ -24938,7 +24938,6 @@ do
     "stdlib/sys.ml") CONFIG_FILES="$CONFIG_FILES stdlib/sys.ml" ;;
     "manual/src/version.tex") CONFIG_FILES="$CONFIG_FILES manual/src/version.tex" ;;
     "manual/src/html_processing/src/common.ml") CONFIG_FILES="$CONFIG_FILES manual/src/html_processing/src/common.ml" ;;
-    "ocamltest/ocamltest_config.ml") CONFIG_FILES="$CONFIG_FILES ocamltest/ocamltest_config.ml" ;;
     "otherlibs/dynlink/dynlink_config.ml") CONFIG_FILES="$CONFIG_FILES otherlibs/dynlink/dynlink_config.ml" ;;
     "utils/config.common.ml") CONFIG_FILES="$CONFIG_FILES utils/config.common.ml" ;;
     "utils/config.generated.ml") CONFIG_FILES="$CONFIG_FILES utils/config.generated.ml" ;;
@@ -24962,6 +24961,7 @@ do
     "shebang") CONFIG_COMMANDS="$CONFIG_COMMANDS shebang" ;;
     "otherlibs/systhreads/META") CONFIG_FILES="$CONFIG_FILES otherlibs/systhreads/META" ;;
     "links") CONFIG_COMMANDS="$CONFIG_COMMANDS links" ;;
+    "ocamltest/ocamltest_config.ml") CONFIG_FILES="$CONFIG_FILES ocamltest/ocamltest_config.ml" ;;
     "ocamltest/ocamltest_unix.ml") CONFIG_LINKS="$CONFIG_LINKS ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure
+++ b/configure
@@ -15005,8 +15005,9 @@ otherlibraries="dynlink runtime_events"
 otherlibs="runtime_events"
 optional_libraries="$optional_libraries otherlibs/dynlink/dynlink"
 lib_dynlink=true
-dldir=otherlibs/dynlink
-ac_config_links="$ac_config_links $dldir/dynlink_cmo_format.mli:file_formats/cmo_format.mli $dldir/dynlink_cmxs_format.mli:file_formats/cmxs_format.mli $dldir/dynlink_platform_intf.mli:$dldir/dynlink_platform_intf.ml"
+
+ac_config_links="$ac_config_links otherlibs/dynlink/dynlink_cmo_format.mli:file_formats/cmo_format.mli otherlibs/dynlink/dynlink_cmxs_format.mli:file_formats/cmxs_format.mli otherlibs/dynlink/dynlink_platform_intf.mli:otherlibs/dynlink/dynlink_platform_intf.ml"
+
 
 lib_runtime_events=true
 if test x"$enable_unix_lib" != "xno"
@@ -24952,9 +24953,9 @@ do
     "native-symlinks") CONFIG_COMMANDS="$CONFIG_COMMANDS native-symlinks" ;;
     "ocamldoc/META") CONFIG_FILES="$CONFIG_FILES ocamldoc/META" ;;
     "libtool") CONFIG_COMMANDS="$CONFIG_COMMANDS libtool" ;;
-    "$dldir/dynlink_cmo_format.mli") CONFIG_LINKS="$CONFIG_LINKS $dldir/dynlink_cmo_format.mli:file_formats/cmo_format.mli" ;;
-    "$dldir/dynlink_cmxs_format.mli") CONFIG_LINKS="$CONFIG_LINKS $dldir/dynlink_cmxs_format.mli:file_formats/cmxs_format.mli" ;;
-    "$dldir/dynlink_platform_intf.mli") CONFIG_LINKS="$CONFIG_LINKS $dldir/dynlink_platform_intf.mli:$dldir/dynlink_platform_intf.ml" ;;
+    "otherlibs/dynlink/dynlink_cmo_format.mli") CONFIG_LINKS="$CONFIG_LINKS otherlibs/dynlink/dynlink_cmo_format.mli:file_formats/cmo_format.mli" ;;
+    "otherlibs/dynlink/dynlink_cmxs_format.mli") CONFIG_LINKS="$CONFIG_LINKS otherlibs/dynlink/dynlink_cmxs_format.mli:file_formats/cmxs_format.mli" ;;
+    "otherlibs/dynlink/dynlink_platform_intf.mli") CONFIG_LINKS="$CONFIG_LINKS otherlibs/dynlink/dynlink_platform_intf.mli:otherlibs/dynlink/dynlink_platform_intf.ml" ;;
     "otherlibs/unix/META") CONFIG_FILES="$CONFIG_FILES otherlibs/unix/META" ;;
     "otherlibs/unix/unix.ml") CONFIG_LINKS="$CONFIG_LINKS otherlibs/unix/unix.ml:otherlibs/unix/unix_${unix_or_win32}.ml" ;;
     "otherlibs/str/META") CONFIG_FILES="$CONFIG_FILES otherlibs/str/META" ;;

--- a/configure
+++ b/configure
@@ -3353,6 +3353,7 @@ ocamltest_libunix=None
 ocamltest_unix_impl="dummy"
 unix_library=""
 unix_directory=""
+diff_supports_color=false
 
 # Information about the package
 
@@ -23413,10 +23414,15 @@ fi
   ocamltest='' ;;
 esac
 
+# config.status needs the values of ocamltest_unix_mod and unix_or_win32
+# for creating symlinks
+ac_config_commands="$ac_config_commands links"
+
+
+ocamltest_unix_mod="ocamltest/ocamltest_unix_${ocamltest_unix_impl}.ml"
 if $build_ocamltest
 then :
   optional_libraries="$optional_libraries testsuite/lib/testing"
-  ocamltest_unix_mod="ocamltest/ocamltest_unix_${ocamltest_unix_impl}.ml"
   ac_config_links="$ac_config_links ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}"
 
   for ac_prog in patdiff diff
@@ -24915,6 +24921,9 @@ fi
   ocaml_bindir='$(echo "$ocaml_bindir" | sed -e "s/'/'\"'\"'/g")'
   TARGET_BINDIR='$(echo "$TARGET_BINDIR" | sed -e "s/'/'\"'\"'/g")'
 
+  ocamltest_unix_mod='$ocamltest_unix_mod'
+  unix_or_win32='$unix_or_win32'
+
 _ACEOF
 
 cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
@@ -24951,6 +24960,7 @@ do
     "otherlibs/str/META") CONFIG_FILES="$CONFIG_FILES otherlibs/str/META" ;;
     "shebang") CONFIG_COMMANDS="$CONFIG_COMMANDS shebang" ;;
     "otherlibs/systhreads/META") CONFIG_FILES="$CONFIG_FILES otherlibs/systhreads/META" ;;
+    "links") CONFIG_COMMANDS="$CONFIG_COMMANDS links" ;;
     "ocamltest/ocamltest_unix.ml") CONFIG_LINKS="$CONFIG_LINKS ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,6 @@ AC_CONFIG_FILES([Makefile.config])
 AC_CONFIG_FILES([stdlib/sys.ml])
 AC_CONFIG_FILES([manual/src/version.tex])
 AC_CONFIG_FILES([manual/src/html_processing/src/common.ml])
-AC_CONFIG_FILES([ocamltest/ocamltest_config.ml])
 AC_CONFIG_FILES([otherlibs/dynlink/dynlink_config.ml])
 AC_CONFIG_FILES([utils/config.common.ml])
 AC_CONFIG_FILES([utils/config.generated.ml])
@@ -2739,6 +2738,7 @@ AC_CONFIG_COMMANDS([links], [], [
 ocamltest_unix_mod="ocamltest/ocamltest_unix_${ocamltest_unix_impl}.ml"
 AS_IF([$build_ocamltest],
   [optional_libraries="$optional_libraries testsuite/lib/testing"
+  AC_CONFIG_FILES([ocamltest/ocamltest_config.ml])
   AC_CONFIG_LINKS([
     ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -833,12 +833,16 @@ otherlibraries="dynlink runtime_events"
 otherlibs="runtime_events"
 optional_libraries="$optional_libraries otherlibs/dynlink/dynlink"
 lib_dynlink=true
-dldir=otherlibs/dynlink
-AC_CONFIG_LINKS([
-  $dldir/dynlink_cmo_format.mli:file_formats/cmo_format.mli
-  $dldir/dynlink_cmxs_format.mli:file_formats/cmxs_format.mli
-  $dldir/dynlink_platform_intf.mli:$dldir/dynlink_platform_intf.ml
-])
+dnl dldir needs to be expanded by autoconf, not by configure, if it were instead
+dnl put in $dldir, this would end up in config.status, except that the value
+dnl would be missing.
+m4_define([dldir], [otherlibs/dynlink])
+AC_CONFIG_LINKS(
+  dldir[/dynlink_cmo_format.mli:file_formats/cmo_format.mli]
+  dldir[/dynlink_cmxs_format.mli:file_formats/cmxs_format.mli]
+  dldir[/dynlink_platform_intf.mli:]dldir[/dynlink_platform_intf.ml]
+)
+m4_undefine([dldir])
 lib_runtime_events=true
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ ocamltest_libunix=None
 ocamltest_unix_impl="dummy"
 unix_library=""
 unix_directory=""
+diff_supports_color=false
 
 # Information about the package
 
@@ -2725,9 +2726,15 @@ testsuite/tools/test_in_prefix"])
   [build_ocamltest=false
   ocamltest=''])
 
+# config.status needs the values of ocamltest_unix_mod and unix_or_win32
+# for creating symlinks
+AC_CONFIG_COMMANDS([links], [], [
+  ocamltest_unix_mod='$ocamltest_unix_mod'
+  unix_or_win32='$unix_or_win32'])
+
+ocamltest_unix_mod="ocamltest/ocamltest_unix_${ocamltest_unix_impl}.ml"
 AS_IF([$build_ocamltest],
   [optional_libraries="$optional_libraries testsuite/lib/testing"
-  ocamltest_unix_mod="ocamltest/ocamltest_unix_${ocamltest_unix_impl}.ml"
   AC_CONFIG_LINKS([
     ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}
   ])


### PR DESCRIPTION
Spotted with #14152:

```
$ ./configure --disable-ocamltest --disable-ocamldoc && make -j coldstart && make -j ocamllex && make -j alldepend
...
File "ocamltest/ocamltest_config.ml.in", line 43, characters 0-3:
Error: Syntax error
make: *** [Makefile:2577: ocamltest.depend] Error 2
make: *** Waiting for unfinished jobs....
```

The precise cause of that error is that `$diff_supports_color` is not initialised in `configure.ac` and ends up blank, instead of a boolean. Fix that, and you instead get a diff in `.depend` instead: ocamldoc's and ocamltest's dependencies change and the dependencies for the binaries in testsuite/tools are completely missing.

The reason for that is that the `OPTIONAL_BYTECODE_TOOLS`, `OPTIONAL_NATIVE_TOOLS` and `OPTIONAL_LIBRARIES` set-up in `configure.ac` are being mis-used in `Makefile`. They convey whether the tools are _needed_, but they are also being used to control if the tools are even _defined_. The rules for building ocamldoc should be defined whether ocamldoc is actually going to be compiled or not. Similarly, the definitions for ocamltest were rather too eagerly guarded by a test as to whether ocamltest is actually going to be compiled. Fix those, and ocamltest's dependencies are still wrong because of the missing `ocamltest/ocamltest_unix.ml` link.

That's easy to fix in the `Makefile` using a `beforedepend::` rule, because `config.status` includes the ability to make all the things it knows how to do, even if they weren't requested. It does however reveal some mistakes in the way `config.status` was being generated, which is the final part of the first commit (note that we already have similar levels of m4sh fun for `config.status` for other things - there's nothing new in that `AC_CONFIG_COMMANDS` call).

The second commit in passing makes a similar fix to the generation of the symlinks in otherlibs/dynlink, but using an m4 variable for a _constant_ (as opposed to do `$unix_or_win32` and `$ocamltest_unix_mod` which are _variables_ determined at `configure`-time)

The last two commits are extracted from #14152.