### PR TITLE
Allow strings to be shared by Lambda.make_key

### DIFF
--- a/.depend
+++ b/.depend
@@ -4436,6 +4436,7 @@ lambda/lambda.cmo : \
     typing/path.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
+    parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
@@ -4449,6 +4450,7 @@ lambda/lambda.cmx : \
     typing/path.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
+    parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -434,9 +434,8 @@ let make_key e =
         try Ident.find_same id env
         with Not_found -> e
       end
-    | Lconst  (Const_base (Const_string _)) ->
-        (* Mutable constants are not shared *)
-        raise Not_simple
+    | Lconst (Const_base (Const_string (s, _, _))) ->
+        Lconst (Const_base (Const_string (s, Location.none, None)))
     | Lconst _ -> e
     | Lapply ap ->
         Lapply {ap with ap_func = tr_rec env ap.ap_func;


### PR DESCRIPTION
`Lambda.make_key` normalises Lambda terms by deleting locations, etc. and used to share common code between arms of a match: if `make_key e = make_key e'` (and `make_key` didn't raise), then it's safe to share the code of `e` and `e'`.

It's needlessly conservative around strings, though, which this patch fixes. This results in the following compiling to a simple `if` rather than a four-way match, as is already the case for non-string values:
```
type t = A | B | C | Other
let f = function
  | A -> "boo"
  | B -> "boo"
  | C -> "boo"
  | Other -> raise Not_found
```

This is a tiny change that I think was missed years ago in the safe-string patch: now that strings are immutable, it's safe to share them.
