### PR TITLE
Fix ocamltest criterion for using `-custom` to link test file.

### DIFF
--- a/Changes
+++ b/Changes
@@ -298,8 +298,8 @@ Working version
   result in uninitialized memory seen by Weak.get on another domain.
   (Damien Doligez, review by Gabriel Scherer)
 
-- #????? : ocamltest fails to link test program with -custom in some cases
-  (Damien Doligez, review by xxx)
+- #14230 : ocamltest fails to link test program with -custom in some cases
+  (Damien Doligez, review by David Allsopp)
 
 OCaml 5.4.0
 ---------------

--- a/Changes
+++ b/Changes
@@ -298,6 +298,9 @@ Working version
   result in uninitialized memory seen by Weak.get on another domain.
   (Damien Doligez, review by Gabriel Scherer)
 
+- #????? : ocamltest fails to link test program with -custom in some cases
+  (Damien Doligez, review by xxx)
+
 OCaml 5.4.0
 ---------------
 


### PR DESCRIPTION
Before this fix, `ocamltest` looks at the libraries being linked into the program and decides to use `-custom` if:
1) C shared libraries are not available, and
2) at least one of the libraries uses dynamically-linked C code

After the fix, it simply uses `-custom` if at least one of the libraries has its `lib_custom` flag set.

This is the source of the failure of the `slow-machines` CI job: `tools/ci/inria/light` configures the build with `--disable-shared-libraries` and `dynlink.cma` has the flag set, but it has an empty list of C files (because it does not need additional C primitives beyond those provided by the standard runtime). Why does it have the flag set if it doesn't need any C code? That's the topic of my next PR: #14231.
