### PR TITLE
[5.4]: parsetree mapper, map on new locations in toplevel directives

### DIFF
--- a/Changes
+++ b/Changes
@@ -785,7 +785,7 @@ OCaml 5.4.0
 - #13748: Add a .editorconfig file for basic editor auto-configuration.
   (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
 
-- #13302: Store locations of longidents components
+- #13302, #14236: Store locations of longidents components
   (Ulysse Gérard and Jules Aguillon, review by Jules Aguillon
    and Florian Angeletti)
 

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -89,19 +89,19 @@ let iter_opt f = function None -> () | Some x -> f x
 
 let iter_loc sub {loc; txt = _} = sub.location sub loc
 
-let rec iter_loc_lid sub lid =
+let rec iter_lid sub lid =
   let open Longident in
   match lid with
   | Lident _ -> ()
   | Ldot (lid, id) ->
-    iter_loc sub lid; iter_loc_lid sub lid.txt; iter_loc sub id
+    iter_loc sub lid; iter_lid sub lid.txt; iter_loc sub id
   | Lapply (lid, lid') ->
-    iter_loc sub lid; iter_loc_lid sub lid.txt;
-    iter_loc sub lid'; iter_loc_lid sub lid'.txt
+    iter_loc sub lid; iter_lid sub lid.txt;
+    iter_loc sub lid'; iter_lid sub lid'.txt
 
 let iter_loc_lid sub {loc; txt} =
   iter_loc sub {loc; txt};
-  iter_loc_lid sub txt
+  iter_lid sub txt
 
 module T = struct
   (* Type expressions for the core language *)
@@ -749,7 +749,10 @@ let default_iterator =
 
     directive_argument =
       (fun this a ->
-         this.location this a.pdira_loc
+         this.location this a.pdira_loc;
+         match a.pdira_desc with
+         | Pdir_ident lid -> iter_lid this lid
+         | Pdir_int _ | Pdir_string _ | Pdir_bool _ -> ()
       );
 
     toplevel_directive =

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -93,20 +93,20 @@ let map_opt f = function None -> None | Some x -> Some (f x)
 
 let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 
-let rec map_loc_lid sub lid =
+let rec map_lid sub lid =
   let open Longident in
   match lid with
   | Lident id -> Lident id
   | Ldot (lid, id) ->
-      let lid = { lid with txt = map_loc_lid sub lid.txt } in
+      let lid = { lid with txt = map_lid sub lid.txt } in
       Ldot (map_loc sub lid, map_loc sub id)
   | Lapply (lid, lid') ->
-    let lid = { lid with txt = map_loc_lid sub lid.txt } in
-    let lid' = { lid' with txt = map_loc_lid sub lid'.txt } in
+    let lid = { lid with txt = map_lid sub lid.txt } in
+    let lid' = { lid' with txt = map_lid sub lid'.txt } in
     Lapply(map_loc sub lid, map_loc sub lid')
 
 let map_loc_lid sub {loc; txt} =
-  let txt = map_loc_lid sub txt in
+  let txt = map_lid sub txt in
   map_loc sub {loc; txt}
 
 module C = struct
@@ -842,7 +842,10 @@ let default_mapper =
 
     directive_argument =
       (fun this a ->
-         { pdira_desc= a.pdira_desc
+         { pdira_desc= begin match a.pdira_desc with
+               | Pdir_ident lid -> Pdir_ident (map_lid this lid)
+               | Pdir_int _ | Pdir_bool _ | Pdir_string _ as x -> x
+             end
          ; pdira_loc= this.location this a.pdira_loc} );
 
     toplevel_directive =


### PR DESCRIPTION
This PR fixes a forgotten new location in the parsetree (in toplevel directive argument like `#show Int.t`) that was forgotten in ast mappers and iterators. This is a 5.4 fix since ignoring on this location can spell troubles for tools that normalize locations. Typically, I spot the issue when updating ocamlformat for 5.4 .