### PR TITLE
dsource: preserve (mod) whenever this form is allowed

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,6 +339,10 @@ Working version
 - #14230 : ocamltest fails to link test program with -custom in some cases
   (Damien Doligez, review by David Allsopp)
 
+- #14279: -dsource, preserve (mod) and other escaped infix keyword operators in
+  the printed source wherever possible.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 OCaml 5.4.0
 ---------------
 

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7493,8 +7493,11 @@ let mmod = M.\#mod
 type tmod = M.\#mod
 type tlet = M.\#let
 type ttrue = M.\#true
+type t = { \#mod:int }
+let f ({\#mod=_} as x) = x.\#mod, {\#mod}
+let f x = x#\#mod
 
-class \#mod = object end
+class \#mod = object val mutable \#mod=0  method \#mod = \#mod<- 1; (mod) end
 let f: #M.\#mod -> _ =  new \#mod, new M.\#mod
 
 class type \#mod = object end

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flags="-dsource";
    expect;
 *)
 
@@ -17,13 +18,25 @@ end = struct
 end
 let obj = new M.\#and
 [%%expect{|
+
+module M :
+  sig class \#and : object val  mutable \#and : int method  \#and : int end
+  end =
+  struct
+    class \#and = let \#and = 1 in
+      object val mutable \#and = \#and method \#and = 2 end
+  end ;;
 module M :
   sig class \#and : object val mutable \#and : int method \#and : int end end
+
+let obj = new M.\#and;;
 val obj : M.\#and = <obj>
 |}]
 
 module M : sig type \#and = int end = struct type \#and = string end
 [%%expect{|
+
+module M : sig type \#and = int end = struct type \#and = string end ;;
 Line 1, characters 38-68:
 1 | module M : sig type \#and = int end = struct type \#and = string end
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +55,11 @@ Error: Signature mismatch:
 let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
 let `\#let \#rec = x
 [%%expect{|
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ]);;
 val x : [ `\#let of [ `\#and ] ] = `\#let `\#and
+
+let `\#let \#rec = x;;
 val \#rec : [ `\#and ] = `\#and
 |}]
 
@@ -50,6 +67,8 @@ val \#rec : [ `\#and ] = `\#and
 let f g ~\#let ?\#and ?(\#for = \#and) () =
   g ~\#let ?\#and ()
 [%%expect{|
+
+let f g ~\#let ?\#and ?(\#for= \#and) () = g ~\#let ?\#and ();;
 val f :
   (\#let:'a -> ?\#and:'b -> unit -> 'c) ->
   \#let:'a -> ?\#and:'b -> ?\#for:'b option -> unit -> 'c = <fun>
@@ -58,6 +77,8 @@ val f :
 
 type t = '\#let
 [%%expect{|
+
+type t = '\#let;;
 Line 1, characters 9-15:
 1 | type t = '\#let
              ^^^^^^
@@ -67,19 +88,31 @@ Error: The type variable "'\#let" is unbound in this type declaration.
 type \#mutable = { mutable \#mutable : \#mutable }
 let rec \#rec = { \#mutable = \#rec }
 [%%expect{|
+
+type \#mutable = {
+  mutable \#mutable: \#mutable };;
 type \#mutable = { mutable \#mutable : \#mutable; }
+
+let rec \#rec = { \#mutable = \#rec };;
 val \#rec : \#mutable = {\#mutable = <cycle>}
 |}]
 
 type \#and = ..
 type \#and += Foo
 [%%expect{|
+
+type \#and = ..;;
 type \#and = ..
+
+type \#and +=
+  | Foo ;;
 type \#and += Foo
 |}]
 
 let x = (++);;
 [%%expect{|
+
+let x = (++);;
 Line 1, characters 8-12:
 1 | let x = (++);;
             ^^^^
@@ -88,6 +121,8 @@ Error: Unbound value "(++)"
 
 let x = \#let;;
 [%%expect{|
+
+let x = \#let;;
 Line 1, characters 8-13:
 1 | let x = \#let;;
             ^^^^^
@@ -96,11 +131,15 @@ Error: Unbound value "\#let"
 
 let f ~\#let ?\#and () = 1
 [%%expect{|
+
+let f ~\#let ?\#and () = 1;;
 val f : \#let:'a -> ?\#and:'b -> unit -> int = <fun>
 |}]
 
 let x = (true:int)
 [%%expect {|
+
+let x = (true : int);;
 Line 1, characters 9-13:
 1 | let x = (true:int)
              ^^^^
@@ -111,7 +150,12 @@ Error: This expression should not be a boolean literal, the expected type is
 module M = struct type \#true = true end
 let x = M.(true)
 [%%expect {|
+
+module M = struct type \#true =
+                    | true  end;;
 module M : sig type \#true = true end
+
+let x = let open M in true;;
 val x : M.\#true = M.(true)
 |}]
 
@@ -120,8 +164,17 @@ type u = { \#true:int }
 
 let f { \#false; \#true } = 0
 [%%expect {|
+
+type t = {
+  \#false: int ;
+  x: int };;
 type t = { \#false : int; x : int; }
+
+type u = {
+  \#true: int };;
 type u = { \#true : int; }
+
+let f { \#false; \#true } = 0;;
 Line 4, characters 17-23:
 4 | let f { \#false; \#true } = 0
                      ^^^^^^
@@ -137,16 +190,62 @@ end
 type t = { \#false:int }
 let _ = ( { M.\#true=0 } : t );;
 [%%expect {|
+
+module M =
+  struct type t = {
+           \#true: int ;
+           y: int }
+         type r = {
+           \#true: int ;
+           y: int } end;;
 module M :
   sig
     type t = { \#true : int; y : int; }
     type r = { \#true : int; y : int; }
   end
+
+type t = {
+  \#false: int };;
 type t = { \#false : int; }
+
+let _ = ({ M.\#true = 0 } : t);;
 Line 6, characters 12-20:
 6 | let _ = ( { M.\#true=0 } : t );;
                 ^^^^^^^^
 Error: The field "M.\#true" belongs to one of the following record types:
          "M.r"  "M.t"
        but a field was expected belonging to the record type "t"
+|}]
+
+let f (mod) = (mod)
+type 'a t = { \#mod: 'a}
+let f {\#mod} = (mod)#\#mod;;
+[%%expect {|
+
+let f (mod) = (mod);;
+val f : 'a -> 'a = <fun>
+
+type 'a t = {
+  \#mod: 'a };;
+type 'a t = { \#mod : 'a; }
+
+let f { \#mod } = (mod)#\#mod;;
+val f : < \#mod : 'a; .. > t -> 'a = <fun>
+|}]
+
+class \#mod = object
+  val mutable \#mod = (mod)
+  method \#mod =
+    \#mod <- (mod);
+    {<\#mod = (+) >}
+end;;
+[%%expect {|
+
+class \#mod =
+  object
+    val mutable \#mod = (mod)
+    method \#mod = \#mod <- (mod); {<\#mod = (+)>}
+  end;;
+class \#mod :
+  object ('a) val mutable \#mod : int -> int -> int method \#mod : 'a end
 |}]


### PR DESCRIPTION
This PR tweaks the parsetree pretty printer to make it generate the `(keyword)` form for infix keyword operators like `mod`or  `lsl` rather than `\#keyword` whenever we are in a context where this is allowed.

Beyond the æsthetic improvement, this changes increases the backward compatibility of the pretty printer with older version of the parser.

In particular, this should resolve an update issue for F* which is using recent version of the pretty printers from ppxlib to generate code for older versions of OCaml (https://github.com/ocaml/opam-repository/pull/28610#issuecomment-3362301901).

