### PR TITLE
#14214: functor error messages: don't forget equality

### DIFF
--- a/.depend
+++ b/.depend
@@ -1040,6 +1040,7 @@ typing/includemod.cmx : \
 typing/includemod.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/subst.cmi \
     typing/shape.cmi \
     typing/path.cmi \
     parsing/longident.cmi \
@@ -1052,6 +1053,7 @@ typing/includemod.cmi : \
 typing/includemod_errorprinter.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/subst.cmi \
     typing/printtyp.cmi \
     typing/primitive.cmi \
     typing/path.cmi \
@@ -1071,6 +1073,7 @@ typing/includemod_errorprinter.cmo : \
 typing/includemod_errorprinter.cmx : \
     typing/types.cmx \
     typing/typedtree.cmx \
+    typing/subst.cmx \
     typing/printtyp.cmx \
     typing/primitive.cmx \
     typing/path.cmx \

--- a/Changes
+++ b/Changes
@@ -1039,6 +1039,10 @@ OCaml 5.4.0
 - #14200, #14202 : bad variance check with private aliases
   (Jacques Garrigue, report and review by Stephen Dolan)
 
+- #14214, #14221: fix a confused error message for module inclusions,
+  functor error messages were missing some type equalities potentially leading
+  to nonsensical "type t is not compatible with type t" submessage
+  (Florian Angeletti, report by Basile Clément, review by Gabriel Scherer)
 
 OCaml 5.3.0 (8 January 2025)
 ----------------------------

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -104,6 +104,7 @@ module Error = struct
 
   and signature_symptom = {
     env: Env.t;
+    subst: Subst.t;
     missings: signature_item list;
     incompatibles: (Ident.t * sigitem_symptom) list;
     oks: (int * module_coercion) list;
@@ -756,6 +757,7 @@ and signatures ~core ~direction ~loc env subst sig1 sig2 mod_shape =
             | missings, incompatibles, runtime_coercions, leftovers ->
                 Error {
                   Error.env=new_env;
+                  subst;
                   missings;
                   incompatibles;
                   oks=runtime_coercions;
@@ -1203,7 +1205,8 @@ module Functor_inclusion_diff = struct
         in
         expand_params { st with env; subst }
 
-  let diff env (l1,res1) (l2,_) =
+  type inclusion_env = { i_env:Env.t; i_subst:Subst.t }
+  let diff {i_env=env; i_subst=subst} (l1,res1) (l2,_) =
     let module Compute = Diff.Left_variadic(struct
         let test st mty1 mty2 =
           let loc = Location.none in
@@ -1220,7 +1223,7 @@ module Functor_inclusion_diff = struct
     let param1 = Array.of_list l1 in
     let param2 = Array.of_list l2 in
     let state =
-      { env; subst = Subst.identity; res = keep_expansible_param res1}
+      { env; subst; res = keep_expansible_param res1}
     in
     Compute.diff state param1 param2
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -82,6 +82,7 @@ module Error: sig
 
   and signature_symptom = {
     env: Env.t;
+    subst: Subst.t;
     missings: Types.signature_item list;
     incompatibles: (Ident.t * sigitem_symptom) list;
     oks: (int * Typedtree.module_coercion) list;
@@ -246,7 +247,8 @@ module Functor_inclusion_diff: sig
     type diff = (Types.functor_parameter, unit) Error.functor_param_symptom
     type state
   end
-  val diff: Env.t ->
+  type inclusion_env = { i_env:Env.t; i_subst:Subst.t }
+  val diff: inclusion_env ->
     Types.functor_parameter list * Types.module_type ->
     Types.functor_parameter list * Types.module_type ->
     Diffing.Define(Defs).patch

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -16,6 +16,8 @@
 module Style = Misc.Style
 module Fmt = Format_doc
 module Printtyp = Printtyp.Doc
+type inclusion_env = Includemod.Functor_inclusion_diff.inclusion_env =
+  { i_env:Env.t; i_subst:Subst.t }
 
 module Context = struct
   type pos =
@@ -607,7 +609,7 @@ module Functor_suberror = struct
       Fmt.pp_open_tbox ()
       Diffing.prefix (pos, Diffing.classify diff)
       Fmt.pp_set_tab ()
-      (Printtyp.wrap_printing_env env ~error:true
+      (Printtyp.wrap_printing_env env.i_env ~error:true
          (fun () -> sub ~expansion_token env diff)
       )
      Fmt.pp_close_tbox ()
@@ -615,7 +617,7 @@ module Functor_suberror = struct
   let onlycase sub ~expansion_token env (_, diff) =
     Location.msg "%a@[<hv 2>%t@]"
       Fmt.pp_print_tab ()
-      (Printtyp.wrap_printing_env env ~error:true
+      (Printtyp.wrap_printing_env env.i_env ~error:true
          (fun () -> sub ~expansion_token env diff)
       )
 
@@ -845,7 +847,7 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
 and functor_params ~expansion_token ~env ~before ~ctx diff =
   match diff.got.params, diff.expected.params with
   | [], _ -> functor_expected ~before ~ctx
-  | _, [] -> unexpected_functor ~env ~before ~ctx diff
+  | _, [] -> unexpected_functor ~env:env.i_env ~before ~ctx diff
   | _ :: _, _ :: _ ->
       compare_functor_params ~expansion_token ~env ~before ~ctx diff
 
@@ -887,12 +889,14 @@ and signature ~expansion_token ~env:_ ~before ~ctx sgs =
             :: before
           else
             before
-      | [], a :: _ -> sigitem ~expansion_token ~env:sgs.env ~before ~ctx a
+      | [], a :: _ ->
+          let env = {i_env=sgs.env; i_subst=sgs.subst } in
+          sigitem ~expansion_token ~env ~before ~ctx a
       | [], [] -> assert false
     )
 and sigitem ~expansion_token ~env ~before ~ctx (name,s) = match s with
   | Core c ->
-      dwith_context ctx (core env name c) :: before
+      dwith_context ctx (core env.i_env name c) :: before
   | Module_type diff ->
       module_type ~expansion_token ~eqmode:false ~env ~before
         ~ctx:(Context.Module name :: ctx) diff
@@ -924,7 +928,8 @@ and module_type_decl ~expansion_token ~env ~before ~ctx id diff =
       | None -> assert false
       | Some mty ->
           with_context (Modtype id::ctx)
-            (Runtime_coercion.illegal_permutation Context.alt_pp env) (mty,c)
+            (Runtime_coercion.illegal_permutation Context.alt_pp env.i_env)
+            (mty,c)
           :: before
       end
 
@@ -971,17 +976,17 @@ let module_type_subst ~env id diff =
         ~ctx:[Modtype id] mts.less_than
   | Illegal_permutation c ->
       let mty = diff.got in
-      let main =
-        with_context [Modtype id]
-          (Runtime_coercion.illegal_permutation Context.alt_pp env) (mty,c) in
-      [main]
+      [with_context [Modtype id]
+         (Runtime_coercion.illegal_permutation Context.alt_pp env.i_env)
+         (mty,c)
+      ]
 
 let all env = function
   | In_Compilation_unit diff ->
       let first = Location.msg "%a" interface_mismatch diff in
       signature ~expansion_token:true ~env ~before:[first] ~ctx:[] diff.symptom
   | In_Type_declaration (id,reason) ->
-      [Location.msg "%t" (core env id reason)]
+      [Location.msg "%t" (core env.i_env id reason)]
   | In_Module_type diff ->
       module_type ~expansion_token:true ~eqmode:false ~before:[] ~env ~ctx:[]
         diff
@@ -998,7 +1003,7 @@ let all env = function
 
 let err_msgs ppf (env, err) =
   Printtyp.wrap_printing_env ~error:true env
-    (fun () -> (coalesce @@ all env err)  ppf)
+    (fun () -> (coalesce @@ all {i_env=env; i_subst=Subst.identity} err) ppf)
 
 let report_error_doc err =
   Location.errorf
@@ -1017,7 +1022,8 @@ let report_apply_error_doc ~loc env (app_name, mty_f, args) =
   | [ _, Change (g, e,  Err.Mismatch mty_diff) ] ->
       let more () =
         subcase_list @@
-        module_type_symptom ~eqmode:false ~expansion_token:true ~env ~before:[]
+        module_type_symptom ~eqmode:false ~expansion_token:true
+          ~env:{i_env=env; i_subst=Subst.identity} ~before:[]
           ~ctx:[] mty_diff.symptom
       in
       Location.errorf ~loc ~footnote "%t"
@@ -1057,6 +1063,7 @@ let report_apply_error_doc ~loc env (app_name, mty_f, args) =
         let actual = Functor_suberror.App.got d in
         let expected = Functor_suberror.expected d in
         let sub =
+          let env = {i_env=env; i_subst=Subst.identity} in
           List.rev @@
           Functor_suberror.params functor_app_diff env ~expansion_token:true d
         in


### PR DESCRIPTION
Higher-level error messages for functors recompute inclusion checks when trying to discover more macro-level error messages. For this reconstruction to be accurate, those computations must use the same environment than the one used when detecting the original problem.

In particular, this environment must include equalities added during the pairing of types and modules during the signature inclusion test. For instance, in

```ocaml
module M: sig
  type t
  module F(X:sig val f:t val g:int end): sig end
end = struct
  type t
  module F(X:sig val f:t val g:float end)= struct end
end
```
we must remember that the interface-side `t` is equal to the implementation-side `t`.

This part of the inclusion checking environment was ignored before this commit leading to non-sensical error messages complaining that `t` is not compatible with `t`:
>```
>  ...
> In module F:
> Modules do not match:
>   (X : $S1) -> ...
> is not included in
>    (X : $T1) -> ...
>       ...
> Values do not match: val f : t is not included in val f : t
> The type t is not compatible with the type t
> Type t is abstract because no corresponding cmi file was found
> in path.
>```

This PR fixes this issue by extending the captured environment for errors in signature to include the substitution recording the equalities between items on both side of the check which restores the expected error message:

>```
>Values do not match: val g : int is not included in val g : float
> The type int is not compatible with the type float
>```

close #14214 