### PR TITLE
Always use the `"I"` format specifier for `size_t` with mingw

### DIFF
--- a/Changes
+++ b/Changes
@@ -299,9 +299,9 @@ Working version
 - #14094: toplevel, simplify check on installed printer types
   (Florian Angeletti, review by Gabriel Scherer)
 
-- #13656, #14114: Use C99 stdint.h/inttypes.h fixed-width integer types and
-  macros to define OCaml integers.
-  (Antonin Décimo, review by Nick Barnes)
+- #13656, #14114, #14308: Use C99 stdint.h/inttypes.h fixed-width
+  integer types and macros to define OCaml integers.
+  (Antonin Décimo, review by Nick Barnes and David Allsopp)
 
 - #14148: Remove an unused field from package_type in typedtree
   (Samuel Vivien, review by Gabriel Scherer)

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -65,7 +65,7 @@
   #define __USE_MINGW_ANSI_STDIO 0
 #endif
 
-#if defined(__MINGW32__) && !__USE_MINGW_ANSI_STDIO && !defined(_UCRT)
+#if defined(__MINGW32__)
 #define ARCH_SIZET_PRINTF_FORMAT "I"
 #else
 #define ARCH_SIZET_PRINTF_FORMAT "z"


### PR DESCRIPTION
Cross-compiling with mingw-w64 13 and GCC 15.2 (packaged in homebrew) started failing for me.

    runtime/domain.c:520:7: error: unknown conversion type character 'z'
    in format [-Werror=format=]
      520 |       "young_start: %p,"
          |       ^~~~~~~~~~~~~~~~~~
    In file included from runtime/domain.c:22:
    runtime/caml/config.h:71:35: note: format string is defined here
       71 | #define ARCH_SIZET_PRINTF_FORMAT "z"
          |                                   ^

In some configurations GCC will warn about `"%z"` not being supported. Partially revert a change introduced in 295dd45852688c7c8b5df5e974c460588cdd9696. This commit is in trunk but not in 5.4.

> Some types are different sizes in 32-bit and 64-bit code. For example, `size_t` is 32 bits long in code compiled for x86, and 64 bits in code compiled for x64. To create platform-agnostic formatting code for variable-width types, you can use a variable-width argument size modifier. Instead, use a 64-bit argument size modifier and explicitly promote the variable-width argument type to 64 bits. The Microsoft-specific `I` (uppercase i) argument size modifier handles variable-width integer arguments, but we recommend the type-specific `j`, `t`, and `z` modifiers for portability.

> Microsoft-specific:
> The `I` (uppercase i) […] argument size modifier prefix [is] Microsoft extension and is not ISO C-compatible.

[Format specification syntax: `printf` and `wprintf` functions > Argument size specification](https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170#size)

Presumably the GCC warning is outdated or erroneous, but there seem to be no way around it. I haven't looked in details to understand what causes the warning to appear in some settings and not others.