### PR TITLE
Avoid an undefined variable warning from Make

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -489,6 +489,8 @@ HEADER_NAME = runtime-launch-info
 ifeq "$(UNIX_OR_WIN32)" "win32"
 # Ensure that no command can create Cygwin symbolic links by ensuring that
 # symlink(2) will fail if native NTFS symlinks aren't available.
+CYGWIN ?=
+MSYS ?=
 export CYGWIN := $(strip \
   $(filter-out winsymlinks winsymlinks:%, $(CYGWIN)) winsymlinks:nativestrict)
 export MSYS := $(strip \


### PR DESCRIPTION
A warning is triggered with GNU Make `--warn-undefined-variable` option (we pass it in the CI runs), if either the `CYGWIN` or `MSYS` environment variables are undefined.

```
Makefile.common:492: warning: undefined variable 'CYGWIN'
Makefile.common:494: warning: undefined variable 'MSYS'
```

I've checked that `ifdef` works with GNU Make 3.81 [from 300 years ago](https://en.wikipedia.org/wiki/1725#July%E2%80%93September).

Cf #13494, cc @dra27 (no change entry needed)