### PR TITLE
Fix TSan bug with C calls that take many arguments

### DIFF
--- a/Changes
+++ b/Changes
@@ -372,6 +372,10 @@ Working version
   in an unbounded number of labeled or optional arguments.
   (Stefan Muenzel, report by Samuel Vivien, review by Florian Angeletti)
 
+- #14255: Fix TSan bug with C calls that take many arguments
+  (Olivier Nicole and Miod Vallat, report by Nathan Taylor, review by Gabriel
+   Scherer)
+
 - #14230 : ocamltest fails to link test program with -custom in some cases
   (Damien Doligez, review by David Allsopp)
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -578,6 +578,26 @@ G(caml_system__code_begin):
 #define TSAN_RESTORE_CALLER_REGS
 #endif
 
+#ifdef WITH_THREAD_SANITIZER
+/* Push return value registers %rax and %xmm0 onto the stack. */
+#define TSAN_PUSH_RETURN_REGS              \
+        pushq   %rax; CFI_ADJUST(8);       \
+        subq    $16, %rsp; CFI_ADJUST(16); \
+        movupd  %xmm0, (%rsp)
+#else
+#define TSAN_PUSH_RETURN_REGS
+#endif
+
+#ifdef WITH_THREAD_SANITIZER
+/* Pop return value registers %rax and %xmm0 from the stack. */
+#define TSAN_POP_RETURN_REGS                \
+        movupd  (%rsp), %xmm0;              \
+        addq    $16, %rsp; CFI_ADJUST(-16); \
+        popq    %rax; CFI_ADJUST(-8)
+#else
+#define TSAN_POP_RETURN_REGS
+#endif
+
 FUNCTION(caml_call_realloc_stack)
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
@@ -712,16 +732,9 @@ LBL(caml_c_call):
         movq    Caml_state(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
-#ifdef WITH_THREAD_SANITIZER
-    /* Save non-callee-saved registers %rax and %xmm0 before C call */
-        pushq   %rax; CFI_ADJUST(8);
-        subq    $16, %rsp; CFI_ADJUST(16);
-        movupd   %xmm0, (%rsp)
+        TSAN_PUSH_RETURN_REGS /* Save return value before C call */
         TSAN_EXIT_FUNCTION
-        movupd  (%rsp), %xmm0
-        addq    $16, %rsp; CFI_ADJUST(-16);
-        popq    %rax; CFI_ADJUST(-8);
-#endif
+        TSAN_POP_RETURN_REGS
         LEAVE_FUNCTION
     /* Return to OCaml caller */
         RET_FROM_C_CALL
@@ -732,6 +745,9 @@ FUNCTION(caml_c_call_stack_args)
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
+        TSAN_SAVE_CALLER_REGS
+        TSAN_ENTER_FUNCTION(0)
+        TSAN_RESTORE_CALLER_REGS
     /* Arguments:
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
         C function          : %rax
@@ -746,6 +762,9 @@ CFI_STARTPROC
         movq    Caml_state(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
+        TSAN_PUSH_RETURN_REGS /* Save return value before C call */
+        TSAN_EXIT_FUNCTION
+        TSAN_POP_RETURN_REGS
     /* Return to OCaml caller */
         LEAVE_FUNCTION
         RET_FROM_C_CALL
@@ -764,6 +783,17 @@ CFI_STARTPROC
         pushq   %rbp; CFI_ADJUST(8)
         movq    %rsp, %rbp
         CFI_DEF_CFA_REGISTER(DW_REG_rbp)
+#ifdef WITH_THREAD_SANITIZER
+    /* The pushed arguments will be considered to be a stack frame, TSan must
+       know about it. */
+       TSAN_SAVE_CALLER_REGS /* Save the arguments */
+        movq    8(%rsp), C_ARG_1
+    /* Note that we are already on the C stack. For this reason, we do not use
+       the usual TSAN_* macros which assume we start on the OCaml stack. */
+        C_call  (GCALL(caml_tsan_func_entry_asm));
+    /* Restore the arguments */
+        TSAN_RESTORE_CALLER_REGS
+#endif
     /* Copy arguments from OCaml to C stack */
 LBL(105):
         subq    $8, %r12
@@ -779,6 +809,13 @@ LBL(106):
 #endif
     /* Call the function (address in %rax) */
         C_call  (*%rax)
+#ifdef WITH_THREAD_SANITIZER
+    /* We can't use the TSAN_EXIT_FUNCTION macro as it assumes an OCaml stack,
+       and we are on a C stack. */
+        TSAN_PUSH_RETURN_REGS /* Save return value */
+        C_call  (GCALL(caml_tsan_func_exit_asm))
+        TSAN_POP_RETURN_REGS
+#endif
     /* Pop arguments back off the stack */
         movq    %rbp, %rsp
         CFI_DEF_CFA_REGISTER(DW_REG_rsp)
@@ -881,10 +918,10 @@ LBL(108):
 #if defined(WITH_THREAD_SANITIZER)
     /* We can't use the TSAN_EXIT_FUNCTION macro as it assumes an OCaml stack,
        and we are on a C stack. */
-        /* Save %rax before C call */
-        pushq   %rax; CFI_ADJUST(8)
+        /* Save return value before C call */
+        TSAN_PUSH_RETURN_REGS
         C_call  (GCALL(caml_tsan_func_exit_asm))
-        popq    %rax; CFI_ADJUST(-8)
+        TSAN_POP_RETURN_REGS
 #endif
     /* Restore callee-save registers. */
         POP_CALLEE_SAVE_REGS

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -449,6 +449,22 @@ G(name):
         ldr     TRAP_PTR, Caml_state(exn_handler)
 .endm
 
+/* Save return value registers. To cover all possible function returns, save
+   both x0 and d0:d1. */
+.macro TSAN_PUSH_RETURN_REGS
+        stp     x0, x1, [sp, -16]!
+        CFI_ADJUST(16)
+        stp     d0, d1, [sp, -16]!
+        CFI_ADJUST(16)
+.endm
+
+.macro TSAN_POP_RETURN_REGS
+        ldp     d0, d1, [sp], 16
+        CFI_ADJUST(-16)
+        ldp     x0, x1, [sp], 16
+        CFI_ADJUST(-16)
+.endm
+
 #else /* } { */
 
 .macro TSAN_ENTER_FUNCTION
@@ -461,6 +477,12 @@ G(name):
 .endm
 
 .macro TSAN_RESTORE_CALLER_REGS
+.endm
+
+.macro TSAN_PUSH_RETURN_REGS
+.endm
+
+.macro TSAN_POP_RETURN_REGS
 .endm
 
 #endif /* } WITH_THREAD_SANITIZER */
@@ -590,21 +612,9 @@ FUNCTION(caml_c_call)
         ldr     TRAP_PTR, Caml_state(exn_handler)
     /* Load ocaml stack */
         SWITCH_C_TO_OCAML
-#if defined(WITH_THREAD_SANITIZER)
-    /* Save return value registers. Since the called function could be
-       anything, it may have returned its result (if any) either in x0
-       or d0:d1. */
-        stp     x0, x1, [sp, -16]!
-        CFI_ADJUST(16)
-        stp     d0, d1, [sp, -16]!
-        CFI_ADJUST(16)
+        TSAN_PUSH_RETURN_REGS
         TSAN_EXIT_FUNCTION
-    /* Restore return value registers */
-        ldp     d0, d1, [sp], 16
-        CFI_ADJUST(-16)
-        ldp     x0, x1, [sp], 16
-        CFI_ADJUST(-16)
-#endif
+        TSAN_POP_RETURN_REGS
     /* Return */
         LEAVE_FUNCTION
         NORMALIZE_RETURN_ADDRESS
@@ -621,6 +631,9 @@ FUNCTION(caml_c_call_stack_args)
         C stack args : begin=STACK_ARG_BEGIN
                        end=STACK_ARG_END */
         ENTER_FUNCTION
+        TSAN_SAVE_CALLER_REGS
+        TSAN_ENTER_FUNCTION
+        TSAN_RESTORE_CALLER_REGS
     /* Switch from OCaml to C */
         SWITCH_OCAML_TO_C
     /* Make the exception handler alloc ptr available to the C code */
@@ -633,6 +646,9 @@ FUNCTION(caml_c_call_stack_args)
         ldr     TRAP_PTR, Caml_state(exn_handler)
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
+        TSAN_PUSH_RETURN_REGS /* Save returned value. */
+        TSAN_EXIT_FUNCTION
+        TSAN_POP_RETURN_REGS
     /* Return */
         LEAVE_FUNCTION
         NORMALIZE_RETURN_ADDRESS
@@ -649,6 +665,15 @@ FUNCTION(caml_c_call_copy_stack_args)
         CFI_STARTPROC
         ENTER_FUNCTION
         CFI_DEF_CFA_REGISTER(DW_REG_x29)
+#if defined(WITH_THREAD_SANITIZER)
+        TSAN_SAVE_CALLER_REGS
+        /* TSAN_ENTER_FUNCTION, but without switching stacks */
+        mov     x0, x30        /* arg1: return address in caller */
+        TSAN_SETUP_C_CALL
+        bl      G(caml_tsan_func_entry_asm)
+        TSAN_CLEANUP_AFTER_C_CALL
+        TSAN_RESTORE_CALLER_REGS
+#endif
     /* Copy arguments from OCaml to C stack
        NB: STACK_ARG_{BEGIN,END} are 16-byte aligned */
 1:      sub     STACK_ARG_END, STACK_ARG_END, 16
@@ -659,6 +684,14 @@ FUNCTION(caml_c_call_copy_stack_args)
         b       1b
 2:  /* Call the function */
         blr     ADDITIONAL_ARG
+#if defined(WITH_THREAD_SANITIZER)
+        TSAN_PUSH_RETURN_REGS /* Save returned value. */
+        /* TSAN_EXIT_FUNCTION, but without switching stacks */
+        TSAN_SETUP_C_CALL
+        bl      G(caml_tsan_func_exit_asm)
+        TSAN_CLEANUP_AFTER_C_CALL
+        TSAN_POP_RETURN_REGS
+#endif
     /* Restore stack */
         mov     sp, x29
         CFI_DEF_CFA_REGISTER(DW_REG_sp)

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -408,6 +408,22 @@ name:
         ld      TRAP_PTR, Caml_state(exn_handler)
 .endm
 
+.macro TSAN_PUSH_RETURN_REGS
+        addi    sp, sp, -32
+        CFI_ADJUST(32)
+        sd      a0, 0(sp)
+        fsd     fa0, 16(sp)
+        fsd     fa1, 24(sp)
+.endm
+
+.macro TSAN_POP_RETURN_REGS
+        fld     fa1, 24(sp)
+        fld     fa0, 16(sp)
+        ld      a0, 0(sp)
+        addi    sp, sp, 32
+        CFI_ADJUST(-32)
+.endm
+
 #else /* } { */
 
 .macro TSAN_ENTER_FUNCTION
@@ -420,6 +436,12 @@ name:
 .endm
 
 .macro TSAN_RESTORE_CALLER_REGS
+.endm
+
+.macro TSAN_PUSH_RETURN_REGS
+.endm
+
+.macro TSAN_POP_RETURN_REGS
 .endm
 
 #endif /* } WITH_THREAD_SANITIZER */
@@ -532,23 +554,9 @@ L(caml_c_call):
         ld      TRAP_PTR, Caml_state(exn_handler)
     /* Load ocaml stack */
         SWITCH_C_TO_OCAML
-#if defined(WITH_THREAD_SANITIZER)
-    /* Save return value registers. Since the called function could be
-       anything, it may have returned its result (if any) either in a0
-       or fa0:fa1. */
-        addi    sp, sp, -32
-        CFI_ADJUST(32)
-        sd      a0, 0(sp)
-        fsd     fa0, 16(sp)
-        fsd     fa1, 24(sp)
+        TSAN_PUSH_RETURN_REGS /* Save return value. */
         TSAN_EXIT_FUNCTION
-    /* Restore return value registers */
-        fld     fa1, 24(sp)
-        fld     fa0, 16(sp)
-        ld      a0, 0(sp)
-        addi    sp, sp, 32
-        CFI_ADJUST(-32)
-#endif
+        TSAN_POP_RETURN_REGS
     /* Return */
         LEAVE_FUNCTION
         RET_FROM_C_CALL
@@ -562,6 +570,9 @@ FUNCTION(caml_c_call_stack_args)
         C stack args : begin=STACK_ARG_BEGIN
                        end=STACK_ARG_END */
         ENTER_FUNCTION
+        TSAN_SAVE_CALLER_REGS
+        TSAN_ENTER_FUNCTION
+        TSAN_RESTORE_CALLER_REGS
     /* Switch from OCaml to C */
         SWITCH_OCAML_TO_C
     /* Make the exception handler alloc ptr available to the C code */
@@ -589,6 +600,9 @@ FUNCTION(caml_c_call_stack_args)
         ld      TRAP_PTR, Caml_state(exn_handler)
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
+        TSAN_PUSH_RETURN_REGS /* Save return value. */
+        TSAN_EXIT_FUNCTION
+        TSAN_POP_RETURN_REGS
     /* Return */
         LEAVE_FUNCTION
         RET_FROM_C_CALL

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -368,12 +368,26 @@ caml_system__code_begin:
         lg      ALLOC_PTR, Caml_state(young_ptr);      \
         lg      TRAP_PTR, Caml_state(exn_handler)
 
+#define TSAN_PUSH_RETURN_REGS    \
+        lay     %r15, -16(%r15); \
+        CFI_ADJUST(16);          \
+        stg     %r2, 0(%r15);    \
+        std     %f0, 8(%r15)
+
+#define TSAN_POP_RETURN_REGS     \
+        ld      %f0, 8(%r15);    \
+        lg      %r2, 0(%r15);    \
+        la      %r15, 16(%r15);  \
+        CFI_ADJUST(-16)
+
 #else /* } { */
 
 #define TSAN_ENTER_FUNCTION
 #define TSAN_EXIT_FUNCTION
 #define TSAN_SAVE_CALLER_REGS
 #define TSAN_RESTORE_CALLER_REGS
+#define TSAN_PUSH_RETURN_REGS
+#define TSAN_POP_RETURN_REGS
 
 #endif /* } */
 
@@ -507,21 +521,9 @@ LBL(caml_c_call):
         lg      TRAP_PTR, Caml_state(exn_handler)
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
-#if defined(WITH_THREAD_SANITIZER)
-    /* Save return value registers. Since the called function could be
-       anything, it may have returned its result (if any) either in %r2
-       or %f0. */
-        lay     %r15, -16(%r15)
-        CFI_ADJUST(16)
-        stg     %r2, 0(%r15)
-        std     %f0, 8(%r15)
+        TSAN_PUSH_RETURN_REGS /* Save return value. */
         TSAN_EXIT_FUNCTION
-    /* Restore return value registers */
-        ld      %f0, 8(%r15)
-        lg      %r2, 0(%r15)
-        la      %r15, 16(%r15)
-        CFI_ADJUST(-16)
-#endif
+        TSAN_POP_RETURN_REGS
     /* Return to OCaml caller */
         LEAVE_FUNCTION
         RET_FROM_C_CALL
@@ -537,6 +539,13 @@ CFI_STARTPROC
         C arguments         : %r2, %r3, %r4, %r5, %r6
         C function          : ADDITIONAL_ARG
         C stack args        : begin=%r9 end=%r8 */
+#if defined(WITH_THREAD_SANITIZER)
+    /* We can't use TSAN_{SAVE,RESTORE}_CALLER_REGS here as we need to
+       also preserve %r6-%r9. */
+        SAVE_ALL_REGS
+        TSAN_ENTER_FUNCTION
+        RESTORE_ALL_REGS
+#endif
     /* Switch from OCaml to C */
         SWITCH_OCAML_TO_C
     /* Make the exception handler alloc ptr available to the C code */
@@ -572,6 +581,9 @@ LBL(106):
         lg      TRAP_PTR, Caml_state(exn_handler)
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
+        TSAN_PUSH_RETURN_REGS /* Save return value. */
+        TSAN_EXIT_FUNCTION
+        TSAN_POP_RETURN_REGS
     /* Return */
         LEAVE_FUNCTION
         RET_FROM_C_CALL

--- a/testsuite/tests/tsan/array_elt.reference
+++ b/testsuite/tests/tsan/array_elt.reference
@@ -1,6 +1,6 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlArray_elt$writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -27,7 +27,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/callbacks.c
+++ b/testsuite/tests/tsan/callbacks.c
@@ -25,3 +25,22 @@ value print_and_raise(value unit)
   caml_failwith("test");
   return Val_unit; /* Unreachable */
 }
+
+value print_and_raise_many_args(value arg1, value arg2, value arg3, value arg4,
+                                value arg5, value arg6, value arg7, value arg8,
+                                value arg9)
+{
+  (void)arg1;
+  (void)arg2;
+  (void)arg3;
+  (void)arg4;
+  (void)arg5;
+  (void)arg6;
+  (void)arg7;
+  (void)arg8;
+  (void)arg9;
+
+  fprintf(stderr, "Hello from print_and_raise_many_args\n");
+  caml_raise_not_found();
+  return Val_unit; /* Unreachable */
+}

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -11,7 +11,7 @@ Called from Exn_from_c.g in file "exn_from_c.ml", line 48, characters 2-6
 Called from Exn_from_c.f in file "exn_from_c.ml", line 53, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlExn_from_c$writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -39,7 +39,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/exn_from_c_stack_args.ml
+++ b/testsuite/tests/tsan/exn_from_c_stack_args.ml
@@ -1,0 +1,74 @@
+(* TEST
+
+ ocamlopt_flags = "-g -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
+
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ tsan;
+ readonly_files = "callbacks.c waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml exn_from_c_stack_args.ml";
+ native;
+
+*)
+
+external print_and_raise_many_args
+  : int -> int -> int -> int -> int -> int -> int -> int -> int -> unit
+  = "print_and_raise_many_args" (* for bytecode, unused *)
+    "print_and_raise_many_args"
+
+open Printf
+
+(* We use two waitgroups (synchronizing barriers, not detectable by TSan). The
+   first barrier ensures that there is always a data race from TSan's point of
+   view, by delaying the synchronizing [Domain.join] until after both domains
+   have accessed the shared mutable field; and that these accesses always
+   happen in the same order (write first or read first).
+
+   The role of the second barrier is to always enforce the same order between
+   the TSan report and logging lines such as "Leaving f". Not enforcing that
+   order used to be a source of flakiness in the tests. *)
+let wg = Waitgroup.create 2
+let wg' = Waitgroup.create 2
+let r = ref 0
+
+let [@inline never] race () =
+  ignore @@ !r;
+  Waitgroup.join wg
+
+let [@inline never] i () =
+  printf "Entering i\n%!";
+  printf "Calling print_and_raise_many_args...\n%!";
+  print_and_raise_many_args 1 2 3 4 5 6 7 8 9;
+  printf "Leaving i\n%!"
+
+let [@inline never] h () =
+  printf "Entering h\n%!";
+  i ();
+  printf "Leaving h\n%!"
+
+let [@inline never] g () =
+  printf "Entering g\n%!";
+  h ();
+  printf "Leaving g\n%!"
+
+let [@inline never] f () =
+  printf "Entering f\n%!";
+  (try g ()
+  with Not_found ->
+    printf "Caught Not_found\n%!";
+    Printexc.print_backtrace stderr;
+    flush stderr;
+    race ());
+  Waitgroup.join wg';
+  printf "Leaving f\n%!"
+
+let [@inline never] writer () =
+  Waitgroup.join wg;
+  r := 1;
+  Waitgroup.join wg'
+
+let () =
+  Printexc.record_backtrace true;
+  let d = Domain.spawn writer in
+  f ();
+  Domain.join d

--- a/testsuite/tests/tsan/exn_from_c_stack_args.reference
+++ b/testsuite/tests/tsan/exn_from_c_stack_args.reference
@@ -1,0 +1,53 @@
+Entering f
+Entering g
+Entering h
+Entering i
+Calling print_and_raise_many_args...
+Hello from print_and_raise_many_args
+Caught Not_found
+Raised by primitive operation at Exn_from_c_stack_args.i in file "exn_from_c_stack_args.ml", line 41, characters 2-45
+Called from Exn_from_c_stack_args.h in file "exn_from_c_stack_args.ml", line 46, characters 2-6
+Called from Exn_from_c_stack_args.g in file "exn_from_c_stack_args.ml", line 51, characters 2-6
+Called from Exn_from_c_stack_args.f in file "exn_from_c_stack_args.ml", line 56, characters 7-11
+==================
+WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
+  Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
+    #0 camlExn_from_c_stack_args$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
+    #0 camlExn_from_c_stack_args$race_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlExn_from_c_stack_args$f_<implemspecific> <implemspecific> (<implemspecific>)
+    #2 camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
+  As if synchronized via sleep:
+    #0 nanosleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlExn_from_c_stack_args$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  Mutex M<implemspecific> (<implemspecific>) created at:
+    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
+    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    #2 caml_init_domains <implemspecific> (<implemspecific>)
+    #3 caml_init_gc <implemspecific> (<implemspecific>)
+
+  Mutex M<implemspecific> (<implemspecific>) created at:
+    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
+    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    #2 caml_init_domains <implemspecific> (<implemspecific>)
+    #3 caml_init_gc <implemspecific> (<implemspecific>)
+
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
+    #0 pthread_create <implemspecific> (<implemspecific>)
+    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #2 caml_c_call <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #4 camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
+    #5 caml_program <implemspecific> (<implemspecific>)
+
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c_stack_args$writer_<implemspecific>
+==================
+Leaving f
+ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_from_c_stack_args.run
+++ b/testsuite/tests/tsan/exn_from_c_stack_args.run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+${program} 2>&1 \
+  | ${test_source_directory}/filter-locations.sh ${program} >${output}

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -10,7 +10,7 @@ Raised by primitive operation at Exn_in_callback.g in file "exn_in_callback.ml",
 Called from Exn_in_callback.f in file "exn_in_callback.ml", line 52, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlExn_in_callback$writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -38,7 +38,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -10,7 +10,7 @@ Called from Exn_reraise.g in file "exn_reraise.ml", line 42, characters 2-6
 Called from Exn_reraise.f in file "exn_reraise.ml", line 47, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlExn_reraise$writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -38,7 +38,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/perform.reference
+++ b/testsuite/tests/tsan/perform.reference
@@ -12,7 +12,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #3 camlPerform$entry <implemspecific> (<implemspecific>)
     #4 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -34,7 +34,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)
@@ -58,7 +58,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 camlPerform$entry <implemspecific> (<implemspecific>)
     #8 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -80,7 +80,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)
@@ -104,7 +104,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlPerform$entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -126,7 +126,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/raise_through_handler.reference
+++ b/testsuite/tests/tsan/raise_through_handler.reference
@@ -4,7 +4,7 @@ Entering g
 In exception handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlRaise_through_handler$reader_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -32,7 +32,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/record_field.reference
+++ b/testsuite/tests/tsan/record_field.reference
@@ -5,7 +5,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 camlRecord_field$entry <implemspecific> (<implemspecific>)
     #2 caml_program <implemspecific> (<implemspecific>)
 
-  Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlRecord_field$writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -28,7 +28,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/reperform.reference
+++ b/testsuite/tests/tsan/reperform.reference
@@ -12,7 +12,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlReperform$entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -34,7 +34,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)
@@ -60,7 +60,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 camlReperform$entry <implemspecific> (<implemspecific>)
     #11 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -82,7 +82,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)
@@ -105,7 +105,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 camlReperform$entry <implemspecific> (<implemspecific>)
     #2 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -127,7 +127,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/unhandled.reference
+++ b/testsuite/tests/tsan/unhandled.reference
@@ -7,7 +7,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 camlUnhandled$entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlUnhandled$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -29,7 +29,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)
@@ -58,7 +58,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 camlUnhandled$entry <implemspecific> (<implemspecific>)
     #10 caml_program <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+  Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
     #0 camlUnhandled$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
@@ -80,7 +80,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
 
-  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+  Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
     #1 caml_domain_spawn <implemspecific> (<implemspecific>)
     #2 caml_c_call <implemspecific> (<implemspecific>)


### PR DESCRIPTION
Currently a draft as it is only implemented for x86_64, and depends on #14213.

This addresses a wrong signaling to TSan in `caml_c_call_stack_args`, both regarding the routine's stack frame itself, but also the stack frame constituted by the additional arguments on the C stack (see individual commit messages).