### PR TITLE
No usage warnings on sum constructors implemented/defined as `private`

### DIFF
--- a/Changes
+++ b/Changes
@@ -217,6 +217,13 @@ Working version
   e.g. `< foo : int; .. as $0>` when $0 is introduced by a GADT constructor
   (Stefan Muenzel, review by Jacques Garrigue and Florian Angeletti)
 
+- #14225: do not raise unused-constructor warning on private
+  constructor in type implementations, for example
+  `type safe = private Safe`, which are typically used to
+  create new fresh/generative types (here `safe`) to be used
+  as GADT indices.
+  (Gabriel Scherer, review by Nicolás Ojeda Bär and Florian Angeletti,
+   report by Kate Deplaix)
 
 
 ### Internal/compiler-libs changes:

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -136,10 +136,12 @@ module Used_private_constructor : sig type t val nothing : t -> unit end
       type _ t = KA : a t | KB : b t
    ]}
 
-   Our exceptation is that private constructors in type
-   definitions/implementations (not declarations/signatures) are meant
-   to make their types fresh type-level indices and never used
-   directly.
+   Our expectation is that private constructors in type
+   definitions/implementations (not declarations/signatures) are
+   typically used to make their types fresh type-level indices and
+   never used directly -- they are un-constructible, so there is
+   little point in tracking their usage in the rest of the program and
+   complaining that they are never constructed.
 *)
 module Unused_private_constructor : sig
   type t
@@ -148,11 +150,6 @@ end = struct
 end
 ;;
 [%%expect {|
-Line 4, characters 19-20:
-4 |   type t = private T
-                       ^
-Warning 37 [unused-constructor]: unused constructor "T".
-
 module Unused_private_constructor : sig type t end
 |}]
 
@@ -166,11 +163,6 @@ end = struct
 end
 ;;
 [%%expect {|
-Line 3, characters 19-20:
-3 |   type t = private T
-                       ^
-Warning 37 [unused-constructor]: unused constructor "T".
-
 module Hidden_private_constructor : sig end
 |}]
 
@@ -374,11 +366,6 @@ end = struct
 end
 ;;
 [%%expect {|
-Line 5, characters 20-31:
-5 |   type t += private Private_ext
-                        ^^^^^^^^^^^
-Warning 38 [unused-extension]: unused extension constructor "Private_ext"
-
 module Unused_private_extension : sig type t end
 |}]
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -64,7 +64,9 @@ let constructor_usages () =
 let constructor_usage_complaint ~rebind priv cu
   : Warnings.constructor_usage_warning option =
   match priv, rebind with
-  | Asttypes.Private, _ | _, true ->
+  | Asttypes.Private, false ->
+      None
+  | _, true ->
       if cu.cu_positive || cu.cu_pattern || cu.cu_exported_private then None
       else Some Unused
   | Asttypes.Public, false -> begin


### PR DESCRIPTION
In trunk (future 5.5) we changed the behavior of local, purely abstract definitions (`type a`) used as GADT indices. In the corresponding manual documentation (#13994), I proposed to use private sum constructors (`type a = private A`) to give index types a generative identity. @kit-ty-kate remarked in https://github.com/ocaml/ocaml/issues/14224#issuecomment-3253853445 that this use-case incurs an unused-constructor warning, which should be silenced if we want to encourage this style.

The present PR silences unused-constructor warnings on variant constructors that are defined/implemented as private.

(cc @Octachron who heard about in-progress versions of this PR.)