### PR TITLE
Make the type checker more deterministic

### DIFF
--- a/.depend
+++ b/.depend
@@ -2215,6 +2215,7 @@ typing/typetexp.cmo : \
     parsing/parsetree.cmi \
     typing/out_type.cmi \
     typing/oprint.cmi \
+    utils/numbers.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
@@ -2239,6 +2240,7 @@ typing/typetexp.cmx : \
     parsing/parsetree.cmi \
     typing/out_type.cmx \
     typing/oprint.cmx \
+    utils/numbers.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \

--- a/Changes
+++ b/Changes
@@ -328,6 +328,9 @@ Working version
 - #13913: Use Blake128 as the hash function for the compiler's CRCs
   (Vincent Laviron, review by Xavier Leroy and Gabriel Scherer)
 
+- #14297: Avoid iterating on hash tables to produce types
+  (Vincent Laviron, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/testsuite/tests/typing-recmod/t08bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t08bad.compilers.reference
@@ -5,8 +5,8 @@ Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t
        but it is used as
-         'a array A.t
+         'a list A.t
        after the following expansion(s):
-         < m : 'a list B.t; n : 'a array B.t > contains 'a array B.t,
-         'a array B.t = 'a array A.t
+         < m : 'a list B.t; n : 'a array B.t > contains 'a list B.t,
+         'a list B.t = 'a list A.t
        All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t09bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t09bad.compilers.reference
@@ -5,8 +5,8 @@ Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t
        but it is used as
-         'a array A.t
+         'a list A.t
        after the following expansion(s):
          'a B.t = < m : 'a list A.t; n : 'a array A.t >,
-         < m : 'a list A.t; n : 'a array A.t > contains 'a array A.t
+         < m : 'a list A.t; n : 'a array A.t > contains 'a list A.t
        All uses need to match the definition for the recursive type to be regular.

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -586,6 +586,8 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let mkfield l f =
         newty (Tvariant (create_row ~fields:[l,f] ~more:(newvar())
                            ~closed:true ~fixed:None ~name:None)) in
+      (* Using a reference to a map rather than a hash table gives us
+         a canonical order when iterating. *)
       let module HMap = Numbers.Int.Map in
       let hfields = ref HMap.empty in
       let add_typed_field loc l f =
@@ -724,6 +726,8 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
 and transl_fields env ~policy ~row_context o fields =
+  (* Using a reference to a map rather than a hash table gives us
+     a canonical order when iterating. *)
   let module HMap = Misc.Stdlib.String.Map in
   let hfields = ref HMap.empty in
   let add_typed_field loc l ty =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -586,11 +586,12 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let mkfield l f =
         newty (Tvariant (create_row ~fields:[l,f] ~more:(newvar())
                            ~closed:true ~fixed:None ~name:None)) in
-      let hfields = Hashtbl.create ~random:false 17 in
+      let module HMap = Numbers.Int.Map in
+      let hfields = ref HMap.empty in
       let add_typed_field loc l f =
         let h = Btype.hash_variant l in
         try
-          let (l',f') = Hashtbl.find hfields h in
+          let (l',f') = HMap.find h !hfields in
           (* Check for tag conflicts *)
           if l <> l' then raise(Error(styp.ptyp_loc, env, Variant_tags(l, l')));
           let ty = mkfield l f and ty' = mkfield l f' in
@@ -599,7 +600,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
           with Unify _trace ->
             raise(Error(loc, env, Constructor_mismatch (ty,ty')))
         with Not_found ->
-          Hashtbl.add hfields h (l,f)
+          hfields := HMap.add h (l, f) !hfields
       in
       let add_field row_context field =
         let rf_loc = field.prf_loc in
@@ -632,7 +633,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
                 Tconstr(p, tl, _) -> Some(p, tl)
               | _                 -> None
             in
-            name := if Hashtbl.length hfields <> 0 then None else nm;
+            name := if HMap.is_empty !hfields then nm else None;
             let fl = match get_desc (expand_head env cty.ctyp_type), nm with
               Tvariant row, _ when Btype.static_row row ->
                 row_fields row
@@ -662,7 +663,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         if aliased then row_context else more_slot :: row_context
       in
       let tfields = List.map (add_field row_context) fields in
-      let fields = List.rev (Hashtbl.fold (fun _ p l -> p :: l) hfields []) in
+      let fields = HMap.fold (fun _ p l -> p :: l) !hfields [] in
       begin match present with None -> ()
       | Some present ->
           List.iter
@@ -723,16 +724,17 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
 and transl_fields env ~policy ~row_context o fields =
-  let hfields = Hashtbl.create ~random:false 17 in
+  let module HMap = Misc.Stdlib.String.Map in
+  let hfields = ref HMap.empty in
   let add_typed_field loc l ty =
     try
-      let ty' = Hashtbl.find hfields l in
+      let ty' = HMap.find l !hfields in
       if is_equal env false [ty] [ty'] then () else
         try unify env ty ty'
         with Unify _trace ->
           raise(Error(loc, env, Method_mismatch (l, ty, ty')))
     with Not_found ->
-      Hashtbl.add hfields l ty in
+      hfields := HMap.add l ty !hfields in
   let add_field {pof_desc; pof_loc; pof_attributes;} =
     let of_loc = pof_loc in
     let of_attributes = pof_attributes in
@@ -778,7 +780,7 @@ and transl_fields env ~policy ~row_context o fields =
     { of_desc; of_loc; of_attributes; }
   in
   let object_fields = List.map add_field fields in
-  let fields = Hashtbl.fold (fun s ty l -> (s, ty) :: l) hfields [] in
+  let fields = HMap.fold (fun s ty l -> (s, ty) :: l) !hfields [] in
   let ty_init =
      match o with
      | Closed -> newty Tnil

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -586,7 +586,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let mkfield l f =
         newty (Tvariant (create_row ~fields:[l,f] ~more:(newvar())
                            ~closed:true ~fixed:None ~name:None)) in
-      let hfields = Hashtbl.create 17 in
+      let hfields = Hashtbl.create ~random:false 17 in
       let add_typed_field loc l f =
         let h = Btype.hash_variant l in
         try
@@ -723,7 +723,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
 and transl_fields env ~policy ~row_context o fields =
-  let hfields = Hashtbl.create 17 in
+  let hfields = Hashtbl.create ~random:false 17 in
   let add_typed_field loc l ty =
     try
       let ty' = Hashtbl.find hfields l in


### PR DESCRIPTION
Follows from the discussion at #14291.

The first commit implements the simple fix: ensure the hash tables are not randomized.
The second commit implements a suggestion by @gasche (using maps instead of hash tables).
Note that the second commit removes a `List.rev` in the polymorphic variant case (this magically makes the order the same as the boot compiler on the single polymorphic variant type of the standard library, so no bootstrap is required), and introducing a `List.rev` in the object case would avoid the need for promoting the testsuite (but I prefer updating the testsuite in this case).
