### PR TITLE
Fix INRIA CI job other-configs

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -291,8 +291,9 @@ case $NODE_NAME in
     # Native compilation not supported
     ;;
   *)
-    # Include ocamlnat in the in-prefix tests
-    confoptions="$confoptions --enable-native-toplevel";;
+    # Include ocamlnat (for the in-prefix tests) unless explicitly disabled:
+    # a later --disable-native-toplevel will take precedence if present.
+    confoptions="--enable-native-toplevel $confoptions";;
 esac
 
 eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
@@ -319,9 +320,15 @@ if $make_native && $check_make_alldepend; then
   $make --warn-undefined-variables alldepend
 fi
 
-$make --warn-undefined-variables install
-$make -f Makefile.test -C testsuite/in_prefix test-in-prefix
-rm -rf "$instdir"
+case $confoptions in
+  *--disable-unix-lib*) ;;         # test-in-prefix needs Unix lib
+  *--disable-native-toplevel*) ;;  # test-in-prefix needs ocamlnat
+  *)
+    $make --warn-undefined-variables install
+    $make -f Makefile.test -C testsuite/in_prefix test-in-prefix
+    rm -rf "$instdir"
+    ;;
+esac
 
 cd testsuite
 if test -n "$jobs" && test -x /usr/bin/parallel

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -320,15 +320,14 @@ if $make_native && $check_make_alldepend; then
   $make --warn-undefined-variables alldepend
 fi
 
+$make --warn-undefined-variables install
 case $confoptions in
   *--disable-unix-lib*) ;;         # test-in-prefix needs Unix lib
-  *--disable-native-toplevel*) ;;  # test-in-prefix needs ocamlnat
   *)
-    $make --warn-undefined-variables install
     $make -f Makefile.test -C testsuite/in_prefix test-in-prefix
-    rm -rf "$instdir"
     ;;
 esac
+rm -rf "$instdir"
 
 cd testsuite
 if test -n "$jobs" && test -x /usr/bin/parallel

--- a/tools/ci/inria/other-configs/script
+++ b/tools/ci/inria/other-configs/script
@@ -37,6 +37,7 @@ ${main} -conf --disable-native-compiler \
         -conf --disable-unix-lib \
         -conf --disable-ocamldoc \
         -conf --disable-dependency-generation \
+        -conf --disable-native-toplevel \
         -no-native
 
 echo "============== no flat float arrays, clang, C23 ================="

--- a/tools/ci/inria/other-configs/script
+++ b/tools/ci/inria/other-configs/script
@@ -26,9 +26,10 @@ echo "============== minimal build ================="
 # The "MIN_BUILD" (formerly on Travis) builds with everything disabled (apart
 # from ocamltest). Its goals:
 #  - Ensure that the system builds correctly without native compilation
-#  - Ensure ocamltest builds correctly with Unix
+#  - Ensure ocamltest builds correctly without Unix
 #  - Ensure the testsuite runs correctly with everything switched off
 ${main} -conf --disable-native-compiler \
+        -conf --disable-native-toplevel \
         -conf --disable-shared \
         -conf --disable-debug-runtime \
         -conf --disable-instrumented-runtime \
@@ -37,7 +38,6 @@ ${main} -conf --disable-native-compiler \
         -conf --disable-unix-lib \
         -conf --disable-ocamldoc \
         -conf --disable-dependency-generation \
-        -conf --disable-native-toplevel \
         -no-native
 
 echo "============== no flat float arrays, clang, C23 ================="


### PR DESCRIPTION
Some changes to `main` have impacted `other-configs`, which uses it as a subroutine.

cc @dra27 because this touches the test-in-prefix workflow.
