### PR TITLE
Improve doc of Runtime_events.Timestamp

### DIFF
--- a/Changes
+++ b/Changes
@@ -193,6 +193,8 @@ Working version
 
 ### Manual and documentation:
 
+- #14293: Improve documentation of Runtime_events.Timestamp (Raphaël Proust)
+
 - #13747: Document support for native debugging with GDB and LLDB.
    (Tim McGilchrist, review by Daniel Bünzli, Samuel Hym, Olivier Nicole
    and Antonin Décimo)

--- a/Changes
+++ b/Changes
@@ -193,7 +193,8 @@ Working version
 
 ### Manual and documentation:
 
-- #14293: Improve documentation of Runtime_events.Timestamp (Raphaël Proust)
+- #14293: Improve documentation of Runtime_events.Timestamp (Raphaël Proust,
+  review by Gabriel Scherer)
 
 - #13747: Document support for native debugging with GDB and LLDB.
    (Tim McGilchrist, review by Daniel Bünzli, Samuel Hym, Olivier Nicole

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -534,9 +534,15 @@ module Timestamp : sig
     (** Abstract timestamp included in events. *)
 
     val to_int64 : t -> int64
-    (** Convert a timestamp to a number of nanosecond. The starting point for
-        timestamps in unspecified but the difference between two timestamps is
-        the number of nanoseconds ellapsed between them. *)
+    (** Convert a timestamp to a number of nanosecond.
+
+        Note that the starting point for timestamps in unspecified: the absolute
+        value is meaningless, only differences matter.
+
+        Also note that the precision of the underlying clock may be coarser than
+        nanoseconds: events may have equal timestamp if they are emitted within
+        the coarseness of the clock. Thus the differences only matter to a
+        point. *)
 
     val get_current : unit -> t
     (** Access the current timestamp.

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -541,8 +541,7 @@ module Timestamp : sig
 
         Also note that the precision of the underlying clock may be coarser than
         nanoseconds: events may have equal timestamp if they are emitted within
-        the coarseness of the clock. Thus the differences only matter to a
-        point. *)
+        the coarseness of the clock. *)
 
     val get_current : unit -> t
     (** Access the current timestamp.

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -531,13 +531,15 @@ type cursor
 
 module Timestamp : sig
     type t
-    (** Type for the int64 timestamp to allow for future changes. *)
+    (** Abstract timestamp included in events. *)
 
     val to_int64 : t -> int64
+    (** Convert a timestamp to a number of nanosecond. The starting point for
+        timestamps in unspecified but the difference between two timestamps is
+        the number of nanoseconds ellapsed between them. *)
 
     val get_current : unit -> t
-    (** Access the current timestamp. The timestamp is incremented by one
-        every nanosecond, but the starting point is unspecified.
+    (** Access the current timestamp.
         @since 5.4 *)
 end
 


### PR DESCRIPTION
Small improvements to the documentation of `Runtime_events.Timestamp`:

- remove reference to implementation details in the documentation of `t`
- document that `to_int64` is in nanoseconds
- move documentation about absolute and relative meanings of timestamp from `get_current` into `to_int64`