### PR TITLE
Better error message when a functor is its own unsafe functor

### DIFF
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1670,7 +1670,7 @@ let get_relative_path top_module path =
   let comps = collect_components path in
   let comps =
     match comps with
-    | h :: t when h = top_module -> t
+    | h :: (_ :: _ as t) when h = top_module -> t
     | _ -> comps
   in
   String.concat "." comps

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -181,3 +181,21 @@ Line 5, characters 4-15:
         ^^^^^^^^^^^
   Module "M1" defines an unsafe value, "List.nil" .
 |}]
+
+module rec F : functor (X:sig type t end) -> sig
+  type t = X.t * X.t
+  type u = [`C of F(X).u]
+end = F;;
+
+[%%expect{|
+Line 4, characters 6-7:
+4 | end = F;;
+          ^
+Error: Cannot safely evaluate the definition of the following cycle
+       of recursively-defined modules: F -> F.
+       There are no safe modules in this cycle (see manual section 12.2).
+Line 4, characters 6-7:
+4 | end = F;;
+          ^
+  Module "F" defines an unsafe functor, "F" .
+|}]

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -185,17 +185,19 @@ Line 5, characters 4-15:
 module rec F : functor (X:sig type t end) -> sig
   type t = X.t * X.t
   type u = [`C of F(X).u]
+
+  val unsafe : int
 end = F;;
 
 [%%expect{|
-Line 4, characters 6-7:
-4 | end = F;;
+Line 6, characters 6-7:
+6 | end = F;;
           ^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: F -> F.
        There are no safe modules in this cycle (see manual section 12.2).
-Line 4, characters 6-7:
-4 | end = F;;
+Line 6, characters 6-7:
+6 | end = F;;
           ^
   Module "F" defines an unsafe functor, "F" .
 |}]


### PR DESCRIPTION
When a functor `F` references itself in its own definition, we get an error message:
```
Module F defines an unsafe functor,  .
```

But we should get something like:

```
Module "F" defines an unsafe functor, "F" .
```

For the unsafe functor
```ocaml
module rec F : functor (X:sig type t end) -> sig
  type t = X.t * X.t
  type u = [`C of F(X).u]
end = F
```