### PR TITLE
[5.4] #14184: toplevel, fix printing of qualified labels

### DIFF
--- a/Changes
+++ b/Changes
@@ -637,8 +637,8 @@ OCaml 5.4.0
   output.
   (Romain Beauxis, review by David Allsopp)
 
-- #12642, #13536: in the toplevel, print shorter paths for constructors
-  and labels when only some modules along their path are open.
+- #12642, #13536, #14184, #14192: in the toplevel, print shorter paths for
+  constructors and labels when only some modules along their path are open.
   (Gabriel Scherer, review by Florian Angeletti)
 
 - #13199, #13485, #13665, #13762, #13965: Support running native debuggers in

--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -99,3 +99,32 @@ let x = let module FB = F(B) in FB.A X
 [%%expect {|
 val x : M.N.F(M.N.A.B).t = M.N.F(M.N.A.B).A X
 |}]
+
+module X__A = struct type t = A type r = { f: int } end
+module X__B = struct type t = B end
+
+module X = struct
+  module A = X__A
+  module B = X__B
+end
+
+let x = X__A.A, X__B.B, { X__A.f = 0 }
+[%%expect {|
+module X__A : sig type t = A type r = { f : int; } end
+module X__B : sig type t = B end
+module X : sig module A = X__A module B = X__B end
+val x : X.A.t * X.B.t * X.A.r = (X.A.A, X.B.B, {X.A.f = 0})
+|}]
+
+open X
+let y = x
+
+[%%expect{|
+val y : X.A.t * X.B.t * X.A.r = (A.A, B.B, {A.f = 0})
+|}]
+
+open A
+let z = x
+[%%expect{|
+val z : X.A.t * X.B.t * X.A.r = (A, B.B, {f = 0})
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -200,6 +200,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
        a module that has been opened. *)
 
     let tree_of_qualified lookup_all get_path env ty_path name =
+      (*First, we rewrite double underscore [__] into [.] whenever possible *)
+      let ty_path = Out_type.rewrite_double_underscore_paths env ty_path in
       (* If [ty_path] is [M.N.t] and [name] is [Foo], we want to find
          a short name for [M.N.Foo] in the current typing environment.
          Our strategy is to try [Foo], [N.Foo] and [M.N.Foo] in


### PR DESCRIPTION
This one-line PR restores the hiding of modules paths of the form `Lib__Module` when printing qualified variant constructors and record labels in the toplevel. 