### PR TITLE
manual(etex): trim leading spaces

### DIFF
--- a/Changes
+++ b/Changes
@@ -194,6 +194,10 @@ Working version
   for attributes.
   (Shon Feder)
 
+- #14228: Trim leading spaces from first lines of LaTeX `ocamldoccode`
+  environments.
+  (Yukai Chou)
+
 ### Compiler user-interface and warnings:
 
 - #12628: Improved error message for unsafe values: print out the full path for

--- a/Changes
+++ b/Changes
@@ -196,7 +196,7 @@ Working version
 
 - #14228: Trim leading spaces from first lines of LaTeX `ocamldoccode`
   environments.
-  (Yukai Chou)
+  (Yukai Chou, review by Nicolás Ojeda Bär)
 
 ### Compiler user-interface and warnings:
 

--- a/manual/src/library/builtin.etex
+++ b/manual/src/library/builtin.etex
@@ -10,7 +10,7 @@ consequence, they can only be referred by their short names.
 %\vspace{0.1cm}
 
 \begin{ocamldoccode}
- type int
+type int
 \end{ocamldoccode}
 \index{int@\verb`int`}
 \begin{ocamldocdescription}
@@ -18,7 +18,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type char
+type char
 \end{ocamldoccode}
 \index{char@\verb`char`}
 \begin{ocamldocdescription}
@@ -26,7 +26,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type bytes
+type bytes
 \end{ocamldoccode}
 \index{bytes@\verb`bytes`}
 \begin{ocamldocdescription}
@@ -34,7 +34,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type string
+type string
 \end{ocamldoccode}
 \index{string@\verb`string`}
 \begin{ocamldocdescription}
@@ -42,7 +42,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type float
+type float
 \end{ocamldoccode}
 \index{float@\verb`float`}
 \begin{ocamldocdescription}
@@ -50,7 +50,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type bool = false | true
+type bool = false | true
 \end{ocamldoccode}
 \index{bool@\verb`bool`}
 \begin{ocamldocdescription}
@@ -58,7 +58,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type unit = ()
+type unit = ()
 \end{ocamldoccode}
 \index{unit@\verb`unit`}
 \begin{ocamldocdescription}
@@ -66,7 +66,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type exn
+type exn
 \end{ocamldoccode}
 \index{exn@\verb`exn`}
 \begin{ocamldocdescription}
@@ -74,7 +74,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type 'a array
+type 'a array
 \end{ocamldoccode}
 \index{array@\verb`array`}
 \begin{ocamldocdescription}
@@ -82,7 +82,7 @@ consequence, they can only be referred by their short names.
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
- type 'a list = [] | :: of 'a * 'a list
+type 'a list = [] | :: of 'a * 'a list
 \end{ocamldoccode}
 \index{list@\verb`list`}
 \begin{ocamldocdescription}


### PR DESCRIPTION
This PR trims leading spaces from `*.etex` files, the first lines of LaTeX `ocamldoccode` environments.

**Background**

When reading manual for the core library (https://ocaml.org/manual/5.3/core.html), I found the first several types (explicitly, 10 types) are all documented with a leading space.

<img width="420" height="294" alt="image" src="https://github.com/user-attachments/assets/f368730b-c81b-4348-ba53-ee846e876b75" />

Searching in all the `*.etex` files (or all files except the `testsuite` directory) shows that all the first lines in `ocamldoccode` environments have no leading spaces, but the 10 `␣type ...` cases in `builtin.etex`.

Thus this PR trims leading spaces for these 10 cases.

```
$ rg -U '\\begin\{ocamldoccode\}\s*\n\s' -g '*.etex'
manual/src/library/builtin.etex
12:\begin{ocamldoccode}
13: type int
20:\begin{ocamldoccode}
21: type char
28:\begin{ocamldoccode}
29: type bytes
36:\begin{ocamldoccode}
37: type string
44:\begin{ocamldoccode}
45: type float
52:\begin{ocamldoccode}
53: type bool = false | true
60:\begin{ocamldoccode}
61: type unit = ()
68:\begin{ocamldoccode}
69: type exn
76:\begin{ocamldoccode}
77: type 'a array
84:\begin{ocamldoccode}
85: type 'a list = [] | :: of 'a * 'a list
```
