### PR TITLE
Qualify what GC statistics are printed with v=0x400

### DIFF
--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -192,7 +192,7 @@ The following environment variables are also consulted:
         \item[256 (= 0x100)] Startup messages (loading the bytecode
            executable file, resolving shared libraries).
         \item[512 (= 0x200)] Computation of compaction-triggering condition.
-        \item[1024 (= 0x400)] Output GC statistics at program exit.
+        \item[1024 (= 0x400)] Output GC statistics of the initial domain at program exit.
         \item[2048 (= 0x800)] GC debugging messages.
         \item[4096 (= 0x1000)] Address space reservation changes.
   \end{options}


### PR DESCRIPTION
Currently the documentation for this runtime option says "Output GC statistics at program exit." which might be interpreted as covering GC statistics for a multi-domain program. At least that's how I read it. Looking at the implementation in `caml_do_exit` it accesses caml_domain_state so is more accurately described as printing the initial domain's GC stats.

The code in question https://github.com/ocaml/ocaml/blob/trunk/runtime/sys.c#L135-L181

This documentation update applies since OCaml 5.0. Probably doesn't need an entry in [Changes](https://github.com/ocaml/ocaml/blob/trunk/Changes).