### PR TITLE
stdlib: add filter_mapi function

### DIFF
--- a/Changes
+++ b/Changes
@@ -101,7 +101,8 @@ Working version
   (Sacha-Élie Ayoun, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 - #14227: Add List.filter_mapi.
-  (Émile Trotignon, review by Nicolás Ojeda Bär, Jan Midtgaard and Damien Doligez)
+  (Émile Trotignon, review by Nicolás Ojeda Bär, Jan Midtgaard and
+   Damien Doligez)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -101,7 +101,7 @@ Working version
   (Sacha-Élie Ayoun, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 - #14227: Add List.filter_mapi.
-  (Émile Trotignon, review by Nicolás Ojeda Bär and Jan Midtgaard)
+  (Émile Trotignon, review by Nicolás Ojeda Bär, Jan Midtgaard and Damien Doligez)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -94,7 +94,7 @@ Working version
   (Sacha-Élie Ayoun, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 - #14227: Add List.filter_mapi.
-  (Émile Trotignon, review by Nicolás Ojeda Bär)
+  (Émile Trotignon, review by Nicolás Ojeda Bär and Jan Midtgaard)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -93,6 +93,9 @@ Working version
 - #14060: Add Hashtbl.find_and_replace and Hashtbl.find_and_remove.
   (Sacha-Élie Ayoun, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
+- #14227: Add List.filter_mapi.
+  (Émile Trotignon, review by Nicolás Ojeda Bär)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -283,6 +283,16 @@ let[@tail_mod_cons] rec filter_map f = function
       | None -> filter_map f l
       | Some v -> v :: filter_map f l
 
+let[@tail_mod_cons] rec filter_mapi f i = function
+  | [] -> []
+  | x :: l ->
+      let i' = i + 1 in
+      match f i x with
+      | None -> filter_mapi f i' l
+      | Some v -> v :: filter_mapi f i' l
+
+let filter_mapi f l = filter_mapi f 0 l
+
 let[@tail_mod_cons] rec concat_map f = function
   | [] -> []
   | x::xs -> prepend_concat_map (f x) f xs

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -204,7 +204,7 @@ val filter_map : ('a -> 'b option) -> 'a list -> 'b list
     @since 4.08
  *)
 
-val filter_mapi : (int ->'a -> 'b option) -> 'a list -> 'b list
+val filter_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b list
 (** Same as {!filter_map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -208,6 +208,7 @@ val filter_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b list
 (** Same as {!filter_map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
+   @since 5.5
  *)
 
 val concat_map : ('a -> 'b list) -> 'a list -> 'b list

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -204,6 +204,12 @@ val filter_map : ('a -> 'b option) -> 'a list -> 'b list
     @since 4.08
  *)
 
+val filter_mapi : (int ->'a -> 'b option) -> 'a list -> 'b list
+(** Same as {!filter_map}, but the function is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+ *)
+
 val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 (** [concat_map f l] gives the same result as
     {!concat}[ (]{!map}[ f l)]. Tail-recursive.

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -204,6 +204,13 @@ val filter_map : f:('a -> 'b option) -> 'a list -> 'b list
     @since 4.08
  *)
 
+val filter_mapi : f:(int -> 'a -> 'b option) -> 'a list -> 'b list
+(** Same as {!filter_map}, but the function is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+   @since 5.5
+ *)
+
 val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
 (** [concat_map ~f l] gives the same result as
     {!concat}[ (]{!map}[ f l)]. Tail-recursive.

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -8,6 +8,12 @@ let string_of_even_opt x =
   else
     None
 
+let string_of_add_even_opt i x =
+  if is_even ( i + x) then
+    Some (string_of_int (i + x))
+  else
+    None
+
 let string_of_even_or_int x =
   if is_even x then
     Either.Left (string_of_int x)
@@ -109,6 +115,9 @@ let () =
   assert (not (List.is_empty [1]));
 
   assert (List.filter_map string_of_even_opt l = ["0";"2";"4";"6";"8"]);
+  assert
+    ( List.filter_mapi string_of_add_even_opt l
+    = ["0";"2";"4";"6";"8";"10";"12";"14";"16";"18"]);
   assert (List.concat_map (fun i -> [i; i+1]) [1; 5] = [1; 2; 5; 6]);
   assert (
     let count = ref 0 in


### PR DESCRIPTION
I found myself reaching out to this function quite a few times recently, only to find out it does not exist.

It feels like a pretty natural extension: `mapi` and `filteri` both exist.

I wrote it in the same style as the filter_map function.