### PR TITLE
Fix test-in-prefix

### DIFF
--- a/testsuite/tools/testRelocation.ml
+++ b/testsuite/tools/testRelocation.ml
@@ -62,8 +62,8 @@ let bindir_rules config file =
         (* The runtime binaries all contain OCAML_STDLIB_DIR and everything
            except flexlink and ocamllex link with the Config module, either
            directly or via ocamlcommon *)
-        not (List.mem basename ["flexlink.byte"; "flexlink.opt"; "flexlink";   
-                                "ocamllex.byte"; "ocamllex.opt"; "ocamllex";   
+        not (List.mem basename ["flexlink.byte"; "flexlink.opt"; "flexlink";
+                                "ocamllex.byte"; "ocamllex.opt"; "ocamllex";
                                 "ocamlyacc"])
       in
       let linker_embeds_stdlib_location =

--- a/testsuite/tools/testRelocation.ml
+++ b/testsuite/tools/testRelocation.ml
@@ -62,8 +62,8 @@ let bindir_rules config file =
         (* The runtime binaries all contain OCAML_STDLIB_DIR and everything
            except flexlink and ocamllex link with the Config module, either
            directly or via ocamlcommon *)
-        not (List.mem basename ["flexlink.byte"; "flexlink.opt";
-                                "ocamllex.byte"; "ocamllex.opt";
+        not (List.mem basename ["flexlink.byte"; "flexlink.opt"; "flexlink";   
+                                "ocamllex.byte"; "ocamllex.opt"; "ocamllex";   
                                 "ocamlyacc"])
       in
       let linker_embeds_stdlib_location =


### PR DESCRIPTION
The first commit fixes another problem I hit when debugging the main one: when I configure from a cygwin terminal, `configure` decides that `ln -sf` doesn't work and uses `cp -pf` instead, then the installed `flexlink.exe` and `ocamllex.exe` are copies rather than symlinks, and they are not ignored by `TestRelocation.run`.

The second commit works around the main problem: after the tests, some processes appear to linger for a while and prevent `Sys.rename` from working. The error message from OCaml is "Permission denied" but if you try do rename from the Windows GUI you get "some file or folder is open in another program". The problem disappears after a few seconds.

I couldn't find out which process is holding things up (and even if I did, how do we wait for it to stop?) so I propose this hack: just wait and retry until the rename goes through.

cc @dra27 