### PR TITLE
Gradual reservation of minor heap adresses

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,12 @@ Working version
   Added the function [Gc.Memprof.is_sampling].
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
 
+- #14153, #14162: reserve minor-heap memory space gradually, first for only 1
+  domain, then 8, 16, 32, etc. This avoids space-reservation issues on some
+  systems when using large minor heaps.
+  (Gabriel Scherer, review by KC Sivaramakrishnan,
+   report by Guillaume Melquiond)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -286,7 +286,7 @@ static void check_stw_domains(void) {
 #endif
 }
 
-static int find_stw_domain(int start, int end, dom_internal *dom) {
+static int find_stw_domain_noexc(int start, int end, dom_internal *dom) {
   check_domain_limit(start);
   check_domain_limit(end);
   for (int i = start; i < end; i++)
@@ -294,17 +294,21 @@ static int find_stw_domain(int start, int end, dom_internal *dom) {
     if (stw_domains.domains[i] == dom)
       return i;
   }
-  caml_fatal_error("find_stw_domain");
+  return (-1);
 }
 static int find_active_domain(dom_internal *dom) {
   int start = 0;
   int end = stw_domains.active_domains;
-  return find_stw_domain(start, end, dom);
+  int idx = find_stw_domain_noexc(start, end, dom);
+  if (idx < 0) caml_fatal_error("find_active_domain");
+  return idx;
 }
 static int find_parked_domain(dom_internal *dom) {
   int start = stw_domains.active_domains;
   int end = stw_domains.parked_domains;
-  return find_stw_domain(start, end, dom);
+  int idx = find_stw_domain_noexc(start, end, dom);
+  if (idx < 0) caml_fatal_error("find_parked_domain");
+  return idx;
 }
 
 static void swap_stw_domains(int idx1, int idx2) {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -252,17 +252,20 @@ CAMLexport atomic_uintnat caml_num_domains_running = 0;
      in the process of spawning.
    - [parked_domains, caml_params->max_domains) are the 'stopped' domains,
      which are currently unused by the runtime.
+   - [peak_parked_domains] is the peak value of [parked_domains]:
+     domains at this position and later have always been stopped.
  */
 static struct {
   int active_domains;
   int parked_domains;
+  int peak_parked_domains;
   dom_internal** domains;
 } stw_domains = {
   0,
   0,
+  0,
   NULL
 };
-
 
 static void check_domain_limit(int idx) {
   CAMLassert(0 <= idx && idx <= caml_params->max_domains);
@@ -307,6 +310,8 @@ static void check_stw_domains(void) {
   check_domain_limit(stw_domains.parked_domains);
   CAMLassert(stw_domains.active_domains
              <= stw_domains.parked_domains);
+  CAMLassert(stw_domains.parked_domains
+             <= stw_domains.peak_parked_domains);
 #ifdef DEBUG
   /* Check here the invariants for early-exit in
      [caml_interrupt_all_signal_safe], because the latter must be
@@ -351,6 +356,8 @@ static dom_internal* park_next_stopped_domain(void) {
 
   dom_internal *dom = stw_domains.domains[stw_domains.parked_domains];
   stw_domains.parked_domains++;
+  if (stw_domains.parked_domains > stw_domains.peak_parked_domains)
+    stw_domains.peak_parked_domains = stw_domains.parked_domains;
   check_stw_domains();
   return dom;
 }
@@ -469,7 +476,7 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 /* Note [minor heap layout]:
 
 - The 'minor heaps reservation' is a contiguous address space of size
-    [caml_minor_heap_max_wsz * caml_params->max_domains]
+    [minor_heaps_reservation_num_domains * caml_minor_heap_max_wsz]
   reserved by [caml_init_domains]. Its boundaries are
     [caml_minor_heaps_start]
   and
@@ -517,6 +524,9 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 
 /* Size of the virtual memory reservation for the minor heap, per domain. */
 uintnat caml_minor_heap_max_wsz;
+
+/* Number of domains with a reserved minor heap. */
+static uintnat minor_heaps_reservation_num_domains = 0;
 
 /* The boundaries of the reserved address space for all minor heaps. */
 CAMLexport uintnat caml_minor_heaps_start;
@@ -652,16 +662,50 @@ int caml_reallocate_minor_heap_arena(asize_t wsize)
 
 /* Minor heaps reservation: initialization and resizing */
 
-static void reserve_minor_heaps_reservation_from_stw_single(void) {
+struct reservation_params {
+  uintnat new_minor_wsz;
+  uintnat ensure_num_domains;
+};
+
+static void reserve_minor_heaps_reservation_from_stw_single(
+  struct reservation_params* p)
+{
   void* heaps_base;
   uintnat minor_heaps_reservation_bsize;
   uintnat minor_heap_max_bsz;
 
+  /* new_minor_wsz is page-aligned by caml_norm_minor_heap_size. */
+  caml_minor_heap_max_wsz = caml_norm_minor_heap_size(p->new_minor_wsz);
   CAMLassert (caml_mem_round_up_pages(Bsize_wsize(caml_minor_heap_max_wsz))
           == Bsize_wsize(caml_minor_heap_max_wsz));
 
+  if (p->ensure_num_domains > caml_params->max_domains)
+      p->ensure_num_domains = caml_params->max_domains;
+
+  if (minor_heaps_reservation_num_domains < p->ensure_num_domains) {
+
+    /* 1, 8, 16, 32...
+       Start at 1 which remains the most common cases.
+       Jump straight to 8 to avoid several resizes in a row
+       for small domain counts.
+     */
+    int new_num_domains = 1;
+    while (new_num_domains < p->ensure_num_domains) {
+      if (new_num_domains < 8) {
+        new_num_domains = 8;
+      } else {
+        new_num_domains *= 2;
+      }
+    }
+    if (new_num_domains > caml_params->max_domains)
+      new_num_domains = caml_params->max_domains;
+
+    minor_heaps_reservation_num_domains = new_num_domains;
+  }
+
   minor_heap_max_bsz = (uintnat)Bsize_wsize(caml_minor_heap_max_wsz);
-  minor_heaps_reservation_bsize = minor_heap_max_bsz * caml_params->max_domains;
+  minor_heaps_reservation_bsize =
+    minor_heap_max_bsz * minor_heaps_reservation_num_domains;
 
   /* reserve memory space for minor heaps */
   heaps_base = caml_mem_map(minor_heaps_reservation_bsize, 1/* reserve_only */);
@@ -672,11 +716,15 @@ static void reserve_minor_heaps_reservation_from_stw_single(void) {
   caml_minor_heaps_end =
     (uintnat) heaps_base + minor_heaps_reservation_bsize;
 
-  caml_gc_log("new minor heaps reservation from %p to %p",
+  caml_gc_log("new minor heaps reservation from %p to %p"
+              " (%" CAML_PRIuSZT " domains"
+              " * %" CAML_PRIuSZT "KB heap reservations)",
               (value*)caml_minor_heaps_start,
-              (value*)caml_minor_heaps_end);
+              (value*)caml_minor_heaps_end,
+              minor_heaps_reservation_num_domains,
+              minor_heap_max_bsz / 1024);
 
-  for (int i = 0; i < caml_params->max_domains; i++) {
+  for (int i = 0; i < minor_heaps_reservation_num_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
 
     uintnat domain_minor_heap_reservation =
@@ -697,7 +745,7 @@ static void unreserve_minor_heaps_reservation_from_stw_single(void) {
 
   caml_gc_log("unreserve_minor_heaps_reservation");
 
-  for (int i = 0; i < caml_params->max_domains; i++) {
+  for (int i = 0; i < minor_heaps_reservation_num_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
 
     CAMLassert(
@@ -719,24 +767,22 @@ static void unreserve_minor_heaps_reservation_from_stw_single(void) {
   }
 
   size = caml_minor_heaps_end - caml_minor_heaps_start;
-  CAMLassert (Bsize_wsize(caml_minor_heap_max_wsz) * caml_params->max_domains
+  CAMLassert (Bsize_wsize(caml_minor_heap_max_wsz)
+              * minor_heaps_reservation_num_domains
               == size);
   caml_mem_unmap((void *) caml_minor_heaps_start, size);
 }
 
 static
-void domain_resize_heaps_reservation_from_stw_single(uintnat new_minor_wsz)
+void domain_resize_heaps_reservation_from_stw_single(
+  struct reservation_params* params)
 {
   CAML_EV_BEGIN(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
   caml_gc_log("stw_resize_minor_heaps_reservation: unreserve");
-
   unreserve_minor_heaps_reservation_from_stw_single();
-  /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
-     been called to normalize it earlier.
-  */
-  caml_minor_heap_max_wsz = new_minor_wsz;
+
   caml_gc_log("stw_resize_minor_heaps_reservation: reserve");
-  reserve_minor_heaps_reservation_from_stw_single();
+  reserve_minor_heaps_reservation_from_stw_single(params);
   /* The call to [reserve_minor_heaps_reservation_from_stw_single] makes a new
      reservation, and it also updates the reservation boundaries of each
      domain by mutating its [minor_heap_reservation_start{,_end}] variables.
@@ -751,7 +797,7 @@ void domain_resize_heaps_reservation_from_stw_single(uintnat new_minor_wsz)
 
 static void
 stw_resize_minor_heaps_reservation(caml_domain_state* domain,
-                                  void* minor_wsz_data,
+                                  void* reservation_params,
                                   int participating_count,
                                   caml_domain_state** participating) {
   caml_gc_log("stw_resize_minor_heaps_reservation: "
@@ -766,8 +812,7 @@ stw_resize_minor_heaps_reservation(caml_domain_state* domain,
   free_minor_heap_arena();
 
   Caml_global_barrier_if_final(participating_count) {
-    uintnat new_minor_wsz = (uintnat) minor_wsz_data;
-    domain_resize_heaps_reservation_from_stw_single(new_minor_wsz);
+    domain_resize_heaps_reservation_from_stw_single(reservation_params);
   }
 
   caml_gc_log("stw_resize_minor_heaps_reservation: allocate_minor_heap_arena");
@@ -784,9 +829,26 @@ void caml_update_minor_heap_max(uintnat requested_wsz) {
   caml_gc_log("Changing heap_max_wsz from %" CAML_PRIuNAT
               " to %" CAML_PRIuNAT ".",
               caml_minor_heap_max_wsz, requested_wsz);
+  struct reservation_params params = {
+    .new_minor_wsz = requested_wsz,
+    .ensure_num_domains = 1
+  };
   while (requested_wsz > caml_minor_heap_max_wsz) {
     caml_try_run_on_all_domains(
-      &stw_resize_minor_heaps_reservation, (void*)requested_wsz, 0);
+      &stw_resize_minor_heaps_reservation, &params, 0);
+  }
+  check_minor_heap();
+}
+
+static void ensure_minor_heaps_reservation(uintnat ensure_num_domains) {
+  CAMLassert(ensure_num_domains <= caml_params->max_domains);
+  struct reservation_params params = {
+    .new_minor_wsz = caml_minor_heap_max_wsz,
+    .ensure_num_domains = ensure_num_domains
+  };
+  while (minor_heaps_reservation_num_domains < ensure_num_domains) {
+    caml_try_run_on_all_domains(
+      &stw_resize_minor_heaps_reservation, &params, 0);
   }
   check_minor_heap();
 }
@@ -1096,7 +1158,11 @@ void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
   if (stw_domains.domains == NULL)
     caml_fatal_error("Failed to allocate stw_domains.domains");
 
-  reserve_minor_heaps_reservation_from_stw_single();
+  struct reservation_params reservation_params = {
+    .new_minor_wsz = minor_heap_wsz,
+    .ensure_num_domains = 1
+  };
+  reserve_minor_heaps_reservation_from_stw_single(&reservation_params);
   /* stw_single: mutators and domains have not started yet. */
 
   for (int i = 0; i < max_domains; i++) {
@@ -1443,7 +1509,6 @@ static void* domain_thread_func(void* v)
       running code with its domain lock held.
 */
 
-
 CAMLprim value caml_domain_spawn(value callback, value term_sync)
 {
   CAMLparam2 (callback, term_sync);
@@ -1460,9 +1525,35 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
     caml_fatal_error("ocamldebug does not support spawning multiple domains");
 #endif
 
+  caml_plat_lock_blocking(&all_domains_lock);
   dom_internal *newdom = park_next_stopped_domain();
+  int peak_parked_domains = stw_domains.peak_parked_domains;
+  caml_plat_unlock(&all_domains_lock);
+
   if (newdom == NULL) {
     caml_failwith("Maximum number of domains reached.");
+  }
+
+  // Ensure that there is a minor heap reservation for this domain.
+  if (newdom->minor_heap_reservation_start == 0
+      && newdom->minor_heap_reservation_end == 0)
+  {
+    /* Note: the domain structures are not necessarily in the same
+       order in [stw_domains] and in [all_domains], and [dom_idx] is
+       relative to [stw_domains] while heap reservation happens in
+       [all_domains] order. Domains start in the same order in both
+       arrays, and then their position changes when they are parked,
+       activated or stopped.
+
+       We use [peak_parked_domains] for our reservation request; all
+       domains that have ever been parked or activated
+       (including [newdom]) are placed before this limit in both
+       [stw_domains] and [all_domains]. This guarantees that all
+       domains with a previous reservation will still have one, and
+       that [newdom] will have one.
+     */
+    ensure_minor_heaps_reservation(peak_parked_domains);
+    CAMLassert(newdom->minor_heap_reservation_end != 0);
   }
 
   p.newdom = newdom;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -267,24 +267,6 @@ static struct {
 static void check_domain_limit(int idx) {
   CAMLassert(0 <= idx && idx <= caml_params->max_domains);
 }
-static void check_stw_domains(void) {
-  check_domain_limit(stw_domains.active_domains);
-  check_domain_limit(stw_domains.parked_domains);
-  CAMLassert(stw_domains.active_domains
-             <= stw_domains.parked_domains);
-#ifdef DEBUG
-  /* Check here the invariant for early-exit in
-     [caml_interrupt_all_signal_safe], because the latter must be
-     async-signal-safe and one cannot CAMLassert inside it. */
-  bool prev_has_interrupt_word = true;
-  for (int i = 0; i < caml_params->max_domains; i++) {
-    bool has_interrupt_word = all_domains[i].interruptor.interrupt_word != NULL;
-    if (i < stw_domains.active_domains) CAMLassert(has_interrupt_word);
-    if (!prev_has_interrupt_word) CAMLassert(!has_interrupt_word);
-    prev_has_interrupt_word = has_interrupt_word;
-  }
-#endif
-}
 
 static int find_stw_domain_noexc(int start, int end, dom_internal *dom) {
   check_domain_limit(start);
@@ -317,6 +299,46 @@ static void swap_stw_domains(int idx1, int idx2) {
   dom_internal *dom2 = stw_domains.domains[idx2];
   stw_domains.domains[idx1] = dom2;
   stw_domains.domains[idx2] = dom1;
+}
+
+/* One needs to hold [all_domains_lock] to call this debug function. */
+static void check_stw_domains(void) {
+  check_domain_limit(stw_domains.active_domains);
+  check_domain_limit(stw_domains.parked_domains);
+  CAMLassert(stw_domains.active_domains
+             <= stw_domains.parked_domains);
+#ifdef DEBUG
+  /* Check here the invariants for early-exit in
+     [caml_interrupt_all_signal_safe], because the latter must be
+     async-signal-safe and one cannot CAMLassert inside it. */
+
+  int active_domains = stw_domains.active_domains;
+
+  /* Invariant 1: the active domains have a non-null interrupt word. */
+  for (int i = 0; i < active_domains; i++) {
+    dom_internal *dom = stw_domains.domains[i];
+    bool has_interrupt_word = dom->interruptor.interrupt_word != NULL;
+    CAMLassert(has_interrupt_word);
+  }
+
+  /* Invariant 2: active domains are placed before the first
+     NULL-interrupt word in [all_domains] order. */
+  bool after_first_null = false;
+  for (int i = 0; i < caml_params->max_domains; i++) {
+    dom_internal *dom = &all_domains[i];
+    bool has_interrupt_word = dom->interruptor.interrupt_word != NULL;
+    if (!has_interrupt_word) after_first_null = true;
+    /* We already know from checking Invariant 1 that active domains
+       have a non-NULL interrupt word, so we only need to check
+       domains with a non-NULL interrupt word after the first NULL.
+       Typically there are none, so the check is fast. */
+    if (has_interrupt_word && after_first_null) {
+      bool is_active_domain =
+        (find_stw_domain_noexc(0, active_domains, dom) >= 0);
+      CAMLassert(!is_active_domain);
+    }
+  }
+#endif
 }
 
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -800,10 +800,10 @@ static uintnat fresh_domain_unique_id(void) {
 }
 
 /* must be run on the domain's thread */
-static void domain_create(uintnat initial_minor_heap_wsize,
+static void domain_create(dom_internal *d,
+                          uintnat initial_minor_heap_wsize,
                           caml_domain_state *parent)
 {
-  dom_internal* d = 0;
   caml_domain_state* domain_state;
   struct interruptor* s;
   uintnat stack_wsize = caml_get_init_stack_wsize();
@@ -839,11 +839,6 @@ static void domain_create(uintnat initial_minor_heap_wsize,
       break;
     }
   }
-
-  d = park_next_stopped_domain();
-
-  if (d == NULL)
-    goto domain_parking_failure;
 
   s = &d->interruptor;
   CAMLassert(!s->running);
@@ -1032,10 +1027,7 @@ init_memprof_failure:
   domain_self = NULL;
 
   atomic_fetch_add(&caml_num_domains_running, -1);
-
 domain_state_init_failure:
-  stop_parked_domain(d);
-domain_parking_failure:
 
 domain_init_complete:
   caml_gc_log("domain init complete");
@@ -1109,7 +1101,9 @@ void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
     dom->domain_canceled = false;
   }
 
-  domain_create(minor_heap_wsz, NULL);
+  dom_internal *first_dom = park_next_stopped_domain();
+  CAMLassert(first_dom != NULL);
+  domain_create(first_dom, minor_heap_wsz, NULL);
   if (!domain_self) caml_fatal_error("Failed to create main domain");
   CAMLassert (domain_self->state->unique_id == 0);
 
@@ -1161,7 +1155,7 @@ struct domain_startup_params {
   enum domain_status status; /* in+out:
                                 parent and child synchronize on this value. */
   struct domain_ml_values* ml_values; /* in */
-  dom_internal* newdom; /* out */
+  dom_internal* newdom; /* in */
   uintnat unique_id; /* out */
 };
 
@@ -1346,12 +1340,12 @@ static void* domain_thread_func(void* v)
   }
 #endif
 
-  domain_create(caml_params->init_minor_heap_wsz, p->parent->state);
+  domain_create(
+    p->newdom, caml_params->init_minor_heap_wsz, p->parent->state);
+  /* this domain is now part of the STW participant set */
+
   if (domain_self)
     domain_self->tid = pthread_self();
-
-  /* this domain is now part of the STW participant set */
-  p->newdom = domain_self;
 
   /* handshake with the parent domain */
   caml_plat_lock_blocking(&p->parent->interruptor.lock);
@@ -1446,6 +1440,13 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   if (caml_debugger_in_use)
     caml_fatal_error("ocamldebug does not support spawning multiple domains");
 #endif
+
+  dom_internal *newdom = park_next_stopped_domain();
+  if (newdom == NULL) {
+    caml_failwith("Maximum number of domains reached.");
+  }
+
+  p.newdom = newdom;
   p.parent = domain_self;
   p.status = Dom_starting;
 
@@ -1481,6 +1482,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
     /* failed */
     pthread_join(th, 0);
     free_domain_ml_values(p.ml_values);
+    stop_parked_domain(newdom);
     caml_failwith("failed to allocate domain");
   }
   /* When domain 0 first spawns a domain, the backup thread is not active, we

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -674,13 +674,19 @@ static void reserve_minor_heaps_reservation_from_stw_single(
   uintnat minor_heaps_reservation_bsize;
   uintnat minor_heap_max_bsz;
 
-  /* new_minor_wsz is page-aligned by caml_norm_minor_heap_size. */
-  caml_minor_heap_max_wsz = caml_norm_minor_heap_size(p->new_minor_wsz);
-  CAMLassert (caml_mem_round_up_pages(Bsize_wsize(caml_minor_heap_max_wsz))
-          == Bsize_wsize(caml_minor_heap_max_wsz));
+  /* normalize input parameters */
 
   if (p->ensure_num_domains > caml_params->max_domains)
       p->ensure_num_domains = caml_params->max_domains;
+
+  p->new_minor_wsz = caml_norm_minor_heap_size(p->new_minor_wsz);
+  CAMLassert (caml_mem_round_up_pages(Bsize_wsize(p->new_minor_wsz))
+              == Bsize_wsize(p->new_minor_wsz));
+
+  /* Update runtime state if necessary */
+  if (p->new_minor_wsz > caml_minor_heap_max_wsz) {
+    caml_minor_heap_max_wsz = p->new_minor_wsz;
+  }
 
   if (minor_heaps_reservation_num_domains < p->ensure_num_domains) {
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -523,8 +523,8 @@ CAMLexport uintnat caml_minor_heaps_start;
 CAMLexport uintnat caml_minor_heaps_end;
 
 Caml_inline void check_minor_heap(void) {
+  #ifdef DEBUG
   caml_domain_state* domain_state = Caml_state;
-  CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
   caml_gc_log(
       "young_start: %p,"
@@ -537,6 +537,20 @@ Caml_inline void check_minor_heap(void) {
       (value*)domain_self->minor_heap_reservation_start,
       (value*)domain_self->minor_heap_reservation_end,
       domain_state->minor_heap_wsz);
+  #endif
+
+  CAMLassert(
+    /* initialized minor heap reservation */
+    caml_minor_heaps_start
+    <= domain_self->minor_heap_reservation_start
+    &&
+    domain_self->minor_heap_reservation_start
+    + Bsize_wsize(caml_minor_heap_max_wsz)
+    == domain_self->minor_heap_reservation_end
+    &&
+    domain_self->minor_heap_reservation_end
+    <= caml_minor_heaps_end
+  );
   CAMLassert(
     (/* uninitialized minor heap arena */
       domain_state->young_start == NULL
@@ -545,8 +559,13 @@ Caml_inline void check_minor_heap(void) {
     (/* initialized minor heap arena */
       domain_state->young_start
       == (value*)domain_self->minor_heap_reservation_start
+      &&
+      (value*)(domain_self->minor_heap_reservation_start
+               + Bsize_wsize(domain_state->minor_heap_wsz))
+      == domain_state->young_end
       && domain_state->young_end
-         <= (value*)domain_self->minor_heap_reservation_end));
+      <= (value*)domain_self->minor_heap_reservation_end));
+  CAMLassert(domain_state->young_ptr == domain_state->young_end);
 }
 
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -523,7 +523,7 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 */
 
 /* Size of the virtual memory reservation for the minor heap, per domain. */
-uintnat caml_minor_heap_max_wsz;
+uintnat caml_minor_heap_max_wsz = 0;
 
 /* Number of domains with a reserved minor heap. */
 static uintnat minor_heaps_reservation_num_domains = 0;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -829,11 +829,11 @@ void caml_update_minor_heap_max(uintnat requested_wsz) {
   caml_gc_log("Changing heap_max_wsz from %" CAML_PRIuNAT
               " to %" CAML_PRIuNAT ".",
               caml_minor_heap_max_wsz, requested_wsz);
-  struct reservation_params params = {
-    .new_minor_wsz = requested_wsz,
-    .ensure_num_domains = 1
-  };
   while (requested_wsz > caml_minor_heap_max_wsz) {
+    struct reservation_params params = {
+      .new_minor_wsz = requested_wsz,
+      .ensure_num_domains = 1
+    };
     caml_try_run_on_all_domains(
       &stw_resize_minor_heaps_reservation, &params, 0);
   }
@@ -842,11 +842,14 @@ void caml_update_minor_heap_max(uintnat requested_wsz) {
 
 static void ensure_minor_heaps_reservation(uintnat ensure_num_domains) {
   CAMLassert(ensure_num_domains <= caml_params->max_domains);
-  struct reservation_params params = {
-    .new_minor_wsz = caml_minor_heap_max_wsz,
-    .ensure_num_domains = ensure_num_domains
-  };
   while (minor_heaps_reservation_num_domains < ensure_num_domains) {
+    /* Note: the read to [caml_minor_heap_max_wsz] below should not be
+       hoisted out of the loop, as the value could be updated by
+       a concurrent STW section. */
+    struct reservation_params params = {
+      .new_minor_wsz = caml_minor_heap_max_wsz,
+      .ensure_num_domains = ensure_num_domains
+    };
     caml_try_run_on_all_domains(
       &stw_resize_minor_heaps_reservation, &params, 0);
   }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -330,9 +330,6 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  caml_minor_heap_max_wsz =
-    caml_norm_minor_heap_size(caml_params->init_minor_heap_wsz);
-
   caml_max_stack_wsize = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
   atomic_store_relaxed(&caml_percent_free,

--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -118,6 +118,11 @@ then this will run all the tests in those three directories.
   with `KEEP_TEST_DIR_ON_SUCCESS=1` to inspect the test output. By default
   `OCAMLTESTDIR` is `_ocamltest`.
 
+`USE_RUNTIME=d`::
+  Set `USE_RUNTIME` to `d` to use the debug runtime while running the
+  tests, and `i` to use the instrumented runtime. (You can also use
+  `V=1` to force the debug runtime to also perform heap verification.)
+
 == Dimensioning the tests
 
 By default, tests should run well on small virtual machines (2 cores,


### PR DESCRIPTION
This PR proposes a fix for #14153 . Instead of reserving minor-heap address space for 128 domains at once, it start by reserving enough address space for 1 domain, then 8, 16, 32, 64, etc. This is useful for programs that want to use large minor heaps, and run in environments that refuse large address space reservations. (Apparently Rocq is hit by this limitation in some settings.)

The PR sits on top of both #14160 (a refactoring changing naming conventions about the minor heap reservation, suggested by @kayceesrk) and #14161 (a refactoring that makes it possible to reserve domain structures before initialization, without adding them as STW participants yet). I am marking it as a "draft" with the intention to encourage reviewing and merging those PRs first, so that the diff here becomes simpler and thus the PR easier to review.

In the present PR:
- we change the `Domain.spawn` process so that the *parent* domains reserves the domain structure for the child, by making it a 'parked' domain in the terminology of #14161 (this is fairly simple)
- then we add a mechanism to allocate the minor heaps reservation gradually; when the parent reserves a domain structure, it may need to increase the size the reservation.

The growth strategy implemented in the PR is to first reserve virtual address space only for 1 domain (the common case for most OCaml 5 programs), then 8, then 16, 32, 64... doubling until `caml_params->max_domains` is reached. (I could do 1, 2, 4, 8, but my guesstimate was that most programs that spawn at least one domain actually use as many as CPUs, which is typically in the 4-8 range on today's machines.)

The change is relatively simple, but note that the mechanism for updating the minor heaps reservation was very rarely used before (it would only kick in if the user increases the size of the minor heap while running), and now it runs on every program that spawns domains, so we may hit issues with it that we had not noticed before. (I already found and fixed something odd, #14158, while working on this.)