### PR TITLE
runtime/memprof.c: in 'sampling', only read atomic fields

### DIFF
--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1939,7 +1939,7 @@ Caml_inline bool sampling(memprof_domain_t domain)
 
   if (thread && !thread->suspended) {
     value config = thread_config(thread);
-    return Sampling(config) && !Min_lambda(config);
+    return Sampling(config);
   }
   return false;
 }


### PR DESCRIPTION
I have found two different fixes for #14300, namely #14304 and this one.
I wonder if @NickBarnes has a preference between either approaches.

---


The `Sampling(config)` macro accesses the "status" field of the statmemprof configuration (which may be shared between domains), which is atomic. This is important as `Sampling` may be called from several domains sharing a configuration profile.

The documentation says:

```
 * However, there are some structures shared between domains. The main
 * such structure is the profile configuration object on the Caml
 * heap. The only field written in this object is the status field,
 * used to communicate between domains sharing the profile, when a
 * profile is stopped or discarded. This field is inspected or set
 * atomically by the `Status` and `Set_status` macros.
```

But before the present commit it would also access the `1LOGML` field, which is a float which may appear to be mutated by the GC when promoted to the major heap. We avoid this data race by restricting the `Sampling` reads to documented-as-shared fields only (status, not 1logml).
