### PR TITLE
Disable flaky test under TSan (see #14300)

### DIFF
--- a/testsuite/tests/statmemprof/restart.ml
+++ b/testsuite/tests/statmemprof/restart.ml
@@ -1,4 +1,13 @@
-(* TEST *)
+(* TEST
+ no-tsan; (* (Probably spurious) TSan alarm on this test, see
+              https://github.com/ocaml/ocaml/issues/14300 *)
+ {
+   bytecode;
+ }
+ {
+   native;
+ }
+*)
 
 module M = Gc.Memprof
 


### PR DESCRIPTION
The goal of this is to disable a test in the TSan CI. The alarm is tracked by #14300. It seems legit to do this because the alarm seems niche and minor.