### PR TITLE
runtime: clean ephemeron data using relaxed atomic writes

### DIFF
--- a/Changes
+++ b/Changes
@@ -405,6 +405,10 @@ Working version
   uses of libraries bundled with the compiler (unix,re,threads,dynlink)
   (Florian Angeletti, report by Ali Caglayan, review by Gabriel Scherer)
 
+- #14210: fix TSan-reported data race in weak pointers runtime
+  (Gabriel Scherer and Damien Doligez, report by Olivier Nicole,
+   review by KC Sivaramakrishnan)
+
 - #14213: Fix shadow-stack-related crashes with TSan
   (Olivier Nicole, report by Nathan Taylor, review by Gabriel Scherer and
    Stefan Muenzel)

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -75,6 +75,7 @@ struct caml_ephe_info {
 
 #define Ephe_link(e) (*(Op_val(e) + CAML_EPHE_LINK_OFFSET))
 #define Ephe_data(e) (*(Op_val(e) + CAML_EPHE_DATA_OFFSET))
+#define Ephe_data_addr(e) (Op_atomic_val(e) + CAML_EPHE_DATA_OFFSET)
 
 value caml_ephe_await_key(value ephe, uintnat i);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 
 #include "caml/addrmap.h"
+#include "caml/camlatomic.h"
 #include "caml/config.h"
 #include "caml/codefrag.h"
 #include "caml/domain.h"

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -758,7 +758,7 @@ static void ephe_clean_minor (caml_domain_state* domain)
     } else {
       /* collected */
       v = caml_ephe_none;
-      Ephe_data(re->ephe) = caml_ephe_none;
+      atomic_store_relaxed(Ephe_data_addr(re->ephe), caml_ephe_none);
     }
     atomic_store_release(Op_atomic_val(re->ephe) + re->offset, v);
   }

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -139,7 +139,7 @@ static void do_check_key_clean(value e, mlsize_t offset)
     if (Tag_val(elt) == Infix_tag) elt -= Infix_offset_val(elt);
     if (is_unmarked(elt)) {
       Field(e, offset) = caml_ephe_none;
-      Field(e,CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
+      atomic_store_relaxed(Ephe_data_addr(e), caml_ephe_none);
     }
   }
 }
@@ -183,7 +183,7 @@ void caml_ephe_clean (value v) {
   child = Ephe_data(v);
   if (child != caml_ephe_none) {
     if (release_data) {
-      Field(v, CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
+      atomic_store_relaxed(Ephe_data_addr(v), caml_ephe_none);
     }
 #ifdef DEBUG
     else if (Is_block (child) && !Is_young (child)) {


### PR DESCRIPTION
This is another attempt at fixing #14061, after my first failed attempt in #14206.

Ephemerons have keys and optionally a `data` field (weak pointers only have keys). The runtime mostly tries to avoid non-atomic data races on keys, but it performs non-atomic data races on the `data` field which result in the TSan failure reported in #14061. (This PR also discusses a correctness bug that we now know to be separate, see #14209.)

In particular, the runtime may write to the `data` field concurrently with other writes from other domains (as in the `weak_array_par` test), and it could also write to the field concurrently with reads from the user in some scenarios.

The implementation of ephemerons is complex and it is unclear to me which concurrency guarantees can be given. (In particular `Obj.Ephemeron.{get,set}_data` allow direct read/write access to the `data` field in a way that is currently completely unprotected, as far as I can tell.) Fixing this for general ephemerons is subtle and would require more expertise than I have.

The scope of the present PR is to fix TSan data race reports for *weak pointers*, which are a special case of ephemerons whose `data` field is always `caml_ephe_none`. To ensure the absence of races for weak pointers, it suffices to use relaxed writes whenever we write `caml_ephe_none` in the data field (and stick to atomic reads otherwise). For general ephemerons, this is not fully correct in terms of synchronization, but no worse than the previous code which used non-atomic accesses.

(cc @damiendoligez, @OlivierNicole, @jberdine)