### PR TITLE
#14163: deprecation alert: file location

### DIFF
--- a/Changes
+++ b/Changes
@@ -259,6 +259,10 @@ Working version
 - #14169: runtime, fix cache miss within the stack fragments cache
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14163, #14176: add a filename location to the deprecation alert for implicit
+  uses of libraries bundled with the compiler (unix,re,threads,dynlink)
+  (Florian Angeletti, report by Ali Caglayan, review by Gabriel Scherer)
+
 OCaml 5.4.0
 ---------------
 

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -971,7 +971,7 @@ let auto_include_alert lib =
     {Warnings.kind="ocaml_deprecated_auto_include"; use=none; def=none;
      message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
   in
-  prerr_alert none alert
+  prerr_alert (in_file !input_name) alert
 
 let deprecated_script_alert program =
   let message = Fmt.asprintf "\


### PR DESCRIPTION
This small PR changes the location for the alert on missing include for otherlibs (in other words a missing `-I +unix`)
to `in_file !input_name` rather than `none`.

This should give some clues on where the alert is coming from, and thus makes it easier to add the missing dependency on the library in the relevant build system.


Close #14163