### PR TITLE
Restore multicoretests CI workflow

### DIFF
--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: c-cube/qcheck
-          ref: v0.25
+          ref: v0.26
           path: multicoretests/qcheck
           persist-credentials: false
       - name: Checkout dune

--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml-multicore/multicoretests
-          ref: 0.8
+          ref: 0.9
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck


### PR DESCRIPTION
The `multicoretests` CI workflow was broken on `trunk` due to ocaml/ocaml#13712 as observed on https://github.com/ocaml/ocaml/pull/13580#issuecomment-3112907029.
This PR bumps the CI workflow to the new, trunk-compatible `0.9` release and thus restores it.
While we are at it, the PR also bumps the used `qcheck` version to 0.26 as it has an improved `float` generator.

No changes entry needed - but I would appreciate if someone with permissions could label it with `run-multicoretests` for confirmation. :slightly_smiling_face::pray: 