### PR TITLE
Set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
I’m gonna set up Dependabot to auto-update GitHub Actions versions, like in the other OCaml org repos. Just adding a config file makes it work. Lately I saw some repos already using the new `actions/checkout` release and some not.

Ref: https://github.com/ocaml/graphics/pull/50