### PR TITLE
Allow using -use-runtime together with -runtime-variant

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -381,7 +381,7 @@ let find_bin_sh () =
    called) *)
 
 let write_header outchan =
-  let use_runtime, runtime =
+  let use_runtime, runtime_base =
     if String.length !Clflags.use_runtime > 0 then
       (* Do not use BUILD_PATH_PREFIX_MAP mapping for this. *)
       let make_absolute file =
@@ -389,8 +389,9 @@ let write_header outchan =
         else file in
       (true, make_absolute !Clflags.use_runtime)
     else
-      (false, "ocamlrun" ^ !Clflags.runtime_variant)
+      (false, "ocamlrun")
   in
+  let runtime = runtime_base ^ !Clflags.runtime_variant in
   (* Write the header *)
   let runtime_info =
     let header = "runtime-launch-info" in

--- a/testsuite/tests/link-test/runtime_variant_and_use_runtime.ml
+++ b/testsuite/tests/link-test/runtime_variant_and_use_runtime.ml
@@ -1,0 +1,13 @@
+(* TEST
+
+flags += " -runtime-variant d";
+bytecode;
+
+*)
+
+(* This file tests that we can use -runtime-variant in conjunction with
+   -use-runtime.
+   When testing in bytecode, ocamltest always uses -use-runtime, and here
+   we add -runtime-variant. Comparison with the .reference file will check
+   that -runtime-variant is correctly added to the runtime file name.
+*)

--- a/testsuite/tests/link-test/runtime_variant_and_use_runtime.reference
+++ b/testsuite/tests/link-test/runtime_variant_and_use_runtime.reference
@@ -1,0 +1,2 @@
+### OCaml runtime: debug mode ###
+### set OCAMLRUNPARAM=v=0 to silence this message


### PR DESCRIPTION
Loose end: point (4) of https://github.com/ocaml/ocaml/issues/13941#issuecomment-2797016263.

Although it is technically not backward compatible, I don't expect any breakage from this change.
