### PR TITLE
CAML*alloc macros: remove unused variadic argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -59,6 +59,10 @@ Working version
   (Tim McGilchrist, review by Nick Barnes, Sadiq Jaffer and
   Gabriel Scherer)
 
+- #14238: Fix certain variadic macros in misc.h which could trigger C warnings
+  under certain conditions.
+  (Antonin Décimo, review by Nicolás Ojeda Bär)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -245,17 +245,17 @@ CAMLdeprecated_typedef(addr, char *);
 /* [CAMLrealloc(n)] indicates that the function is [realloc]-like, and implies
    that the [n]-th argument number equals the number of available bytes at the
    returned pointer. */
-#define CAMLrealloc(alloc_size_N,...)                           \
+#define CAMLrealloc(alloc_size_N)                                       \
   __attribute__ ((warn_unused_result,alloc_size(alloc_size_N)))
 
 /* [CAMLalloc(dealloc, p)] indicates that the function allocates a resource,
    which must be deallocated by passing it as the [p]-th argument of the
    function [dealloc]. */
 #if defined(__GNUC__) && !defined(__llvm__)
-#define CAMLalloc(deallocator,ptr_index,...)                            \
+#define CAMLalloc(deallocator,ptr_index)                                \
   __attribute__ ((malloc,malloc(deallocator,ptr_index),warn_unused_result))
 #else
-#define CAMLalloc(deallocator,ptr_index,...)    \
+#define CAMLalloc(deallocator,ptr_index)      \
   __attribute__ ((malloc,warn_unused_result))
 #endif
 
@@ -263,15 +263,15 @@ CAMLdeprecated_typedef(addr, char *);
    implies that it allocates a memory block whose size is set by the function's
    [n]-th argument, and which must be deallocated by passing it as the [p]-th
    argument of the function [dealloc]. */
-#define CAMLmalloc(deallocator,ptr_index,alloc_size_N,...)      \
-  CAMLalloc(deallocator,ptr_index)                              \
+#define CAMLmalloc(deallocator,ptr_index,alloc_size_N)  \
+  CAMLalloc(deallocator,ptr_index)                      \
     __attribute__ ((alloc_size(alloc_size_N)))
 
 /* [CAMLcalloc(dealloc, p, n, m)] indicates that the function is [calloc]-like,
    and implies that it allocates a memory block whose size is set by the product
    of the function's [n]-th and [m]-th arguments, and which must be deallocated
    by passing it as the [p]-th argument of the function [dealloc]. */
-#define CAMLcalloc(deallocator,ptr_index,alloc_size_N,alloc_size_M,...) \
+#define CAMLcalloc(deallocator,ptr_index,alloc_size_N,alloc_size_M)     \
   CAMLalloc(deallocator,ptr_index)                                      \
     __attribute__ ((alloc_size(alloc_size_N,alloc_size_M)))
 
@@ -280,17 +280,17 @@ CAMLdeprecated_typedef(addr, char *);
    is set by the function's [n]-th argument, aligned on a boundary given by the
    function's [a]-th argument, and which must be deallocated by passing it as
    the [p]-th argument of the function [dealloc]. */
-#define CAMLaligned_alloc(deallocator,ptr_index,alloc_size_N,alloc_align_,...) \
+#define CAMLaligned_alloc(deallocator,ptr_index,alloc_size_N,alloc_align_) \
   CAMLmalloc(deallocator,ptr_index,alloc_size_N)                        \
     __attribute__ ((alloc_align(alloc_align_)))
 
 #else
 #define CAMLreturns_nonnull()
-#define CAMLrealloc(...)
-#define CAMLalloc(...)
-#define CAMLmalloc(...)
-#define CAMLcalloc(...)
-#define CAMLaligned_alloc(...)
+#define CAMLrealloc(asN)
+#define CAMLalloc(d,pi)
+#define CAMLmalloc(d,pi,asN)
+#define CAMLcalloc(d,pi,asN,asM)
+#define CAMLaligned_alloc(d,pi,asN,aa)
 #endif
 
 /* GC timing hooks. These can be assigned by the user. These hooks


### PR DESCRIPTION
There are some macros in `misc.h` (or rather, their callsites) which are not strictly valid according to C99:
```
In file included from ./link.c:42:
/home/malc/x/scm/git/llpp/build/lib/ocaml/caml/memory.h:89:32: error: ISO C99 requires at least one argument for the "..." in a variadic macro [-Werror]
   89 | CAMLmalloc(caml_stat_free, 1, 1) CAMLreturns_nonnull()
```
This warning does not trigger in the compiler build because not enough warnings are enabled. But since this header is liable to be included in user code which may be compiled with more strict warnings, I think it would be a good idea to fix this, as per this PR.