### PR TITLE
Remove misleading comment, and improve function call

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -130,9 +130,7 @@ void caml_set_minor_heap_size (asize_t wsize)
 
   if (domain_state->young_ptr != domain_state->young_end) {
     CAML_EV_COUNTER (EV_C_FORCE_MINOR_SET_MINOR_HEAP_SIZE, 1);
-    // Don't call caml_minor_collection, since that can run the
-    // caml_domain_external_interrupt_hook, which can allocate.
-    caml_empty_minor_heaps_once();
+    caml_minor_collection();
   }
   CAMLassert (domain_state->young_ptr == domain_state->young_end);
 


### PR DESCRIPTION
As @gadmm [points out](https://github.com/ocaml/ocaml/pull/12879#issuecomment-3168535459), the merge of #12879 added a comment which is out of date (since #12882 merged), and needlessly changes a function call (since `caml_minor_collection()` can no longer leave the minor heap non-empty). This tiny change backs out those parts of #12879. No change entry needed IMO.