### PR TITLE
Less committal documentation of the constraint for `caml_thread_register_in_domain`

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2623,9 +2623,10 @@ already-registered thread does nothing and returns 0.
 calling thread with the OCaml run-time system in the domain with
 identifier "dom_unique_id" as provided by "Domain.self" and "Domain.get_id".
 The domain must be running when this function is called.  Registering an
-already-registered thread does nothing and returns 0, even if it was previously
-registered in another domain. It is an error to register in one domain,
-unregister, and then later register in another domain.
+already-registered thread does nothing and returns 0, even if it was
+previously registered in another domain. Registering a thread in one
+domain, unregistering it, and then registering it later in a different
+domain is not supported.
 \item
 "caml_c_thread_unregister()"  must be called before the thread
   terminates, to unregister it from the OCaml run-time system.

--- a/otherlibs/systhreads/caml/threads.h
+++ b/otherlibs/systhreads/caml/threads.h
@@ -66,10 +66,8 @@ CAMLextern int caml_c_thread_unregister(void);
    Both functions return 1 on success, 0 on error.
    Threads registered by [caml_c_thread_register_in_domain] belong to
    the domain given by the unique id which must be running when calling this
-   function. It is an error to call [caml_c_thread_unregister] on a
-   thread registered in a domain and later call
-   [caml_c_thread_register_in_domain] to register it with a different
-   domain.
+   function. After a call to [caml_c_thread_unregister], it is unsupported to
+   call [caml_c_thread_register_in_domain] with a different domain.
    The function [caml_c_thread_register] is an alias for
    [caml_c_thread_register_in_domain(0)] (where 0 is the identifier
    of the main domain).

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -861,9 +861,9 @@ int caml_c_thread_register_in_domain_index(uintnat domain_index,
   /* Check that domain unique ID is as expected:
      - We got the domain we requested (given the inherently racy
        nature of [caml_find_index_of_running_domain]).
-     - We were not previously registered on a different domain (to
-       allow C programs to store domain-specific data in thread-local
-       storage) */
+     - We were not previously registered on a different domain (for
+       programs that currently store domain-specific data in
+       thread-local storage). */
   if (!caml_thread_running_on_expected_domain(expected_unique_id)) goto out_err;
 
   /* Create tick thread if not already done */


### PR DESCRIPTION
The implementation of `caml_thread_register_in_domain` (#14275) includes the following constraint:
- After a call to `caml_c_thread_unregister`, calling `caml_c_thread_register_in_domain` with a different domain is an error.

As explained in #14275, this allows users to use implicit TLS to implement an efficient DLS.

This PR amends the text to leave the door open to a removal of this constraint in the future should someone have a good motivation.

During a discussion with @gasche, we disagreed whether the current documentation committed to support the DLS-over-TLS pattern. We agreed to rephrase it to be less committal, and to then leave things as they are until someone has a good motivation to remove the constraint. Supporting efficient DLS without this constraint requires something like hooks in `caml_thread_unregister` whose complexity is currently unjustified.