### PR TITLE
fix local variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -960,7 +960,7 @@ ocamlc_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
 
 ocamlc_SOURCES = driver/main.mli driver/main.ml
 
-ocamlc$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32 -g
+ocamlc_BYTECODE_LINKFLAGS = -compat-32 -g
 
 partialclean::
 	rm -f ocamlc ocamlc.exe ocamlc.opt ocamlc.opt.exe
@@ -971,7 +971,7 @@ ocamlopt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamloptcomp)
 
 ocamlopt_SOURCES = driver/optmain.mli driver/optmain.ml
 
-ocamlopt$(EXE): OC_BYTECODE_LINKFLAGS += -g
+ocamlopt_BYTECODE_LINKFLAGS = -g
 
 partialclean::
 	rm -f ocamlopt ocamlopt.exe ocamlopt.opt ocamlopt.opt.exe
@@ -1697,7 +1697,7 @@ ocamllex: ocamlyacc
 ocamllex.opt: ocamlopt
 	$(MAKE) lex-allopt
 
-lex/ocamllex$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32
+ocamllex_BYTECODE_LINKFLAGS = -compat-32
 
 partialclean::
 	rm -f lex/*.cm* lex/*.o lex/*.obj \
@@ -1964,7 +1964,7 @@ expect_SOURCES = $(addprefix testsuite/tools/,expect.mli expect.ml)
 expect_LIBRARIES = $(addprefix compilerlibs/,\
   ocamlcommon ocamlbytecomp ocamltoplevel)
 
-testsuite/tools/expect$(EXE): OC_BYTECODE_LINKFLAGS += -linkall
+expect_BYTECODE_LINKFLAGS += -linkall
 
 codegen_SOURCES = $(addprefix testsuite/tools/,\
   parsecmmaux.mli parsecmmaux.ml \
@@ -2003,11 +2003,11 @@ test_in_prefix_LIBRARIES = \
 # test_in_prefix% would only match test_in_prefix.opt, hence the missing 'x'!
 testsuite/tools/test_in_prefi%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 
-testsuite/tools/test_in_prefix$(EXE): OC_BYTECODE_LINKFLAGS += -custom
+test_in_prefix_BYTECODE_LINKFLAGS += -custom
 
 testsuite/tools/test_in_prefi%: CAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 
-ocamltest/ocamltest$(EXE): OC_BYTECODE_LINKFLAGS += -custom -g
+ocamltest_BYTECODE_LINKFLAGS = -custom -g
 
 ocamltest/ocamltest$(EXE): ocamlc ocamlyacc ocamllex
 
@@ -2333,7 +2333,7 @@ partialclean::
 ocamldep_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
 ocamldep_SOURCES = tools/ocamldep.mli tools/ocamldep.ml
 
-tools/ocamldep$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32
+ocamldep_BYTECODE_LINKFLAGS = -compat-32
 
 # The profiler
 
@@ -2530,7 +2530,7 @@ ocamlnat_LIBRARIES = \
 
 ocamlnat_SOURCES = $(ocaml_SOURCES)
 
-ocamlnat$(EXE): OC_NATIVE_LINKFLAGS += -linkall -I toplevel/native
+ocamlnat_NATIVE_LINKFLAGS = -linkall -I toplevel/native
 
 COMPILE_NATIVE_MODULE = \
   $(CAMLOPT) $(OC_COMMON_COMPFLAGS) -I $(@D) $(INCLUDES) \


### PR DESCRIPTION
`Makefile` uses a GNU make feature that allows modifying global variables locally in a given target:

```make
ocamltest/ocamltest$(EXE): OC_BYTECODE_LINKFLAGS += -custom -g
```

This feature is broken and should never be used:
1. It does not mean "change the variable when executing the command that builds ocamltest"
2. It does not mean "change the variable when executing the commands that build ocamltest and its dependencies"

It means "change the variable when executing the commands that build ocamltest and its dependencies, except the ones that have already been built for some other target", where "already" refers to the execution order of internal `make` computations.

In this case, it means that `dynlink.cma` will be linked with the `-custom` flag, even if it doesn't need it, but only in parallel builds (-j2, -j3, etc) not in sequential builds.

Fortunately, @shindere has anticipated this problem and provided a solution in d3741bc95dd3b36349bc7e3cd300681697189ad6, so we just have to use it. I've fixed several occurrences, though only `ocamltest` is causing problems right now (see #14230).
