### PR TITLE
Fix ocamlmklib ordering of -L options

### DIFF
--- a/Changes
+++ b/Changes
@@ -247,6 +247,8 @@ Working version
   fix all occurences
   (Stefan Muenzel, review by Gabriel Scherer)
 
+- #14172 : Fix ocamlmklib ordering of -L options
+  (Alexandre Douard, )
 
 OCaml 5.4.0
 ---------------

--- a/Changes
+++ b/Changes
@@ -406,7 +406,7 @@ Working version
   of nonmatching input if a rule is not exhaustive (Martin Jambon,
   review by David Allsopp and Gabriel Scherer)
 
-- #14172: stop reversing the order of -L arguments in ocamlmklib, a quirk
+* #14172: stop reversing the order of -L arguments in ocamlmklib, a quirk
   introduced by accident in 2012.
   (Alexandre Douard, review by Daniel Bünzli and Nicolás Ojeda Bär)
 

--- a/Changes
+++ b/Changes
@@ -406,6 +406,10 @@ Working version
   of nonmatching input if a rule is not exhaustive (Martin Jambon,
   review by David Allsopp and Gabriel Scherer)
 
+- #14172: stop reversing the order of -L arguments in ocamlmklib, a quirk
+  introduced by accident in 2012.
+  (Alexandre Douard, review by Daniel Bünzli and Nicolás Ojeda Bär)
+
 ### Manual and documentation:
 
 - #14598: Add `@since` annotations to `Runtime_events`. (Raphaël Proust)

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -172,7 +172,7 @@ let parse_arguments argv =
   List.iter
     (fun r -> r := List.rev !r)
     [ bytecode_objs; native_objs; caml_libs; caml_opts;
-      c_libs; c_objs; c_opts; ld_opts; rpath ];
+      c_libs; c_objs; c_opts; ld_opts; rpath; c_Lopts ];
 (* Put -L options in front of -l options in -cclib to mimic -ccopt behavior *)
   c_libs := !c_Lopts @ !c_libs;
 

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -175,7 +175,7 @@ let parse_arguments argv =
   List.iter
     (fun r -> r := List.rev !r)
     [ bytecode_objs; native_objs; caml_libs; caml_opts;
-      c_libs; c_objs; c_opts; ld_opts; rpath ];
+      c_libs; c_objs; c_opts; ld_opts; rpath; c_Lopts ];
 (* Put -L options in front of -l options in -cclib to mimic -ccopt behavior *)
   c_libs := !c_Lopts @ !c_libs;
 


### PR DESCRIPTION
Add `c_Lopts` to List.rev to correct -L option ordering

The -L options were accumulated in reverse order due to stack-based  parsing. Adding `c_Lopts` to the `List.rev` operation restores the  correct command-line order for library search paths.

Fixes #14172