### PR TITLE
runtime/minor_gc.c: update young-pointers after leaving the barrier

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -102,6 +102,10 @@ extern int caml_debug_is_minor(value val);
 extern int caml_debug_is_major(value val);
 #endif
 
+/* Initialise young_{ptr,trigger} from young_{start,end}
+   on an empty minor heap. */
+void caml_reset_young_pointers(caml_domain_state *domain);
+
 #define Ref_table_add(ref_table, x) do {                                \
     struct caml_ref_table* ref = (ref_table);                           \
     if (ref->ptr >= ref->limit) {                                       \

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -587,13 +587,7 @@ static int allocate_minor_heap_arena(asize_t wsize) {
   domain_state->young_start = (value*)domain_self->minor_heap_reservation_start;
   domain_state->young_end =
       (value*)(domain_self->minor_heap_reservation_start + Bsize_wsize(wsize));
-  domain_state->young_ptr = domain_state->young_end;
-  /* Trigger a GC poll when half of the minor heap arena is filled. At
-     that point, a major slice is scheduled. */
-  domain_state->young_trigger = domain_state->young_start
-         + (domain_state->young_end - domain_state->young_start) / 2;
-  caml_memprof_set_trigger(domain_state);
-  caml_reset_young_limit(domain_state);
+  caml_reset_young_pointers(domain_state);
 
   check_minor_heap();
   return 0;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1960,15 +1960,18 @@ static void maybe_track_block(memprof_domain_t domain,
   set_action_pending_as_needed(domain);
 }
 
-/* Sets the trigger for the next sample in a domain's minor
- * heap. Could race with sampling and profile-stopping code, so do not
- * call from another domain unless the world is stopped (at the time
- * of writing, this is only actually called from this domain). Must be
- * called after each minor sample and after each minor collection. In
- * practice, this is called at each minor sample, at each minor
- * collection, and when sampling is suspended and unsuspended. Extra
- * calls do not change the statistical properties of the sampling
- * because of the memorylessness of the geometric distribution. */
+/* Sets the trigger for the next sample in a domain's minor heap.
+ *
+ * Could race with sampling and profile-stopping code, so do not call
+ * from another domain. Could also race with the GC or compactor
+ * moving values around, as some memprof state is on the runtime heap.
+ *
+ * Must be called after each minor sample and after each minor
+ * collection. In practice, this is called at each minor sample, at
+ * each minor collection, and when sampling is suspended and
+ * unsuspended. Extra calls do not change the statistical properties
+ * of the sampling because of the memorylessness of the geometric
+ * distribution. */
 
 void caml_memprof_set_trigger(caml_domain_state *state)
 {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -726,7 +726,7 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
   return result;
 }
 
-static void update_young_pointers (caml_domain_state* domain)
+void caml_reset_young_pointers (caml_domain_state* domain)
 {
   domain->young_ptr = domain->young_end;
   /* Trigger a GC poll when half of the minor heap is filled. At that point, a
@@ -881,7 +881,7 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
   promote_result prom =
     caml_empty_minor_heap_promote(domain, participating_count, participating);
 
-  update_young_pointers(domain);
+  caml_reset_young_pointers(domain);
 
   if (prom.locked_ephemerons) {
     CAML_EV_BEGIN(EV_MINOR_EPHE_CLEAN);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -666,14 +666,6 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS);
 
-  domain->young_ptr = domain->young_end;
-  /* Trigger a GC poll when half of the minor heap is filled. At that point, a
-   * major slice is scheduled. */
-  domain->young_trigger = domain->young_start
-    + (domain->young_end - domain->young_start) / 2;
-  caml_memprof_set_trigger(domain);
-  caml_reset_young_limit(domain);
-
   domain->stat_minor_words += Wsize_bsize (minor_allocated_bytes);
   domain->stat_promoted_words += domain->allocated_words - prev_alloc_words;
 
@@ -732,6 +724,17 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
     CAML_EV_END(EV_MINOR_LEAVE_BARRIER);
   }
   return result;
+}
+
+static void update_young_pointers (caml_domain_state* domain)
+{
+  domain->young_ptr = domain->young_end;
+  /* Trigger a GC poll when half of the minor heap is filled. At that point, a
+   * major slice is scheduled. */
+  domain->young_trigger = domain->young_start
+    + (domain->young_end - domain->young_start) / 2;
+  caml_memprof_set_trigger(domain);
+  caml_reset_young_limit(domain);
 }
 
 static void ephe_clean_minor (caml_domain_state* domain)
@@ -877,6 +880,8 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
   caml_gc_log("running stw empty_minor_heap_promote");
   promote_result prom =
     caml_empty_minor_heap_promote(domain, participating_count, participating);
+
+  update_young_pointers(domain);
 
   if (prom.locked_ephemerons) {
     CAML_EV_BEGIN(EV_MINOR_EPHE_CLEAN);


### PR DESCRIPTION
This is another iteration after #14305 failed. The idea is to try to assume that the `memprof` state may be mutated by the GC, and still ensure that the implementation behaves correctly when that occurs.

In #14305 I tried to make `caml_memprof_set_trigger` safe to call during the minor GC critical section, but this approach is doomed to fail. In this new PR, I move the place where `caml_memprof_set_trigger` is called during the minor GC, to *after* the domain has left the GC critical section, so we know that no other domains are running GC code anymore.

---

The implementation of `caml_memprof_set_trigger` accesses memprof internal state that is stored on the GC-ed heap. This cannot be called safely while other domains may be mutating the heap during minor collections. (This results in data races, see #14300).

To avoid this issue, we move the update of the domain's young-pointer to after leaving the minor GC barrier. At this point we know that all domains are done collecting the heap.