### PR TITLE
Bump multicoretests to 0.11 compatible with latest trunk

### DIFF
--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ocaml-multicore/multicoretests
-          ref: 0.10
+          ref: 0.11
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck

--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ocaml-multicore/multicoretests
-          ref: 0.9
+          ref: 0.10
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck


### PR DESCRIPTION
This PR bumps `multicoretests` to 0.10 which is compatible with `trunk` after ocaml/ocaml#14168 
restored `Gc.stat stack_size` from being constant zero ocaml-multicore/multicoretests#567.

The incompatibility has shown up a couple of times as test failures on https://github.com/ocaml/ocaml/pull/13416.

It would be good to add the label `run-multicoretests` for confirmation :slightly_smiling_face: 

(no changes entry needed)