### PR TITLE
attempt at fixing a data race in minor_gc:ephe_clean_minor

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -736,11 +736,15 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
 
 static void ephe_clean_minor (caml_domain_state* domain)
 {
+  /* Limits of *this* minor heap, not other domains.
+     (See the ephemeron logic in [oldify_mopup]). */
+  value young_start = (value)Caml_state->young_start;
+  value young_end = (value)Caml_state->young_end;
   struct caml_ephe_ref_table table =
     domain->minor_tables->ephe_ref;
   for (struct caml_ephe_ref_elt* re = table.base; re < table.ptr; re++) {
     value v = re->locked;
-    if (v == Val_unit)
+    if (v == Val_unit || !(young_start <= v && v < young_end))
       continue;
     /* This runs after the barrier: any promotion has completed,
        so we don't need to get_header_val / spin_on_header */


### PR DESCRIPTION
This is a proposed attempt at fixing a data race in minor_gc.c:ephe_clean_minor which is discussed in #14061. This PR is for discussion and testing purposes for now. (In particular, I have not tested it with TSAN; I need to remember how to configure the build for TSAN and then run the test, or wait for @OlivierNicole to try the fix.)