### PR TITLE
Fix `pthread_setname_np` under NetBSD

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -1021,7 +1021,7 @@ CAMLprim value caml_set_current_thread_name(value name)
   pthread_setname_np(String_val(name));
 #  elif defined(__NetBSD__)
   char buf[1024];
-  int ret = pthread_setname_np(pthread_self(), "%s", String_val(name));
+  int ret = pthread_setname_np(pthread_self(), "%s", (void *)String_val(name));
   if (ret != 0)
     caml_set_current_thread_name_warning(caml_strerror(ret, buf, sizeof(buf)));
 #  else


### PR DESCRIPTION
See [`pthread_setname_np(3)`](https://man.netbsd.org/pthread_setname_np.3). The third argument is a `void *`, and the cast is necessary otherwise the compiler errors.
I think this should be cherry-picked for 5.4 as setting the thread name was introduced in this cycle.