### PR TITLE
Add new function `caml_c_thread_register_in_domain`

### DIFF
--- a/Changes
+++ b/Changes
@@ -72,6 +72,14 @@ Working version
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, B. Szilvasy,
    Miod Vallat)
 
+- #14275: Add function caml_c_thread_register_in_domain, which makes it
+  possible to register "C threads" in another domain than 0 (which is
+  what caml_c_thread_register does). The function takes a domain unique
+  ID in which to register the thread. The domain must be running
+  when the function is called.
+  (Jack Nørskov Jørgensen, review by Gabriel Scherer,
+   Guillaume Munch-Maccagnoni)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2619,6 +2619,14 @@ system.  The following functions are declared in the include file
 run-time system.  Returns 1 on success, 0 on error.  Registering an
 already-registered thread does nothing and returns 0.
 \item
+"caml_c_thread_register_in_domain(uintnat dom_unique_id)" registers the
+calling thread with the OCaml run-time system in the domain with
+identifier "dom_unique_id" as provided by "Domain.self" and "Domain.get_id".
+The domain must be running when this function is called.  Registering an
+already-registered thread does nothing and returns 0, even if it was previously
+registered in another domain. It is an error to register in one domain,
+unregister, and then later register in another domain.
+\item
 "caml_c_thread_unregister()"  must be called before the thread
   terminates, to unregister it from the OCaml run-time system.
 Returns 1 on success, 0 on error.  If the calling thread was not

--- a/otherlibs/systhreads/caml/threads.h
+++ b/otherlibs/systhreads/caml/threads.h
@@ -16,6 +16,8 @@
 #ifndef CAML_THREADS_H
 #define CAML_THREADS_H
 
+#include "caml/config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,17 +53,26 @@ CAMLextern void caml_leave_blocking_section (void);
 */
 
 CAMLextern int caml_c_thread_register(void);
+CAMLextern int caml_c_thread_register_in_domain(uintnat dom_unique_id);
 CAMLextern int caml_c_thread_unregister(void);
 
 /* If a thread is created by C code (instead of by OCaml itself),
    it must be registered with the OCaml runtime system before
    being able to call back into OCaml code or use other runtime system
-   functions.  Just call [caml_c_thread_register] once. The domain lock
-   is not held when [caml_c_thread_register] returns.
+   functions. Just call [caml_c_thread_register_in_domain] once. The domain lock
+   is not held when caml_c_thread_register_in_domain] returns.
    Before the thread finishes, it must call [caml_c_thread_unregister]
    (without holding the domain lock).
    Both functions return 1 on success, 0 on error.
-   Note that threads registered by C code belong to the domain 0.
+   Threads registered by [caml_c_thread_register_in_domain] belong to
+   the domain given by the unique id which must be running when calling this
+   function. It is an error to call [caml_c_thread_unregister] on a
+   thread registered in a domain and later call
+   [caml_c_thread_register_in_domain] to register it with a different
+   domain.
+   The function [caml_c_thread_register] is an alias for
+   [caml_c_thread_register_in_domain(0)] (where 0 is the identifier
+   of the main domain).
 */
 
 #ifdef __cplusplus

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -864,12 +864,7 @@ int caml_c_thread_register_in_domain_index(uintnat domain_index,
      - We were not previously registered on a different domain (to
        allow C programs to store domain-specific data in thread-local
        storage) */
-  static _Thread_local uintnat previous_domain_id = -1;
-  if (Caml_state->unique_id != expected_unique_id ||
-      (previous_domain_id != -1 &&
-       previous_domain_id != expected_unique_id)) {
-      goto out_err;
-  }
+  if (!caml_thread_running_on_expected_domain(expected_unique_id)) goto out_err;
 
   /* Create tick thread if not already done */
   st_retcode err = create_tick_thread();
@@ -886,7 +881,7 @@ int caml_c_thread_register_in_domain_index(uintnat domain_index,
   if (Is_exception_result(res)) goto out_err2;
   th->descr = res;
 
-  previous_domain_id = expected_unique_id;
+  caml_thread_record_domain_id(expected_unique_id);
 
   /* Release the domain lock the regular way. Note: we cannot receive
      an exception here. */

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -92,6 +92,11 @@ CAMLextern uintnat caml_minor_heap_max_wsz;
 
 CAMLextern atomic_uintnat caml_num_domains_running;
 
+/*  Given domain unique id, return the index of the domain.
+ *  If the domain unique id is unknown, return -1.
+*/
+CAMLextern intnat caml_find_index_of_running_domain(uintnat dom_unique_id);
+
 /* When [caml_domain_alone()] is true, there is a single domain
    running. In particular, if the test passes while holding the domain
    lock, then we know that no other domain is running concurrently,

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -26,6 +26,10 @@
 #include "mlvalues.h"
 #include "domain_state.h"
 
+/* See caml_c_thread_register_in_domain_index */
+CAMLextern bool caml_thread_running_on_expected_domain(uintnat);
+CAMLextern void caml_thread_record_domain_id(uintnat);
+
 #ifdef ARCH_SIXTYFOUR
 #define Max_domains_def 128
 #else

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -367,6 +367,21 @@ CAMLexport caml_domain_state* caml_get_domain_state(void)
 }
 #endif
 
+static CAMLthread_local uintnat previous_domain_id = -1;
+
+CAMLexport
+bool caml_thread_running_on_expected_domain(uintnat expected_unique_id)
+{
+  return (Caml_state->unique_id == expected_unique_id &&
+          (previous_domain_id == -1 ||
+            previous_domain_id == expected_unique_id));
+}
+
+CAMLexport void caml_thread_record_domain_id(uintnat domain_id)
+{
+  previous_domain_id = domain_id;
+}
+
 Caml_inline void interrupt_domain(struct interruptor* s)
 {
   atomic_uintnat * interrupt_word = atomic_load_relaxed(&s->interrupt_word);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -166,7 +166,8 @@ struct interruptor {
   int running;
   int terminating;
   /* unlike the domain ID, this ID number is not reused */
-  uintnat unique_id;
+  /* Synchronised with [caml_find_index_of_running_domain] */
+  atomic_uintnat unique_id;
 
   /* indicates whether there is an interrupt pending */
   atomic_uintnat interrupt_pending;
@@ -1956,6 +1957,29 @@ void caml_interrupt_all_signal_safe(void)
     if (interrupt_word == NULL) return;
     interrupt_domain(&d->interruptor);
   }
+}
+
+/*  This function can be called from arbitrary code, possibly running
+    concurrently with the OCaml runtime, as long as it synchronized
+    with the runtime startup which initialized [all_domains] and
+    [caml_params].
+    Returns [-1] on failure -- if the provided unique id is
+    not assigned to a currently-running domain.
+*/
+intnat caml_find_index_of_running_domain(uintnat dom_unique_id)
+{
+  for (int i = 0; i < caml_params->max_domains; i++) {
+    dom_internal *d = &all_domains[i];
+
+    /* See [caml_interrupt_all_signal_safe] above for synchronization
+       and early-exit comments. */
+    atomic_uintnat * interrupt_word =
+      atomic_load_acquire(&d->interruptor.interrupt_word);
+    if (interrupt_word == NULL) return -1;
+
+    if (d->interruptor.unique_id == dom_unique_id) return i;
+  }
+  return -1;
 }
 
 /* To avoid any risk of forgetting an action through a race,

--- a/testsuite/tests/parallel/test_c_thread_register.ml
+++ b/testsuite/tests/parallel/test_c_thread_register.ml
@@ -9,19 +9,59 @@
  }
 *)
 
-(* spins a external thread from C and register it to the OCaml runtime *)
+(* Spawns a external thread from C and register it to the OCaml runtime
+   using caml_c_thread_register *)
 
 external spawn_thread : (unit -> unit) -> unit = "spawn_thread"
 
-let passed () = Printf.printf "passed\n"
+(* Spawns a external thread from C and register it to the OCaml runtime in
+   given domain using caml_c_thread_register_in_domain *)
 
-let _ =
-  let d =
-    Domain.spawn begin fun () ->
-      spawn_thread passed;
-      Thread.delay 0.5
-    end
+external spawn_thread_specific_domain : int -> (unit -> unit) -> unit
+  = "spawn_thread_specific_domain"
+
+(* Spawns a external thread from C and register it to the OCaml runtime twice,
+   in given domains using caml_c_thread_register_in_domain *)
+
+external spawn_thread_specific_domain_twice : int ->
+  int -> (unit -> unit) -> unit = "spawn_thread_specific_domain_twice"
+
+let print_domain () =
+  Printf.printf "Thread running in domain %d\n%!" (Domain.self () :> int)
+
+let run_in_domain f =
+  let d = Domain.spawn (fun () ->
+    begin
+      f ();
+      Thread.delay 0.25
+    end)
   in
-  let t = Thread.create (fun () -> Thread.delay 1.0) () in
+  let t = Thread.create (fun () -> Thread.delay 0.5) () in
   Thread.join t;
   Domain.join d
+
+(* This test assumes that no other domains are spawned, besides the ones
+   spawned explitcly by [run_in_domain], during execution. This allows us
+   to refer to the unique IDs directly and not have to use [Domain.self]. *)
+let _ =
+  (* Test caml_c_thread_register (which must always register in domain 0) *)
+  run_in_domain (fun _ -> spawn_thread print_domain);
+
+  (* Test caml_c_thread_register_in_domain, registering in domain 0. *)
+  run_in_domain (fun _ -> spawn_thread_specific_domain 0 print_domain);
+
+  (* Test caml_c_thread_register_in_domain, registering in the temporary
+     domain, which has unique ID 3. *)
+  run_in_domain (fun () -> spawn_thread_specific_domain 3 print_domain);
+
+  (* Test caml_c_thread_register_in_domain, attempting to register in previous
+     existent domain 3 which no longer exists. *)
+  run_in_domain (fun () -> spawn_thread_specific_domain 3 print_domain);
+
+  (* Test caml_c_thread_register_in_domain, registering in domain that has
+     never existed. *)
+  run_in_domain (fun () -> spawn_thread_specific_domain 6 print_domain);
+
+  (* Test caml_c_thread_register_in_domain, registering in domain and
+     then another domain. *)
+  run_in_domain (fun () -> spawn_thread_specific_domain_twice 6 0 print_domain)

--- a/testsuite/tests/parallel/test_c_thread_register.reference
+++ b/testsuite/tests/parallel/test_c_thread_register.reference
@@ -1,1 +1,7 @@
-passed
+Thread running in domain 0
+Thread running in domain 0
+Thread running in domain 3
+Failed to register thread in domain 3
+Failed to register thread in domain 6
+Thread running in domain 6
+Failed to register thread in domain 0

--- a/testsuite/tests/parallel/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/parallel/test_c_thread_register_cstubs.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdbool.h>
 #ifdef _WIN32
 #include <windows.h>
 #define THREAD_FUNCTION DWORD WINAPI
@@ -6,12 +7,20 @@
 #include <pthread.h>
 #define THREAD_FUNCTION void *
 #endif
+#include <caml/config.h>
 #include <caml/mlvalues.h>
 #include <caml/gc.h>
 #include <caml/memory.h>
 #include <caml/callback.h>
 #include <caml/threads.h>
 
+typedef struct {
+  value *root;
+  uintnat first_domain_unique_id, second_domain_unique_id;
+  bool specific_domain, register_twice;
+} thread_args;
+
+// Note: We never release this, to keep the test code simple.
 void *create_root(value v)
 {
   value *root = malloc(sizeof(value));
@@ -20,36 +29,83 @@ void *create_root(value v)
   return (void*)root;
 }
 
-value consume_root(void *r)
+value root_value(void *r)
 {
   value *root = (value *)r;
-  value v = *root;
-  caml_remove_generational_global_root(root);
-  free(root);
-  return v;
+  return *root;
 }
 
-THREAD_FUNCTION thread_func(void *root)
+THREAD_FUNCTION thread_func(void *arg)
 {
-  caml_c_thread_register();
+  thread_args *args = (thread_args*)arg;
+
+  if (args->specific_domain) {
+    if (!caml_c_thread_register_in_domain(args->first_domain_unique_id)) {
+      fprintf(stderr, "Failed to register thread in domain %" CAML_PRIuNAT "\n",
+          args->first_domain_unique_id);
+      fflush(stderr);
+      goto end;
+    }
+  } else {
+    caml_c_thread_register();
+  }
+
   caml_acquire_runtime_system();
-  caml_callback(consume_root(root), Val_unit);
+  caml_callback(root_value(args->root), Val_unit);
   caml_release_runtime_system();
   caml_c_thread_unregister();
+
+  if (args->register_twice) {
+    args->register_twice = false;
+    args->first_domain_unique_id = args->second_domain_unique_id;
+    return thread_func(args);
+  }
+
+end:
+  free(args);
   return 0;
 }
 
-value spawn_thread(value clos)
+void spawn_thread_internal(bool specific_domain, uintnat first_domain_unique_id,
+  uintnat second_domain_unique_id, bool register_twice, void *root)
 {
-  void *root = create_root(clos);
+  thread_args *args = (thread_args*)malloc(sizeof(thread_args));
+  args->specific_domain = specific_domain;
+  args->register_twice = register_twice;
+  args->first_domain_unique_id = first_domain_unique_id;
+  args->second_domain_unique_id = second_domain_unique_id;
+  args->root = root;
 #if _WIN32
-  CloseHandle(CreateThread(NULL, 0, &thread_func, root, 0, NULL));
+  CloseHandle(CreateThread(NULL, 0, &thread_func, args, 0, NULL));
 #else
   pthread_t thr;
   pthread_attr_t attr;
   pthread_attr_init(&attr);
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-  pthread_create(&thr, &attr, thread_func, root);
+  pthread_create(&thr, &attr, thread_func, args);
 #endif
-  return Val_unit;
+}
+
+CAMLprim value spawn_thread(value clos)
+{
+  CAMLparam1(clos);
+  spawn_thread_internal(false, 0L, 0L, false, create_root(clos));
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value spawn_thread_specific_domain(value domain_unique_id, value clos)
+{
+  CAMLparam2(domain_unique_id, clos);
+  spawn_thread_internal(true, Long_val(domain_unique_id), 0L, false,
+    create_root(clos));
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value spawn_thread_specific_domain_twice(value first_domain_unique_id,
+  value second_domain_unique_id, value clos)
+{
+  CAMLparam3(first_domain_unique_id, second_domain_unique_id, clos);
+  spawn_thread_internal(true, Long_val(first_domain_unique_id),
+    Long_val(second_domain_unique_id), true, create_root(clos));
+  CAMLreturn(Val_unit);
 }

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -252,6 +252,8 @@ case "$1" in
     esac
     find "../$BUILD_PREFIX-$PORT" -type f \( -name \*.dll -o -name \*.so \) | \
       xargs rebase -i "$ARG"
+    find "../$BUILD_PREFIX-$PORT" -type f \( -name \*.dll -o -name \*.so \) | \
+      xargs ldd
 
     ;;
 esac


### PR DESCRIPTION
The current method for C threads to register themselves to the OCaml runtime is via `caml_c_thread_register` which always registers the thread in domain 0. This PR introduces a new way for C threads to register themselves to the OCaml runtime: `caml_c_thread_register_in_domain`. This function takes a parameter, the domain unique ID, into which the C function would like to register.
The use-case is for systems where C threads are created outside of the OCaml runtime and want to be able to call into OCaml in parallel with other C threads.

It is a requirement that the domain, given by the unique ID, is running when the registration is requested.
