### PR TITLE
Typecheck `x |> f y` as `(f y x)`, not `((f y) x)`

### DIFF
--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -110,11 +110,11 @@ and bar () =
   let x = foo () in
   x |> List.fold_left max 0 x
 [%%expect {|
-Line 4, characters 7-29:
+Line 4, characters 26-27:
 4 |   x |> List.fold_left max 0 x
-           ^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "int"
-       This is not a function; it cannot be applied.
+                              ^
+Error: The constant "0" has type "int" but an expression was expected of type
+         "'a -> 'b"
 |}]
 
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3865,6 +3865,40 @@ type 'ret constraint_arg =
     (** Whether the thing being constrained is a [Val_self] ident. *)
   }
 
+(* Typecheck [y |> f x] and [f x @@ y] as [f x y], rather than [(f x) y]. *)
+let flatten_application_operator type_exp env lower_args funct sargs =
+  let type_sfunct sfunct =
+    let funct =
+      with_local_level_generalize_structure_if_principal
+        (fun () -> type_exp env sfunct)
+    in
+    let ty = instance funct.exp_type in
+    wrap_trace_gadt_instances env (lower_args TypeSet.empty) ty;
+    funct
+  in
+  let type_sfunct_args sfunct extra_args =
+    match sfunct.pexp_desc with
+    | Pexp_apply (sfunct, args) ->
+       type_sfunct sfunct, args @ extra_args
+    | _ ->
+       type_sfunct sfunct, extra_args
+  in
+  let funct = type_sfunct funct in
+  match funct.exp_desc, sargs with
+  | Texp_ident (_, _,
+                {val_kind = Val_prim {prim_name="%revapply"}; val_type}),
+    [Nolabel, sarg; Nolabel, actual_sfunct]
+    when is_inferred actual_sfunct
+      && check_apply_prim_type Revapply val_type ->
+      type_sfunct_args actual_sfunct [Nolabel, sarg]
+  | Texp_ident (_, _,
+                {val_kind = Val_prim {prim_name="%apply"}; val_type}),
+    [Nolabel, actual_sfunct; Nolabel, sarg]
+    when check_apply_prim_type Apply val_type ->
+      type_sfunct_args actual_sfunct [Nolabel, sarg]
+  | _ ->
+      funct, sargs
+
 let rec type_exp ?recarg env sexp =
   (* We now delegate everything to type_expect *)
   type_expect ?recarg env sexp (mk_expected (newvar ()))
@@ -4144,38 +4178,8 @@ and type_expect_
       in
       (* one more level for warning on non-returning functions *)
       with_local_level_generalize begin fun () ->
-      let type_sfunct sfunct =
-        let funct =
-          with_local_level_generalize_structure_if_principal
-            (fun () -> type_exp env sfunct)
-        in
-        let ty = instance funct.exp_type in
-        wrap_trace_gadt_instances env (lower_args TypeSet.empty) ty;
-        funct
-      in
-      let type_sfunct_args sfunct extra_args =
-        match sfunct.pexp_desc with
-        | Pexp_apply (sfunct, args) ->
-           type_sfunct sfunct, args @ extra_args
-        | _ ->
-           type_sfunct sfunct, extra_args
-      in
       let funct, sargs =
-        let funct = type_sfunct sfunct in
-        match funct.exp_desc, sargs with
-        | Texp_ident (_, _,
-                      {val_kind = Val_prim {prim_name="%revapply"}; val_type}),
-          [Nolabel, sarg; Nolabel, actual_sfunct]
-          when is_inferred actual_sfunct
-            && check_apply_prim_type Revapply val_type ->
-            type_sfunct_args actual_sfunct [Nolabel, sarg]
-        | Texp_ident (_, _,
-                      {val_kind = Val_prim {prim_name="%apply"}; val_type}),
-          [Nolabel, actual_sfunct; Nolabel, sarg]
-          when check_apply_prim_type Apply val_type ->
-            type_sfunct_args actual_sfunct [Nolabel, sarg]
-        | _ ->
-            funct, sargs
+        flatten_application_operator type_exp env lower_args sfunct sargs
       in
       let (args, ty_res) = type_application env loc funct sargs in
       rue {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4153,6 +4153,13 @@ and type_expect_
         wrap_trace_gadt_instances env (lower_args TypeSet.empty) ty;
         funct
       in
+      let type_sfunct_args sfunct extra_args =
+        match sfunct.pexp_desc with
+        | Pexp_apply (sfunct, args) ->
+           type_sfunct sfunct, args @ extra_args
+        | _ ->
+           type_sfunct sfunct, extra_args
+      in
       let funct, sargs =
         let funct = type_sfunct sfunct in
         match funct.exp_desc, sargs with
@@ -4161,12 +4168,12 @@ and type_expect_
           [Nolabel, sarg; Nolabel, actual_sfunct]
           when is_inferred actual_sfunct
             && check_apply_prim_type Revapply val_type ->
-            type_sfunct actual_sfunct, [Nolabel, sarg]
+            type_sfunct_args actual_sfunct [Nolabel, sarg]
         | Texp_ident (_, _,
                       {val_kind = Val_prim {prim_name="%apply"}; val_type}),
           [Nolabel, actual_sfunct; Nolabel, sarg]
           when check_apply_prim_type Apply val_type ->
-            type_sfunct actual_sfunct, [Nolabel, sarg]
+            type_sfunct_args actual_sfunct [Nolabel, sarg]
         | _ ->
             funct, sargs
       in


### PR DESCRIPTION
This is a change by @stedolan in the https://github.com/oxcaml/oxcaml repository. Conflict of interest note: I’m opening this as part of a Jane Street / Tarides contract.

There are two reasons for this change:

- compatibility: currently, some bits of code typecheck in OxCaml but give an error in upstream due to this difference, despite not using any OxCaml features. (Unfortunately @stedolan could not retrace what the incompatibility was; but it has appeared during Jane Street’s public release process at least once.) This problem would no longer appear if upstream and OxCaml were to agree on how this should be typed.
- performance: if optionals / labelled args are in use, the upstream version will introduce extra closure allocations in some cases that OxCaml avoids. Example:

```ocaml
let f ?(x=1) ~y z = x+y+z
let g () = 42 |> f ~y:1
```

OxCaml gets `g` down to a constant but upstream (tested on 5.2.0) has a remaining closure allocation.