### PR TITLE
manual: always refer to headers as `<caml/example.h>`

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -165,22 +165,22 @@ double caml_int64_float_of_bits_unboxed(int64_t i)
 To write C code that operates on OCaml values, the following
 include files are provided:
 \begin{tableau}{|l|p{12cm}|}{Include file}{Provides}
-\entree{"caml/mlvalues.h"}{definition of the "value" type, and conversion
+\entree{"<caml/mlvalues.h>"}{definition of the "value" type, and conversion
 macros}
-\entree{"caml/alloc.h"}{allocation functions (to create structured OCaml
+\entree{"<caml/alloc.h>"}{allocation functions (to create structured OCaml
 objects)}
-\entree{"caml/memory.h"}{miscellaneous memory-related functions
+\entree{"<caml/memory.h>"}{miscellaneous memory-related functions
 and macros (for GC interface, in-place modification of structures, etc).}
-\entree{"caml/fail.h"}{functions for raising exceptions
+\entree{"<caml/fail.h>"}{functions for raising exceptions
 (see section~\ref{ss:c-exceptions})}
-\entree{"caml/callback.h"}{callback from C to OCaml (see
+\entree{"<caml/callback.h>"}{callback from C to OCaml (see
 section~\ref{s:c-callback}).}
-\entree{"caml/custom.h"}{operations on custom blocks (see
+\entree{"<caml/custom.h>"}{operations on custom blocks (see
 section~\ref{s:c-custom}).}
-\entree{"caml/intext.h"}{operations for writing user-defined
+\entree{"<caml/intext.h>"}{operations for writing user-defined
 serialization and deserialization functions for custom blocks
 (see section~\ref{s:c-custom}).}
-\entree{"caml/threads.h"}{operations for interfacing in the presence
+\entree{"<caml/threads.h>"}{operations for interfacing in the presence
   of multiple threads (see section~\ref{s:C-multithreading}).}
 \end{tableau}
 These files reside in the "caml/" subdirectory of the OCaml
@@ -414,7 +414,7 @@ bytecode executable (so that the bytecode from "unix.cma" and
 \section{s:c-value}{The \texttt{value} type}
 
 All OCaml objects are represented by the C type "value",
-defined in the include file "caml/mlvalues.h", along with macros to
+defined in the include file "<caml/mlvalues.h>", along with macros to
 manipulate values of that type. An object of type "value" is either:
 \begin{itemize}
 \item an unboxed integer;
@@ -615,7 +615,7 @@ fields contain its arguments. Example:
 contains "h", second field "t".}
 \end{tableau}
 
-As a convenience, "caml/mlvalues.h" defines the macros "Val_unit",
+As a convenience, "<caml/mlvalues.h>" defines the macros "Val_unit",
 "Val_false", "Val_true" and "Val_emptylist" to refer to "()",
 "false", "true" and "[]".
 
@@ -864,7 +864,7 @@ From the standpoint of the allocation functions, blocks are divided
 according to their size as zero-sized blocks, small blocks (with size
 less than or equal to \verb"Max_young_wosize"), and large blocks (with
 size greater than \verb"Max_young_wosize"). The constant
-\verb"Max_young_wosize" is declared in the include file "mlvalues.h". It
+\verb"Max_young_wosize" is declared in the include file "<caml/mlvalues.h>". It
 is guaranteed to be at least 64 (words), so that any block with
 constant size less than or equal to 64 can be assumed to be small. For
 blocks whose size is computed at run-time, the size must be compared
@@ -936,7 +936,7 @@ manipulates heap-allocated blocks.
 \subsection{ss:c-simple-gc-harmony}{Simple interface}
 
 All the macros described in this section are declared in the
-"memory.h" header file.
+"<caml/memory.h>" header file.
 
 \begin{gcrule}
 A function that has parameters or local variables of type "value" must
@@ -1536,21 +1536,21 @@ re-raising the exception (if any) or continuing the computation.
 and macros:
 \begin{itemize}
 \item "value caml_get_value_or_raise(caml_result "\var{res}")"
-  (in "fail.h") returns the value contained in \var{res} or reraises
+  (in "<caml/fail.h>") returns the value contained in \var{res} or reraises
   the exception it contains. In particular,
   "(void)caml_get_value_or_raise(res)" can be used to ignore an OCaml
   result of type "unit", yet propagate exceptions to the caller.
 
-\item "Result_value(value "\var{v}")" (in "mlvalues.h") is the result
+\item "Result_value(value "\var{v}")" (in "<caml/mlvalues.h>") is the result
   that represents returning the value \var{v}.
 
-\item "Result_exception(value "\var{exn}")" (in "mlvalues.h") is the
+\item "Result_exception(value "\var{exn}")" (in "<caml/mlvalues.h>") is the
   result that represents raising the exception \var{exn}.
 
 \item "int caml_result_is_exception(caml_result "\var{res}")"
-  (in "mlvalues.h") is true if \var{res} represents an exception.
+  (in "<caml/mlvalues.h>") is true if \var{res} represents an exception.
 
-\item The macro "CAMLlocalresult(foo)" (in "memory.h") is the
+\item The macro "CAMLlocalresult(foo)" (in "<caml/memory.h>") is the
   "caml_result" counterpart of "CAMLlocal1": it declares a local
   variable of type "caml_result", whose content is tracked by the
   OCaml GC. Just like "CAMLlocal1", it can only be used between
@@ -1886,7 +1886,7 @@ turned on programmatically.   This can be achieved from the OCaml side
 by calling "Printexc.record_backtrace true" in the initialization of
 one of the OCaml modules.  This can also be achieved from the C side
 by calling "caml_record_backtraces(1);" in the OCaml-C glue code.
-("caml_record_backtraces" is declared in "backtrace.h")
+("caml_record_backtraces" is declared in "<caml/backtrace.h>")
 
 \paragraph{Unloading the runtime.}
 
@@ -1906,7 +1906,7 @@ descriptors, which are to be released.
 including "dynlink" plugins.
 \item Freeing the memory blocks that were allocated by the runtime with
 "malloc". Inside C primitives, it is advised to use "caml_stat_*" functions
-from "memory.h" for managing static (that is, non-moving) blocks of heap
+from "<caml/memory.h>" for managing static (that is, non-moving) blocks of heap
 memory, as all the blocks allocated with these functions are automatically
 freed by "caml_shutdown". For ensuring compatibility with legacy C stubs that
 have used "caml_stat_*" incorrectly, this behaviour is only enabled if the
@@ -3023,7 +3023,7 @@ which breaks in OCaml $\ge$ 4.10, you should include the "minor_gc" header:
 
 \subsection{ss:c-internal-macros}{OCaml version macros}
 Finally, if including the right headers is not enough, or if you need to support
-version older than OCaml 4.04, the header file "caml/version.h" should help
+version older than OCaml 4.04, the header file "<caml/version.h>" should help
 you to define your own compatibility layer.
 This file provides few macros defining the current OCaml version.
 In particular, the "OCAML_VERSION" macro describes the current version,


### PR DESCRIPTION
A cosmetic change for consistency. No change entry needed.