### PR TITLE
Disable Tsan on one more deliberately-racy test.

### DIFF
--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,4 +1,5 @@
 (* TEST
+ no-tsan;
  {
    bytecode;
  }{


### PR DESCRIPTION
Same as #14219, but for another test. I think this is the last one.