### PR TITLE
Minor heap reservation: change the terminology

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -54,7 +54,7 @@ Caml_inline int caml_check_gc_interrupt(caml_domain_state * dom_st)
   (CAMLunlikely(caml_check_gc_interrupt(dom_st)))
 
 asize_t caml_norm_minor_heap_size (intnat);
-int caml_reallocate_minor_heap(asize_t);
+int caml_reallocate_minor_heap_arena(asize_t);
 void caml_update_minor_heap_max(uintnat minor_heap_wsz);
 
 /* is there a STW interrupt queued that needs servicing */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -133,7 +133,7 @@ void caml_set_minor_heap_size (asize_t wsize)
     caml_minor_collection();
   }
 
-  if(caml_reallocate_minor_heap(wsize) < 0) {
+  if(caml_reallocate_minor_heap_arena(wsize) < 0) {
     caml_fatal_error("Fatal error: No memory for minor heap");
   }
 


### PR DESCRIPTION
The current codebase use 'caml_minor_heaps_{start,end}' for the boundaries of a global address space that is reserved, 'dom->caml_minor_heap_area_{start,end}' for a 'minor heap area', a segment of this address space that is owned by each domain, and then finally 'dom->young_{start,end}' for the prefix of this segment that is actually committed and used as the minor heap of each domain. Some comments refer to the latter as the 'minor heap arena', following terminology from the Retrofitting Parallelism into OCaml paper.

On a suggestion by KC in #14158, I am trying to make the naming scheme more regular by consistently using 'reservation' for a reserved block of address space:

- Use 'minor heaps reservation' for the global reservation. Its boundaries remain stored in 'caml_minor_heaps_{start,end}' to avoid compatibility issues in third-party code.

- Use 'minor heap reservation' for the per-domain segment of the global reservation. Its boundaries are stored in 'dom->minor_heap_reservation_{start,end}'.

- Use 'minor heap' for the prefix of the minor heap reservation that is actually committed, whose boundaries remain 'dom->young_{start,end}'.

This change is purely local to domain.c.
