### PR TITLE
Rename {P,T}exp_{struct_item => letitem}

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -225,7 +225,7 @@ let iter_on_occurrences
       | Texp_send _
       | Texp_assert _ | Texp_lazy _
       | Texp_object _ | Texp_pack _ | Texp_letop _ | Texp_unreachable
-      | Texp_struct_item _ -> ());
+      | Texp_letitem _ -> ());
       default_iterator.expr sub e);
 
   (* Remark: some types get iterated over twice due to how constraints are

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -573,7 +573,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
         (transl_letop ~scopes e.exp_loc e.exp_env let_ ands param body partial)
   | Texp_unreachable ->
       raise (Error (e.exp_loc, Unreachable_reached))
-  | Texp_struct_item (si, e) ->
+  | Texp_letitem (si, e) ->
       !transl_struct_item ~scopes [] None si (fun _ -> transl_exp ~scopes e)
 
 and pure_module m =

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -228,7 +228,7 @@ module Exp = struct
     mk ?loc ?attrs (Pexp_letop {let_; ands; body})
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
-  let struct_item ?loc ?attrs si e = mk ?loc ?attrs (Pexp_struct_item (si, e))
+  let letitem ?loc ?attrs si e = mk ?loc ?attrs (Pexp_letitem (si, e))
 
   let case lhs ?guard rhs =
     {

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -194,7 +194,7 @@ module Exp:
                -> binding_op list -> expression -> expression
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
     val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
-    val struct_item: ?loc:loc -> ?attrs:attrs -> structure_item -> expression
+    val letitem: ?loc:loc -> ?attrs:attrs -> structure_item -> expression
       -> expression
 
     val case: pattern -> ?guard:expression -> expression -> case

--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -111,11 +111,11 @@ let iterator =
               | { pparam_desc = Pparam_val _ } -> false)
             params
         then function_without_value_parameters loc
-    | Pexp_struct_item ({pstr_desc = Pstr_extension _ |
+    | Pexp_letitem ({pstr_desc = Pstr_extension _ |
                                      Pstr_open _ |
                                      Pstr_exception _ |
                                      Pstr_module _}, _) -> ()
-    | Pexp_struct_item ({pstr_loc = loc}, _) -> invalid_struct_item loc
+    | Pexp_letitem ({pstr_loc = loc}, _) -> invalid_struct_item loc
     | _ -> ()
   in
   let extension_constructor self ec =

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -469,7 +469,7 @@ module E = struct
         sub.expr sub body
     | Pexp_extension x -> sub.extension sub x
     | Pexp_unreachable -> ()
-    | Pexp_struct_item (si, e) ->
+    | Pexp_letitem (si, e) ->
         sub.structure_item sub si; sub.expr sub e
 
   let iter_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -529,8 +529,8 @@ module E = struct
           (List.map (sub.binding_op sub) ands) (sub.expr sub body)
     | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
-    | Pexp_struct_item (si, e) ->
-        struct_item ~loc ~attrs (sub.structure_item sub si) (sub.expr sub e)
+    | Pexp_letitem (si, e) ->
+        letitem ~loc ~attrs (sub.structure_item sub si) (sub.expr sub e)
 
   let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
     let open Exp in

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -264,7 +264,7 @@ let rec add_expr bv exp =
       end
   | Pexp_extension e -> handle_extension e
   | Pexp_unreachable -> ()
-  | Pexp_struct_item (si, e) ->
+  | Pexp_letitem (si, e) ->
       let bv, _ = add_struct_item (bv, String.Map.empty) si in
       add_expr bv e
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -2488,7 +2488,7 @@ fun_expr:
 ;
 %inline fun_expr_attrs:
   | LET ext_attributes local_structure_item IN seq_expr
-      { Pexp_struct_item($3, $5), $2 }
+      { Pexp_letitem($3, $5), $2 }
   /* Cf #5939: we used to accept (fun p when e0 -> e) */
   | FUN ext_attributes fun_params preceded(COLON, atomic_type)?
       MINUSGREATER fun_body
@@ -2617,10 +2617,10 @@ simple_expr:
   | simple_expr DOT mkrhs(label_longident)
       { Pexp_field($1, $3) }
   | od=open_dot_declaration DOT LPAREN seq_expr RPAREN
-      { Pexp_struct_item(Str.open_ od, $4) }
+      { Pexp_letitem(Str.open_ od, $4) }
   | od=open_dot_declaration DOT LBRACELESS object_expr_content GREATERRBRACE
       { (* TODO: review the location of Pexp_override *)
-        Pexp_struct_item(Str.open_ od, mkexp ~loc:$sloc (Pexp_override $4)) }
+        Pexp_letitem(Str.open_ od, mkexp ~loc:$sloc (Pexp_override $4)) }
   | mod_longident DOT LBRACELESS object_expr_content error
       { unclosed "{<" $loc($3) ">}" $loc($5) }
   | simple_expr HASH mkrhs(label)
@@ -2630,7 +2630,7 @@ simple_expr:
   | extension
       { Pexp_extension $1 }
   | od=open_dot_declaration DOT mkrhs(LPAREN RPAREN {Lident "()"})
-      { Pexp_struct_item(Str.open_ od,
+      { Pexp_letitem(Str.open_ od,
                          mkexp ~loc:($loc($3)) (Pexp_construct($3, None))) }
   | mod_longident DOT LPAREN seq_expr error
       { unclosed "(" $loc($3) ")" $loc($5) }
@@ -2641,7 +2641,7 @@ simple_expr:
       { unclosed "{" $loc($1) "}" $loc($3) }
   | od=open_dot_declaration DOT LBRACE record_expr_content RBRACE
       { let (exten, fields) = $4 in
-        Pexp_struct_item(Str.open_ od,
+        Pexp_letitem(Str.open_ od,
                          mkexp ~loc:($startpos($3), $endpos)
                            (Pexp_record(fields, exten))) }
   | mod_longident DOT LBRACE record_expr_content error
@@ -2653,11 +2653,11 @@ simple_expr:
   | LBRACKETBAR BARRBRACKET
       { Pexp_array [] }
   | od=open_dot_declaration DOT LBRACKETBAR expr_semi_list BARRBRACKET
-      { Pexp_struct_item(Str.open_ od,
+      { Pexp_letitem(Str.open_ od,
                          mkexp ~loc:($startpos($3), $endpos) (Pexp_array($4))) }
   | od=open_dot_declaration DOT LBRACKETBAR BARRBRACKET
       { (* TODO: review the location of Pexp_array *)
-        Pexp_struct_item(Str.open_ od,
+        Pexp_letitem(Str.open_ od,
                          mkexp ~loc:($startpos($3), $endpos) (Pexp_array [])) }
   | mod_longident DOT
     LBRACKETBAR expr_semi_list error
@@ -2671,9 +2671,9 @@ simple_expr:
           (* TODO: review the location of list_exp *)
           let tail_exp, _tail_loc = mktailexp $loc($5) $4 in
           mkexp ~loc:($startpos($3), $endpos) tail_exp in
-        Pexp_struct_item(Str.open_ od, list_exp) }
+        Pexp_letitem(Str.open_ od, list_exp) }
   | od=open_dot_declaration DOT mkrhs(LBRACKET RBRACKET {Lident "[]"})
-      { Pexp_struct_item(Str.open_ od,
+      { Pexp_letitem(Str.open_ od,
                          mkexp ~loc:$loc($3) (Pexp_construct($3, None))) }
   | mod_longident DOT
     LBRACKET expr_semi_list error
@@ -2683,7 +2683,7 @@ simple_expr:
       { let modexp =
           mkexp_attrs ~loc:($startpos($3), $endpos)
             (Pexp_pack ($6, Some ptyp)) $5 in
-        Pexp_struct_item(Str.open_ od, modexp) }
+        Pexp_letitem(Str.open_ od, modexp) }
   | mod_longident DOT
     LPAREN MODULE ext_attributes module_expr COLON error
       { unclosed "(" $loc($3) ")" $loc($8) }

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -410,7 +410,7 @@ and expression_desc =
   | Pexp_setinstvar of label loc * expression  (** [x <- 2] *)
   | Pexp_override of (label loc * expression) list
       (** [{< x1 = E1; ...; xn = En >}] *)
-  | Pexp_struct_item of structure_item * expression
+  | Pexp_letitem of structure_item * expression
       (** [let SI in E] *)
   | Pexp_assert of expression
       (** [assert E].

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -808,7 +808,7 @@ and expression ctxt f x =
         paren true (expression reset_ctxt) f x
     | Pexp_ifthenelse _ | Pexp_sequence _ when ctxt.ifthenelse ->
         paren true (expression reset_ctxt) f x
-    | Pexp_let _ | Pexp_letop _ | Pexp_struct_item _
+    | Pexp_let _ | Pexp_letop _ | Pexp_letitem _
         when ctxt.semi ->
         paren true (expression reset_ctxt) f x
     | Pexp_newtype (lid, e) ->
@@ -952,7 +952,7 @@ and expression ctxt f x =
           (expression ctxt) body
     | Pexp_extension e -> extension ctxt f e
     | Pexp_unreachable -> pp f "."
-    | Pexp_struct_item (si, e) ->
+    | Pexp_letitem (si, e) ->
         pp f "@[<hov2>let@ %a@ in@ %a@]"
           (structure_item reset_ctxt) si (expression ctxt) e
     | _ -> expression1 ctxt f x

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -393,8 +393,8 @@ and expression i ppf x =
       payload i ppf arg
   | Pexp_unreachable ->
       line i ppf "Pexp_unreachable"
-  | Pexp_struct_item (si, e) ->
-      line i ppf "Pexp_struct_item\n";
+  | Pexp_letitem (si, e) ->
+      line i ppf "Pexp_letitem\n";
       structure_item i ppf si;
       expression i ppf e
 

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -585,7 +585,7 @@ Ptop_def
           pattern (//toplevel//[4,19+4]..[4,19+5])
             Ppat_var "x" (//toplevel//[4,19+4]..[4,19+5])
           expression (//toplevel//[4,19+8]..[4,19+26])
-            Pexp_struct_item
+            Pexp_letitem
             structure_item (_none_[0,0+-1]..[0,0+-1]) ghost
               Pstr_open Fresh
               module_expr (//toplevel//[4,19+8]..[4,19+9])
@@ -613,7 +613,7 @@ Ptop_def
           pattern (//toplevel//[2,1+4]..[2,1+5])
             Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
           expression (//toplevel//[2,1+8]..[2,1+18])
-            Pexp_struct_item
+            Pexp_letitem
             structure_item (_none_[0,0+-1]..[0,0+-1]) ghost
               Pstr_open Fresh
               module_expr (//toplevel//[2,1+8]..[2,1+9])
@@ -660,7 +660,7 @@ Ptop_def
           pattern (//toplevel//[2,1+4]..[2,1+5])
             Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
           expression (//toplevel//[2,1+8]..[2,1+18])
-            Pexp_struct_item
+            Pexp_letitem
             structure_item (_none_[0,0+-1]..[0,0+-1]) ghost
               Pstr_open Fresh
               module_expr (//toplevel//[2,1+8]..[2,1+9])

--- a/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -36,7 +36,7 @@
                 expression (shortcut_ext_attr.ml[12,222+2]..[30,721+31])
                   Pexp_sequence
                   expression (shortcut_ext_attr.ml[12,222+2]..[12,222+36])
-                    Pexp_struct_item
+                    Pexp_letitem
                     structure_item (shortcut_ext_attr.ml[12,222+7]..[12,222+29])
                       Pstr_extension "foo"
                       [
@@ -54,7 +54,7 @@
                   expression (shortcut_ext_attr.ml[13,261+2]..[30,721+31])
                     Pexp_sequence
                     expression (shortcut_ext_attr.ml[13,261+2]..[13,261+30])
-                      Pexp_struct_item
+                      Pexp_letitem
                       structure_item (shortcut_ext_attr.ml[13,261+7]..[13,261+23])
                         Pstr_extension "foo"
                         [

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -297,7 +297,7 @@ and rw_exp iflag sexp =
       rewrite_exp iflag body
   | Pexp_extension _ -> ()
   | Pexp_unreachable -> ()
-  | Pexp_struct_item (si, exp) ->
+  | Pexp_letitem (si, exp) ->
       rewrite_str_item iflag si;
       rewrite_exp iflag exp
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -475,8 +475,8 @@ and expression i ppf x =
       line i ppf "Texp_unreachable"
   | Texp_extension_constructor (li, _) ->
       line i ppf "Texp_extension_constructor %a" fmt_longident li
-  | Texp_struct_item (si, e) ->
-      line i ppf "Texp_struct_item\n";
+  | Texp_letitem (si, e) ->
+      line i ppf "Texp_letitem\n";
       structure_item i ppf si;
       expression i ppf e;
 

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -390,7 +390,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       sub.case sub body
   | Texp_unreachable -> ()
   | Texp_extension_constructor (lid, _) -> iter_loc_lid sub lid
-  | Texp_struct_item (si, e) ->
+  | Texp_letitem (si, e) ->
       sub.structure_item sub si;
       sub.expr sub e
 

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -499,8 +499,8 @@ let expr sub x =
         Texp_unreachable
     | Texp_extension_constructor (lid, path) ->
         Texp_extension_constructor (map_loc_lid sub lid, path)
-    | Texp_struct_item (si, e) ->
-        Texp_struct_item (sub.structure_item sub si, sub.expr sub e)
+    | Texp_letitem (si, e) ->
+        Texp_letitem (sub.structure_item sub si, sub.expr sub e)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2780,7 +2780,7 @@ let rec final_subexpression exp =
   | Texp_try (e, _, _)
   | Texp_ifthenelse (_, e, _)
   | Texp_match (_, {c_rhs=e} :: _, _, _)
-  | Texp_struct_item (_, e)
+  | Texp_letitem (_, e)
     -> final_subexpression e
   | _ -> exp
 
@@ -3135,7 +3135,7 @@ let rec is_nonexpansive exp =
                          ("%raise" | "%reraise" | "%raise_notrace")}}) },
       [Nolabel, Arg e]) ->
      is_nonexpansive e
-  | Texp_struct_item (si, e) ->
+  | Texp_letitem (si, e) ->
       is_nonexpansive_struct_item si && is_nonexpansive e
   | Texp_array (_, _ :: _)
   | Texp_apply _
@@ -3458,7 +3458,7 @@ let check_statement exp =
         match exp_desc with
         | Texp_let (_, _, e)
         | Texp_sequence (_, e)
-        | Texp_struct_item (_, e) ->
+        | Texp_letitem (_, e) ->
             loop e
         | _ ->
             let loc =
@@ -3524,7 +3524,7 @@ let check_partial_application ~statement exp =
             | Texp_ifthenelse (_, e1, Some e2) ->
                 check e1; check e2
             | Texp_let (_, _, e) | Texp_sequence (_, e)
-            | Texp_struct_item (_, e) ->
+            | Texp_letitem (_, e) ->
                 check e
             | Texp_apply _ | Texp_send _ | Texp_new _ | Texp_letop _ ->
                 Location.prerr_warning exp_loc
@@ -4970,7 +4970,7 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
 
-  | Pexp_struct_item (si, e) ->
+  | Pexp_letitem (si, e) ->
       let tv = newvar () in
       let (_, si, exp) =
         with_local_level_generalize begin fun () ->
@@ -4984,7 +4984,7 @@ and type_expect_
         end
       in
       re {
-        exp_desc = Texp_struct_item (si, exp);
+        exp_desc = Texp_letitem (si, exp);
         exp_type = exp.exp_type;
         exp_loc = loc;
         exp_extra = [];

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -148,7 +148,7 @@ and expression_desc =
     }
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
-  | Texp_struct_item of structure_item * expression
+  | Texp_letitem of structure_item * expression
 
 and meth =
   | Tmeth_name of string

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -297,7 +297,7 @@ and expression_desc =
     }
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
-  | Texp_struct_item of structure_item * expression
+  | Texp_letitem of structure_item * expression
 
 and meth =
     Tmeth_name of string

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -571,8 +571,8 @@ let expression sub exp =
                         PStr [ Str.eval ~loc
                                  (Exp.construct ~loc (map_loc sub lid) None)
                              ])
-    | Texp_struct_item (si, exp) ->
-        Pexp_struct_item (sub.structure_item sub si, sub.expr sub exp)
+    | Texp_letitem (si, exp) ->
+        Pexp_letitem (sub.structure_item sub si, sub.expr sub exp)
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -155,7 +155,7 @@ let classify_expression : Typedtree.expression -> sd =
 
     (* non-binding cases *)
     | Texp_sequence (_, e)
-    | Texp_struct_item (_, e) ->
+    | Texp_letitem (_, e) ->
         classify_expression env e
 
     | Texp_construct (_, {cstr_tag = Cstr_unboxed}, [e]) ->
@@ -921,7 +921,7 @@ let rec expression : Typedtree.expression -> term_judg =
       empty
     | Texp_extension_constructor (_lid, pth) ->
       path pth << Dereference
-    | Texp_struct_item (si, e) ->
+    | Texp_letitem (si, e) ->
       structure_item si >> expression e
 
 (* Function bodies.


### PR DESCRIPTION
Following discussion over at #14040 this PR proposes to rename the `Pexp_struct_item` (and its typed tree avatar) to `Pexp_letitem`. The main rationale is that having `let` in the constructor name better reflects what the AST node is about. `Pexp_let_struct_item` could be an alternative, but it is a bit of a mouthful.

For discussion.

(NB: this constructor has not yet been released to the world, so renaming is still OK.)