### PR TITLE
Remove unused variable from fp_backtrace

### DIFF
--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -105,9 +105,8 @@ static void print_symbol(const char* symbol, const regmatch_t* match)
   fflush(stdout);
 }
 
-void fp_backtrace(value argv0)
+void fp_backtrace(CAMLunused value argv0)
 {
-  const char* execname = String_val(argv0);
   const char* symbol = NULL;
 
   for (struct frame_info *fi = __builtin_frame_address(0), *next = NULL;


### PR DESCRIPTION
I did a test build of 5.4.0-rc1 on a Fedora Rawhide machine and saw that 7 tests failed, with messages like this:
```
Running tests from 'tests/frame-pointers' ...
 ... testing 'c_call.ml' => failed
 ... testing 'c_call.ml' with line 2 (frame_pointers) => passed
 ... testing 'c_call.ml' with line 5 (native) => failed (The file /builddir/build/BUILD/ocaml-5.4.0_rc1-build/ocaml-5.4.0-rc1/testsuite/_ocamltest/tests/frame-pointers/c_call/ocamlopt.byte/ocamlopt.byte.output was expected to be empty because there is no reference file /builddir/build/BUILD/ocaml-5.4.0_rc1-build/ocaml-5.4.0-rc1/testsuite/tests/frame-pointers/c_call.compilers.reference but it is not:
========================================
fp_backtrace.c: In function ‘fp_backtrace’:
fp_backtrace.c:110:15: warning: unused variable ‘execname’ [-Wunused-variable]
  110 |   const char* execname = String_val(argv0);
      |               ^~~~~~~~
========================================
)
```

Indeed, `execname` is never used, so this PR removes it and marks the argument as unused.  You may prefer to use `execname` in a log message instead.