### PR TITLE
[refactoring] runtime: add a category of 'parked' domains that are undergoing initialization

### DIFF
--- a/Changes
+++ b/Changes
@@ -214,6 +214,10 @@ Working version
   confusing it with constructors.
   (Stefan Muenzel, review by Nicolás Ojeda Bär)
 
+- #14161: refactor the STW-participants machinery to add an intermediate
+  category of 'parked' domain structures.
+  (Gabriel Scherer, review by Sivaramakrishnan)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets


### PR DESCRIPTION
The current runtime has a global structure `stw_domains` that splits all domains in two categories (represented a partition of an array in two intervals):
- domains that participate to STW events
- domains that do not

There are very strict rule about the runtime state of domains that change categories.

The present PR refines `stw_domains` in three categories of domains:
1. 'active' domains that participate to STW sections
2. 'parked' domains that are in the process of initialization (or un-initialization)
3. 'stopped' domains that are completely inactive

It is easy to move a domain from 'stopped' to 'parked' (before we initialize it) or conversely (after we un-initialized it).

The PR is purely a refactoring that should exactly preserve the behavior of the runtime. But it enables two different kind of changes (not included in the PR):

1. This PR is useful to solve #14153, following an approach where we change `Domain.spawn` so that the *parent* domain reserves a `dom_internal` structure for the child domain (by 'parking' a stopped domain), and updates the minor heaps reservation if necessary.
2. Currently there is a weird possible race between domain termination and domain creation: when we start termination we remove the domain from the set of STW participants, but then a new `Domain.spawn` request could try to reuse this domain structure while domain-termination is still proceeding. (The race is avoided by relying on the domain lock.) The present PR makes it possible to avoid this race by keeping domains 'parked' while they are being terminated, which guarantees that they will not be selected for spawning. This could make the code simpler and also allow for domain termination and spawning to proceed in parallel instead of blocking each other. (I have experimented some changes in this direction but don't have a concrete PR to send and may not do it at all.)

