### PR TITLE
Small cleanup in filename.ml

### DIFF
--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -96,8 +96,8 @@ module Unix : SYSDEPS = struct
   let is_relative n = String.length n < 1 || n.[0] <> '/'
   let is_implicit n =
     is_relative n
-    && (String.length n < 2 || String.sub n 0 2 <> "./")
-    && (String.length n < 3 || String.sub n 0 3 <> "../")
+    && not (String.starts_with n ~prefix:"./")
+    && not (String.starts_with n ~prefix:"../")
   let check_suffix name suff =
     String.ends_with ~suffix:suff name
 
@@ -127,10 +127,10 @@ module Win32 : SYSDEPS = struct
     && (String.length n < 2 || n.[1] <> ':')
   let is_implicit n =
     is_relative n
-    && (String.length n < 2 || String.sub n 0 2 <> "./")
-    && (String.length n < 2 || String.sub n 0 2 <> ".\\")
-    && (String.length n < 3 || String.sub n 0 3 <> "../")
-    && (String.length n < 3 || String.sub n 0 3 <> "..\\")
+    && not (String.starts_with n ~prefix:"./")
+    && not (String.starts_with n ~prefix:".\\")
+    && not (String.starts_with n ~prefix:"../")
+    && not (String.starts_with n ~prefix:"..\\")
   let check_suffix filename suffix =
     let len_s = String.length suffix and len_f = String.length filename in
     if len_f >= len_s then

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -78,7 +78,6 @@ module type SYSDEPS = sig
   val is_relative : string -> bool
   val is_implicit : string -> bool
   val check_suffix : string -> string -> bool
-  val chop_suffix_opt : suffix:string -> string -> string option
   val temp_dir_name : string
   val quote : string -> string
   val quote_command :
@@ -101,17 +100,6 @@ module Unix : SYSDEPS = struct
     && (String.length n < 3 || String.sub n 0 3 <> "../")
   let check_suffix name suff =
     String.ends_with ~suffix:suff name
-
-  let chop_suffix_opt ~suffix filename =
-    let len_s = String.length suffix and len_f = String.length filename in
-    if len_f >= len_s then
-      let r = String.sub filename (len_f - len_s) len_s in
-      if r = suffix then
-        Some (String.sub filename 0 (len_f - len_s))
-      else
-        None
-    else
-      None
 
   let temp_dir_name =
     try Sys.getenv "TMPDIR" with Not_found -> "/tmp"
@@ -143,22 +131,13 @@ module Win32 : SYSDEPS = struct
     && (String.length n < 2 || String.sub n 0 2 <> ".\\")
     && (String.length n < 3 || String.sub n 0 3 <> "../")
     && (String.length n < 3 || String.sub n 0 3 <> "..\\")
-  let check_suffix name suff =
-   String.length name >= String.length suff &&
-   (let s = String.sub name (String.length name - String.length suff)
-                            (String.length suff) in
-    String.lowercase_ascii s = String.lowercase_ascii suff)
-
-  let chop_suffix_opt ~suffix filename =
+  let check_suffix filename suffix =
     let len_s = String.length suffix and len_f = String.length filename in
     if len_f >= len_s then
       let r = String.sub filename (len_f - len_s) len_s in
-      if String.lowercase_ascii r = String.lowercase_ascii suffix then
-        Some (String.sub filename 0 (len_f - len_s))
-      else
-        None
+      String.lowercase_ascii r = String.lowercase_ascii suffix
     else
-      None
+      false
 
   external temp_dir_name: unit -> string = "caml_sys_temp_dir_name"
   let temp_dir_name = temp_dir_name ()
@@ -277,7 +256,6 @@ module Cygwin : SYSDEPS = struct
   let is_relative = Win32.is_relative
   let is_implicit = Win32.is_implicit
   let check_suffix = Win32.check_suffix
-  let chop_suffix_opt = Win32.chop_suffix_opt
   let temp_dir_name = Unix.temp_dir_name
   let quote = Unix.quote
   let quote_command = Unix.quote_command
@@ -303,6 +281,11 @@ let chop_suffix name suff =
   if check_suffix name suff
   then String.sub name 0 (String.length name - String.length suff)
   else invalid_arg "Filename.chop_suffix"
+
+let chop_suffix_opt ~suffix name =
+  if check_suffix name suffix
+  then Some (String.sub name 0 (String.length name - String.length suffix))
+  else None
 
 let extension_len name =
   let rec check i0 i =


### PR DESCRIPTION
- implement `Filename.chop_suffix_opt` in term `check_suffix` (like done for `chop_suffix`). This remove some logic duplication with `check_suffix`.
- Use `String.starts_with` to check prefixes instead of using string comparison on a sub-string.  