### PR TITLE
Disable TSan test on weak_array_par.ml

### DIFF
--- a/testsuite/tests/weak-ephe-final/weak_array_par.ml
+++ b/testsuite/tests/weak-ephe-final/weak_array_par.ml
@@ -1,4 +1,8 @@
-(* TEST *)
+(* TEST
+  no-tsan; (* TSan detects the intentional data race *)
+  { bytecode; }
+  { native; }
+*)
 
 let () = Random.self_init ()
 


### PR DESCRIPTION
Following #14209, TSan now correctly reports a data race in `tests/weak-ephe-final/weak_array_par.ml`.

Since the data race is an essential part of the test, we have to disable the TSan test on this file.
