### PR TITLE
Translobj: ensure consistent order for placing shared constants

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,7 +328,7 @@ Working version
 - #13913: Use Blake128 as the hash function for the compiler's CRCs
   (Vincent Laviron, review by Xavier Leroy and Gabriel Scherer)
 
-- #14297: Avoid iterating on hash tables to produce types
+- #14297, #14299: Avoid iterating on hash tables to produce types or terms
   (Vincent Laviron, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 ### Build system:

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -89,10 +89,17 @@ let prim_makearray =
 (* Also use it for required globals *)
 let transl_label_init_general f =
   let expr = f () in
-  let expr =
+  (* We go through a Map first to ensure that the bindings are placed
+     in an order that doesn't depend on the hash table iteration order *)
+  let all_consts =
     Hashtbl.fold
-      (fun c id expr -> Llet(Alias, Pgenval, id, Lconst c, expr))
-      consts expr
+      (fun c id all_consts -> Ident.Map.add id c all_consts)
+      consts Ident.Map.empty
+  in
+  let expr =
+    Ident.Map.fold
+      (fun id c expr -> Llet(Alias, Pgenval, id, Lconst c, expr))
+      all_consts expr
   in
   (*let expr =
     List.fold_right


### PR DESCRIPTION
With randomized hash tables, placement of constants could vary from one compilation to the other, leading to non-reproducible builds (see #14291).
This PR first builds a map (indexed by the `Ident.t` for the constants), and places the constants by iterating on the map.