### PR TITLE
runtime/memprof.c: store configuration fields on the major heap

### DIFF
--- a/Changes
+++ b/Changes
@@ -359,6 +359,10 @@ Working version
   the printed source wherever possible.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14300, #14304: fix a race between memprof and the minor GC, detected by TSan
+  (Gabriel Scherer, review by Stephen Dolan and Nick Barnes,
+   report by Olivier Nicole)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -2213,7 +2213,7 @@ CAMLexport void caml_memprof_enter_thread(memprof_thread_t thread)
 CAMLprim value caml_memprof_start(value lv, value szv, value tracker)
 {
   CAMLparam3(lv, szv, tracker);
-  CAMLlocal2(one_log1m_lambda_v, config);
+  CAMLlocal3(lambda_v, one_log1m_lambda_v, config);
 
   double lambda = Double_val(lv);
   intnat sz = Long_val(szv);
@@ -2233,7 +2233,11 @@ CAMLprim value caml_memprof_start(value lv, value szv, value tracker)
     one_log1m_lambda = MIN_ONE_LOG1M_LAMBDA; /* negative infinity */
   }
 
-  one_log1m_lambda_v = caml_copy_double(one_log1m_lambda);
+  lambda_v = caml_alloc_shr(Double_wosize, Double_tag);
+  Store_double_val(lambda_v, lambda);
+
+  one_log1m_lambda_v = caml_alloc_shr(Double_wosize, Double_tag);
+  Store_double_val(one_log1m_lambda_v, one_log1m_lambda);
 
   config = caml_alloc_shr(CONFIG_FIELDS, 0);
   caml_initialize(&Field(config, CONFIG_FIELD_STATUS),


### PR DESCRIPTION
I have found two different fixes for #14300, this one and #14306.
I wonder if @NickBarnes has a preference between either approaches.

---

The documentation says:

```
 * However, there are some structures shared between domains. The main
 * such structure is the profile configuration object on the Caml
 * heap. The only field written in this object is the status field,
 * used to communicate between domains sharing the profile, when a
 * profile is stopped or discarded. This field is inspected or set
 * atomically by the `Status` and `Set_status` macros.
```

But in fact the `lambda` and `1log1ml` fields are boxed float values, and boxed float values get moved around by the GC during promotion, resulting in a write to the `1log1ml` field that results in a TSan race report.

To avoid this race, we ensure that both float values are allocated on the major heap directly, so that the corresponding fields in the `config` record are not mutated by the GC. (Well, they can in fact be moved around during compaction.)