### PR TITLE
Two trivial fixes to AppVeyor

### DIFF
--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -124,8 +124,10 @@ if "%PORT%" equ "mingw32" (
   set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% i686-w64-mingw32-gcc cygcheck
 )
 if "%PORT%" equ "mingw64" (
-  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-x86_64-gcc-core
-  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% x86_64-w64-mingw32-gcc
+  rem mingw64-x86_64-runtime does not need explicitly installing, but it's
+  rem useful to have the version reported.
+  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-x86_64-gcc-core mingw64-x86_64-runtime
+  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% x86_64-w64-mingw32-gcc cygcheck
 )
 if "%PORT%" equ "cygwin32" (
   set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% cygwin32-gcc-core flexdll

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -152,7 +152,7 @@ case "$1" in
     run_testsuite=true
     if [[ -n $APPVEYOR_PULL_REQUEST_NUMBER ]]; then
       API_URL="https://api.github.com/repos/$APPVEYOR_REPO_NAME/issues/$APPVEYOR_PULL_REQUEST_NUMBER"
-      if curl --silent "$API_URL/labels" | grep -q "no-testsuite"; then
+      if curl --silent "$API_URL/labels" | grep -q 'CI: Skip testsuite'; then
         run_testsuite=false
       fi
     fi


### PR DESCRIPTION
Mistake in #14013 - the AppVeyor script was using an older version of the label for skipping the testsuite. A long time ago #10046 added a display of the mingw-w64 runtime version, but only to the i686 build. It's useful to have on the x86_64 build as well (cf. #14223).