### PR TITLE
ocamltest: show test name before running the test

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -288,12 +288,13 @@ let test_file test_filename =
          loop rootenv rootenv_statements
        in
        let rootenv = Environments.initialize Environments.Post log rootenv in
+       let common_prefix = " ... testing '" ^ test_basename ^ "'" in
+       Printf.printf "%s%!" common_prefix;
        let summary =
          run_test_tree log add_msg initial_status rootenv initial_summary
            tsl_ast
        in
-       let common_prefix = " ... testing '" ^ test_basename ^ "'" in
-       Printf.printf "%s => %s%s\n%!" common_prefix (string_of_summary summary)
+       Printf.printf " => %s%s\n%!" (string_of_summary summary)
          (if Options.show_timings && summary = Pass then
             let wall_clock_duration = Unix.gettimeofday () -. start in
             Printf.sprintf " (wall clock: %.02fs)" wall_clock_duration


### PR DESCRIPTION
It is much more convenient to have the test name displayed in the ocamltest log before the test itself is run: when a test takes too long to run, we can see at a glance which test is causing problems.
