### PR TITLE
Stdlib: make the Hashtbl per default seeded, unless OCAMLRUNPARAM includes "R=0"

### DIFF
--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stdbool.h>
+
 #include "misc.h"
 
 CAMLextern atomic_uintnat caml_max_stack_wsize;
@@ -28,6 +30,7 @@ void caml_init_gc (void);
 value caml_gc_stat(value);
 value caml_gc_major(value);
 
+extern atomic_bool caml_runtime_randomized;
 
 #define caml_stat_top_heap_wsz caml_top_heap_words(Caml_state->shared_heap)
 #define caml_stat_compactions 0

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -18,8 +18,6 @@
 
 #ifdef CAML_INTERNALS
 
-#include <stdbool.h>
-
 #include "misc.h"
 
 CAMLextern atomic_uintnat caml_max_stack_wsize;

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -28,7 +28,7 @@ void caml_init_gc (void);
 value caml_gc_stat(value);
 value caml_gc_major(value);
 
-extern atomic_bool caml_runtime_randomized;
+extern atomic_bool caml_runtime_hashtbl_randomized;
 
 #define caml_stat_top_heap_wsz caml_top_heap_words(Caml_state->shared_heap)
 #define caml_stat_compactions 0

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -372,6 +372,19 @@ CAMLprim value caml_runtime_variant (value unit)
 #endif
 }
 
+atomic_bool caml_runtime_randomized = false;
+
+CAMLprim value caml_runtime_randomize(value vunit)
+{
+  caml_runtime_randomized = true;
+  return Val_unit;
+}
+
+CAMLprim value caml_runtime_is_randomized(value vunit)
+{
+  return Val_bool(caml_runtime_randomized);
+}
+
 CAMLprim value caml_runtime_parameters (value unit)
 {
 #define F_Z CAML_PRIuNAT
@@ -380,7 +393,7 @@ CAMLprim value caml_runtime_parameters (value unit)
   CAMLassert (unit == Val_unit);
   return caml_alloc_sprintf
       ("b=%d,c=%"F_Z",e=%"F_Z",l=%"F_Z",M=%"F_Z",m=%"F_Z",n=%"F_Z","
-       "o=%"F_Z",p=%d,s=%"F_S",t=%"F_Z",v=%"F_Z",V=%"F_Z",W=%"F_Z"",
+       "o=%"F_Z",p=%d,R=%u,s=%"F_S",t=%"F_Z",v=%"F_Z",V=%"F_Z",W=%"F_Z"",
        /* b */ (int) Caml_state->backtrace_active,
        /* c */ caml_params->cleanup_on_exit,
        /* e */ caml_params->runtime_events_log_wsize,
@@ -390,7 +403,7 @@ CAMLprim value caml_runtime_parameters (value unit)
        /* n */ caml_custom_minor_max_bsz,
        /* o */ caml_percent_free,
        /* p */ Caml_state->parser_trace,
-       /* R */ /* missing */
+       /* R */ caml_runtime_randomized,
        /* s */ Caml_state->minor_heap_wsz,
        /* t */ caml_params->trace_level,
        /* v */ caml_verb_gc,

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -372,7 +372,7 @@ CAMLprim value caml_runtime_variant (value unit)
 #endif
 }
 
-atomic_bool caml_runtime_hashtbl_randomized = false;
+atomic_bool caml_runtime_hashtbl_randomized = true;
 
 CAMLprim value caml_runtime_hashtbl_randomize(value vunit)
 {

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -372,17 +372,17 @@ CAMLprim value caml_runtime_variant (value unit)
 #endif
 }
 
-atomic_bool caml_runtime_randomized = false;
+atomic_bool caml_runtime_hashtbl_randomized = false;
 
-CAMLprim value caml_runtime_randomize(value vunit)
+CAMLprim value caml_runtime_hashtbl_randomize(value vunit)
 {
-  caml_runtime_randomized = true;
+  caml_runtime_hashtbl_randomized = true;
   return Val_unit;
 }
 
-CAMLprim value caml_runtime_is_randomized(value vunit)
+CAMLprim value caml_runtime_hashtbl_is_randomized(value vunit)
 {
-  return Val_bool(caml_runtime_randomized);
+  return Val_bool(caml_runtime_hashtbl_randomized);
 }
 
 CAMLprim value caml_runtime_parameters (value unit)
@@ -403,7 +403,7 @@ CAMLprim value caml_runtime_parameters (value unit)
        /* n */ caml_custom_minor_max_bsz,
        /* o */ caml_percent_free,
        /* p */ Caml_state->parser_trace,
-       /* R */ caml_runtime_randomized,
+       /* R */ caml_runtime_hashtbl_randomized,
        /* s */ Caml_state->minor_heap_wsz,
        /* t */ caml_params->trace_level,
        /* v */ caml_verb_gc,

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -113,7 +113,7 @@ void caml_parse_ocamlrunparam(void)
       case 'p': scanmult (opt, &params.parser_trace); break;
       case 'R':
         scanmult (opt, &val);
-        caml_runtime_randomized = !!val;
+        caml_runtime_hashtbl_randomized = !!val;
         break;
       case 's': scanmult (opt, &params.init_minor_heap_wsz); break;
       case 't': scanmult (opt, &params.trace_level); break;
@@ -140,6 +140,7 @@ void caml_parse_ocamlrunparam(void)
                      "The maximum value is %d.", Max_domains_max);
   }
 }
+
 
 /* The number of outstanding calls to caml_startup */
 static int startup_count = 0;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -27,12 +27,14 @@
 #ifndef NATIVE_CODE
 #include "caml/dynlink.h"
 #endif
+#include "caml/gc_ctrl.h"
 #include "caml/gc_stats.h"
 #include "caml/osdeps.h"
 #include "caml/shared_heap.h"
 #include "caml/startup_aux.h"
 #include "caml/prims.h"
 #include "caml/signals.h"
+#include "caml/platform.h"
 
 #ifdef _WIN32
 extern void caml_win32_unregister_overflow_detection (void);
@@ -109,7 +111,10 @@ void caml_parse_ocamlrunparam(void)
       case 'n': scanmult (opt, &params.init_custom_minor_max_bsz); break;
       case 'o': scanmult (opt, &params.init_percent_free); break;
       case 'p': scanmult (opt, &params.parser_trace); break;
-      case 'R': break; /*  see stdlib/hashtbl.mli */
+      case 'R':
+        scanmult (opt, &val);
+        caml_runtime_randomized = !!val;
+        break;
       case 's': scanmult (opt, &params.init_minor_heap_wsz); break;
       case 't': scanmult (opt, &params.trace_level); break;
       case 'v':
@@ -135,7 +140,6 @@ void caml_parse_ocamlrunparam(void)
                      "The maximum value is %d.", Max_domains_max);
   }
 }
-
 
 /* The number of outstanding calls to caml_startup */
 static int startup_count = 0;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -34,7 +34,6 @@
 #include "caml/startup_aux.h"
 #include "caml/prims.h"
 #include "caml/signals.h"
-#include "caml/platform.h"
 
 #ifdef _WIN32
 extern void caml_win32_unregister_overflow_detection (void);

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -403,7 +403,6 @@ stdlib__Gc.cmi : gc.mli \
     stdlib__Printexc.cmi
 stdlib__Hashtbl.cmo : hashtbl.ml \
     stdlib__Sys.cmi \
-    stdlib__String.cmi \
     stdlib__Seq.cmi \
     stdlib__Random.cmi \
     stdlib__Obj.cmi \
@@ -414,7 +413,6 @@ stdlib__Hashtbl.cmo : hashtbl.ml \
     stdlib__Hashtbl.cmi
 stdlib__Hashtbl.cmx : hashtbl.ml \
     stdlib__Sys.cmx \
-    stdlib__String.cmx \
     stdlib__Seq.cmx \
     stdlib__Random.cmx \
     stdlib__Obj.cmx \

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -46,15 +46,24 @@ let flip_ongoing_traversal h =
 
 (* To pick random seeds if requested *)
 
-let randomized_default =
-  let params =
-    try Sys.getenv "OCAMLRUNPARAM" with Not_found ->
-    try Sys.getenv "CAMLRUNPARAM" with Not_found -> "" in
-  String.contains params 'R'
+(* The runtime stores the initial value of "R" in caml_runtime_randomized. We
+   choose to copy this initial value here and then keep then in sync in order to
+   avoid adding a C call to every call to Hashtbl.create. *)
+external randomized : unit -> bool = "caml_runtime_is_randomized" [@@noalloc]
+let randomized = Atomic.make (randomized ())
 
-let randomized = Atomic.make randomized_default
+external randomize : unit -> unit = "caml_runtime_randomize" [@@noalloc]
+let randomize () =
+  Atomic.set randomized true;
+  (* Update the runtime's value so that the result from Sys.runtime_parameters
+     includes "R". There is technically a race here where Hashtbl.create ()
+     creates randomized hash tables, but Sys.runtime_parameters doesn't yet
+     return R=1. We choose not to care - Hashtbl.is_randomized will always
+     return the correct value, and making Sys.runtime_parameters always be in
+     sync would either add a C call to every Hashtbl.create call or would
+     introduce a complicated dependency cycle between Sys and Hashtbl *)
+  randomize ()
 
-let randomize () = Atomic.set randomized true
 let is_randomized () = Atomic.get randomized
 
 let prng_key = Domain.DLS.new_key Random.State.make_self_init

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -46,13 +46,15 @@ let flip_ongoing_traversal h =
 
 (* To pick random seeds if requested *)
 
-(* The runtime stores the initial value of "R" in caml_runtime_randomized. We
-   choose to copy this initial value here and then keep then in sync in order to
-   avoid adding a C call to every call to Hashtbl.create. *)
-external randomized : unit -> bool = "caml_runtime_is_randomized" [@@noalloc]
+(* The runtime stores the initial value of "R" in
+   caml_runtime_hashtbl_randomized. We choose to copy this initial value here
+   and then keep then in sync in order to avoid adding a C call to every call to
+   Hashtbl.create. *)
+external randomized : unit -> bool =
+  "caml_runtime_hashtbl_is_randomized" [@@noalloc]
 let randomized = Atomic.make (randomized ())
 
-external randomize : unit -> unit = "caml_runtime_randomize" [@@noalloc]
+external randomize : unit -> unit = "caml_runtime_hashtbl_randomize" [@@noalloc]
 let randomize () =
   Atomic.set randomized true;
   (* Update the runtime's value so that the result from Sys.runtime_parameters

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -95,12 +95,13 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    different orders at different runs of the program.
 
    If no [~random] parameter is given, hash tables are created
-   in non-random mode by default.  This default can be changed
-   either programmatically by calling {!randomize} or by
-   setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
+   in random mode by default.  This default can be changed by
+   setting the [R=0] flag in the [OCAMLRUNPARAM] environment variable.
 
    @before 4.00 the [~random] parameter was not present and all
-   hash tables were created in non-randomized mode. *)
+    hash tables were created in non-randomized mode.
+
+   @before 5.5 the default was to create deterministic hash tables. *)
 
 val clear : ('a, 'b) t -> unit
 (** Empty a hash table. Use [reset] instead of [clear] to shrink the

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -99,7 +99,7 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    setting the [R=0] flag in the [OCAMLRUNPARAM] environment variable.
 
    @before 4.00 the [~random] parameter was not present and all
-    hash tables were created in non-randomized mode.
+   hash tables were created in non-randomized mode.
 
    @before 5.5 the default was to create deterministic hash tables. *)
 

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -112,12 +112,13 @@ module Hashtbl : sig
      different orders at different runs of the program.
 
      If no [~random] parameter is given, hash tables are created
-     in non-random mode by default.  This default can be changed
-     either programmatically by calling {!randomize} or by
-     setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
+     in random mode by default.  This default can be changed by
+     setting the [R=0] flag in the [OCAMLRUNPARAM] environment variable.
 
      @before 4.00 the [~random] parameter was not present and all
-     hash tables were created in non-randomized mode. *)
+     hash tables were created in non-randomized mode.
+
+     @before 5.5 the default was to create deterministic hash tables. *)
 
   val clear : ('a, 'b) t -> unit
   (** Empty a hash table. Use [reset] instead of [clear] to shrink the

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -95,12 +95,13 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    different orders at different runs of the program.
 
    If no [~random] parameter is given, hash tables are created
-   in non-random mode by default.  This default can be changed
-   either programmatically by calling {!randomize} or by
-   setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
+   in random mode by default.  This default can be changed by
+   setting the [R=0] flag in the [OCAMLRUNPARAM] environment variable.
 
    @before 4.00 the [~random] parameter was not present and all
-   hash tables were created in non-randomized mode. *)
+   hash tables were created in non-randomized mode.
+
+   @before 5.5 the default was to create deterministic hash tables. *)
 
 val clear : ('a, 'b) t -> unit
 (** Empty a hash table. Use [reset] instead of [clear] to shrink the

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 584, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 593, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 584, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 593, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.do_force_block.(fun) in file "camlinternalLazy.ml", line 54, characters 43-50
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 593, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 595, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 593, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 595, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.do_force_block.(fun) in file "camlinternalLazy.ml", line 54, characters 43-50
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27

--- a/testsuite/tools/testLinkModes.ml
+++ b/testsuite/tools/testLinkModes.ml
@@ -557,7 +557,7 @@ let compile_test usr_bin_sh config env test test_program description =
           test_program_path
       in
       let with_unix = (Config.supports_shared_libraries || not tendered) in
-      let is_randomized = false in
+      let is_randomized = true in
       let verbose = Environment.verbose env in
       write_test_program ~verbose ~is_randomized ~with_unix description;
       let options =


### PR DESCRIPTION
The compiler requires deterministic hashtable; Consistbl passes ~random:false

As discussed on the OCaml office hours today. This PR needs:
- [x] documentation updates
- [ ] further testing about the breakage in opam packages (there's tooling for that, but I don't know how to use / whom to ask)

Of course, further work may include to dig deeper into why the OCaml compiler requires deterministic hash tables and remove this requirement (by applying a sort before serializing/hashing).

This is meant for early reviews, whether the direction is the right one, or whether there are opinions that this shouldn't be done at all, ever.