### PR TITLE
Fix #14200 (without breaking pr7321_ok.ml)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1012,6 +1012,10 @@ OCaml 5.4.0
 - #14196, #14197: ocamlprof: do not instrument unreachable clauses
   (Gabriel Scherer, review by Nicolás Ojeda Bär, report by Ali Caglayan)
 
+- #14200, # : bad variance check with private aliases
+  (Jacques Garrigue, report by Stephen Dolan, review by ?)
+
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/Changes
+++ b/Changes
@@ -1012,8 +1012,8 @@ OCaml 5.4.0
 - #14196, #14197: ocamlprof: do not instrument unreachable clauses
   (Gabriel Scherer, review by Nicolás Ojeda Bär, report by Ali Caglayan)
 
-- #14200, # : bad variance check with private aliases
-  (Jacques Garrigue, report by Stephen Dolan, review by ?)
+- #14200, #14202 : bad variance check with private aliases
+  (Jacques Garrigue, report and review by Stephen Dolan)
 
 
 OCaml 5.3.0 (8 January 2025)

--- a/testsuite/tests/typing-misc/variance.ml
+++ b/testsuite/tests/typing-misc/variance.ml
@@ -162,7 +162,7 @@ module M : sig
 end = struct
   type 'a t = string
   type foo = private int
-  type bar = private int  
+  type bar = private int
   let foo = "foo"
 end;;
 [%%expect{|

--- a/testsuite/tests/typing-misc/variance.ml
+++ b/testsuite/tests/typing-misc/variance.ml
@@ -150,3 +150,122 @@ Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be covariant,
        but it is invariant.
 |}]
+
+
+(* #14200 *)
+
+module M : sig
+  type 'a t = private string
+  type foo = private int
+  type bar = private int
+  val foo : foo t
+end = struct
+  type 'a t = string
+  type foo = private int
+  type bar = private int  
+  let foo = "foo"
+end;;
+[%%expect{|
+module M :
+  sig
+    type 'a t = private string
+    type foo = private int
+    type bar = private int
+    val foo : foo t
+  end
+|}]
+
+module Coerce : sig
+  type +'a pos = private string
+  type -'a neg = private string
+
+  val p : 'a M.t -> 'a pos
+  val pn : 'a pos -> 'a neg
+  val n : 'a neg -> 'a M.t
+end = struct
+  type 'a pos = 'a M.t
+  type 'a neg = 'a M.t
+
+  let p = Fun.id
+  let pn = Fun.id
+  let n = Fun.id
+end
+
+let bar : M.bar M.t =
+  M.foo
+  |> Coerce.p
+  |> (fun t -> (t :> int Coerce.pos))
+  |> Coerce.pn
+  |> (fun t -> (t :> M.bar Coerce.neg))
+  |> Coerce.n ;;
+[%%expect{|
+Lines 8-15, characters 6-3:
+ 8 | ......struct
+ 9 |   type 'a pos = 'a M.t
+10 |   type 'a neg = 'a M.t
+11 |
+12 |   let p = Fun.id
+13 |   let pn = Fun.id
+14 |   let n = Fun.id
+15 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a pos = 'a M.t
+           type 'a neg = 'a M.t
+           val p : 'a -> 'a
+           val pn : 'a -> 'a
+           val n : 'a -> 'a
+         end
+       is not included in
+         sig
+           type +'a pos = private string
+           type -'a neg = private string
+           val p : 'a M.t -> 'a pos
+           val pn : 'a pos -> 'a neg
+           val n : 'a neg -> 'a M.t
+         end
+       Type declarations do not match:
+         type 'a pos = 'a M.t
+       is not included in
+         type +'a pos = private string
+       Their variances do not agree.
+Unexecuted phrases: 1 phrases did not execute due to an error
+|}]
+
+type 'a priv = private int
+
+module Bad : sig
+  type +-'a t = private int
+  val inj : 'a priv -> 'a t
+  val prj : 'a t -> 'a priv
+end = struct
+  type 'a t = 'a priv
+  let inj = Fun.id
+  let prj = Fun.id
+end
+let cast x = x |> Bad.inj |> (fun x -> (x :> _ M.t)) |> Bad.prj;;
+[%%expect{|
+type 'a priv = private int
+Lines 7-11, characters 6-3:
+ 7 | ......struct
+ 8 |   type 'a t = 'a priv
+ 9 |   let inj = Fun.id
+10 |   let prj = Fun.id
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a priv val inj : 'a -> 'a val prj : 'a -> 'a end
+       is not included in
+         sig
+           type +-'a t = private int
+           val inj : 'a priv -> 'a t
+           val prj : 'a t -> 'a priv
+         end
+       Type declarations do not match:
+         type 'a t = 'a priv
+       is not included in
+         type +-'a t = private int
+       Their variances do not agree.
+Unexecuted phrases: 1 phrases did not execute due to an error
+|}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1039,10 +1039,21 @@ let type_declarations ?(equality = false) ~loc env ~mark name
       | Error violation -> Some (Immediate violation)
   in
   if err <> None then err else
+  (* We need to check coherence of internal and exported variance  either
+     * when the export type is abstract, as there is no manifest to get
+       the minimal variance from
+     * when the export type is private, as the private manifest may be
+       result of expansions within Ctype.equal_private, forgetting
+       an explicit variance annotation in the internal type
+     * when the internal type is private, but this is already included
+       in the above two cases (a private type can only be exported as
+       abstract or private)
+     * when the internal type is open, as we do not allow changing the
+       variance in that case  *)
+  let abstr' = abstr || decl2.type_private = Private in
   let need_variance =
-    abstr || decl1.type_private = Private || decl1.type_kind = Type_open in
+    abstr' || decl1.type_private = Private || decl1.type_kind = Type_open in
   if not need_variance then None else
-  let abstr = abstr || decl2.type_private = Private in
   let opn = decl2.type_kind = Type_open && decl2.type_manifest = None in
   let constrained ty = not (Btype.is_Tvar ty) in
   if List.for_all2
@@ -1050,11 +1061,13 @@ let type_declarations ?(equality = false) ~loc env ~mark name
         let open Variance in
         let imp a b = not a || b in
         let (co1,cn1) = get_upper v1 and (co2,cn2) = get_upper v2 in
-        (if abstr then (imp co1 co2 && imp cn1 cn2)
+        (if abstr' then (imp co1 co2 && imp cn1 cn2)
          else if opn || constrained ty then (co1 = co2 && cn1 = cn2)
          else true) &&
         let (p1,n1,j1) = get_lower v1 and (p2,n2,j2) = get_lower v2 in
-        imp abstr (imp p2 p1 && imp n2 n1 && imp j2 j1))
+        (* for private types, the lower bound can be inferred, and
+           the internal one may be wrong in the result of functors *)
+        imp abstr (imp (abstr && p2) p1 && imp n2 n1 && imp j2 j1))
       decl2.type_params (List.combine decl1.type_variance decl2.type_variance)
   then None else Some Variance
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1065,8 +1065,9 @@ let type_declarations ?(equality = false) ~loc env ~mark name
          else if opn || constrained ty then (co1 = co2 && cn1 = cn2)
          else true) &&
         let (p1,n1,j1) = get_lower v1 and (p2,n2,j2) = get_lower v2 in
-        (* for private types, the lower bound can be inferred, and
-           the internal one may be wrong in the result of functors *)
+        (* Only check the lower bound for abstract types.
+           For private types, the lower bound can be inferred, and
+           the internal one may be wrong in the result of functors. *)
         imp abstr (imp (abstr && p2) p1 && imp n2 n1 && imp j2 j1))
       decl2.type_params (List.combine decl1.type_variance decl2.type_variance)
   then None else Some Variance

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1068,7 +1068,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
         (* Only check the lower bound for abstract types.
            For private types, the lower bound can be inferred, and
            the internal one may be wrong in the result of functors. *)
-        imp abstr (imp (abstr && p2) p1 && imp n2 n1 && imp j2 j1))
+        imp abstr (imp p2 p1 && imp n2 n1 && imp j2 j1))
       decl2.type_params (List.combine decl1.type_variance decl2.type_variance)
   then None else Some Variance
 


### PR DESCRIPTION
This fixes #14200 by checking that types exported as private keep the same variance as their internal definition.

This was supposed to be as simple as switching two lines, handling such types the same way as abstract types, but this actually breaks `typing-module-bugs/pr7321_ok.ml`.
The problem is that the lower bound side of variance is inferred for private types, and it may not match the one obtained as the result of a functor application.
So we should only check the upper-bound side of the variance, and just accept the inferred variance for the lower-bound side.

Note: this should at least go in 5.4, so I put the change log there.
This is not a strict unsoundness, as it only allows to change the variance given by the user, not the one inferred from the definition. But this is still serious, as phantom parameters used to encode some safety property may be ignored.