### PR TITLE
domain.c: terminate_backup_thread must synchronize with the backup thread

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1242,7 +1242,9 @@ static void terminate_backup_thread(dom_internal *di)
   if (backup_thread_running(di)) {
     atomic_store_release(&di->backup_thread_msg, BT_TERMINATE);
     /* Wakeup backup thread if it is sleeping */
+    caml_plat_lock_blocking(&di->interruptor.lock);
     caml_plat_broadcast(&di->interruptor.cond);
+    caml_plat_unlock(&di->interruptor.lock);
     caml_plat_signal(&di->domain_cond);
   }
 }


### PR DESCRIPTION
(See #14300: this PR is trying to fix an issue noticed by @OlivierNicole on the TSan CI. Note that the TSan CI failure may be caused by some other problem, but the code might still be worth fixing if the reasoning below is correct.)

`terminate_backup_thread` signals the `domain_cond` condition variable while holding the domain lock, but it also broadcasts on the interruptor's condition variable *without* holding its domain lock. If the backup thread is in the state BT_IN_BLOCKING_SECTION, it waits on the interruptor condition variable, and we want it to synchronize with `terminate_backup_thread`, so that it does see the write to BT_TERMINATE.

To guarantee that the broadcast/wait is synchronizing, we tweak `terminate_backup_thread` to temporarily take the interruptor's lock when broadcasting on its condition variable.