### PR TITLE
runtime: host aligned fibers inside the fiber cache whenever possible

### DIFF
--- a/Changes
+++ b/Changes
@@ -236,6 +236,8 @@ Working version
   fix all occurences
   (Stefan Muenzel, review by Gabriel Scherer)
 
+- #14169: runtime, fix cache miss within the stack fragments cache
+  (Florian Angeletti, review by Gabriel Scherer)
 
 OCaml 5.4.0
 ---------------

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -153,21 +153,6 @@ Caml_inline int stack_cache_bucket (mlsize_t wosize) {
   return -1;
 }
 
-Caml_inline mlsize_t grow_size_in_cache_bucket (mlsize_t wosize) {
-  mlsize_t size_bucket_wsz = caml_fiber_wsz;
-  int bucket=0;
-
-  while (bucket < NUM_STACK_SIZE_CLASSES) {
-    if (wosize == size_bucket_wsz)
-      return (2 * wosize);
-    else if (wosize <= size_bucket_wsz)
-      return size_bucket_wsz;
-    ++bucket;
-    size_bucket_wsz += size_bucket_wsz;
-  }
-  return (2*wosize);
-}
-
 static struct stack_info*
 alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
                              value hexn, value heff, int64_t id)
@@ -483,7 +468,8 @@ int caml_try_realloc_stack(asize_t required_space)
   wsize = Stack_high(old_stack) - Stack_base(old_stack);
   uintnat max_stack_wsize = caml_max_stack_wsize;
   if (wsize >= max_stack_wsize) return 0;
-  wsize = grow_size_in_cache_bucket(wsize);
+  // zero alignment bit
+  wsize = 2 * (wsize & (~1));
   while (wsize < stack_used + required_space) {
     if (wsize >= max_stack_wsize) return 0;
     wsize *= 2;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -149,7 +149,7 @@ Caml_inline int stack_cache_bucket (mlsize_t wosize) {
     ++bucket;
     size_bucket_wsz += size_bucket_wsz;
   }
-
+  CAMLassert(wosize>=size_bucket_wsz/2);
   return -1;
 }
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -467,13 +467,11 @@ int caml_try_realloc_stack(asize_t required_space)
   stack_used = Stack_high(old_stack) - (value*)old_stack->sp;
   wsize = Stack_high(old_stack) - Stack_base(old_stack);
   uintnat max_stack_wsize = caml_max_stack_wsize;
-  if (wsize >= max_stack_wsize) return 0;
-  // zero alignment bit
-  wsize = 2 * (wsize & (~1));
-  while (wsize < stack_used + required_space) {
+  wsize = wsize & (~1); // zero alignment bit
+  do {
     if (wsize >= max_stack_wsize) return 0;
     wsize *= 2;
-  }
+  } while (wsize < stack_used + required_space);
 
   if (wsize > 4096 / sizeof(value)) {
     caml_gc_log ("Growing stack to %" CAML_PRIuNAT "k bytes",

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -144,13 +144,28 @@ Caml_inline int stack_cache_bucket (mlsize_t wosize) {
   int bucket=0;
 
   while (bucket < NUM_STACK_SIZE_CLASSES) {
-    if (wosize <= size_bucket_wsz)
+    if (wosize == size_bucket_wsz)
       return bucket;
     ++bucket;
     size_bucket_wsz += size_bucket_wsz;
   }
 
   return -1;
+}
+
+Caml_inline mlsize_t grow_size_in_cache_bucket (mlsize_t wosize) {
+  mlsize_t size_bucket_wsz = caml_fiber_wsz;
+  int bucket=0;
+
+  while (bucket < NUM_STACK_SIZE_CLASSES) {
+    if (wosize == size_bucket_wsz)
+      return (2 * wosize);
+    else if (wosize <= size_bucket_wsz)
+      return size_bucket_wsz;
+    ++bucket;
+    size_bucket_wsz += size_bucket_wsz;
+  }
+  return (2*wosize);
 }
 
 static struct stack_info*
@@ -213,9 +228,6 @@ caml_alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
                        int64_t id)
 {
   int cache_bucket = stack_cache_bucket (wosize);
-  if (cache_bucket != -1) {
-    wosize = caml_fiber_wsz << cache_bucket;
-  }
   return alloc_size_class_stack_noexc(wosize, cache_bucket, hval, hexn, heff,
                                       id);
 }
@@ -470,10 +482,12 @@ int caml_try_realloc_stack(asize_t required_space)
   stack_used = Stack_high(old_stack) - (value*)old_stack->sp;
   wsize = Stack_high(old_stack) - Stack_base(old_stack);
   uintnat max_stack_wsize = caml_max_stack_wsize;
-  do {
+  if (wsize >= max_stack_wsize) return 0;
+  wsize = grow_size_in_cache_bucket(wsize);
+  while (wsize < stack_used + required_space) {
     if (wsize >= max_stack_wsize) return 0;
     wsize *= 2;
-  } while (wsize < stack_used + required_space);
+  }
 
   if (wsize > 4096 / sizeof(value)) {
     caml_gc_log ("Growing stack to %" CAML_PRIuNAT "k bytes",

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -144,7 +144,7 @@ Caml_inline int stack_cache_bucket (mlsize_t wosize) {
   int bucket=0;
 
   while (bucket < NUM_STACK_SIZE_CLASSES) {
-    if (wosize == size_bucket_wsz)
+    if (wosize <= size_bucket_wsz)
       return bucket;
     ++bucket;
     size_bucket_wsz += size_bucket_wsz;
@@ -213,6 +213,9 @@ caml_alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
                        int64_t id)
 {
   int cache_bucket = stack_cache_bucket (wosize);
+  if (cache_bucket != -1) {
+    wosize = caml_fiber_wsz << cache_bucket;
+  }
   return alloc_size_class_stack_noexc(wosize, cache_bucket, hval, hexn, heff,
                                       id);
 }


### PR DESCRIPTION
This PR proposes to fix a corner case where fibers of a small size successfully avoid the fiber cache on reallocation.

Currently, fibers are associated within an ever growing cache of fiber of size `caml_fiber_wsz`,  `2  caml_fiber_wsz`, ...  `16 caml_fiber_wsz`. Fibers beyond this size are allocated outside of the cache. By default fibers start to be allocated at size `caml_fiber_wsz`, and their size is doubled whenever they need to be reallocated.

Unfortunately, the size of the fiber can be increased to fit alignment constraint for the stack handler.
Thus a fiber inside the `2 caml_fiber_wsz` cache bucket can end up with a real size of `2 caml_fiber_wsz + 1`.
In this case, every subsequent reallocation of the fiber will then avoid the cache because the current code expects the fiber size to exactly match the size of the bucket to place them inside a bucket.

This PR proposes to nest those aligned fibers inside the first cache bucket that can hold them on reallocation.
~~Note that this fix is naive, and can result with the size of some fibers growing by a factor nearly x4 in one reallocation.
I don't know if this matters.~~