### PR TITLE
Un-archive our opam scripts!

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -216,9 +216,6 @@ runtime/caml/sizeclasses.h typo.missing-header
 
 /tools/gdb_ocamlrun.py typo.long-line
 
-/tools/opam/gen_ocaml-system_config.ml.in typo.long-line
-/tools/opam/gen_ocaml_config.ml.in typo.long-line
-
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
 testsuite/tests/basic-modules/anonymous.ml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -217,7 +217,7 @@ runtime/caml/sizeclasses.h typo.missing-header
 /tools/gdb_ocamlrun.py typo.long-line
 
 /tools/opam/gen_ocaml-system_config.ml.in typo.long-line
-/tools/opam/gen_ocaml_config.ml.in typo.very-long-line
+/tools/opam/gen_ocaml_config.ml.in typo.long-line
 
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.

--- a/.gitattributes
+++ b/.gitattributes
@@ -216,8 +216,8 @@ runtime/caml/sizeclasses.h typo.missing-header
 
 /tools/gdb_ocamlrun.py typo.long-line
 
-/tools/opam/gen_ocaml-system_config.ml.in typo.missing-header
-/tools/opam/gen_ocaml_config.ml.in typo.very-long-line typo.missing-header
+/tools/opam/gen_ocaml-system_config.ml.in typo.long-line
+/tools/opam/gen_ocaml_config.ml.in typo.very-long-line
 
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.

--- a/tools/opam/Layout.md
+++ b/tools/opam/Layout.md
@@ -79,7 +79,7 @@ This means `%` symbols should be doubled.
 Historically, this file lived in opam-repository itself, and was installed as a
 script by the `ocaml-config` package and then used by each of the `ocaml`
 packages. opam-repository no longer stores files directly in its repo, but the
-script is downloaded from this repository by the `ocaml-config` package.
+script is still downloaded from this repository by the `ocaml` package.
 
 ### `gen_ocaml-system_config.ml.in`
 

--- a/tools/opam/Layout.md
+++ b/tools/opam/Layout.md
@@ -46,15 +46,15 @@ There are various additional packages which assist in the process:
   installed).
 - `ocaml-beta` is a single package used to prevent accidental installation of
   pre-release compilers when using opam 2.0.
-- `ocaml-config` packaged the tools/opam/gen\_ocaml\_config.ml.in script, but is
-  no longer required.
+- `ocaml-config` packaged the tools/opam/gen\_ocaml\_config.ml script, but is no
+  longer required.
 - `flexdll` and `winpthreads` are source-installing packages which provide the
   source code, when required, for the flexdll and winpthreads submodules when
   compiling OCaml on Windows.
 
 ## Scripts
 
-### `gen_ocaml_config.ml.in`
+### `gen_ocaml_config.ml`
 
 Packages in opam are able to set variables as part of their build process; the
 `ocaml` package defines six:
@@ -72,22 +72,20 @@ Packages in opam are able to set variables as part of their build process; the
   compiler) or the compiler version (e.g. "5.4.0"), otherwise.
 
 This script is used by the `ocaml` package to generate the file `ocaml.config`
-when the `ocaml` package is installed. It's written using opam's `substs`
-format where opam will replace everything in `%{...}%` with the correct value.
-This means `%` symbols should be doubled.
+when the `ocaml` package is installed.
 
 Historically, this file lived in opam-repository itself, and was installed as a
 script by the `ocaml-config` package and then used by each of the `ocaml`
 packages. opam-repository no longer stores files directly in its repo, but the
 script is still downloaded from this repository by the `ocaml` package.
 
-### `gen_ocaml-system_config.ml.in`
+### `gen_ocaml-system_config.ml`
 
 This script is used by the `ocaml-system` package to generate the file
 `ocaml-system.config` when using a compiler which has been installed outside of
-opam. It works in a similar way to `gen_ocaml_config.ml.in`. `ocaml-system`
-defines one variable `path` which contains the directory where the compiler's
-binaries are located. The script also sets up another mechanism in opam to
+opam. It works in a similar way to `gen_ocaml_config.ml`. `ocaml-system` defines
+one variable `path` which contains the directory where the compiler's binaries
+are located. The script also sets up another mechanism in opam to
 ensure that the package is recompiled by opam if the compiler is altered (for
 example, by upgrading the compiler through the OS's package manager via
 `apt upgrade` or `brew upgrade`). This is done by recording the digest of

--- a/tools/opam/Layout.md
+++ b/tools/opam/Layout.md
@@ -1,0 +1,150 @@
+# OCaml opam packaging
+
+Users in opam primarily see the OCaml compiler through the `ocaml` package. For
+example, installing the [ocaml.5.4.0](https://ocaml.org/p/ocaml/5.4.0) package
+in a switch succeeds if and only if OCaml 5.4.0 (or some variant of it) is
+available in the opam switch.
+
+There are various additional packages which assist in the process:
+- `ocaml-compiler` contains the actual build instructions and is responsible for
+  configuring and building a compiler from sources.
+- `ocaml-system` is available if the user has installed OCaml outside of opam
+  and made it available in PATH. For example, if `/usr/bin/ocaml` is an
+  installation of OCaml 5.4.0, then `ocaml-system.5.4.0` can be installed.
+- `arch-*` and `system-*` are meta-packages used to control exactly which
+  architecture and C compiler ecosystem are targetted by the compiler (at
+  present these are only used for Windows).
+- `ocaml-option-*` are meta-packages used to control features of the compiler,
+  for example whether frame pointers are used ([ocaml-option-fp](https://ocaml.org/p/ocaml-option-fp/latest))
+  or the flambda optimizer enabled ([ocaml-option-flambda](https://ocaml.org/p/ocaml-option-flambda/latest)).
+- `ocaml-options-vanilla` and `ocaml-options-only-*` are additional
+  meta-packages used to aid creation of switches with fixed specific options.
+  `ocaml-options-vanilla` is the "default" build of OCaml with no additional
+  options set. `ocaml-options-only-flambda`, for example, creates a switch with
+  the flambda optimizer enabled, but which prohibits the reconfiguration of the
+  compiler with different options. The idea behind these packages is that if
+  they are used when creating a switch, for example by running
+  `opam switch create release-builds ocaml-options-only-flambda ocaml.5.4.0`,
+  then packages which _conflict_ `ocaml-option-flambda` for some reason will be
+  rejected, rather than causing the compiler to be rebuilt with flambda support
+  disabled.
+- `ocaml-base-compiler` is a meta-package which builds OCaml sources and depends
+  on `ocaml-options-vanilla` - i.e. it installs an altered OCaml compiler.
+- `ocaml-variants` was used extensively prior to OCaml 4.12 when the
+  ocaml-option- packages were introduced for alternate configurations (for
+  example, `ocaml-variants.4.11.0+flambda` provided OCaml 4.11.0 with the
+  flambda optimizer enabled). It was also, and still is, used for experimental
+  branches of OCaml (e.g. MetaOCaml, Multicore OCaml, OxCaml, etc.)
+- `host-arch-*` and `host-system-*` are work-in-progress meta-packages which
+  _indicate_ which architecture and system the compiler targets. Their purpose
+  is to allow other packages in opam-repository to indicate a requirement or a
+  conflict with a given architecture or system.
+- `base-*` are similarly applied for some compiler features. For example,
+  [base-nnp](https://ocaml.org/p/base-nnp/latest) is installed with any compiler
+  which does not permit naked pointers in the heap (i.e. OCaml 5.x or 4.x when
+  [ocaml-option-nnp](https://ocaml.org/p/ocaml-option-nnp/latest) has been
+  installed).
+- `ocaml-beta` is a single package used to prevent accidental installation of
+  pre-release compilers when using opam 2.0.
+- `ocaml-config` packaged the tools/opam/gen\_ocaml\_config.ml.in script, but is
+  no longer required.
+- `flexdll` and `winpthreads` are source-installing packages which provide the
+  source code, when required, for the flexdll and winpthreads submodules when
+  compiling OCaml on Windows.
+
+## Scripts
+
+### `gen_ocaml_config.ml.in`
+
+Packages in opam are able to set variables as part of their build process; the
+`ocaml` package defines six:
+- `native` (boolean): indicates that `ocamlopt` is available
+- `native-tools` (boolean): indicates that the ocamlopt-compiled versions of
+  tools are available (`ocamlc.opt`, `ocamlopt.opt`, etc.)
+- `native-dynlink` (boolean): indicates that `dynlink.cmxa` is available
+- `stubsdir` (string): contains the lines of `ld.conf` presented in a format
+  suitable for `CAML_LD_LIBRARY_PATH`
+- `preinstalled` (boolean): is true if the `ocaml-system` package provided the
+  compiler (i.e. if OCaml is being used from an installation outside of opam)
+- `compiler` (string): OPAM 1.x derived value reflecting the name of the switch
+  based on the compiler's version. This is largely a legacy value, and is
+  essentially either "system" (if the ocaml-system package provided the
+  compiler) or the compiler version (e.g. "5.4.0"), otherwise.
+
+This script is used by the `ocaml` package to generate the file `ocaml.config`
+when the `ocaml` package is installed. It's written using opam's `substs`
+format where opam will replace everything in `%{...}%` with the correct value.
+This means `%` symbols should be doubled.
+
+Historically, this file lived in opam-repository itself, and was installed as a
+script by the `ocaml-config` package and then used by each of the `ocaml`
+packages. opam-repository no longer stores files directly in its repo, but the
+script is downloaded from this repository by the `ocaml-config` package.
+
+### `gen_ocaml-system_config.ml.in`
+
+This script is used by the `ocaml-system` package to generate the file
+`ocaml-system.config` when using a compiler which has been installed outside of
+opam. It works in a similar way to `gen_ocaml_config.ml.in`. `ocaml-system`
+defines one variable `path` which contains the directory where the compiler's
+binaries are located. The script also sets up another mechanism in opam to
+ensure that the package is recompiled by opam if the compiler is altered (for
+example, by upgrading the compiler through the OS's package manager via
+`apt upgrade` or `brew upgrade`). This is done by recording the digest of
+the `ocamlc` binary and the `graphics.cmi` file. The latter is a legacy check
+from when the Graphics library was part of OCaml, but not necessary installed,
+and could be added via a separate package.
+
+Historically, this file lived in opam-repository itself, but opam-repository no
+longer stores files directly in its repo. This script is referenced in this
+repository by each of the `ocaml-system` packages.
+
+### `generate.ml`
+
+The `install` target of the build system is meta-programmed to allow extraction
+of the directories, files and symlinks which are required for a given
+installation. This script is called automatically by the build system and takes
+the files emitted during:
+
+```
+make OPAM_PACKAGE_NAME=ocaml-compiler INSTALL_MODE=opam install
+```
+
+and produces `ocaml-compiler.install` and `ocaml-compiler-fixup.sh`. The
+.install file can be used by opam instead of running `make install`. At present,
+there are two limitations in opam's installation mechanism. It is not possible
+to specify symlinks and it is not possible to install documentation files to
+arbitrary package locations. These two limitations are dealt with by the
+`ocaml-compiler-fixup.sh` script - i.e. `ocaml-compiler.install` provides opam
+with almost the entire installation manifest, and then the
+`ocaml-compiler-fixup.sh` script completes the missing parts (as it happens, the
+`-fixup` script runs first). Future versions of opam will hopefully deal with
+these two limitations, at which point the `-fixup` script will become
+unnecessary.
+
+`generate.ml` is also used with `INSTALL_MODE=clone` and then produces
+`ocaml-compiler-clone.sh`. This script is used by `process.sh` as part of
+Relocatable OCaml to allow compilers to be duplicated by opam, instead of built
+from sources each time. The script is intended to be run from the prefix
+directory and receives as a single argument the directory to which the new
+compiler should be written. The script's preference is to use copy-on-write (via
+`cp --reflink=always`) but falls back to hard-linking or normal copying
+otherwise.
+
+### `process.sh`
+
+This script is used by `ocaml-compiler` packages which support Relocatable OCaml
+and provides the ability to clone a compiler from an existing opam switch,
+rather than freshly building it from sources. It uses the `-clone.sh` scripts
+produced by `generate.ml` in order to do this.
+
+`process.sh` is called in both the `build` and `install` sections of the
+`ocaml-compiler` package. In the `build` section, it is passed enough
+information to be able to build the compiler from sources if necessary, but also
+the opam `build-id` of the compiler. The script searches for an existing
+compiler. If one is found, the script records these details to be used when it
+is called again from the `install` section. Otherwise, it builds the compiler
+from the sources available. When invoked from the `install` section,
+`process.sh` then either clones the compiler which was found in the `build`
+stage, or installs the compiler which was built in the `build` stage, along with
+its cloning script, which allows subsuquent switches to clone it.

--- a/tools/opam/gen_ocaml-system_config.ml
+++ b/tools/opam/gen_ocaml-system_config.ml
@@ -47,9 +47,9 @@ let ocamlc =
 let () =
   if Sys.ocaml_version <> expected_ocaml_version then begin
     Printf.eprintf
-      "ERROR: The compiler found at %%s has version %%s,\n\
-       and this package requires %%s.\n\
-       You should use e.g. 'opam switch create %%s.%%s' instead.\n"
+      "ERROR: The compiler found at %s has version %s,\n\
+       and this package requires %s.\n\
+       You should use e.g. 'opam switch create %s.%s' instead.\n"
        ocamlc Sys.ocaml_version expected_ocaml_version package_name
        Sys.ocaml_version;
     exit 1
@@ -66,7 +66,7 @@ let () =
       let r = input_line ic in
       close_in ic; Sys.remove "where"; r
     else begin
-      Printf.eprintf "Unexpected exit code %%d from `ocamlc -where'\n" exit_code;
+      Printf.eprintf "Unexpected exit code %d from `ocamlc -where'\n" exit_code;
       exit 1
     end
   in
@@ -79,7 +79,7 @@ let () =
   in
   let oc = open_out package_config_file in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
-                     variables { path: %%S }\n"
+                     file-depends: [ [ %S %S ] [ %S %S ] ]\n\
+                     variables { path: %S }\n"
     ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/tools/opam/gen_ocaml-system_config.ml
+++ b/tools/opam/gen_ocaml-system_config.ml
@@ -59,6 +59,15 @@ let () =
 let () =
   let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
   let libdir =
+    let ocamlc =
+      if Sys.os_type = "Win32" then
+        if String.contains ocamlc ' ' then
+          "\"" ^ ocamlc ^ "\""
+        else
+          ocamlc
+      else
+        Filename.quote ocamlc
+    in
     let exit_code = Sys.command (ocamlc ^ " -where > where") in
     if exit_code = 0 then
       (* Must be opened in text mode for Windows *)

--- a/tools/opam/gen_ocaml-system_config.ml.in
+++ b/tools/opam/gen_ocaml-system_config.ml.in
@@ -1,32 +1,61 @@
-let () =
-  let exe = ".exe" in
-  let ocamlc =
-    let (base, suffix) =
-      let s = Sys.executable_name in
-      if Filename.check_suffix s exe then
-        (Filename.chop_suffix s exe, exe)
-      else
-        (s, "") in
-    base ^ "c" ^ suffix in
-  if Sys.ocaml_version <> "%{_:version}%" then
-    (Printf.eprintf
-       "ERROR: The compiler found at %%s has version %%s,\n\
-        and this package requires %{_:version}%.\n\
-        You should use e.g. 'opam switch create %{_:name}%.%%s' \
-        instead."
-       ocamlc Sys.ocaml_version Sys.ocaml_version;
-     exit 1)
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Louis Gesbert, OCamlPro                         *)
+(*                                                                        *)
+(*   Copyright 2017 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* For as long it remains not totally impractical to do so, this script is
+   written in OCaml 3.07. Its purpose is to generate an opam .config file
+   for the ocaml-system package. It defines one package variable path, which is
+   the directory containing the compiler binaries (e.g. /usr/bin). It also uses
+   opam's file-depends mechanism adding the checksum for the ocamlc binary,
+   which causes the ocaml-system to be reconsidered if the user changes the
+   system compiler (e.g. by running brew upgrade). For legacy support, it also
+   captures the checksum of graphics.cmi, which is used by the graphics package
+   for old compilers to manually add the graphics library if it isn't compiled
+   by default. The purpose of this is to ensure that an opam switch recompiles
+   for example if the user switches from the Debian ocaml-nox to the full ocaml
+   package. *)
+
+let ocamlc =
+  if Filename.check_suffix Sys.executable_name "exe" then
+    Filename.chop_suffix Sys.executable_name "exe" ^ "c.exe"
   else
+    Sys.executable_name ^ "c"
+
+(* Check that Sys.ocaml_version is as expected *)
+let () =
+  if Sys.ocaml_version <> "%{_:version}%" then begin
+    Printf.eprintf
+      "ERROR: The compiler found at %%s has version %%s,\n\
+       and this package requires %{_:version}%.\n\
+       You should use e.g. 'opam switch create %{%:_name}%.%%s' instead.\n"
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+    exit 1
+  end
+
+(* Write the .config file *)
+let () =
   let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
   let libdir =
-    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
-      let ic = open_in "%{_:name}%.config" in
+    let exit_code = Sys.command (ocamlc ^ " -where > where") in
+    if exit_code = 0 then
+      (* Must be opened in text mode for Windows *)
+      let ic = open_in "where" in
       let r = input_line ic in
-      close_in ic;
-      Sys.remove "%{_:name}%.config";
-      r
-    else
-      failwith "Bad return from 'ocamlc -where'"
+      close_in ic; Sys.remove "where"; r
+    else begin
+      Printf.eprintf "Unexpected exit code %%d from `ocamlc -where'\n" exit_code;
+      exit 1
+    end
   in
   let graphics = Filename.concat libdir "graphics.cmi" in
   let graphics_digest =

--- a/tools/opam/gen_ocaml-system_config.ml.in
+++ b/tools/opam/gen_ocaml-system_config.ml.in
@@ -25,6 +25,18 @@
    for example if the user switches from the Debian ocaml-nox to the full ocaml
    package. *)
 
+(* The script must be invoked using the interpreter, for example:
+      ocaml gen_ocaml-system_config.ml 5.4.0 ocaml-system
+   where "5.4.0" is the expected value of Sys.ocaml_version, the resulting
+   configuration should be written to "ocaml-system.config". *)
+let expected_ocaml_version, package_name, package_config_file =
+  match Sys.argv with
+  | [| _; expected_ocaml_version; package_name |] ->
+      expected_ocaml_version, package_name, package_name ^ ".config"
+  | _ ->
+      prerr_endline "Invalid arguments";
+      exit 1
+
 let ocamlc =
   if Filename.check_suffix Sys.executable_name "exe" then
     Filename.chop_suffix Sys.executable_name "exe" ^ "c.exe"
@@ -33,12 +45,13 @@ let ocamlc =
 
 (* Check that Sys.ocaml_version is as expected *)
 let () =
-  if Sys.ocaml_version <> "%{_:version}%" then begin
+  if Sys.ocaml_version <> expected_ocaml_version then begin
     Printf.eprintf
       "ERROR: The compiler found at %%s has version %%s,\n\
-       and this package requires %{_:version}%.\n\
-       You should use e.g. 'opam switch create %{%:_name}%.%%s' instead.\n"
-       ocamlc Sys.ocaml_version Sys.ocaml_version;
+       and this package requires %%s.\n\
+       You should use e.g. 'opam switch create %%s.%%s' instead.\n"
+       ocamlc Sys.ocaml_version expected_ocaml_version package_name
+       Sys.ocaml_version;
     exit 1
   end
 
@@ -64,7 +77,7 @@ let () =
     else
       String.make 32 '0'
   in
-  let oc = open_out "%{_:name}%.config" in
+  let oc = open_out package_config_file in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
                      file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"

--- a/tools/opam/gen_ocaml_config.ml
+++ b/tools/opam/gen_ocaml_config.ml
@@ -81,7 +81,18 @@ let () =
       fun name -> Filename.concat dir name
   in
   let libdir =
-    let exit_code = Sys.command (binary "ocamlc" ^ " -where > where") in
+    let exit_code =
+      let ocamlc = binary "ocamlc" in
+      let ocamlc =
+        if Sys.os_type = "Win32" then
+          if String.contains ocamlc ' ' then
+            "\"" ^ ocamlc ^ "\""
+          else
+            ocamlc
+        else
+          Filename.quote ocamlc
+      in
+      Sys.command (ocamlc ^ " -where > where") in
     if exit_code = 0 then
       (* Must be opened in text mode for Windows *)
       let ic = open_in "where" in

--- a/tools/opam/gen_ocaml_config.ml
+++ b/tools/opam/gen_ocaml_config.ml
@@ -58,15 +58,15 @@ let expected_ocaml_version,
 (* Check that Sys.ocaml_version is as expected *)
 let () =
   let ocaml_version =
-    Scanf.sscanf Sys.ocaml_version "%%u.%%u" (fun major minor ->
+    Scanf.sscanf Sys.ocaml_version "%u.%u" (fun major minor ->
       if (major, minor) > (3, 7) then
         (* Strip off any additional information *)
-        Scanf.sscanf Sys.ocaml_version "%%[^~+]" (fun x -> x)
+        Scanf.sscanf Sys.ocaml_version "%[^~+]" (fun x -> x)
       else
         Sys.ocaml_version)
   in
   if ocaml_version <> expected_ocaml_version then begin
-    Printf.eprintf "OCaml version mismatch: %%s, expected %%s\n"
+    Printf.eprintf "OCaml version mismatch: %s, expected %s\n"
                    ocaml_version expected_ocaml_version;
     exit 1
   end
@@ -88,7 +88,7 @@ let () =
       let r = input_line ic in
       close_in ic; Sys.remove "where"; r
     else begin
-      Printf.eprintf "Unexpected exit code %%d from `ocamlc -where'\n" exit_code;
+      Printf.eprintf "Unexpected exit code %d from `ocamlc -where'\n" exit_code;
       exit 1
     end
   in
@@ -115,12 +115,12 @@ let () =
   Printf.fprintf oc "\
     opam-version: \"2.0\"\n\
     variables {\n  \
-      native: %%b\n  \
-      native-tools: %%b\n  \
-      native-dynlink: %%b\n  \
-      stubsdir: %%S\n  \
-      preinstalled: %%s\n  \
-      compiler: \"%%s%%s\"\n\
+      native: %b\n  \
+      native-tools: %b\n  \
+      native-dynlink: %b\n  \
+      stubsdir: %S\n  \
+      preinstalled: %s\n  \
+      compiler: \"%s%s\"\n\
     }\n" native native_tools native_dynlink stubsdir preinstalled
          compiler_package_version option_names;
   close_out oc

--- a/tools/opam/gen_ocaml_config.ml
+++ b/tools/opam/gen_ocaml_config.ml
@@ -93,14 +93,18 @@ let () =
     end
   in
   let stubsdir =
-    let ic = open_in (Filename.concat libdir "ld.conf") in
-    let rec input_lines acc =
-      try input_lines (input_line ic :: acc)
-      with End_of_file -> close_in ic; List.rev acc
-    in
-    let lines = input_lines [] in
-    let sep = if Sys.os_type = "Win32" then ";" else ":" in
-    String.concat sep lines
+    let ld_conf = Filename.concat libdir "ld.conf" in
+    if Sys.file_exists ld_conf then
+      let ic = open_in ld_conf in
+      let rec input_lines acc =
+        try input_lines (input_line ic :: acc)
+        with End_of_file -> close_in ic; List.rev acc
+      in
+      let lines = input_lines [] in
+      let sep = if Sys.os_type = "Win32" then ";" else ":" in
+      String.concat sep lines
+    else
+      ""
   in
   let native = Sys.file_exists (binary "ocamlopt") in
   let native_tools = Sys.file_exists (binary "ocamlc.opt") in

--- a/tools/opam/gen_ocaml_config.ml
+++ b/tools/opam/gen_ocaml_config.ml
@@ -106,6 +106,25 @@ let () =
   let stubsdir =
     let ld_conf = Filename.concat libdir "ld.conf" in
     if Sys.file_exists ld_conf then
+      let input_line ic =
+        let line = input_line ic in
+        if line = Filename.current_dir_name then
+          libdir
+        else if line = Filename.parent_dir_name then
+          Filename.concat libdir line
+        else
+          Scanf.sscanf line "%[.]%1[/\\]" (fun prefix separator ->
+            if separator = "/" || Sys.os_type <> "Unix" && separator = "\\" then
+              if prefix = Filename.current_dir_name then
+                let line = String.sub line 2 (String.length line - 2) in
+                Filename.concat libdir line
+              else if prefix = Filename.parent_dir_name then
+                Filename.concat libdir line
+              else
+                line
+            else
+              line)
+      in
       let ic = open_in ld_conf in
       let rec input_lines acc =
         try input_lines (input_line ic :: acc)

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -29,14 +29,28 @@
                unstable. *)
 
 (* The script must be invoked using the interpreter, for example:
-      ocaml gen_ocaml_config.ml 5.4.0 ocaml
+      ocaml gen_ocaml_config.ml 5.4.0 ocaml 5.4.0+options false +flambda
    where "5.4.0" is the expected value of Sys.ocaml_version (with any additional
-   information removed) and the resulting configuration should be written to
-   "ocaml.config". *)
-let expected_ocaml_version, package_config_file =
-  match Sys.argv with
-  | [| _; expected_ocaml_version; package_config_file |] ->
-      expected_ocaml_version, package_config_file ^ ".config"
+   information removed), the resulting configuration should be written to
+   "ocaml.config" and the "compiler" variable should be set to
+   "5.4.0+options+flambda". *)
+let expected_ocaml_version,
+    package_config_file,
+    compiler_package_version,
+    preinstalled,
+    option_names =
+  match Array.to_list Sys.argv with
+  | _ ::
+    expected_ocaml_version ::
+    package_config_file ::
+    compiler_package_version ::
+    preinstalled ::
+    options ->
+      expected_ocaml_version,
+      package_config_file ^ ".config",
+      compiler_package_version,
+      preinstalled,
+      String.concat "" (List.filter ((<>) "") options)
   | _ ->
       prerr_endline "Invalid arguments";
       exit 1
@@ -105,7 +119,8 @@ let () =
       native-tools: %%b\n  \
       native-dynlink: %%b\n  \
       stubsdir: %%S\n  \
-      preinstalled: %{ocaml-system:installed}%\n  \
-      compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"\n\
-    }\n" native native_tools native_dynlink stubsdir;
+      preinstalled: %%s\n  \
+      compiler: \"%%s%%s\"\n\
+    }\n" native native_tools native_dynlink stubsdir preinstalled
+         compiler_package_version option_names;
   close_out oc

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -1,65 +1,111 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Louis Gesbert, OCamlPro                         *)
+(*                                                                        *)
+(*   Copyright 2017 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* For as long it remains not totally impractical to do so, this script is
+   written in OCaml 3.07. Its purpose is to generate an opam .config file
+   containing the following variables:
+   - native: True if ocamlopt is located with ocaml
+   - native-tools: True if ocamlc.opt is located with ocaml
+   - native-dynlink: True if dynlink.cmxa exists in -I + or -I +dynlink
+   - stubsdir: Content of +ld.conf in CAML_LD_LIBRARY_PATH format
+   - preinstalled: True if this installation is provided by the system, rather
+                   than compiled from sources by opam
+   - compiler: ["system"], if [preinstalled], otherwise the version of the opam
+               compiler package which provided the compiler (e.g. "5.4.0"). For
+               largely historical reasons, custom compiler append additional
+               configuration information (e.g. "5.4.0+options+flambda"). This
+               variable should be considered deprecated and the content
+               unstable. *)
+
+(* The script must be invoked using the interpreter, for example:
+      ocaml gen_ocaml_config.ml 5.4.0 ocaml
+   where "5.4.0" is the expected value of Sys.ocaml_version (with any additional
+   information removed) and the resulting configuration should be written to
+   "ocaml.config". *)
+let expected_ocaml_version, package_config_file =
+  match Sys.argv with
+  | [| _; expected_ocaml_version; package_config_file |] ->
+      expected_ocaml_version, package_config_file ^ ".config"
+  | _ ->
+      prerr_endline "Invalid arguments";
+      exit 1
+
+(* Check that Sys.ocaml_version is as expected *)
 let () =
   let ocaml_version =
-    let v = Sys.ocaml_version in
-    let l = String.length v in
-    let plus = try String.index v '+' with Not_found -> l in
-    (* Introduced in 4.11.0; used from 4.12.0 *)
-    let tilde = try String.index v '~' with Not_found -> l in
-    String.sub v 0 (min (min plus tilde) l)
+    Scanf.sscanf Sys.ocaml_version "%%u.%%u" (fun major minor ->
+      if (major, minor) > (3, 7) then
+        (* Strip off any additional information *)
+        Scanf.sscanf Sys.ocaml_version "%%[^~+]" (fun x -> x)
+      else
+        Sys.ocaml_version)
   in
-  if ocaml_version <> Sys.argv.(1) then
-    (Printf.eprintf
-       "OCaml version mismatch: %%s, expected %s"
-       ocaml_version Sys.argv.(1);
-     exit 1)
-  else
-  let oc = open_out (Sys.argv.(2) ^ ".config") in
-  let exe = ".exe" in
-  let (ocaml, suffix) =
-    let s = Sys.executable_name in
-    if Filename.check_suffix s exe then
-      (Filename.chop_suffix s exe, exe)
+  if ocaml_version <> expected_ocaml_version then begin
+    Printf.eprintf "OCaml version mismatch: %%s, expected %%s\n"
+                   ocaml_version expected_ocaml_version;
+    exit 1
+  end
+
+(* Write the .config file *)
+let () =
+  let binary =
+    let dir = Filename.dirname Sys.executable_name in
+    if Filename.check_suffix Sys.executable_name ".exe" then
+      fun name -> Filename.concat dir (name ^ ".exe")
     else
-      (s, "")
+      fun name -> Filename.concat dir name
   in
-  let ocamlc = ocaml^"c"^suffix in
   let libdir =
-    if Sys.command (ocamlc^" -where > where") = 0 then
+    let exit_code = Sys.command (binary "ocamlc" ^ " -where > where") in
+    if exit_code = 0 then
       (* Must be opened in text mode for Windows *)
       let ic = open_in "where" in
       let r = input_line ic in
-      close_in ic; r
-    else
-      failwith "Bad return from 'ocamlc -where'"
+      close_in ic; Sys.remove "where"; r
+    else begin
+      Printf.eprintf "Unexpected exit code %%d from `ocamlc -where'\n" exit_code;
+      exit 1
+    end
   in
   let stubsdir =
     let ic = open_in (Filename.concat libdir "ld.conf") in
-    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
-    let lines = List.rev (r []) in
-    close_in ic;
+    let rec input_lines acc =
+      try input_lines (input_line ic :: acc)
+      with End_of_file -> close_in ic; List.rev acc
+    in
+    let lines = input_lines [] in
     let sep = if Sys.os_type = "Win32" then ";" else ":" in
     String.concat sep lines
   in
-  let has_native_dynlink =
+  let native = Sys.file_exists (binary "ocamlopt") in
+  let native_tools = Sys.file_exists (binary "ocamlc.opt") in
+  let native_dynlink =
     let check_dir libdir =
       Sys.file_exists (Filename.concat libdir "dynlink.cmxa")
     in
     List.exists check_dir [Filename.concat libdir "dynlink"; libdir]
   in
-  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
-  p "opam-version: \"2.0\"";
-  p "variables {";
-  p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"^suffix));
-  p "  native-tools: %%b"
-    (* The variable [ocamlc] already has a suffix on Windows
-       (ex. '...\bin\ocamlc.exe') so we use [ocaml] to check *)
-    (Sys.file_exists (ocaml^"c.opt"^suffix));
-  p "  native-dynlink: %%b"
-    has_native_dynlink;
-  p "  stubsdir: %%S"
-    stubsdir;
-  p "  preinstalled: %{ocaml-system:installed}%";
-  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"";
-  p "}";
+  let oc = open_out package_config_file in
+  (* Quoted strings need OCaml 4.02; "\ " needs OCaml 3.09! *)
+  Printf.fprintf oc "\
+    opam-version: \"2.0\"\n\
+    variables {\n  \
+      native: %%b\n  \
+      native-tools: %%b\n  \
+      native-dynlink: %%b\n  \
+      stubsdir: %%S\n  \
+      preinstalled: %{ocaml-system:installed}%\n  \
+      compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"\n\
+    }\n" native native_tools native_dynlink stubsdir;
   close_out oc

--- a/tools/opam/ocaml-config.install
+++ b/tools/opam/ocaml-config.install
@@ -1,1 +1,0 @@
-share: ["gen_ocaml_config.ml"]


### PR DESCRIPTION
Part of this commit is being used for the test opam-repository for Relocatable OCaml at [dra27/opam-repository#relocatable](https://github.com/dra27/opam-repository/tree/relocatable/packages/ocaml), but it's not part of Relocatable itself. This is also related - and should be updated with - the equivalent scripts for `ocaml-system` (cf. ocaml/opam-repository#28455 and ocaml/opam-source-archives#52).

opam 2.0 generalised the packaging of the compiler and introduced the `ocaml` meta-package. This virtual package has a few variables associated with it which can be seen if you run `opam config list ocaml` in a switch:

```console
ocaml:native         true
ocaml:native-tools   true
ocaml:native-dynlink true
ocaml:stubsdir       <switch>\lib\ocaml\..\stublibs;<switch>\lib\ocaml\stublibs;<switch>\lib\ocaml
ocaml:preinstalled   false
ocaml:compiler       5.4.0
```

These variables are probed by an OCaml script run by the `ocaml` package itself. A copy of this script was stored with each of the `ocaml` packages versions in opam-repository which was a bit tedious when it needed updating (cf. https://github.com/ocaml/opam-repository/pull/11928) and so I aggregated it in https://github.com/ocaml/opam-repository/pull/12832 to create the `ocaml-config` package, which reduced the duplication. The `ocaml-config` existed _solely_ to contain this script in opam-repository.

Since last year, opam-repository (very sensibly) does not allow scripts and other files to be stored directly in the repository, for reasons that don't need listing here. The scripts were therefore moved as part of https://github.com/ocaml/opam-repository/pull/25960 to [ocaml/opam-source-archives](https://github.com/ocaml/opam-source-archives/tree/main/patches/ocaml-config). There are two things about this which I find unfortunate and which this PR seeks to fix:
1. A repository with word "archives" in it is in fact the primary source of a maintenance script which is executed by _every single installation of OCaml_. That's a bit strange...
2. The `ocaml-config` package was a bit of a hack necessary to stop duplicating the file in opam-repository - the switch to refer to it with a download URL actually removes the need for a separate `ocaml-config` package.

The first six commits in this branch simply cherry-pick the script and `ocaml-config.install` file from opam-repository, placing the result in `tools/opam`. Note that the same name is used throughout - the `ocaml-config` packages would simply refer to the appropriate commit in the `extra-source` section. For example, [https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/gen\_ocaml\_config.ml.in.3](https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/gen_ocaml_config.ml.in.3) (sha256 a9ad8d84a08961159653a978db92d10f694510182b206cacb96d5c9f63b5121e) can instead refer to [https://raw.githubusercontent.com/ocaml/ocaml/ec64d4913170fda621fe77bef77c596e5f50cb47/tools/opam/gen\_ocaml\_config.ml.in](https://raw.githubusercontent.com/ocaml/ocaml/ec64d4913170fda621fe77bef77c596e5f50cb47/tools/opam/gen\_ocaml\_config.ml.in).

The seventh commit ("Fully unify and update gen_ocaml_config.ml") refactors the script to eliminate the use of opam's substs mechanism. That requires changes to the `ocaml` packages, a demo of which is in https://github.com/dra27/opam-repository/commit/dc288c2320af5c5451fc831c59bba72f1da792ea (only the changes to the `ocaml` package in that commit matter), but it essentially removes the `ocaml-config` package completely and puts the variable expansions explicitly into the build recipe, so we have this in ocaml.5.4.0:

```
build: [
  ["ocaml" "gen_ocaml_config.ml" _:version _:name
     # The packages referred to in this string must be in the disjunction above
     # and also all be in the ocaml-core-compiler conflict-class
     "%{ocaml-system:installed?system}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%"
     ocaml-system:installed
     # The order of these parameters matches the "convention" for the
     # ocaml-options-only packages
     "%{ocaml-option-32bit:installed?+32bit:}%"
     "%{ocaml-option-afl:installed?+afl:}%"
     "%{ocaml-option-bytecode-only:installed?+bytecode-only:}%"
     "%{ocaml-option-fp:installed?+fp:}%"
     "%{ocaml-option-flambda:installed?+flambda:}%"
     "%{ocaml-option-musl:installed?+musl:}%"
     "%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%"
     "%{ocaml-option-static:installed?+static:}%"]
]
```

where before we had this unfortunate layout in `gen_ocaml_config.ml.in` (note the doubling of `%` for actual `printf`s, and so forth:

```ocaml

  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
  p "opam-version: \"2.0\"";
  p "variables {";
  p "  native: %%b"
    (Sys.file_exists (ocaml^"opt"^suffix));
  p "  native-tools: %%b"
    (* The variable [ocamlc] already has a suffix on Windows
       (ex. '...\bin\ocamlc.exe') so we use [ocaml] to check *)
    (Sys.file_exists (ocaml^"c.opt"^suffix));
  p "  native-dynlink: %%b"
    has_native_dynlink;
  p "  stubsdir: %%S"
    stubsdir;
  p "  preinstalled: %{ocaml-system:installed}%";
  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"";
  p "}";
```

The last commit then updates the script to be able to cope with the relative paths proposed in #14243.

In terms of review, the first six commits are (immutable) history - the key thing is that the files in them are the same as those stored in opam-source-archives. The seventh commit is then best viewed as a "new" script that we (OCaml core devs) are "taking ownership" (I'd say blame is more appropriate!) and then the last commit is the proposed alteration for Relocatable OCaml.

- [x] Relocatable OCaml commit either confirmed or moved to a separate PR
- [x] Follow-up PR to opam-repository to switch the URLs from ocaml/opam-source-archives to ocaml/ocaml
- [x] `tools/opam/Layout.md`
- [x] Update with `ocaml-system`'s `gen_ocaml_config.ml.in`