### PR TITLE
Fix memory model for Weak.set

### DIFF
--- a/Changes
+++ b/Changes
@@ -283,6 +283,10 @@ Working version
   in an unbounded number of labeled or optional arguments.
   (Stefan Muenzel, report by Samuel Vivien, review by Florian Angeletti)
 
+- #14061, #14209: fix a memory-ordering bug in Weak.set that could
+  result in uninitialized memory seen by Weak.get on another domain.
+  (Damien Doligez, review by Gabriel Scherer)
+
 OCaml 5.4.0
 ---------------
 

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -205,25 +205,38 @@ static void clean_field (value e, mlsize_t offset)
     do_check_key_clean(e, offset);
 }
 
-/* FIXME: do we want to do the same tsan stuff here as for caml_modify ? */
-/* See the comments in [caml_modify] for an explanation of the
-   atomic_* calls.
-*/
-static void do_set (value e, mlsize_t offset, value v)
+Caml_inline void ephe_write_barrier (value e, mlsize_t offset, value v)
 {
-  volatile value *fp = &Field(e, offset);
-  
-  if (Is_block(v) && Is_young(v)) {
-    value old = *fp;
-    atomic_thread_fence(memory_order_acquire);
-    atomic_store_release(&Op_atomic_val((value)fp)[0], v);
-    if (!(Is_block(old) && Is_young(old)))
+  if (Is_block (v) && Is_young (v)){
+    value old = Field (e, offset);
+    if (!(Is_block (old) && Is_young (old))){
       add_to_ephe_ref_table (&Caml_state->minor_tables->ephe_ref,
                              e, offset);
-  } else {
-    atomic_thread_fence(memory_order_acquire);
-    atomic_store_release(&Op_atomic_val((value)fp)[0], v);
+    }
   }
+}
+
+CAMLno_tsan /* See caml_modify in memory.c for the tsan annotations on this
+               function. */
+static void ephe_modify (value e, mlsize_t offset, value val)
+{
+  volatile value *fp = &Field(e, offset);
+
+#if defined(WITH_THREAD_SANITIZER) && defined(NATIVE_CODE)
+  caml_tsan_func_entry(__builtin_return_address(0));
+#endif
+
+  ephe_write_barrier(e, offset, val);
+
+  /* See Note [MM] in memory.c */
+  atomic_thread_fence(memory_order_acquire);
+
+#if defined(WITH_THREAD_SANITIZER) && defined(NATIVE_CODE)
+  caml_tsan_write8((void *)fp);
+  caml_tsan_func_exit();
+#endif
+
+  atomic_store_release(&Op_atomic_val((value)fp)[0], val);
 }
 
 static value ephe_set_field (value e, mlsize_t offset, value el)
@@ -231,7 +244,7 @@ static value ephe_set_field (value e, mlsize_t offset, value el)
   CAMLparam2(e,el);
 
   clean_field(e, offset);
-  do_set(e, offset, el);
+  ephe_modify(e, offset, el);
   CAMLreturn(Val_unit);
 }
 
@@ -478,12 +491,12 @@ static value ephe_blit_keys (value es, mlsize_t offset_s,
   if (offset_d < offset_s) {
     for (long i = 0; i < length; i++) {
       caml_ephe_await_key(ed, offset_d + i);
-      do_set(ed, offset_d + i, Ephe_key(es, offset_s + i));
+      ephe_modify(ed, offset_d + i, Ephe_key(es, offset_s + i));
     }
   } else {
     for (long i = length - 1; i >= 0; i--) {
       caml_ephe_await_key(ed, offset_d + i);
-      do_set(ed, offset_d + i, Ephe_key(es, offset_s + i));
+      ephe_modify(ed, offset_d + i, Ephe_key(es, offset_s + i));
     }
   }
   CAMLreturn(Val_unit);
@@ -514,7 +527,7 @@ CAMLprim value caml_ephe_blit_data (value es, value ed)
   caml_ephe_clean(ed);
 
   value v = Ephe_data(es);
-  do_set(ed, CAML_EPHE_DATA_OFFSET, v);
+  ephe_modify(ed, CAML_EPHE_DATA_OFFSET, v);
   if (caml_marking_started())
     caml_darken(Caml_state, v, 0);
   /* [ed] may be in [Caml_state->ephe_info->live] list. The data value may be


### PR DESCRIPTION
As far as I understand the code, `Weak.set` does a memory write without any synchronization, which allows it to publish a pointer to some data that is seen as uninitialized by other domains.

This is the source of the failure reported in https://github.com/ocaml/ocaml/issues/14061#issuecomment-3132368617, https://github.com/ocaml/ocaml/pull/14053#issuecomment-3132043362, https://github.com/ocaml/ocaml/issues/14061#issuecomment-3189996831.

I don't know why it seems to be relatively recent. I can reproduce the bug with about 5% probability on my Mac M2, and about 80% on my Raspberry Pi. With this fix, the bug disappears.

cc @stedolan because I don't understand the memory model as well as I would like.