### PR TITLE
Fix `#show_constructor` printing wrong type parameters

### DIFF
--- a/Changes
+++ b/Changes
@@ -202,6 +202,9 @@ Working version
 - #14032, #14034: Update to and require FlexDLL 0.44.
   (Jan Midtgaard, Antonin Décimo, review by David Allsopp)
 
+- #14239: Fix `#show_constructor` when printing non-GADT type parameters
+  (Takafumi Saikawa, Jacques Garrigue, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #14293: Improve documentation of Runtime_events.Timestamp (Raphaël Proust,

--- a/testsuite/tests/tool-toplevel/show.ml
+++ b/testsuite/tests/tool-toplevel/show.ml
@@ -125,7 +125,15 @@ type _ t += A : int t
 type 'a t += A : int t
 |}];;
 
+type 'b t += B of 'b list;;
+[%%expect{|
+type 'b t += B of 'b list
+|}];;
 
+#show B;;
+[%%expect{|
+type 'b t += B of 'b list
+|}];;
 
 
 (* regression tests for #11533 *)

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -335,6 +335,10 @@ let () =
          raise Not_found;
        let path = Data_types.cstr_res_type_path desc in
        let type_decl = Env.find_type path env in
+       let params =
+         if desc.cstr_generalized
+         then type_decl.type_params
+         else Data_types.cstr_res_type_params desc in
        if is_extension_constructor desc.cstr_tag then
          let ret_type =
            if desc.cstr_generalized then Some desc.cstr_res
@@ -342,7 +346,7 @@ let () =
          in
          let ext =
            { ext_type_path = path;
-             ext_type_params = type_decl.type_params;
+             ext_type_params = params;
              ext_args = Cstr_tuple desc.cstr_args;
              ext_ret_type = ret_type;
              ext_private = Asttypes.Public;

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -69,6 +69,11 @@ let cstr_res_type_path cstr =
   | Tconstr (p, _, _) -> p
   | _ -> assert false
 
+let cstr_res_type_params cstr =
+  match get_desc cstr.cstr_res with
+  | Tconstr (_, tyl, _) -> tyl
+  | _ -> assert false
+
 type label_description =
   { lbl_name: string;                   (* Short name *)
     lbl_res: type_expr;                 (* Type of the result (the record) *)

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -55,6 +55,9 @@ val may_equal_constr :
 (* Type constructor of the constructor's result type. *)
 val cstr_res_type_path : constructor_description -> Path.t
 
+(* Parameters of the type constructor *)
+val cstr_res_type_params : constructor_description -> type_expr list
+
 type label_description =
   { lbl_name: string;                   (* Short name *)
     lbl_res: type_expr;                 (* Type of the result (the record) *)


### PR DESCRIPTION
The `#show_constructor` directive has been printing non-GADT type parameters wrongly:
```
# type 'a t = ..;;
type 'a t = ..
# type 'a t += A of 'a list;;
type 'a t += A of 'a list
# type 'b t += B of 'b list;;
type 'b t += B of 'b list
# #show A;;
type 'a t += A of 'a0 list
# #show B;;
type 'a t += B of 'b list
```

This PR fixes that:
```
# type 'a t = ..;;
type 'a t = ..
# type 'a t += A of 'a list;;
type 'a t += A of 'a list
# type 'b t += B of 'b list;;
type 'b t += B of 'b list
# #show A;;
type 'a t += A of 'a list
# #show B;;
type 'b t += B of 'b list
```

Co-authored by @garrigue 