### PR TITLE
Fix Android cross-build, minor GitHub Actions updates

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  res: 0
+  failed: 0
   TESTDIR: >-
     C:\Бактріан🐫
   STR_UTF8: >-
@@ -50,8 +50,11 @@ jobs:
           set -x
           ./configure --disable-warn-error --disable-ocamldoc \
               --disable-ocamltest --disable-stdlib-manpages \
-              --disable-dependency-generation --prefix="$PREFIX" || res=$?
-          if ! [ "$res" = 0 ]; then cat config.log; exit "$res"; fi
+              --disable-dependency-generation --prefix="$PREFIX" || failed=$?
+          if ((failed)) ; then set +x
+            echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
+            cat config.log ; echo '::endgroup::' ; exit $failed
+          fi
           make -j
           make install
           cd "$HOME"
@@ -88,8 +91,11 @@ jobs:
         run: |
           set -x
           ./configure --prefix="$HOME/cross" --target=x86_64-w64-mingw32 \
-              TARGET_LIBDIR="$TESTDIR" || res=$?
-          if ! [ "$res" = 0 ]; then cat config.log; exit "$res"; fi
+              TARGET_LIBDIR="$TESTDIR" || failed=$?
+          if ((failed)) ; then set +x
+            echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
+            cat config.log ; echo '::endgroup::' ; exit $failed
+          fi
           # The OOM-killer may be triggered if the number of parallel
           # jobs isn't limited.
           make crossopt -j$(nproc)
@@ -159,8 +165,11 @@ jobs:
         run: |
           set -x
           ./configure --prefix="$HOME/cross" --target=aarch64-linux-gnu \
-              || res=$?
-          if ! [ "$res" = 0 ]; then cat config.log; exit "$res"; fi
+              || failed=$?
+          if ((failed)) ; then set +x
+            echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
+            cat config.log ; echo '::endgroup::' ; exit $failed
+          fi
           make crossopt -j
           make installcross
       - name: Show opt.opt configuration
@@ -250,8 +259,11 @@ jobs:
               AR="$DIR/llvm-ar" \
               PARTIALLD="$DIR/ld -r" \
               RANLIB="$DIR/llvm-ranlib" \
-              STRIP="$DIR/llvm-strip" || res=$?
-          if ! [ "$res" = 0 ]; then cat config.log; exit "$res"; fi
+              STRIP="$DIR/llvm-strip" || failed=$?
+          if ((failed)) ; then set +x
+            echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
+            cat config.log ; echo '::endgroup::' ; exit $failed
+          fi
           make crossopt -j
           make installcross
       - name: Show opt.opt configuration

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -191,6 +191,10 @@ jobs:
   cross-android:
     runs-on: ubuntu-latest
     needs: non-cross
+    env:
+      # https://developer.android.com/ndk/downloads#lts-downloads
+      NDK: r27d # Latest LTS Version
+      API_LEVEL: 21
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -208,22 +212,22 @@ jobs:
         with:
           path: |
             /home/runner/android
-          key: android-ndk
+          key: android-ndk-${{ env.NDK }}
       - name: Download the Android NDK
         run: |
           set -x
           mkdir -p "$HOME/android"
           cd "$HOME/android"
-          wget --no-verbose https://dl.google.com/android/repository/android-ndk-r27b-linux.zip
-          unzip android-ndk-r27b-linux.zip
-          rm android-ndk-r27b-linux.zip
+          wget --no-verbose "https://dl.google.com/android/repository/android-ndk-$NDK-linux.zip"
+          unzip android-ndk-$NDK-linux.zip
+          rm android-ndk-$NDK-linux.zip
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Save the Android NDK to cache
         uses: actions/cache/save@v4
         with:
           path: |
             /home/runner/android
-          key: android-ndk
+          key: android-ndk-${{ env.NDK }}
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Checkout OCaml
         uses: actions/checkout@v5
@@ -231,8 +235,8 @@ jobs:
           persist-credentials: false
       - name: Configure, build and install Linux-to-Android OCaml
         env:
-          TARGET: x86_64-linux-android21
-          TOOLDIR: android-ndk-r27b/toolchains/llvm/prebuilt/linux-x86_64/bin
+          TARGET: x86_64-linux-android${{ env.API_LEVEL }}
+          TOOLDIR: android-ndk-${{ env.NDK }}/toolchains/llvm/prebuilt/linux-x86_64/bin
         run: |
           DIR="$HOME/android/$TOOLDIR"
           set -x
@@ -265,7 +269,7 @@ jobs:
       - name: Run example
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 21
+          api-level: ${{ env.API_LEVEL }}
           arch: x86_64
           disable-animations: true
           script: |

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout OCaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Configure, build and install OCaml
@@ -80,7 +80,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64-x86-64
       - name: Checkout OCaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false
@@ -151,7 +151,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-aarch64-linux-gnu qemu-user
       - name: Checkout OCaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false
@@ -226,7 +226,7 @@ jobs:
           key: android-ndk
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Checkout OCaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Configure, build and install Linux-to-Android OCaml

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -249,13 +249,12 @@ jobs:
         run: |
           DIR="$HOME/android/$TOOLDIR"
           set -x
-          # Hack around the fact that pthread_cancel isn't available on Android
-          # So the result program should _not_ be run with cleanup on exit
-          # (so no `c=1` in `OCAMLRUNPARAM`)
+          # `pthread_cancel` isn't available on Android, so the result
+          # program should _not_ be run with cleanup on exit (so no
+          # `c=1` in `OCAMLRUNPARAM`)
           ./configure --prefix="$HOME/cross" --target=$TARGET \
               TARGET_LIBDIR="/dummy/directory" \
               CC="$DIR/clang --target=$TARGET" \
-              CPPFLAGS='-Dpthread_cancel=assert' \
               AR="$DIR/llvm-ar" \
               PARTIALLD="$DIR/ld -r" \
               RANLIB="$DIR/llvm-ranlib" \

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
 
       - name: Fetch OCaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: config
     container:
-      image: debian:12
+      image: debian:13
       options: --platform linux/i386 --user root
     steps:
       - name: OS Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Check for manual changes
@@ -216,7 +216,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: macOS Dependencies

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -28,7 +28,7 @@ jobs:
         # context variable.
         if: failure()
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 50
           persist-credentials: false

--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -25,7 +25,7 @@ jobs:
             ocamlrunparam: b,s=4096
     steps:
       - name: Checkout OCaml
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ocaml
           persist-credentials: false
@@ -33,21 +33,21 @@ jobs:
         run: |
           bash -xe ocaml/tools/ci/actions/multicoretests.sh ocaml
       - name: Checkout multicoretests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ocaml-multicore/multicoretests
           ref: 0.9
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: c-cube/qcheck
           ref: v0.26
           path: multicoretests/qcheck
           persist-credentials: false
       - name: Checkout dune
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ocaml/dune
           ref: 3.18.2

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -29,7 +29,7 @@ jobs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install libunwind

--- a/configure
+++ b/configure
@@ -22986,6 +22986,21 @@ then :
 fi
 
 
+
+  for ac_func in pthread_setname_np pthread_set_name_np
+do :
+  as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"
+then :
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+ break
+fi
+
+done
+
 ## prctl
 
   for ac_func in prctl
@@ -22995,34 +23010,6 @@ if test "x$ac_cv_func_prctl" = xyes
 then :
   printf "%s\n" "#define HAVE_PRCTL 1" >>confdefs.h
  printf "%s\n" "#define HAS_PRCTL 1" >>confdefs.h
-
-fi
-
-done
-
-## pthread_setname_np
-
-  for ac_func in pthread_setname_np
-do :
-  ac_fn_c_check_func "$LINENO" "pthread_setname_np" "ac_cv_func_pthread_setname_np"
-if test "x$ac_cv_func_pthread_setname_np" = xyes
-then :
-  printf "%s\n" "#define HAVE_PTHREAD_SETNAME_NP 1" >>confdefs.h
- printf "%s\n" "#define HAS_PTHREAD_SETNAME_NP 1" >>confdefs.h
-
-fi
-
-done
-
-## pthread_set_name_np
-
-  for ac_func in pthread_set_name_np
-do :
-  ac_fn_c_check_func "$LINENO" "pthread_set_name_np" "ac_cv_func_pthread_set_name_np"
-if test "x$ac_cv_func_pthread_set_name_np" = xyes
-then :
-  printf "%s\n" "#define HAVE_PTHREAD_SET_NAME_NP 1" >>confdefs.h
- printf "%s\n" "#define HAS_PTHREAD_SET_NAME_NP 1" >>confdefs.h
 
 fi
 

--- a/configure
+++ b/configure
@@ -22977,6 +22977,15 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
+# pthread_cancel isn't implemented on Android Bionic libc
+ac_fn_c_check_func "$LINENO" "pthread_cancel" "ac_cv_func_pthread_cancel"
+if test "x$ac_cv_func_pthread_cancel" = xyes
+then :
+  printf "%s\n" "#define HAVE_PTHREAD_CANCEL 1" >>confdefs.h
+
+fi
+
+
 ## prctl
 
   for ac_func in prctl

--- a/configure.ac
+++ b/configure.ac
@@ -2611,6 +2611,9 @@ AC_LINK_IFELSE(
     AC_DEFINE([HAS_BSD_GETAFFINITY_NP], [1])],
     [AC_MSG_RESULT([pthread_getaffinity_np not found])])])
 
+# pthread_cancel isn't implemented on Android Bionic libc
+AC_CHECK_FUNCS([pthread_cancel])
+
 ## prctl
 AC_CHECK_FUNCS(
   [prctl],

--- a/configure.ac
+++ b/configure.ac
@@ -2047,9 +2047,9 @@ void __tsan_write8       (void *location);
   # Define a C macro based on the detected __tsan_func_exit signature
   AS_CASE([$ocaml_cv_func_which___tsan_func_exit],
     [void_void_p], [AC_DEFINE([HAVE___TSAN_FUNC_EXIT_VOID_VOID_P], [1],
-                  [ThreadSanitizer exit function signature: void (*)(void*)])],
+                  [ThreadSanitizer exit function signature: void (void*)])],
     [void_void], [AC_DEFINE([HAVE___TSAN_FUNC_EXIT_VOID_VOID], [1],
-                  [ThreadSanitizer exit function signature: void (*)(void)])],
+                  [ThreadSanitizer exit function signature: void (void)])],
     [AC_MSG_ERROR([libtsan uses an unexpected signature for __tsan_func_exit])])
 
   AS_CASE([$ocaml_cc_vendor],
@@ -2614,20 +2614,12 @@ AC_LINK_IFELSE(
 # pthread_cancel isn't implemented on Android Bionic libc
 AC_CHECK_FUNCS([pthread_cancel])
 
+AC_CHECK_FUNCS([pthread_setname_np pthread_set_name_np], [break])
+
 ## prctl
 AC_CHECK_FUNCS(
   [prctl],
   [AC_DEFINE([HAS_PRCTL], [1])])
-
-## pthread_setname_np
-AC_CHECK_FUNCS(
-  [pthread_setname_np],
-  [AC_DEFINE([HAS_PTHREAD_SETNAME_NP], [1])])
-
-## pthread_set_name_np
-AC_CHECK_FUNCS(
-  [pthread_set_name_np],
-  [AC_DEFINE([HAS_PTHREAD_SET_NAME_NP], [1])])
 
 ## SetThreadDescription
 AC_CHECK_FUNCS(

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -50,7 +50,7 @@ SetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription);
 
 #elif defined(HAS_PRCTL)
 #  include <sys/prctl.h>
-#elif defined(HAS_PTHREAD_SETNAME_NP) || defined(HAS_PTHREAD_SET_NAME_NP)
+#elif defined(HAVE_PTHREAD_SETNAME_NP) || defined(HAVE_PTHREAD_SET_NAME_NP)
 #  include <pthread.h>
 
 #  if defined(HAS_PTHREAD_NP_H)
@@ -1002,7 +1002,7 @@ CAMLprim value caml_set_current_thread_name(value name)
     caml_set_current_thread_name_warning("SetThreadDescription failed!");
 #  endif
 
-#  if defined(HAS_PTHREAD_SETNAME_NP)
+#  if defined(HAVE_PTHREAD_SETNAME_NP)
   // We are using both methods.
   // See: https://github.com/ocaml/ocaml/pull/13504#discussion_r1786358928
   char buf[1024];
@@ -1017,7 +1017,7 @@ CAMLprim value caml_set_current_thread_name(value name)
   if (ret == -1)
     caml_set_current_thread_name_warning(
       caml_strerror(errno, buf, sizeof(buf)));
-#elif defined(HAS_PTHREAD_SETNAME_NP)
+#elif defined(HAVE_PTHREAD_SETNAME_NP)
 #  if defined(__APPLE__)
   // Darwin implementation does not return any error code.
   pthread_setname_np(String_val(name));
@@ -1034,7 +1034,7 @@ CAMLprim value caml_set_current_thread_name(value name)
   if (ret != 0)
     caml_set_current_thread_name_warning(caml_strerror(ret, buf, sizeof(buf)));
 #  endif
-#elif defined(HAS_PTHREAD_SET_NAME_NP)
+#elif defined(HAVE_PTHREAD_SET_NAME_NP)
   // pthread_set_name_np seems to be the no-error alternative.
   pthread_set_name_np(pthread_self(), String_val(name));
 #else

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -113,9 +113,9 @@
 /* Define to 1 if you have the 'pthread_cancel' function. */
 #undef HAVE_PTHREAD_CANCEL
 
-#undef HAS_PTHREAD_SETNAME_NP
+#undef HAVE_PTHREAD_SETNAME_NP
 
-#undef HAS_PTHREAD_SET_NAME_NP
+#undef HAVE_PTHREAD_SET_NAME_NP
 
 #undef HAS_SETTHREADDESCRIPTION
 
@@ -325,9 +325,8 @@
 
 /* 3. Language extensions. */
 
+/* Define if the C compiler supports the labels as values extension. */
 #undef HAVE_LABELS_AS_VALUES
 
 #undef HAVE___TSAN_FUNC_EXIT_VOID_VOID_P
 #undef HAVE___TSAN_FUNC_EXIT_VOID_VOID
-
-/* Define if the C compiler supports the labels as values extension. */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -110,6 +110,9 @@
 
 #undef HAS_PRCTL
 
+/* Define to 1 if you have the 'pthread_cancel' function. */
+#undef HAVE_PTHREAD_CANCEL
+
 #undef HAS_PTHREAD_SETNAME_NP
 
 #undef HAS_PTHREAD_SET_NAME_NP

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2337,7 +2337,9 @@ static void stw_terminate_domain(caml_domain_state *domain, void *data,
       /* If this STW request is handled by the backup thread, the
          domain thread is currently running C code. */
       domain_self->domain_canceled = true;
+#ifdef HAVE_PTHREAD_CANCEL
       (void)pthread_cancel(domain_self->tid);
+#endif
       /* We are intentionally not waiting for the thread to terminate here,
          and not decrementing the number of running domains either, since
          we don't know the state of the various locks and condition


### PR DESCRIPTION
This started off as a minor fix for the [Android cross-build](https://github.com/ocaml/ocaml/actions/runs/17516318571/job/49754411678?pr=13416#step:8:895):

```
runtime/unix.c:578:10: error: call to undeclared function 'assert'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  578 |   return pthread_cancel(t);
      |          ^
<command line>:4:24: note: expanded from macro 'pthread_cancel'
    4 | #define pthread_cancel assert
      |                        ^
1 error generated.
```

Android's Bionic libc doesn't support thread cancellation, thus doesn't define `pthread_cancel`. We had a hack in CI during the invocation of configure to replace it with an `assert` call: `CPPFLAGS='-Dpthread_cancel=assert'` but the `assert.h` header was missing. Fix this problem by discovering at configure-time whether `pthread_cancel` is supported.

As I can never stop myself from doing this, I'm also including a few updates and refactors in the GitHub Actions scripts.

No change entry needed. Please consider adding the `run-crosscompiler-tests` label (though the run is successful on my fork).