### PR TITLE
Normalise string constants in Lambda

### DIFF
--- a/.depend
+++ b/.depend
@@ -2511,7 +2511,6 @@ bytecomp/emitcode.cmo : \
     utils/clflags.cmi \
     bytecomp/bytegen.cmi \
     typing/btype.cmi \
-    parsing/asttypes.cmi \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmx : \
     parsing/unit_info.cmx \
@@ -2532,7 +2531,6 @@ bytecomp/emitcode.cmx : \
     utils/clflags.cmx \
     bytecomp/bytegen.cmx \
     typing/btype.cmx \
-    parsing/asttypes.cmx \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmi : \
     parsing/unit_info.cmi \
@@ -4436,7 +4434,6 @@ lambda/lambda.cmo : \
     typing/path.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
-    parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
@@ -4450,7 +4447,6 @@ lambda/lambda.cmx : \
     typing/path.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
-    parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \

--- a/Changes
+++ b/Changes
@@ -294,6 +294,10 @@ Working version
 - #14198 Constraints on module unpacking are not ghost
   (Thomas Refis, review by Nicolás Ojeda Bär)
 
+- #14260: Refactor Lambda.structured_constant to avoid duplicate
+  representations for string constants
+  (Vincent Laviron, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -570,7 +570,7 @@ let rec comp_expr stack_info env exp sz cont =
       let getmethod, args' =
         if kind = Self then (Kgetmethod, met::obj::args) else
         match met with
-          Lconst(Const_base(Const_int n)) -> (Kgetpubmet n, obj::args)
+          Lconst(Const_int n) -> (Kgetpubmet n, obj::args)
         | _ -> (Kgetdynmet, met::obj::args)
       in
       if is_tailcall cont then
@@ -667,17 +667,17 @@ let rec comp_expr stack_info env exp sz cont =
       end
   | Lprim(Praise k, [arg], _) ->
       comp_expr stack_info env arg sz (Kraise k :: discard_dead_code cont)
-  | Lprim(Paddint, [arg; Lconst(Const_base(Const_int n))], _)
+  | Lprim(Paddint, [arg; Lconst(Const_int n)], _)
     when is_immed n ->
       comp_expr stack_info env arg sz (Koffsetint n :: cont)
-  | Lprim(Psubint, [arg; Lconst(Const_base(Const_int n))], _)
+  | Lprim(Psubint, [arg; Lconst(Const_int n)], _)
     when is_immed (-n) ->
       comp_expr stack_info env arg sz (Koffsetint (-n) :: cont)
   | Lprim (Poffsetint n, [arg], _)
     when not (is_immed n) ->
       comp_expr stack_info env arg sz
         (Kpush::
-         Kconst (Const_base (Const_int n))::
+         Kconst (Const_int n)::
          Kaddint::cont)
   | Lprim(Pmakearray (kind, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
@@ -1043,7 +1043,7 @@ let comp_block env exp sz cont =
   let code = comp_expr stack_info env exp sz cont in
   let used_safe = !(stack_info.max_stack_used) + Config.stack_safety_margin in
   if used_safe > Config.stack_threshold then
-    Kconst(Const_base(Const_int used_safe)) ::
+    Kconst(Const_int used_safe) ::
     Kccall("caml_ensure_stack_capacity", 1) ::
     code
   else

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -17,7 +17,6 @@
 
 open Config
 open Misc
-open Asttypes
 open Lambda
 open Instruct
 open Opcodes

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -82,8 +82,8 @@ let out opcode =
 exception AsInt
 
 let const_as_int = function
-  | Const_base(Const_int i) -> i
-  | Const_base(Const_char c) -> Char.code c
+  | Const_int i -> i
+  | Const_char c -> Char.code c
   | _ -> raise AsInt
 
 let is_immed i = immed_min <= i && i <= immed_max
@@ -259,11 +259,11 @@ let emit_instr = function
   | Ksetglobal q -> out opSETGLOBAL; slot_for_setglobal q
   | Kconst sc ->
       begin match sc with
-        Const_base(Const_int i) when is_immed i ->
+        Const_int i when is_immed i ->
           if i >= 0 && i <= 3
           then out (opCONST0 + i)
           else (out opCONSTINT; out_int i)
-      | Const_base(Const_char c) ->
+      | Const_char c ->
           out opCONSTINT; out_int (Char.code c)
       | Const_block(t, []) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
@@ -391,11 +391,11 @@ let rec emit = function
       out opPUSHGETGLOBAL; slot_for_getglobal id; emit c
   | Kpush :: Kconst sc :: c ->
       begin match sc with
-        Const_base(Const_int i) when is_immed i ->
+        Const_int i when is_immed i ->
           if i >= 0 && i <= 3
           then out (opPUSHCONST0 + i)
           else (out opPUSHCONSTINT; out_int i)
-      | Const_base(Const_char c) ->
+      | Const_char c ->
           out opPUSHCONSTINT; out_int(Char.code c)
       | Const_block(t, []) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -207,7 +207,6 @@ const char * const caml_names_of_builtin_cprim[] = {
 let rec transl_const = function
     Const_base(Const_int i) -> Obj.repr i
   | Const_base(Const_char c) -> Obj.repr c
-  | Const_base(Const_string (s, _, _)) -> Obj.repr s
   | Const_base(Const_float f) -> Obj.repr (float_of_string f)
   | Const_base(Const_int32 i) -> Obj.repr i
   | Const_base(Const_int64 i) -> Obj.repr i

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -238,7 +238,7 @@ let init () =
       let c = slot_for_setglobal global in
       let cst = Const_block
           (Obj.object_tag,
-           [Const_base(Const_string (name, Location.none,None));
+           [Const_immstring name;
             Const_base(Const_int (-i-1))
            ])
       in

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -205,12 +205,12 @@ const char * const caml_names_of_builtin_cprim[] = {
 (* Translate structured constants *)
 
 let rec transl_const = function
-    Const_base(Const_int i) -> Obj.repr i
-  | Const_base(Const_char c) -> Obj.repr c
-  | Const_base(Const_float f) -> Obj.repr (float_of_string f)
-  | Const_base(Const_int32 i) -> Obj.repr i
-  | Const_base(Const_int64 i) -> Obj.repr i
-  | Const_base(Const_nativeint i) -> Obj.repr i
+    Const_int i -> Obj.repr i
+  | Const_char c -> Obj.repr c
+  | Const_float f -> Obj.repr (float_of_string f)
+  | Const_int32 i -> Obj.repr i
+  | Const_int64 i -> Obj.repr i
+  | Const_nativeint i -> Obj.repr i
   | Const_immstring s -> Obj.repr s
   | Const_block(tag, fields) ->
       let block = Obj.new_block tag (List.length fields) in
@@ -238,7 +238,7 @@ let init () =
       let cst = Const_block
           (Obj.object_tag,
            [Const_immstring name;
-            Const_base(Const_int (-i-1))
+            Const_int (-i-1)
            ])
       in
       literal_table := (c, transl_const cst) :: !literal_table)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -214,16 +214,13 @@ let equal_value_kind x y =
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
 
 
-type constant =
+type structured_constant =
     Const_int of int
   | Const_char of char
   | Const_float of string
   | Const_int32 of int32
   | Const_int64 of int64
   | Const_nativeint of nativeint
-
-type structured_constant =
-    Const_base of constant
   | Const_block of int * structured_constant list
   | Const_float_array of string list
   | Const_immstring of string
@@ -377,7 +374,7 @@ type program =
     required_globals : Ident.Set.t;
     code : lambda }
 
-let const_int n = Const_base (Const_int n)
+let const_int n = Const_int n
 
 let const_unit = const_int 0
 
@@ -385,12 +382,12 @@ let dummy_constant = Lconst (const_int (0xBBBB / 2))
 
 let lambda_of_const (c : Asttypes.constant) =
   match c with
-  | Const_int n -> Lconst (Const_base (Const_int n))
-  | Const_char c -> Lconst (Const_base (Const_char c))
-  | Const_float f -> Lconst (Const_base (Const_float f))
-  | Const_int32 n -> Lconst (Const_base (Const_int32 n))
-  | Const_int64 n -> Lconst (Const_base (Const_int64 n))
-  | Const_nativeint n -> Lconst (Const_base (Const_nativeint n))
+  | Const_int n -> Lconst (Const_int n)
+  | Const_char c -> Lconst (Const_char c)
+  | Const_float f -> Lconst (Const_float f)
+  | Const_int32 n -> Lconst (Const_int32 n)
+  | Const_int64 n -> Lconst (Const_int64 n)
+  | Const_nativeint n -> Lconst (Const_nativeint n)
   | Const_string (s, _, _) -> Lconst (Const_immstring s)
 
 let max_arity () =

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -214,6 +214,14 @@ let equal_value_kind x y =
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
 
 
+type constant =
+    Const_int of int
+  | Const_char of char
+  | Const_float of string
+  | Const_int32 of int32
+  | Const_int64 of int64
+  | Const_nativeint of nativeint
+
 type structured_constant =
     Const_base of constant
   | Const_block of int * structured_constant list
@@ -444,8 +452,6 @@ let make_key e =
         try Ident.find_same id env
         with Not_found -> e
       end
-    | Lconst (Const_base (Const_string (s, _, _))) ->
-        Lconst (Const_base (Const_string (s, Location.none, None)))
     | Lconst _ -> e
     | Lapply ap ->
         Lapply {ap with ap_func = tr_rec env ap.ap_func;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -375,6 +375,16 @@ let const_unit = const_int 0
 
 let dummy_constant = Lconst (const_int (0xBBBB / 2))
 
+let lambda_of_const (c : Asttypes.constant) =
+  match c with
+  | Const_int n -> Lconst (Const_base (Const_int n))
+  | Const_char c -> Lconst (Const_base (Const_char c))
+  | Const_float f -> Lconst (Const_base (Const_float f))
+  | Const_int32 n -> Lconst (Const_base (Const_int32 n))
+  | Const_int64 n -> Lconst (Const_base (Const_int64 n))
+  | Const_nativeint n -> Lconst (Const_base (Const_nativeint n))
+  | Const_string (s, _, _) -> Lconst (Const_immstring s)
+
 let max_arity () =
   if !Clflags.native_code then 126 else max_int
   (* 126 = 127 (the maximal number of parameters supported in C--)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -386,6 +386,8 @@ val const_unit: structured_constant
 val const_int : int -> structured_constant
 val lambda_unit: lambda
 
+val lambda_of_const : Asttypes.constant -> lambda
+
 (** [dummy_constant] produces a plecholder value with a recognizable
     bit pattern (currently 0xBBBB in its tagged form) *)
 val dummy_constant: lambda

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -213,16 +213,13 @@ val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
-type constant =
+type structured_constant =
     Const_int of int
   | Const_char of char
   | Const_float of string
   | Const_int32 of int32
   | Const_int64 of int64
   | Const_nativeint of nativeint
-
-type structured_constant =
-    Const_base of constant
   | Const_block of int * structured_constant list
   | Const_float_array of string list
   | Const_immstring of string

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -213,6 +213,14 @@ val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
+type constant =
+    Const_int of int
+  | Const_char of char
+  | Const_float of string
+  | Const_int32 of int32
+  | Const_int64 of int64
+  | Const_nativeint of nativeint
+
 type structured_constant =
     Const_base of constant
   | Const_block of int * structured_constant list

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3105,12 +3105,12 @@ let combine_constant loc arg cst partial ctx def
     (const_lambda_list, total, _pats) =
   let fail, local_jumps = mk_failaction_neg partial ctx def in
   let lambda1 =
-    match cst with
+    match (cst : Asttypes.constant) with
     | Const_int _ ->
         let int_lambda_list =
           List.map
             (function
-              | Const_int n, l -> (n, l)
+              | Asttypes.Const_int n, l -> (n, l)
               | _ -> assert false)
             const_lambda_list
         in
@@ -3119,7 +3119,7 @@ let combine_constant loc arg cst partial ctx def
         let int_lambda_list =
           List.map
             (function
-              | Const_char c, l -> (Char.code c, l)
+              | Asttypes.Const_char c, l -> (Char.code c, l)
               | _ -> assert false)
             const_lambda_list
         in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2575,7 +2575,7 @@ let rec do_tests_fail loc fail tst arg = function
   | [] -> fail
   | (c, act) :: rem ->
       Lifthenelse
-        ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
+        ( Lprim (tst, [ arg; lambda_of_const c ], loc),
           do_tests_fail loc fail tst arg rem,
           act )
 
@@ -2584,7 +2584,7 @@ let rec do_tests_nofail loc tst arg = function
   | [ (_, act) ] -> act
   | (c, act) :: rem ->
       Lifthenelse
-        ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
+        ( Lprim (tst, [ arg; lambda_of_const c ], loc),
           do_tests_nofail loc tst arg rem,
           act )
 
@@ -2605,7 +2605,7 @@ let make_test_sequence loc fail tst lt_tst arg const_lambda_list =
       rev_split_at (List.length const_lambda_list / 2) const_lambda_list
     in
     Lifthenelse
-      ( Lprim (lt_tst, [ arg; Lconst (Const_base (fst (List.hd list2))) ], loc),
+      ( Lprim (lt_tst, [ arg; lambda_of_const (fst (List.hd list2)) ], loc),
         make_test_sequence list1,
         make_test_sequence list2 )
   in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4010,7 +4010,7 @@ let failure_handler ~scopes loc ~failer () =
                 Lconst
                   (Const_block
                      ( 0,
-                       [ Const_base (Const_string (fname, loc, None));
+                       [ Const_immstring fname;
                          Const_base (Const_int line);
                          Const_base (Const_int char)
                        ] ))

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2179,7 +2179,7 @@ let inline_lazy_force_cond arg loc =
   let varg = Lvar idarg in
   let tag = Ident.create_local "tag" in
   let test_tag t =
-    Lprim(Pintcomp Ceq, [Lvar tag; Lconst(Const_base(Const_int t))], loc)
+    Lprim(Pintcomp Ceq, [Lvar tag; Lconst(Const_int t)], loc)
   in
 
   Llet
@@ -2244,7 +2244,7 @@ let inline_lazy_force arg loc =
       { ap_tailcall = Default_tailcall;
         ap_loc = loc;
         ap_func = Lazy.force code_force_lazy;
-        ap_args = [ Lconst (Const_base (Const_int 0)); arg ];
+        ap_args = [ Lconst (Const_int 0); arg ];
         ap_inlined = Never_inline;
         ap_specialised = Default_specialise
       }
@@ -2393,7 +2393,7 @@ let get_expr_args_array ~scopes kind head { arg; mut } rem =
       let arg =
         Lprim
           (Parrayrefu kind,
-           [ arg; Lconst (Const_base (Const_int pos)) ], loc)
+           [ arg; Lconst (Const_int pos) ], loc)
       in
       {
         arg;
@@ -2476,7 +2476,7 @@ let rec split k xs =
         let xs, y0, ys = split (k - 2) xs in
         (x0 :: xs, y0, ys)
 
-let zero_lam = Lconst (Const_base (Const_int 0))
+let zero_lam = Lconst (Const_int 0)
 
 let tree_way_test loc arg lt eq gt =
   Lifthenelse
@@ -2648,7 +2648,7 @@ module SArg = struct
     in
     bind Alias newvar arg (body newarg)
 
-  let make_const i = Lconst (Const_base (Const_int i))
+  let make_const i = Lconst (Const_int i)
 
   let make_isout h arg = Lprim (Pisout, [ h; arg ], Loc_unknown)
 
@@ -2657,7 +2657,7 @@ module SArg = struct
   let make_is_nonzero arg =
     if !Clflags.native_code then
       Lprim (Pintcomp Cne,
-             [arg; Lconst (Const_base (Const_int 0))],
+             [arg; Lconst (Const_int 0)],
              Loc_unknown)
     else
       arg
@@ -4011,8 +4011,8 @@ let failure_handler ~scopes loc ~failer () =
                   (Const_block
                      ( 0,
                        [ Const_immstring fname;
-                         Const_base (Const_int line);
-                         Const_base (Const_int char)
+                         Const_int line;
+                         Const_int char
                        ] ))
               ],
               sloc )

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -23,8 +23,7 @@ open Lambda
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n
   | Const_base(Const_char c) -> fprintf ppf "%C" c
-  | Const_base(Const_string (s, _, _)) -> fprintf ppf "%S" s
-  | Const_immstring s -> fprintf ppf "#%S" s
+  | Const_immstring s -> fprintf ppf "%S" s
   | Const_base(Const_float f) -> fprintf ppf "%s" f
   | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
   | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -21,13 +21,13 @@ open Lambda
 
 
 let rec struct_const ppf = function
-  | Const_base(Const_int n) -> fprintf ppf "%i" n
-  | Const_base(Const_char c) -> fprintf ppf "%C" c
+  | Const_int n -> fprintf ppf "%i" n
+  | Const_char c -> fprintf ppf "%C" c
   | Const_immstring s -> fprintf ppf "%S" s
-  | Const_base(Const_float f) -> fprintf ppf "%s" f
-  | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
-  | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
-  | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
+  | Const_float f -> fprintf ppf "%s" f
+  | Const_int32 n -> fprintf ppf "%lil" n
+  | Const_int64 n -> fprintf ppf "%LiL" n
+  | Const_nativeint n -> fprintf ppf "%nin" n
   | Const_block(tag, []) ->
       fprintf ppf "[%i]" tag
   | Const_block(tag, sc1::scl) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -248,11 +248,11 @@ let simplify_exits lam =
     match p, ll with
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
-        [Lconst (Const_base (Const_int tag));
+        [Lconst (Const_int tag);
          Lprim (Pmakeblock (_, mut, shape), fields, loc)] ->
          Lprim (Pmakeblock(tag, mut, shape), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
-        [Lconst (Const_base (Const_int tag));
+        [Lconst (Const_int tag);
          Lconst (Const_block (_, fields))] ->
          Lconst (Const_block (tag, fields))
 

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -131,7 +131,7 @@ end = struct
     let k_with_placeholder =
       apply { constr with flag = Mutable } tmc_placeholder in
     let placeholder_pos = List.length constr.before in
-    let placeholder_pos_lam = Lconst (Const_base (Const_int placeholder_pos)) in
+    let placeholder_pos_lam = Lconst (Const_int placeholder_pos) in
     let block_var = Ident.create_local "block" in
     Llet (Strict, Pgenval, block_var, k_with_placeholder,
           body {

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -84,7 +84,7 @@ let extract_constant = function
   | _ -> raise Not_constant
 
 let extract_float = function
-    Const_base(Const_float f) -> f
+    Const_float f -> f
   | _ -> fatal_error "Translcore.extract_float"
 
 (* Insertion of debugging events *)
@@ -123,8 +123,8 @@ let assert_failed loc ~scopes exp =
           [slot;
            Lconst(Const_block(0,
               [Const_immstring fname;
-               Const_base(Const_int line);
-               Const_base(Const_int char)]))], loc))], loc)
+               Const_int line;
+               Const_int char]))], loc))], loc)
 
 (* In cases where we're careful to preserve syntactic arity, we disable
    the arity fusion attempted by simplif.ml *)
@@ -1082,7 +1082,7 @@ and transl_atomic_loc ~scopes arg lbl =
           "Translcore.transl_atomic_loc: atomic field in unboxed record"
     | Record_extension _ -> 1
   in
-  let lbl = Lconst (Const_base (Const_int (lbl.lbl_pos + offset))) in
+  let lbl = Lconst (Const_int (lbl.lbl_pos + offset)) in
   (arg, lbl)
 
 and transl_match ~scopes e arg pat_expr_list partial =
@@ -1245,7 +1245,7 @@ and transl_handler ~scopes e body val_caselist exn_caselist eff_caselist =
        (lfunction ~kind:Curried ~params:[param, Pgenval] ~return:Pgenval
                   ~attr:default_function_attribute ~loc:Loc_unknown
                   ~body,
-        Lconst(Const_base(Const_int 0)))
+        Lconst(Const_int 0))
   in
   let alloc_stack =
     Lprim(prim_alloc_stack, [val_fun; exn_fun; eff_fun], Loc_unknown)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -69,7 +69,7 @@ let transl_extension_constructor ~scopes env path ext =
   match ext.ext_kind with
     Text_decl _ ->
       Lprim (Pmakeblock (Obj.object_tag, Immutable, None),
-        [Lconst (Const_base (Const_string (name, ext.ext_loc, None)));
+        [Lconst (Const_immstring name);
          Lprim (prim_fresh_oo_id, [Lconst (const_int 0)], loc)],
         loc)
   | Text_rebind(path, _lid) ->
@@ -122,7 +122,7 @@ let assert_failed loc ~scopes exp =
     (Lprim(Pmakeblock(0, Immutable, None),
           [slot;
            Lconst(Const_block(0,
-              [Const_base(Const_string (fname, exp.exp_loc, None));
+              [Const_immstring fname;
                Const_base(Const_int line);
                Const_base(Const_int char)]))], loc))], loc)
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -209,7 +209,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
       transl_ident (of_location ~scopes e.exp_loc)
         e.exp_env e.exp_type path desc
   | Texp_constant cst ->
-      Lconst(Const_base cst)
+      Lambda.lambda_of_const cst
   | Texp_let(rec_flag, pat_expr_list, body) ->
       transl_let ~scopes rec_flag pat_expr_list
         (event_before ~scopes body (transl_exp ~scopes body))

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -228,7 +228,7 @@ let mod_prim = Lambda.transl_prim "CamlinternalMod"
 let undefined_location loc =
   let (fname, line, char) = Location.get_pos_info loc.Location.loc_start in
   Lconst(Const_block(0,
-                     [Const_base(Const_string (fname, loc, None));
+                     [Const_immstring fname;
                       const_int line;
                       const_int char]))
 
@@ -1418,8 +1418,7 @@ let toploop_getvalue id =
     ap_func=Lprim(Pfield (toploop_getvalue_pos, Pointer, Mutable),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
-    ap_args=[Lconst(Const_base(
-      Const_string (toplevel_name id, Location.none, None)))];
+    ap_args=[Lconst(Const_immstring (toplevel_name id))];
     ap_tailcall=Default_tailcall;
     ap_inlined=Default_inline;
     ap_specialised=Default_specialise;
@@ -1432,8 +1431,7 @@ let toploop_setvalue id lam =
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=
-      [Lconst(Const_base(
-         Const_string(toplevel_name id, Location.none, None)));
+      [Lconst(Const_immstring (toplevel_name id));
        lam];
     ap_tailcall=Default_tailcall;
     ap_inlined=Default_inline;

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -43,12 +43,12 @@ let method_cache = ref lambda_unit
 let method_count = ref 0
 let method_table = ref []
 
-let meth_tag s = Lconst(Const_base(Const_int(Btype.hash_variant s)))
+let meth_tag s = Lconst(Const_int(Btype.hash_variant s))
 
 let next_cache tag =
   let n = !method_count in
   incr method_count;
-  (tag, [!method_cache; Lconst(Const_base(Const_int n))])
+  (tag, [!method_cache; Lconst(Const_int n)])
 
 let rec is_path = function
     Lvar _ | Lprim (Pgetglobal _, [], _) | Lconst _ -> true
@@ -81,7 +81,7 @@ let reset_labels () =
 
 (* Insert labels *)
 
-let int n = Lconst (Const_base (Const_int n))
+let int n = Lconst (Const_int n)
 
 let prim_makearray =
   Primitive.simple ~name:"caml_array_make" ~arity:2 ~alloc:true

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -658,9 +658,9 @@ let lambda_of_loc kind sloc =
   | Loc_POS ->
     Lconst (Const_block (0, [
           Const_immstring file;
-          Const_base (Const_int lnum);
-          Const_base (Const_int cnum);
-          Const_base (Const_int enum);
+          Const_int lnum;
+          Const_int cnum;
+          Const_int enum;
         ]))
   | Loc_FILE -> Lconst (Const_immstring file)
   | Loc_MODULE ->
@@ -672,7 +672,7 @@ let lambda_of_loc kind sloc =
     let loc = Printf.sprintf "File %S, line %d, characters %d-%d"
         file lnum cnum enum in
     Lconst (Const_immstring loc)
-  | Loc_LINE -> Lconst (Const_base (Const_int lnum))
+  | Loc_LINE -> Lconst (Const_int lnum)
   | Loc_FUNCTION ->
     let scope_name = Debuginfo.Scoped_location.string_of_scoped_location sloc in
     Lconst (Const_immstring scope_name)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -148,7 +148,7 @@ let find_size_of_alloc_prim prim args =
     String.equal prim.prim_name other_prim.prim_name
   in
   let int_arg = match args with
-    | [Lconst (Const_base (Const_int n))] -> Some n
+    | [Lconst (Const_int n)] -> Some n
     | _ ->  None
   in
   if same_as alloc_prim then

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -905,8 +905,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
         Uconst_ref (name, Some cst)
       in
       let rec transl = function
-        | Const_base(Const_int n) -> Uconst_int n
-        | Const_base(Const_char c) -> Uconst_int (Char.code c)
+        | Const_int n -> Uconst_int n
+        | Const_char c -> Uconst_int (Char.code c)
         | Const_block (tag, fields) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->
@@ -914,10 +914,10 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
             str (Uconst_float_array (List.map float_of_string sl))
         | Const_immstring s ->
             str (Uconst_string s)
-        | Const_base(Const_float x) -> str (Uconst_float (float_of_string x))
-        | Const_base(Const_int32 x) -> str (Uconst_int32 x)
-        | Const_base(Const_int64 x) -> str (Uconst_int64 x)
-        | Const_base(Const_nativeint x) -> str (Uconst_nativeint x)
+        | Const_float x -> str (Uconst_float (float_of_string x))
+        | Const_int32 x -> str (Uconst_int32 x)
+        | Const_int64 x -> str (Uconst_int64 x)
+        | Const_nativeint x -> str (Uconst_nativeint x)
       in
       make_const (transl cst)
   | Lfunction funct ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -914,8 +914,6 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
             str (Uconst_float_array (List.map float_of_string sl))
         | Const_immstring s ->
             str (Uconst_string s)
-        | Const_base (Const_string (s, _, _)) ->
-            str (Uconst_string s)
         | Const_base(Const_float x) -> str (Uconst_float (float_of_string x))
         | Const_base(Const_int32 x) -> str (Uconst_int32 x)
         | Const_base(Const_int64 x) -> str (Uconst_int64 x)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -111,12 +111,6 @@ let rec declare_const t (const : Lambda.structured_constant)
   match const with
   | Const_base (Const_int c) -> (Const (Int c), Names.const_int)
   | Const_base (Const_char c) -> (Const (Char c), Names.const_char)
-  | Const_base (Const_string (s, _, _)) ->
-    let const, name =
-      (Flambda.Allocated_const (Immutable_string s),
-       Names.const_immstring)
-    in
-    register_const t const name
   | Const_base (Const_float c) ->
     register_const t
       (Allocated_const (Float (float_of_string c)))

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -109,19 +109,19 @@ let register_const t (constant:Flambda.constant_defining_value) name
 let rec declare_const t (const : Lambda.structured_constant)
     : Flambda.constant_defining_value_block_field * Internal_variable_names.t =
   match const with
-  | Const_base (Const_int c) -> (Const (Int c), Names.const_int)
-  | Const_base (Const_char c) -> (Const (Char c), Names.const_char)
-  | Const_base (Const_float c) ->
+  | Const_int c -> (Const (Int c), Names.const_int)
+  | Const_char c -> (Const (Char c), Names.const_char)
+  | Const_float c ->
     register_const t
       (Allocated_const (Float (float_of_string c)))
       Names.const_float
-  | Const_base (Const_int32 c) ->
+  | Const_int32 c ->
     register_const t (Allocated_const (Int32 c))
       Names.const_int32
-  | Const_base (Const_int64 c) ->
+  | Const_int64 c ->
     register_const t (Allocated_const (Int64 c))
       Names.const_int64
-  | Const_base (Const_nativeint c) ->
+  | Const_nativeint c ->
     register_const t (Allocated_const (Nativeint c)) Names.const_nativeint
   | Const_immstring c ->
     register_const t (Allocated_const (Immutable_string c))
@@ -152,7 +152,7 @@ let lambda_const_bool b : Lambda.structured_constant =
     Lambda.const_int 0
 
 let lambda_const_int i : Lambda.structured_constant =
-  Const_base (Const_int i)
+  Lambda.const_int i
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
   match lam with


### PR DESCRIPTION
This PR (spurred by the discussion in #14259) ensures that we always handle constant strings consistently in Lambda.
The first commit replaces all occurrences of `Const_base (Const_string (s, _, _)` with `Const_immstring s` in the compiler's code. The second commit adds a `lambda_of_const` converter that performs the translation on constants coming from the input program, and calls it at the appropriate places. The third commit duplicates the `Asttypes.constant` type in `Lambda` but without the `Const_string` case, allowing us to check that no cases were missed in the earlier two commits and removing all the code for handling the `Const_string` case (which, most of the time, was already the same as for `Const_immstring`).

Another possibility would be to remove the `Const_immstring` case and use `Const_base (Const_string _)` everywhere, but that is less satisfying as `Lambda.make_key` would still have to make a special case for it.