### PR TITLE
Allow coercion across tuple labels

### DIFF
--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples_coercion.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples_coercion.ml
@@ -4,6 +4,12 @@
 
 (* Testing coercion across labels *)
 
+let ~x, ~y = ((1, 2) :> x:int * y:int)
+[%%expect{|
+val x : int = 1
+val y : int = 2
+|}]
+
 let coerce_tuple x = ((x : int * string :> x:int * y:string) :> foo:int * string)
 [%%expect{|
 val coerce_tuple : int * string -> foo:int * string = <fun>

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples_coercion.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples_coercion.ml
@@ -1,0 +1,106 @@
+(* TEST
+   expect;
+*)
+
+(* Testing coercion across labels *)
+
+let coerce_tuple x = ((x : int * string :> x:int * y:string) :> foo:int * string)
+[%%expect{|
+val coerce_tuple : int * string -> foo:int * string = <fun>
+|}]
+
+let coerce_tuple x = (x : int * string :> x:string * y:int)
+[%%expect{|
+Line 1, characters 21-59:
+1 | let coerce_tuple x = (x : int * string :> x:string * y:int)
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "int * string" is not a subtype of "x:string * y:int"
+       Type "int" is not a subtype of "string"
+|}]
+
+let no_implicit_coercion (x : int * string) = x
+let _ = no_implicit_coercion (1, ~y:"hello")
+[%%expect{|
+val no_implicit_coercion : int * string -> int * string = <fun>
+Line 2, characters 29-44:
+2 | let _ = no_implicit_coercion (1, ~y:"hello")
+                                 ^^^^^^^^^^^^^^^
+Error: This expression has type "int * y:'a"
+       but an expression was expected of type "int * string"
+       The first tuple element is labeled "y",
+       but an unlabeled element was expected
+|}]
+
+(* Label coercion respects private types *)
+
+type private_labeled_tuple = private x:int * y:int
+type private_unlabeled_tuple = private int * int
+
+let coerce_across_private_types (x : private_labeled_tuple) = (x :> private_unlabeled_tuple)
+[%%expect{|
+type private_labeled_tuple = private x:int * y:int
+type private_unlabeled_tuple = private int * int
+Line 4, characters 62-92:
+4 | let coerce_across_private_types (x : private_labeled_tuple) = (x :> private_unlabeled_tuple)
+                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "private_labeled_tuple" is not a subtype of "private_unlabeled_tuple"
+|}]
+
+let coerce_from_private_to_public (x : private_unlabeled_tuple) = (x :> x:int * y:int)
+[%%expect{|
+val coerce_from_private_to_public : private_unlabeled_tuple -> x:int * y:int =
+  <fun>
+|}]
+
+let coerce_from_public_to_private (x : x:int * y:int) = (x :> private_unlabeled_tuple)
+[%%expect{|
+Line 1, characters 56-86:
+1 | let coerce_from_public_to_private (x : x:int * y:int) = (x :> private_unlabeled_tuple)
+                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "x:int * y:int" is not a subtype of "private_unlabeled_tuple"
+|}]
+
+(* Label coercion works in any variance direction *)
+
+(* Motivating example *)
+
+let find_child (rels : (parent:string * child:string) list) ~child =
+  List.assoc child (rels :> (string * string) list)
+;;
+
+let lift_result (x : string -> foo:int * string) = (x :> string -> int * bar:string)
+
+[%%expect{|
+val find_child :
+  (parent:string * child:string) list -> child:string -> string = <fun>
+val lift_result : (string -> foo:int * string) -> string -> int * bar:string =
+  <fun>
+|}]
+
+(* Label coercion doesn't work across invariant types *)
+type !'a injective
+type 'a noninjective
+
+let coerce_injective (x : (int * string) injective) = (x :> (foo:int * string) injective)
+
+[%%expect{|
+type !'a injective
+type 'a noninjective
+Line 4, characters 54-89:
+4 | let coerce_injective (x : (int * string) injective) = (x :> (foo:int * string) injective)
+                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(int * string) injective" is not a subtype of
+         "(foo:int * string) injective"
+       A label "foo" was expected
+|}]
+
+let coerce_noninjective (x : (int * string) noninjective) = (x :> (foo:int * string) noninjective)
+
+[%%expect{|
+Line 1, characters 60-98:
+1 | let coerce_noninjective (x : (int * string) noninjective) = (x :> (foo:int * string) noninjective)
+                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(int * string) noninjective" is not a subtype of
+         "(foo:int * string) noninjective"
+       A label "foo" was expected
+|}]

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples_coercion.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples_coercion.ml
@@ -42,27 +42,27 @@ Error: This expression has type "int * y:'a"
 type private_labeled_tuple = private x:int * y:int
 type private_unlabeled_tuple = private int * int
 
-let coerce_across_private_types (x : private_labeled_tuple) = (x :> private_unlabeled_tuple)
+let coerce_across_private_types x = (x : private_labeled_tuple :> private_unlabeled_tuple)
 [%%expect{|
 type private_labeled_tuple = private x:int * y:int
 type private_unlabeled_tuple = private int * int
-Line 4, characters 62-92:
-4 | let coerce_across_private_types (x : private_labeled_tuple) = (x :> private_unlabeled_tuple)
-                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 4, characters 36-90:
+4 | let coerce_across_private_types x = (x : private_labeled_tuple :> private_unlabeled_tuple)
+                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "private_labeled_tuple" is not a subtype of "private_unlabeled_tuple"
 |}]
 
-let coerce_from_private_to_public (x : private_unlabeled_tuple) = (x :> x:int * y:int)
+let coerce_from_private_to_public x = (x : private_unlabeled_tuple :> x:int * y:int)
 [%%expect{|
 val coerce_from_private_to_public : private_unlabeled_tuple -> x:int * y:int =
   <fun>
 |}]
 
-let coerce_from_public_to_private (x : x:int * y:int) = (x :> private_unlabeled_tuple)
+let coerce_from_public_to_private x = (x : x:int * y:int :> private_unlabeled_tuple)
 [%%expect{|
-Line 1, characters 56-86:
-1 | let coerce_from_public_to_private (x : x:int * y:int) = (x :> private_unlabeled_tuple)
-                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 38-84:
+1 | let coerce_from_public_to_private x = (x : x:int * y:int :> private_unlabeled_tuple)
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "x:int * y:int" is not a subtype of "private_unlabeled_tuple"
 |}]
 
@@ -70,11 +70,11 @@ Error: Type "x:int * y:int" is not a subtype of "private_unlabeled_tuple"
 
 (* Motivating example *)
 
-let find_child (rels : (parent:string * child:string) list) ~child =
-  List.assoc child (rels :> (string * string) list)
+let find_child rels ~child =
+  List.assoc child (rels : (parent:string * child:string) list :> (string * string) list)
 ;;
 
-let lift_result (x : string -> foo:int * string) = (x :> string -> int * bar:string)
+let lift_result x = (x : string -> foo:int * string :> string -> int * bar:string)
 
 [%%expect{|
 val find_child :
@@ -87,25 +87,25 @@ val lift_result : (string -> foo:int * string) -> string -> int * bar:string =
 type !'a injective
 type 'a noninjective
 
-let coerce_injective (x : (int * string) injective) = (x :> (foo:int * string) injective)
+let coerce_injective x = (x : (int * string) injective :> (foo:int * string) injective)
 
 [%%expect{|
 type !'a injective
 type 'a noninjective
-Line 4, characters 54-89:
-4 | let coerce_injective (x : (int * string) injective) = (x :> (foo:int * string) injective)
-                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 4, characters 25-87:
+4 | let coerce_injective x = (x : (int * string) injective :> (foo:int * string) injective)
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "(int * string) injective" is not a subtype of
          "(foo:int * string) injective"
        A label "foo" was expected
 |}]
 
-let coerce_noninjective (x : (int * string) noninjective) = (x :> (foo:int * string) noninjective)
+let coerce_noninjective x = (x : (int * string) noninjective :> (foo:int * string) noninjective)
 
 [%%expect{|
-Line 1, characters 60-98:
-1 | let coerce_noninjective (x : (int * string) noninjective) = (x :> (foo:int * string) noninjective)
-                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 28-96:
+1 | let coerce_noninjective x = (x : (int * string) noninjective :> (foo:int * string) noninjective)
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "(int * string) noninjective" is not a subtype of
          "(foo:int * string) noninjective"
        A label "foo" was expected

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5105,9 +5105,9 @@ and subtype_labeled_list env trace labeled_tl1 labeled_tl2 constraints =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
     subtype_error ~env ~trace ~unification_trace:[];
   List.fold_left2
-    (fun constraints (label1, ty1) (label2, ty2) ->
-      if not (Option.equal String.equal label1 label2) then
-        subtype_error ~env ~trace ~unification_trace:[];
+    (fun constraints (_label1, ty1) (_label2, ty2) ->
+      (* We explicitly ignore the labels here to allow coercion
+         across labels. *)
       subtype_rec
         env
         (Subtype.Diff { got = ty1; expected = ty2 } :: trace)


### PR DESCRIPTION
This PR introduces the ability to coerce tuples across labels, meaning that `(1, 2) :> (x:int * y:int)` becomes valid code. The way this PR is implemented is that coercion works both in the variant and covariant position. This is safe because they share the same runtime representation.

I added a variety of tests to showcase the expected behavior, but I have not updated the manual or change log yet, will do that if this PR is accepted.

Motivation
---------
A lot of existing library functions work on tuples or collections of tuples, and it doesn't make sense to create a new instance for each label combination that might be used. Consider the following toy example:

```ocaml
module Foo : sig
  val find_child_by_parent : (parent:string * child:string) list -> parent:string -> string option
end = struct
  (* without this PR *)
  let find_child_by_parent rels ~parent:parent_to_find =
     List.find_map (fun (~parent, ~child) -> if parent = parent_to_find then Some child else None) rels
  ;;

  (* With this PR *)
  let find_child_by_parent (rels : (parent:string * child:string) list) ~parent =
    List.assoc_opt parent (rels :> (string * string) list)
  ;;
end
```

Some more complicated examples make it impractical to write a custom version for your particular labeled tuple, meaning the user is forced to choose between making the code more verbose/hard to read by specializing the code to that labeled tuple, or paying the cost of an in-practice useless computation by performing this coercion manually (e.g. by doing a `List.map`).