### PR TITLE
Deprecate `union sock_addr_union` for `struct sockaddr_storage`  and `socklen_param_type` for `socklen_t`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
       - name: OS Dependencies
         run: |
           apt-get update -y
-          apt-get install -y git gcc make parallel
+          apt-get install -y git gcc g++ make parallel
           adduser --disabled-password --gecos '' ocaml
       - name: Checkout
         # See https://github.com/actions/checkout/issues/334

--- a/Changes
+++ b/Changes
@@ -170,6 +170,10 @@ Working version
   instead of ENOENT if the command string is not a valid C string.
   (Antonin Décimo, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #14310: Deprecate union sock_addr_union for struct sockaddr_storage
+  and socklen_param_type for socklen_t.
+  (Antonin Décimo, review by Nicolás Ojeda Bär, David Allsopp and Samuel Hym)
+
 ### Tools:
 
 - #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup

--- a/configure
+++ b/configure
@@ -20744,29 +20744,6 @@ then :
 
 fi
 
-## socklen_t
-
-case $target in #(
-  *-w64-mingw32*|*-pc-windows) :
-    ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <ws2tcpip.h>
-"
-if test "x$ac_cv_type_socklen_t" = xyes
-then :
-  printf "%s\n" "#define HAS_SOCKLEN_T 1" >>confdefs.h
-
-fi
- ;; #(
-  *) :
-    ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <sys/socket.h>
-"
-if test "x$ac_cv_type_socklen_t" = xyes
-then :
-  printf "%s\n" "#define HAS_SOCKLEN_T 1" >>confdefs.h
-
-fi
- ;;
-esac
-
 ac_fn_c_check_func "$LINENO" "inet_aton" "ac_cv_func_inet_aton"
 if test "x$ac_cv_func_inet_aton" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -2184,15 +2184,6 @@ AS_CASE([$target],
 
 AS_IF([$sockets], [AC_DEFINE([HAS_SOCKETS], [1])])
 
-## socklen_t
-
-AS_CASE([$target],
-  [*-w64-mingw32*|*-pc-windows],
-    [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T], [1])], [],
-      [#include <ws2tcpip.h>])],
-  [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T], [1])], [],
-    [#include <sys/socket.h>])])
-
 AC_CHECK_FUNC([inet_aton], [AC_DEFINE([HAS_INET_ATON], [1])])
 
 ## Unix domain sockets support on Windows

--- a/otherlibs/unix/accept_unix.c
+++ b/otherlibs/unix/accept_unix.c
@@ -48,7 +48,7 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
 #if !(defined(HAS_ACCEPT4) && defined(SOCK_CLOEXEC))
   if (clo) caml_unix_set_cloexec(retcode, "accept", Nothing);
 #endif
-  a = caml_unix_alloc_sockaddr(&addr, addr_len, retcode);
+  a = caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, retcode);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = Val_int(retcode);
   Field(res, 1) = a;

--- a/otherlibs/unix/accept_unix.c
+++ b/otherlibs/unix/accept_unix.c
@@ -31,17 +31,17 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   CAMLlocal1(a);
   int retcode;
   value res;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
   int clo = caml_unix_cloexec_p(cloexec);
 
   addr_len = sizeof(addr);
   caml_enter_blocking_section();
 #if defined(HAS_ACCEPT4) && defined(SOCK_CLOEXEC)
-  retcode = accept4(Int_val(sock), &addr.s_gen, &addr_len,
+  retcode = accept4(Int_val(sock), (struct sockaddr *) &addr, &addr_len,
                     clo ? SOCK_CLOEXEC : 0);
 #else
-  retcode = accept(Int_val(sock), &addr.s_gen, &addr_len);
+  retcode = accept(Int_val(sock), (struct sockaddr *) &addr, &addr_len);
 #endif
   caml_leave_blocking_section();
   if (retcode == -1) caml_uerror("accept", Nothing);

--- a/otherlibs/unix/accept_unix.c
+++ b/otherlibs/unix/accept_unix.c
@@ -32,7 +32,7 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   int retcode;
   value res;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
   int clo = caml_unix_cloexec_p(cloexec);
 
   addr_len = sizeof(addr);

--- a/otherlibs/unix/accept_win32.c
+++ b/otherlibs/unix/accept_win32.c
@@ -23,7 +23,7 @@
 CAMLprim value caml_unix_accept(value cloexec, value sock)
 {
   CAMLparam0();
-  CAMLlocal2(fd, adr);
+  CAMLlocal2(fd, vaddr);
   SOCKET sconn = Socket_val(sock);
   SOCKET snew;
   value res;
@@ -42,9 +42,9 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   }
   caml_win32_set_cloexec((HANDLE) snew, cloexec);
   fd = caml_win32_alloc_socket(snew);
-  adr = caml_unix_alloc_sockaddr(&addr, addr_len, snew);
+  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, snew);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = fd;
-  Field(res, 1) = adr;
+  Field(res, 1) = vaddr;
   CAMLreturn(res);
 }

--- a/otherlibs/unix/accept_win32.c
+++ b/otherlibs/unix/accept_win32.c
@@ -42,7 +42,7 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   }
   caml_win32_set_cloexec((HANDLE) snew, cloexec);
   fd = caml_win32_alloc_socket(snew);
-  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, snew);
+  vaddr = caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, snew);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = fd;
   Field(res, 1) = vaddr;

--- a/otherlibs/unix/accept_win32.c
+++ b/otherlibs/unix/accept_win32.c
@@ -28,7 +28,7 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   SOCKET snew;
   value res;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
   DWORD err = 0;
 
   addr_len = sizeof(addr);

--- a/otherlibs/unix/accept_win32.c
+++ b/otherlibs/unix/accept_win32.c
@@ -27,13 +27,13 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   SOCKET sconn = Socket_val(sock);
   SOCKET snew;
   value res;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
   DWORD err = 0;
 
   addr_len = sizeof(addr);
   caml_enter_blocking_section();
-  snew = accept(sconn, &addr.s_gen, &addr_len);
+  snew = accept(sconn, (struct sockaddr *) &addr, &addr_len);
   if (snew == INVALID_SOCKET) err = WSAGetLastError ();
   caml_leave_blocking_section();
   if (snew == INVALID_SOCKET) {

--- a/otherlibs/unix/bind_unix.c
+++ b/otherlibs/unix/bind_unix.c
@@ -24,11 +24,11 @@
 CAMLprim value caml_unix_bind(value socket, value address)
 {
   int ret;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
-  ret = bind(Int_val(socket), &addr.s_gen, addr_len);
+  ret = bind(Int_val(socket), (struct sockaddr *) &addr, addr_len);
   if (ret == -1) caml_uerror("bind", Nothing);
   return Val_unit;
 }

--- a/otherlibs/unix/bind_unix.c
+++ b/otherlibs/unix/bind_unix.c
@@ -25,7 +25,7 @@ CAMLprim value caml_unix_bind(value socket, value address)
 {
   int ret;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
   ret = bind(Int_val(socket), (struct sockaddr *) &addr, addr_len);

--- a/otherlibs/unix/bind_win32.c
+++ b/otherlibs/unix/bind_win32.c
@@ -20,11 +20,11 @@
 CAMLprim value caml_unix_bind(value socket, value address)
 {
   int ret;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
-  ret = bind(Socket_val(socket), &addr.s_gen, addr_len);
+  ret = bind(Socket_val(socket), (struct sockaddr *) &addr, addr_len);
   if (ret == -1) {
     caml_win32_maperr(WSAGetLastError());
     caml_uerror("bind", Nothing);

--- a/otherlibs/unix/bind_win32.c
+++ b/otherlibs/unix/bind_win32.c
@@ -21,7 +21,7 @@ CAMLprim value caml_unix_bind(value socket, value address)
 {
   int ret;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
   ret = bind(Socket_val(socket), (struct sockaddr *) &addr, addr_len);

--- a/otherlibs/unix/caml/socketaddr.h
+++ b/otherlibs/unix/caml/socketaddr.h
@@ -45,6 +45,7 @@ struct sockaddr_un {
 #include <arpa/inet.h>
 #endif
 
+/* Deprecated: use struct sockaddr_storage. */
 union sock_addr_union {
   struct sockaddr s_gen;
   struct sockaddr_un s_unix;
@@ -52,6 +53,7 @@ union sock_addr_union {
 #ifdef HAS_IPV6
   struct sockaddr_in6 s_inet6;
 #endif
+  struct sockaddr_storage s_storage;
 };
 
 #ifdef HAS_SOCKLEN_T
@@ -72,9 +74,9 @@ extern "C" {
 #endif /* CAML_BUILDING_UNIX */
 
 extern void caml_unix_get_sockaddr (value vaddr,
-                               union sock_addr_union * addr /*out*/,
+                               struct sockaddr_storage * addr /*out*/,
                                socklen_param_type * addr_len /*out*/);
-extern value caml_unix_alloc_sockaddr (union sock_addr_union * addr /*in*/,
+extern value caml_unix_alloc_sockaddr (struct sockaddr_storage * addr /*in*/,
                                   socklen_param_type addr_len,
                                   int close_on_error);
 extern value caml_unix_alloc_inet_addr (struct in_addr * inaddr);
@@ -92,6 +94,42 @@ extern value caml_unix_alloc_inet6_addr (struct in6_addr * inaddr);
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef __cplusplus
+/* API compatibility between union sock_addr_union and
+   struct sockaddr_storage.
+   C++ doesn't support C11 _Generic, so use function overloading. */
+static inline void
+caml_unix_get_sockaddr(value vaddr, union sock_addr_union * addr /*out*/,
+                       socklen_param_type * addr_len /*out*/) {
+  caml_unix_get_sockaddr(vaddr, &addr->s_storage, addr_len);
+}
+static inline value
+caml_unix_alloc_sockaddr(union sock_addr_union * addr /*in*/,
+                         socklen_param_type addr_len,
+                         int close_on_error) {
+  return caml_unix_alloc_sockaddr(&addr->s_storage, addr_len, close_on_error);
+}
+#else
+/* API compatibility between union sock_addr_union and
+   struct sockaddr_storage. */
+#define caml_unix_get_sockaddr(vaddr, addr, addr_len)         \
+  caml_unix_get_sockaddr(                                     \
+    (vaddr),                                                  \
+    _Generic((addr),                                          \
+             union sock_addr_union *:                         \
+               &((union sock_addr_union *)(addr))->s_storage, \
+             default: (addr)),                                \
+    (addr_len))
+#define caml_unix_alloc_sockaddr(addr, addr_len, close_on_error)  \
+  caml_unix_alloc_sockaddr(                                       \
+    _Generic((addr),                                              \
+             union sock_addr_union *:                             \
+               &((union sock_addr_union *)(addr))->s_storage,     \
+             default: (addr)),                                    \
+    (addr_len),                                                   \
+    (close_on_error))
 #endif
 
 #endif /* CAML_SOCKETADDR_H */

--- a/otherlibs/unix/caml/socketaddr.h
+++ b/otherlibs/unix/caml/socketaddr.h
@@ -23,6 +23,7 @@
 /* Code duplication with runtime/debugger.c is inevitable, because
  * pulling winsock2.h creates many naming conflicts. */
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #ifdef HAS_AFUNIX_H
 #include <afunix.h>
 #else
@@ -56,11 +57,8 @@ union sock_addr_union {
   struct sockaddr_storage s_storage;
 };
 
-#ifdef HAS_SOCKLEN_T
+/* Deprecated: use socklen_t */
 typedef socklen_t socklen_param_type;
-#else
-typedef int socklen_param_type;
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,9 +73,9 @@ extern "C" {
 
 extern void caml_unix_get_sockaddr (value vaddr,
                                struct sockaddr_storage * addr /*out*/,
-                               socklen_param_type * addr_len /*out*/);
+                               socklen_t * addr_len /*out*/);
 extern value caml_unix_alloc_sockaddr (struct sockaddr_storage * addr /*in*/,
-                                  socklen_param_type addr_len,
+                                  socklen_t addr_len,
                                   int close_on_error);
 extern value caml_unix_alloc_inet_addr (struct in_addr * inaddr);
 #define GET_INET_ADDR(v) (*((struct in_addr *) (v)))

--- a/otherlibs/unix/caml/socketaddr.h
+++ b/otherlibs/unix/caml/socketaddr.h
@@ -71,7 +71,7 @@ extern "C" {
 #define alloc_inet_addr caml_unix_alloc_inet_addr
 #endif /* CAML_BUILDING_UNIX */
 
-extern void caml_unix_get_sockaddr (value mladdr,
+extern void caml_unix_get_sockaddr (value vaddr,
                                union sock_addr_union * addr /*out*/,
                                socklen_param_type * addr_len /*out*/);
 extern value caml_unix_alloc_sockaddr (union sock_addr_union * addr /*in*/,

--- a/otherlibs/unix/caml/socketaddr.h
+++ b/otherlibs/unix/caml/socketaddr.h
@@ -74,7 +74,7 @@ extern "C" {
 extern void caml_unix_get_sockaddr (value vaddr,
                                struct sockaddr_storage * addr /*out*/,
                                socklen_t * addr_len /*out*/);
-extern value caml_unix_alloc_sockaddr (struct sockaddr_storage * addr /*in*/,
+extern value caml_unix_alloc_sockaddr (struct sockaddr * addr /*in*/,
                                   socklen_t addr_len,
                                   int close_on_error);
 extern value caml_unix_alloc_inet_addr (struct in_addr * inaddr);
@@ -107,7 +107,7 @@ static inline value
 caml_unix_alloc_sockaddr(union sock_addr_union * addr /*in*/,
                          socklen_param_type addr_len,
                          int close_on_error) {
-  return caml_unix_alloc_sockaddr(&addr->s_storage, addr_len, close_on_error);
+  return caml_unix_alloc_sockaddr(&addr->s_gen, addr_len, close_on_error);
 }
 #else
 /* API compatibility between union sock_addr_union and
@@ -124,7 +124,7 @@ caml_unix_alloc_sockaddr(union sock_addr_union * addr /*in*/,
   caml_unix_alloc_sockaddr(                                       \
     _Generic((addr),                                              \
              union sock_addr_union *:                             \
-               &((union sock_addr_union *)(addr))->s_storage,     \
+               &((union sock_addr_union *)(addr))->s_gen,         \
              default: (addr)),                                    \
     (addr_len),                                                   \
     (close_on_error))

--- a/otherlibs/unix/channels_unix.c
+++ b/otherlibs/unix/channels_unix.c
@@ -46,7 +46,7 @@ static int caml_unix_check_stream_semantics(int fd)
 #ifdef HAS_SOCKETS
   case S_IFSOCK: {
     int so_type;
-    socklen_param_type so_type_len = sizeof(so_type);
+    socklen_t so_type_len = sizeof(so_type);
     if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &so_type, &so_type_len) == -1)
       return errno;
     switch (so_type) {

--- a/otherlibs/unix/connect_unix.c
+++ b/otherlibs/unix/connect_unix.c
@@ -25,12 +25,12 @@
 CAMLprim value caml_unix_connect(value socket, value address)
 {
   int retcode;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
   caml_enter_blocking_section();
-  retcode = connect(Int_val(socket), &addr.s_gen, addr_len);
+  retcode = connect(Int_val(socket), (struct sockaddr *) &addr, addr_len);
   caml_leave_blocking_section();
   if (retcode == -1) caml_uerror("connect", Nothing);
   return Val_unit;

--- a/otherlibs/unix/connect_unix.c
+++ b/otherlibs/unix/connect_unix.c
@@ -26,7 +26,7 @@ CAMLprim value caml_unix_connect(value socket, value address)
 {
   int retcode;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
   caml_enter_blocking_section();

--- a/otherlibs/unix/connect_win32.c
+++ b/otherlibs/unix/connect_win32.c
@@ -22,7 +22,7 @@ CAMLprim value caml_unix_connect(value socket, value address)
 {
   SOCKET s = Socket_val(socket);
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
   DWORD err = 0;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);

--- a/otherlibs/unix/connect_win32.c
+++ b/otherlibs/unix/connect_win32.c
@@ -21,13 +21,13 @@
 CAMLprim value caml_unix_connect(value socket, value address)
 {
   SOCKET s = Socket_val(socket);
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
   DWORD err = 0;
 
   caml_unix_get_sockaddr(address, &addr, &addr_len);
   caml_enter_blocking_section();
-  if (connect(s, &addr.s_gen, addr_len) == -1)
+  if (connect(s, (struct sockaddr *) &addr, addr_len) == -1)
     err = WSAGetLastError();
   caml_leave_blocking_section();
   if (err) {

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -39,7 +39,7 @@ static value convert_addrinfo(const struct addrinfo * a)
   CAMLparam0();
   CAMLlocal3(vres,vaddr,vcanonname);
   struct sockaddr_storage addr;
-  socklen_param_type len;
+  socklen_t len;
 
   len = a->ai_addrlen;
   if (len > sizeof(addr)) len = sizeof(addr);

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -34,17 +34,17 @@
 extern const int caml_unix_socket_domain_table[]; /* from socket.c */
 extern const int caml_unix_socket_type_table[];   /* from socket.c */
 
-static value convert_addrinfo(struct addrinfo * a)
+static value convert_addrinfo(const struct addrinfo * a)
 {
   CAMLparam0();
   CAMLlocal3(vres,vaddr,vcanonname);
-  union sock_addr_union sa;
+  union sock_addr_union addr;
   socklen_param_type len;
 
   len = a->ai_addrlen;
-  if (len > sizeof(sa)) len = sizeof(sa);
-  memcpy(&sa.s_gen, a->ai_addr, len);
-  vaddr = caml_unix_alloc_sockaddr(&sa, len, -1);
+  if (len > sizeof(addr)) len = sizeof(addr);
+  memcpy(&addr.s_gen, a->ai_addr, len);
+  vaddr = caml_unix_alloc_sockaddr(&addr, len, -1);
   vcanonname = caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
   vres = caml_alloc_small(5, 0);
   Field(vres, 0) =

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -38,12 +38,12 @@ static value convert_addrinfo(const struct addrinfo * a)
 {
   CAMLparam0();
   CAMLlocal3(vres,vaddr,vcanonname);
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type len;
 
   len = a->ai_addrlen;
   if (len > sizeof(addr)) len = sizeof(addr);
-  memcpy(&addr.s_gen, a->ai_addr, len);
+  memcpy(&addr, a->ai_addr, len);
   vaddr = caml_unix_alloc_sockaddr(&addr, len, -1);
   vcanonname = caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
   vres = caml_alloc_small(5, 0);

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -44,7 +44,7 @@ static value convert_addrinfo(const struct addrinfo * a)
   len = a->ai_addrlen;
   if (len > sizeof(addr)) len = sizeof(addr);
   memcpy(&addr, a->ai_addr, len);
-  vaddr = caml_unix_alloc_sockaddr(&addr, len, -1);
+  vaddr = caml_unix_alloc_sockaddr((struct sockaddr *) &addr, len, -1);
   vcanonname = caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
   vres = caml_alloc_small(5, 0);
   Field(vres, 0) =

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -46,7 +46,7 @@ static value alloc_one_addr_16(char const *a)
 static value alloc_host_entry(struct hostent *entry)
 {
   CAMLparam0();
-  CAMLlocal4(name, aliases, addr_list, adr);
+  CAMLlocal3(name, aliases, addr_list);
   value (*alloc_one_addr)(char const *);
   value res;
 
@@ -79,7 +79,7 @@ static value alloc_host_entry(struct hostent *entry)
 
 CAMLprim value caml_unix_gethostbyaddr(value a)
 {
-  const char * adr;
+  const char * addr;
   struct in_addr in4;
   struct hostent * hp;
   int addr_type = AF_INET;
@@ -90,11 +90,11 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
     addr_type = AF_INET6;
     addr_len = 16;
     in6 = GET_INET6_ADDR(a);
-    adr = (char *)&in6;
+    addr = (char *)&in6;
   } else {
 #endif
     in4 = GET_INET_ADDR(a);
-    adr = (char *)&in4;
+    addr = (char *)&in4;
 #if HAS_IPV6
   }
 #endif
@@ -102,7 +102,7 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
 #ifdef _WIN32
   caml_enter_blocking_section();
 #endif
-  hp = gethostbyaddr(adr, addr_len, addr_type);
+  hp = gethostbyaddr(addr, addr_len, addr_type);
 #ifdef _WIN32
   caml_leave_blocking_section();
 #endif
@@ -111,7 +111,7 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
   char buffer[NETDB_BUFFER_SIZE];
   int h_errnop;
   caml_enter_blocking_section();
-  hp = gethostbyaddr_r(adr, addr_len, addr_type,
+  hp = gethostbyaddr_r(addr, addr_len, addr_type,
                        &h, buffer, sizeof(buffer), &h_errnop);
   caml_leave_blocking_section();
 #elif HAS_GETHOSTBYADDR_R == 8
@@ -119,7 +119,7 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
   char buffer[NETDB_BUFFER_SIZE];
   int h_errnop, rc;
   caml_enter_blocking_section();
-  rc = gethostbyaddr_r(adr, addr_len, addr_type,
+  rc = gethostbyaddr_r(addr, addr_len, addr_type,
                        &h, buffer, sizeof(buffer), &hp, &h_errnop);
   caml_leave_blocking_section();
   if (rc != 0) hp = NULL;

--- a/otherlibs/unix/getnameinfo.c
+++ b/otherlibs/unix/getnameinfo.c
@@ -37,7 +37,7 @@ CAMLprim value caml_unix_getnameinfo(value vaddr, value vopts)
 {
   CAMLparam0();
   CAMLlocal3(vhost, vserv, vres);
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
   char host[4096];
   char serv[1024];
@@ -47,7 +47,7 @@ CAMLprim value caml_unix_getnameinfo(value vaddr, value vopts)
   opts = caml_convert_flag_list(vopts, getnameinfo_flag_table);
   caml_enter_blocking_section();
   retcode =
-    getnameinfo((const struct sockaddr *) &addr.s_gen, addr_len,
+    getnameinfo((struct sockaddr *) &addr, addr_len,
                 host, sizeof(host), serv, sizeof(serv), opts);
   caml_leave_blocking_section();
   /* TODO: detailed error reporting? */

--- a/otherlibs/unix/getnameinfo.c
+++ b/otherlibs/unix/getnameinfo.c
@@ -38,7 +38,7 @@ CAMLprim value caml_unix_getnameinfo(value vaddr, value vopts)
   CAMLparam0();
   CAMLlocal3(vhost, vserv, vres);
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
   char host[4096];
   char serv[1024];
   int opts, retcode;

--- a/otherlibs/unix/getpeername_unix.c
+++ b/otherlibs/unix/getpeername_unix.c
@@ -30,7 +30,7 @@ CAMLprim value caml_unix_getpeername(value sock)
   addr_len = sizeof(addr);
   retcode = getpeername(Int_val(sock), (struct sockaddr *) &addr, &addr_len);
   if (retcode == -1) caml_uerror("getpeername", Nothing);
-  return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  return caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
 }
 
 #else

--- a/otherlibs/unix/getpeername_unix.c
+++ b/otherlibs/unix/getpeername_unix.c
@@ -24,11 +24,11 @@
 CAMLprim value caml_unix_getpeername(value sock)
 {
   int retcode;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   addr_len = sizeof(addr);
-  retcode = getpeername(Int_val(sock), &addr.s_gen, &addr_len);
+  retcode = getpeername(Int_val(sock), (struct sockaddr *) &addr, &addr_len);
   if (retcode == -1) caml_uerror("getpeername", Nothing);
   return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
 }

--- a/otherlibs/unix/getpeername_unix.c
+++ b/otherlibs/unix/getpeername_unix.c
@@ -25,7 +25,7 @@ CAMLprim value caml_unix_getpeername(value sock)
 {
   int retcode;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   addr_len = sizeof(addr);
   retcode = getpeername(Int_val(sock), (struct sockaddr *) &addr, &addr_len);

--- a/otherlibs/unix/getpeername_win32.c
+++ b/otherlibs/unix/getpeername_win32.c
@@ -20,11 +20,11 @@
 CAMLprim value caml_unix_getpeername(value sock)
 {
   int retcode;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   addr_len = sizeof(addr);
-  retcode = getpeername(Socket_val(sock), &addr.s_gen, &addr_len);
+  retcode = getpeername(Socket_val(sock), (struct sockaddr *) &addr, &addr_len);
   if (retcode == -1) {
     caml_win32_maperr(WSAGetLastError());
     caml_uerror("getpeername", Nothing);

--- a/otherlibs/unix/getpeername_win32.c
+++ b/otherlibs/unix/getpeername_win32.c
@@ -29,5 +29,5 @@ CAMLprim value caml_unix_getpeername(value sock)
     caml_win32_maperr(WSAGetLastError());
     caml_uerror("getpeername", Nothing);
   }
-  return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  return caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
 }

--- a/otherlibs/unix/getpeername_win32.c
+++ b/otherlibs/unix/getpeername_win32.c
@@ -21,7 +21,7 @@ CAMLprim value caml_unix_getpeername(value sock)
 {
   int retcode;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   addr_len = sizeof(addr);
   retcode = getpeername(Socket_val(sock), (struct sockaddr *) &addr, &addr_len);

--- a/otherlibs/unix/getsockname_unix.c
+++ b/otherlibs/unix/getsockname_unix.c
@@ -25,7 +25,7 @@ CAMLprim value caml_unix_getsockname(value sock)
 {
   int retcode;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   addr_len = sizeof(addr);
   retcode = getsockname(Int_val(sock), (struct sockaddr *) &addr, &addr_len);

--- a/otherlibs/unix/getsockname_unix.c
+++ b/otherlibs/unix/getsockname_unix.c
@@ -24,11 +24,11 @@
 CAMLprim value caml_unix_getsockname(value sock)
 {
   int retcode;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   addr_len = sizeof(addr);
-  retcode = getsockname(Int_val(sock), &addr.s_gen, &addr_len);
+  retcode = getsockname(Int_val(sock), (struct sockaddr *) &addr, &addr_len);
   if (retcode == -1) caml_uerror("getsockname", Nothing);
   return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
 }

--- a/otherlibs/unix/getsockname_unix.c
+++ b/otherlibs/unix/getsockname_unix.c
@@ -30,7 +30,7 @@ CAMLprim value caml_unix_getsockname(value sock)
   addr_len = sizeof(addr);
   retcode = getsockname(Int_val(sock), (struct sockaddr *) &addr, &addr_len);
   if (retcode == -1) caml_uerror("getsockname", Nothing);
-  return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  return caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
 }
 
 #else

--- a/otherlibs/unix/getsockname_win32.c
+++ b/otherlibs/unix/getsockname_win32.c
@@ -29,5 +29,5 @@ CAMLprim value caml_unix_getsockname(value sock)
     caml_win32_maperr(WSAGetLastError());
     caml_uerror("getsockname", Nothing);
   }
-  return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  return caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
 }

--- a/otherlibs/unix/getsockname_win32.c
+++ b/otherlibs/unix/getsockname_win32.c
@@ -20,11 +20,11 @@
 CAMLprim value caml_unix_getsockname(value sock)
 {
   int retcode;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   addr_len = sizeof(addr);
-  retcode = getsockname(Socket_val(sock), &addr.s_gen, &addr_len);
+  retcode = getsockname(Socket_val(sock), (struct sockaddr *) &addr, &addr_len);
   if (retcode == -1) {
     caml_win32_maperr(WSAGetLastError());
     caml_uerror("getsockname", Nothing);

--- a/otherlibs/unix/getsockname_win32.c
+++ b/otherlibs/unix/getsockname_win32.c
@@ -21,7 +21,7 @@ CAMLprim value caml_unix_getsockname(value sock)
 {
   int retcode;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   addr_len = sizeof(addr);
   retcode = getsockname(Socket_val(sock), (struct sockaddr *) &addr, &addr_len);

--- a/otherlibs/unix/sendrecv_unix.c
+++ b/otherlibs/unix/sendrecv_unix.c
@@ -56,7 +56,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   long numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
   value res;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   cv_flags = caml_convert_flag_list(flags, msg_flag_table);
@@ -65,7 +65,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   addr_len = sizeof(addr);
   caml_enter_blocking_section();
   ret = recvfrom(Int_val(sock), iobuf, (int) numbytes, cv_flags,
-                 &addr.s_gen, &addr_len);
+                 (struct sockaddr *) &addr, &addr_len);
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("recvfrom", Nothing);
   memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
@@ -100,7 +100,7 @@ CAMLprim value caml_unix_sendto_native(value sock, value buff, value ofs,
   int ret, cv_flags;
   long numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
 
   cv_flags = caml_convert_flag_list(flags, msg_flag_table);
@@ -110,7 +110,7 @@ CAMLprim value caml_unix_sendto_native(value sock, value buff, value ofs,
   memmove (iobuf, &Byte(buff, Long_val(ofs)), numbytes);
   caml_enter_blocking_section();
   ret = sendto(Int_val(sock), iobuf, (int) numbytes, cv_flags,
-               &addr.s_gen, addr_len);
+               (struct sockaddr *) &addr, addr_len);
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("sendto", Nothing);
   return Val_int(ret);

--- a/otherlibs/unix/sendrecv_unix.c
+++ b/otherlibs/unix/sendrecv_unix.c
@@ -51,7 +51,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
                              value flags)
 {
   CAMLparam1(buff);
-  CAMLlocal1(adr);
+  CAMLlocal1(vaddr);
   int ret, cv_flags;
   long numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
@@ -69,10 +69,10 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("recvfrom", Nothing);
   memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
-  adr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = Val_int(ret);
-  Field(res, 1) = adr;
+  Field(res, 1) = vaddr;
   CAMLreturn(res);
 }
 

--- a/otherlibs/unix/sendrecv_unix.c
+++ b/otherlibs/unix/sendrecv_unix.c
@@ -57,7 +57,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   char iobuf[UNIX_BUFFER_SIZE];
   value res;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   cv_flags = caml_convert_flag_list(flags, msg_flag_table);
   numbytes = Long_val(len);
@@ -101,7 +101,7 @@ CAMLprim value caml_unix_sendto_native(value sock, value buff, value ofs,
   long numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
 
   cv_flags = caml_convert_flag_list(flags, msg_flag_table);
   caml_unix_get_sockaddr(dest, &addr, &addr_len);

--- a/otherlibs/unix/sendrecv_unix.c
+++ b/otherlibs/unix/sendrecv_unix.c
@@ -69,7 +69,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("recvfrom", Nothing);
   memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
-  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  vaddr = caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = Val_int(ret);
   Field(res, 1) = vaddr;

--- a/otherlibs/unix/sendrecv_win32.c
+++ b/otherlibs/unix/sendrecv_win32.c
@@ -61,7 +61,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   char iobuf[UNIX_BUFFER_SIZE];
   value res;
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
   DWORD err = 0;
 
   numbytes = Long_val(len);
@@ -117,7 +117,7 @@ value caml_unix_sendto_native(value sock, value buff, value ofs, value len,
   intnat numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
   struct sockaddr_storage addr;
-  socklen_param_type addr_len;
+  socklen_t addr_len;
   DWORD err = 0;
 
   caml_unix_get_sockaddr(dest, &addr, &addr_len);

--- a/otherlibs/unix/sendrecv_win32.c
+++ b/otherlibs/unix/sendrecv_win32.c
@@ -53,7 +53,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
                              value flags)
 {
   CAMLparam1(buff);
-  CAMLlocal1(adr);
+  CAMLlocal1(vaddr);
   SOCKET s = Socket_val(sock);
   int flg = caml_convert_flag_list(flags, msg_flag_table);
   int ret;
@@ -76,10 +76,10 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
     caml_uerror("recvfrom", Nothing);
   }
   memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
-  adr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = Val_int(ret);
-  Field(res, 1) = adr;
+  Field(res, 1) = vaddr;
   CAMLreturn(res);
 }
 

--- a/otherlibs/unix/sendrecv_win32.c
+++ b/otherlibs/unix/sendrecv_win32.c
@@ -77,7 +77,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
     caml_uerror("recvfrom", Nothing);
   }
   memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
-  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  vaddr = caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
   res = caml_alloc_small(2, 0);
   Field(res, 0) = Val_int(ret);
   Field(res, 1) = vaddr;

--- a/otherlibs/unix/sendrecv_win32.c
+++ b/otherlibs/unix/sendrecv_win32.c
@@ -60,7 +60,7 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   intnat numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
   value res;
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
   DWORD err = 0;
 
@@ -68,7 +68,8 @@ CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
   if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
   addr_len = sizeof(addr);
   caml_enter_blocking_section();
-  ret = recvfrom(s, iobuf, (int) numbytes, flg, &addr.s_gen, &addr_len);
+  ret = recvfrom(s, iobuf, (int) numbytes, flg,
+                 (struct sockaddr *) &addr, &addr_len);
   if (ret == -1) err = WSAGetLastError();
   caml_leave_blocking_section();
   if (ret == -1) {
@@ -115,7 +116,7 @@ value caml_unix_sendto_native(value sock, value buff, value ofs, value len,
   int ret;
   intnat numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   socklen_param_type addr_len;
   DWORD err = 0;
 
@@ -124,7 +125,8 @@ value caml_unix_sendto_native(value sock, value buff, value ofs, value len,
   if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
   memmove (iobuf, &Byte(buff, Long_val(ofs)), numbytes);
   caml_enter_blocking_section();
-  ret = sendto(s, iobuf, (int) numbytes, flg, &addr.s_gen, addr_len);
+  ret = sendto(s, iobuf, (int) numbytes, flg,
+               (struct sockaddr *) &addr, addr_len);
   if (ret == -1) err = WSAGetLastError();
   caml_leave_blocking_section();
   if (ret == -1) {

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -51,7 +51,7 @@ CAMLexport value caml_unix_alloc_inet6_addr(struct in6_addr * a)
 
 void caml_unix_get_sockaddr(value vaddr,
                        struct sockaddr_storage * addr /*out*/,
-                       socklen_param_type * addr_len /*out*/)
+                       socklen_t * addr_len /*out*/)
 {
   switch(Tag_val(vaddr)) {
   case 0:                       /* ADDR_UNIX */
@@ -109,7 +109,7 @@ static value alloc_unix_sockaddr(value path) {
 }
 
 value caml_unix_alloc_sockaddr(struct sockaddr_storage * addr /*in*/,
-                          socklen_param_type addr_len, int close_on_error)
+                          socklen_t addr_len, int close_on_error)
 {
   CAMLparam0();
   CAMLlocal1(a);

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -32,71 +32,65 @@
 
 CAMLexport value caml_unix_alloc_inet_addr(struct in_addr * a)
 {
-  value res;
   /* Use a string rather than an abstract block so that it can be
      marshaled safely.  Remember that a is in network byte order,
      hence is marshaled in an endian-independent manner. */
-  res = caml_alloc_initialized_string(4, (char *)a);
-  return res;
+  return caml_alloc_initialized_string(4, (char *)a);
 }
 
 #ifdef HAS_IPV6
 
 CAMLexport value caml_unix_alloc_inet6_addr(struct in6_addr * a)
 {
-  value res;
-  res = caml_alloc_initialized_string(16, (char *)a);
-  return res;
+  return caml_alloc_initialized_string(16, (char *)a);
 }
 
 #endif
 
-void caml_unix_get_sockaddr(value mladr,
-                       union sock_addr_union * adr /*out*/,
-                       socklen_param_type * adr_len /*out*/)
+void caml_unix_get_sockaddr(value vaddr,
+                       union sock_addr_union * addr /*out*/,
+                       socklen_param_type * addr_len /*out*/)
 {
-  switch(Tag_val(mladr)) {
+  switch(Tag_val(vaddr)) {
   case 0:                       /* ADDR_UNIX */
     { value path;
       mlsize_t len;
-      path = Field(mladr, 0);
+      path = Field(vaddr, 0);
       len = caml_string_length(path);
-      adr->s_unix.sun_family = AF_UNIX;
-      if (len >= sizeof(adr->s_unix.sun_path)) {
+      addr->s_unix.sun_family = AF_UNIX;
+      if (len >= sizeof(addr->s_unix.sun_path)) {
         caml_unix_error(ENAMETOOLONG, "", path);
       }
       /* "Abstract" sockets in Linux have names starting with '\0' */
       if (Byte(path, 0) != 0 && ! caml_string_is_c_safe(path)) {
         caml_unix_error(ENOENT, "", path);
       }
-      memmove (adr->s_unix.sun_path, String_val(path), len + 1);
-      *adr_len =
-        ((char *)&(adr->s_unix.sun_path) - (char *)&(adr->s_unix))
-        + len;
+      memmove (addr->s_unix.sun_path, String_val(path), len + 1);
+      *addr_len = offsetof(struct sockaddr_un, sun_path) + len;
       break;
     }
   case 1:                       /* ADDR_INET */
 #ifdef HAS_IPV6
-    if (caml_string_length(Field(mladr, 0)) == 16) {
-      memset(&adr->s_inet6, 0, sizeof(struct sockaddr_in6));
-      adr->s_inet6.sin6_family = AF_INET6;
-      adr->s_inet6.sin6_addr = GET_INET6_ADDR(Field(mladr, 0));
-      adr->s_inet6.sin6_port = htons(Int_val(Field(mladr, 1)));
+    if (caml_string_length(Field(vaddr, 0)) == 16) {
+      memset(&addr->s_inet6, 0, sizeof(struct sockaddr_in6));
+      addr->s_inet6.sin6_family = AF_INET6;
+      addr->s_inet6.sin6_addr = GET_INET6_ADDR(Field(vaddr, 0));
+      addr->s_inet6.sin6_port = htons(Int_val(Field(vaddr, 1)));
 #ifdef SIN6_LEN
-      adr->s_inet6.sin6_len = sizeof(struct sockaddr_in6);
+      addr->s_inet6.sin6_len = sizeof(struct sockaddr_in6);
 #endif
-      *adr_len = sizeof(struct sockaddr_in6);
+      *addr_len = sizeof(struct sockaddr_in6);
       break;
     }
 #endif
-    memset(&adr->s_inet, 0, sizeof(struct sockaddr_in));
-    adr->s_inet.sin_family = AF_INET;
-    adr->s_inet.sin_addr = GET_INET_ADDR(Field(mladr, 0));
-    adr->s_inet.sin_port = htons(Int_val(Field(mladr, 1)));
+    memset(&addr->s_inet, 0, sizeof(struct sockaddr_in));
+    addr->s_inet.sin_family = AF_INET;
+    addr->s_inet.sin_addr = GET_INET_ADDR(Field(vaddr, 0));
+    addr->s_inet.sin_port = htons(Int_val(Field(vaddr, 1)));
 #ifdef SIN6_LEN
-    adr->s_inet.sin_len = sizeof(struct sockaddr_in);
+    addr->s_inet.sin_len = sizeof(struct sockaddr_in);
 #endif
-    *adr_len = sizeof(struct sockaddr_in);
+    *addr_len = sizeof(struct sockaddr_in);
     break;
   }
 }
@@ -109,55 +103,55 @@ static value alloc_unix_sockaddr(value path) {
   CAMLreturn(res);
 }
 
-value caml_unix_alloc_sockaddr(union sock_addr_union * adr /*in*/,
-                          socklen_param_type adr_len, int close_on_error)
+value caml_unix_alloc_sockaddr(union sock_addr_union * addr /*in*/,
+                          socklen_param_type addr_len, int close_on_error)
 {
   CAMLparam0();
   CAMLlocal1(a);
   value res;
-  if (adr_len < offsetof(struct sockaddr, sa_data)) {
+  if (addr_len < offsetof(struct sockaddr, sa_data)) {
     // Only possible for an unnamed AF_UNIX socket, in
     // which case sa_family might be uninitialized.
     CAMLreturn(alloc_unix_sockaddr(caml_alloc_string(0)));
   }
 
-  switch(adr->s_gen.sa_family) {
+  switch(addr->s_gen.sa_family) {
   case AF_UNIX:
     { /* Based on recommendation in section BUGS of Linux unix(7). See
          http://man7.org/linux/man-pages/man7/unix.7.html. */
-      mlsize_t struct_offset = offsetof(struct sockaddr_un, sun_path);
-      mlsize_t path_length = 0;
-      if (adr_len > struct_offset) {
-        path_length = adr_len - struct_offset;
+      size_t struct_offset = offsetof(struct sockaddr_un, sun_path);
+      size_t path_length = 0;
+      if (addr_len > struct_offset) {
+        path_length = addr_len - struct_offset;
 
         /* paths _may_ be null-terminated, but Linux abstract sockets
          * start with a null, and may contain internal nulls. */
         path_length = (
 #ifdef __linux__
-          (adr->s_unix.sun_path[0] == '\0') ? path_length :
+          (addr->s_unix.sun_path[0] == '\0') ? path_length :
 #endif
-          strnlen(adr->s_unix.sun_path, path_length)
+          strnlen(addr->s_unix.sun_path, path_length)
         );
       }
 
       res = alloc_unix_sockaddr(
-        caml_alloc_initialized_string(path_length, (char *)adr->s_unix.sun_path)
-      );
+        caml_alloc_initialized_string(path_length,
+                                      (char *)addr->s_unix.sun_path));
       break;
     }
   case AF_INET:
-    { a = caml_unix_alloc_inet_addr(&adr->s_inet.sin_addr);
+    { a = caml_unix_alloc_inet_addr(&addr->s_inet.sin_addr);
       res = caml_alloc_small(2, 1);
       Field(res,0) = a;
-      Field(res,1) = Val_int(ntohs(adr->s_inet.sin_port));
+      Field(res,1) = Val_int(ntohs(addr->s_inet.sin_port));
       break;
     }
 #ifdef HAS_IPV6
   case AF_INET6:
-    { a = caml_unix_alloc_inet6_addr(&adr->s_inet6.sin6_addr);
+    { a = caml_unix_alloc_inet6_addr(&addr->s_inet6.sin6_addr);
       res = caml_alloc_small(2, 1);
       Field(res,0) = a;
-      Field(res,1) = Val_int(ntohs(adr->s_inet6.sin6_port));
+      Field(res,1) = Val_int(ntohs(addr->s_inet6.sin6_port));
       break;
     }
 #endif

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -163,7 +163,13 @@ value caml_unix_alloc_sockaddr(struct sockaddr * addr /*in*/,
     }
 #endif
   default:
-    if (close_on_error != -1) close (close_on_error);
+    if (close_on_error != -1) {
+#ifdef _WIN32
+      closesocket (close_on_error);
+#else
+      close (close_on_error);
+#endif
+    }
     caml_unix_error(EAFNOSUPPORT, "", Nothing);
   }
   CAMLreturn(res);

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -108,7 +108,7 @@ static value alloc_unix_sockaddr(value path) {
   CAMLreturn(res);
 }
 
-value caml_unix_alloc_sockaddr(struct sockaddr_storage * addr /*in*/,
+value caml_unix_alloc_sockaddr(struct sockaddr * addr /*in*/,
                           socklen_t addr_len, int close_on_error)
 {
   CAMLparam0();
@@ -120,7 +120,7 @@ value caml_unix_alloc_sockaddr(struct sockaddr_storage * addr /*in*/,
     CAMLreturn(alloc_unix_sockaddr(caml_alloc_string(0)));
   }
 
-  switch(addr->ss_family) {
+  switch(addr->sa_family) {
   case AF_UNIX:
     { struct sockaddr_un *s_unix = (struct sockaddr_un *) addr;
       /* Based on recommendation in section BUGS of Linux unix(7). See

--- a/otherlibs/unix/socketpair_win32.c
+++ b/otherlibs/unix/socketpair_win32.c
@@ -39,7 +39,7 @@ static int socketpair(int domain, int type, int protocol,
                       BOOL inherit)
 {
   wchar_t dirname[MAX_PATH + 1], path[MAX_PATH + 1];
-  union sock_addr_union addr;
+  struct sockaddr_un addr;
   socklen_param_type socklen;
 
   /* POSIX states that in case of error, the contents of socket_vector
@@ -64,11 +64,11 @@ static int socketpair(int domain, int type, int protocol,
     goto fail;
   }
 
-  addr.s_unix.sun_family = PF_UNIX;
-  socklen = sizeof(addr.s_unix);
+  addr.sun_family = PF_UNIX;
+  socklen = sizeof(addr);
 
   /* sun_path needs to be set in UTF-8 */
-  rc = WideCharToMultiByte(CP_UTF8, 0, path, -1, addr.s_unix.sun_path,
+  rc = WideCharToMultiByte(CP_UTF8, 0, path, -1, addr.sun_path,
                            UNIX_PATH_MAX, NULL, NULL);
   if (rc == 0) {
     caml_win32_maperr(GetLastError());

--- a/otherlibs/unix/socketpair_win32.c
+++ b/otherlibs/unix/socketpair_win32.c
@@ -23,7 +23,6 @@
 #ifdef HAS_SOCKETS
 
 #include "caml/socketaddr.h"
-#include <ws2tcpip.h>
 
 extern const int caml_unix_socket_domain_table[]; /* from socket.c */
 extern const int caml_unix_socket_type_table[]; /* from socket.c */
@@ -40,7 +39,7 @@ static int socketpair(int domain, int type, int protocol,
 {
   wchar_t dirname[MAX_PATH + 1], path[MAX_PATH + 1];
   struct sockaddr_un addr;
-  socklen_param_type socklen;
+  socklen_t socklen;
 
   /* POSIX states that in case of error, the contents of socket_vector
      shall be unmodified. */

--- a/otherlibs/unix/sockopt_unix.c
+++ b/otherlibs/unix/sockopt_unix.c
@@ -181,7 +181,7 @@ CAMLexport value caml_unix_getsockopt_aux(const char * name,
   CAMLlocal1(err);
   value res;
   union option_value optval;
-  socklen_param_type optsize;
+  socklen_t optsize;
 
 
   switch (ty) {
@@ -236,7 +236,7 @@ CAMLexport value caml_unix_setsockopt_aux(const char * name,
                                      value socket, value val)
 {
   union option_value optval;
-  socklen_param_type optsize;
+  socklen_t optsize;
 
   switch (ty) {
   case TYPE_BOOL:

--- a/otherlibs/unix/sockopt_win32.c
+++ b/otherlibs/unix/sockopt_win32.c
@@ -118,7 +118,7 @@ CAMLexport value caml_unix_getsockopt_aux(const char * name,
   CAMLparam0();
   CAMLlocal1(err);
   union option_value optval;
-  socklen_param_type optsize;
+  socklen_t optsize;
   value res;
 
   switch (ty) {
@@ -174,7 +174,7 @@ CAMLexport value caml_unix_setsockopt_aux(const char * name,
                                      value socket, value val)
 {
   union option_value optval;
-  socklen_param_type optsize;
+  socklen_t optsize;
 
   switch (ty) {
   case TYPE_BOOL:

--- a/otherlibs/unix/strofaddr.c
+++ b/otherlibs/unix/strofaddr.c
@@ -28,22 +28,22 @@ CAMLprim value caml_unix_string_of_inet_addr(value a)
 #ifdef HAS_IPV6
 #ifdef _WIN32
   char buffer[64];
-  union sock_addr_union sa;
+  union sock_addr_union addr;
   int len;
   int retcode;
   if (caml_string_length(a) == 16) {
-    memset(&sa.s_inet6, 0, sizeof(struct sockaddr_in6));
-    sa.s_inet6.sin6_family = AF_INET6;
-    sa.s_inet6.sin6_addr = GET_INET6_ADDR(a);
+    memset(&addr.s_inet6, 0, sizeof(struct sockaddr_in6));
+    addr.s_inet6.sin6_family = AF_INET6;
+    addr.s_inet6.sin6_addr = GET_INET6_ADDR(a);
     len = sizeof(struct sockaddr_in6);
   } else {
-    memset(&sa.s_inet, 0, sizeof(struct sockaddr_in));
-    sa.s_inet.sin_family = AF_INET;
-    sa.s_inet.sin_addr = GET_INET_ADDR(a);
+    memset(&addr.s_inet, 0, sizeof(struct sockaddr_in));
+    addr.s_inet.sin_family = AF_INET;
+    addr.s_inet.sin_addr = GET_INET_ADDR(a);
     len = sizeof(struct sockaddr_in);
   }
   retcode = getnameinfo
-    (&sa.s_gen, len, buffer, sizeof(buffer), NULL, 0, NI_NUMERICHOST);
+    (&addr.s_gen, len, buffer, sizeof(buffer), NULL, 0, NI_NUMERICHOST);
   if (retcode != 0)
     res = NULL;
   else

--- a/otherlibs/unix/strofaddr.c
+++ b/otherlibs/unix/strofaddr.c
@@ -29,15 +29,14 @@ CAMLprim value caml_unix_string_of_inet_addr(value a)
 #ifdef _WIN32
   char buffer[64];
   struct sockaddr_storage addr;
-  int len;
+  socklen_t len;
   int retcode;
+  memset(&addr, 0, sizeof(struct sockaddr_storage));
   if (caml_string_length(a) == 16) {
-    memset(&addr, 0, sizeof(struct sockaddr_storage));
     addr.ss_family = AF_INET6;
     ((struct sockaddr_in6 *) &addr)->sin6_addr = GET_INET6_ADDR(a);
     len = sizeof(struct sockaddr_in6);
   } else {
-    memset(&addr, 0, sizeof(struct sockaddr_storage));
     addr.ss_family = AF_INET;
     ((struct sockaddr_in *) &addr)->sin_addr = GET_INET_ADDR(a);
     len = sizeof(struct sockaddr_in);

--- a/otherlibs/unix/strofaddr.c
+++ b/otherlibs/unix/strofaddr.c
@@ -28,22 +28,22 @@ CAMLprim value caml_unix_string_of_inet_addr(value a)
 #ifdef HAS_IPV6
 #ifdef _WIN32
   char buffer[64];
-  union sock_addr_union addr;
+  struct sockaddr_storage addr;
   int len;
   int retcode;
   if (caml_string_length(a) == 16) {
-    memset(&addr.s_inet6, 0, sizeof(struct sockaddr_in6));
-    addr.s_inet6.sin6_family = AF_INET6;
-    addr.s_inet6.sin6_addr = GET_INET6_ADDR(a);
+    memset(&addr, 0, sizeof(struct sockaddr_storage));
+    addr.ss_family = AF_INET6;
+    ((struct sockaddr_in6 *) &addr)->sin6_addr = GET_INET6_ADDR(a);
     len = sizeof(struct sockaddr_in6);
   } else {
-    memset(&addr.s_inet, 0, sizeof(struct sockaddr_in));
-    addr.s_inet.sin_family = AF_INET;
-    addr.s_inet.sin_addr = GET_INET_ADDR(a);
+    memset(&addr, 0, sizeof(struct sockaddr_storage));
+    addr.ss_family = AF_INET;
+    ((struct sockaddr_in *) &addr)->sin_addr = GET_INET_ADDR(a);
     len = sizeof(struct sockaddr_in);
   }
-  retcode = getnameinfo
-    (&addr.s_gen, len, buffer, sizeof(buffer), NULL, 0, NI_NUMERICHOST);
+  retcode = getnameinfo((struct sockaddr *) &addr, len, buffer, sizeof(buffer),
+                        NULL, 0, NI_NUMERICHOST);
   if (retcode != 0)
     res = NULL;
   else

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -33,4 +33,6 @@
 #define HAS_UNISTD 1
 #endif
 
+#define HAS_SOCKLEN_T 1
+
 #endif  /* CAML_COMPATIBILITY_H */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -93,11 +93,6 @@
 /* Define HAS_SOCKETPAIR if you have the socketpair function. Only
    relevant on Windows. */
 
-#undef HAS_SOCKLEN_T
-
-/* Define HAS_SOCKLEN_T if the type socklen_t is defined in
-   /usr/include/sys/socket.h. */
-
 #undef HAS_AFUNIX_H
 
 /* Define HAS_AFUNIX_H if you have <afunix.h>. */

--- a/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_c.ml
+++ b/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_c.ml
@@ -1,0 +1,12 @@
+(* TEST
+ modules = "sockaddr_c_aux.c";
+ include unix;
+ hasunix;
+ native;
+*)
+external stubs : Unix.sockaddr -> Unix.sockaddr = "stubs"
+
+let () =
+  let addr = Unix.(ADDR_INET (inet6_addr_any, 0)) in
+  let addr' = stubs addr in
+  assert (addr = addr')

--- a/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_c_aux.c
+++ b/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_c_aux.c
@@ -1,0 +1,24 @@
+#if defined(__cplusplus)
+#error "Expected a C compiler, got a C++ compiler"
+#endif
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/socketaddr.h>
+
+/* Test that union sock_addr_union and socklen_param_type still work.
+   struct sockaddr_storage and socklen_t are now preferred.
+ */
+
+value stubs(value vdest)
+{
+  CAMLparam1(vdest);
+  CAMLlocal1(vaddr);
+
+  union sock_addr_union addr;
+  socklen_param_type addr_len;
+  caml_unix_get_sockaddr(vdest, &addr, &addr_len);
+
+  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  CAMLreturn(vaddr);
+}

--- a/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx.ml
+++ b/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx.ml
@@ -1,0 +1,46 @@
+(* TEST
+ not-msvc;
+ readonly_files = "sockaddr_cxx_aux.cpp";
+ hasunix;
+ include unix;
+ {
+   setup-ocamlopt.byte-build-env;
+   script = "${cc} -xc++ -std=c++11 ${cppflags} ${cflags} \
+     -I ${ocamlsrcdir}/runtime \
+     -I ${ocamlsrcdir}/otherlibs/unix \
+     -o ${test_build_directory}/sockaddr_cxx_aux.o \
+     -c ${test_source_directory}/sockaddr_cxx_aux.cpp";
+   script;
+   all_modules = "sockaddr_cxx_aux.o sockaddr_cxx.ml";
+   ocamlopt.byte;
+   output = "${test_build_directory}/program-output";
+   stdout = "${output}";
+   run;
+   check-program-output;
+ }
+ {
+   setup-ocamlc.byte-build-env;
+   script = "${cc} -xc++ -std=c++11 ${cppflags} ${cflags} \
+     -I ${ocamlsrcdir}/runtime \
+     -I ${ocamlsrcdir}/otherlibs/unix \
+     -o ${test_build_directory}/sockaddr_cxx_aux.o \
+     -c ${test_source_directory}/sockaddr_cxx_aux.cpp";
+   script;
+   all_modules = "sockaddr_cxx_aux.o sockaddr_cxx.ml";
+   flags = "-output-complete-exe -cclib -lunixbyt";
+   ocamlc.byte;
+   output = "${test_build_directory}/program-output";
+   stdout = "${output}";
+   run;
+   check-program-output;
+ }
+*)
+external stubs_old : Unix.sockaddr -> Unix.sockaddr = "stubs_old"
+external stubs_new : Unix.sockaddr -> Unix.sockaddr = "stubs_new"
+
+let () =
+  let addr = Unix.(ADDR_INET (inet6_addr_any, 0)) in
+  let addr' = stubs_old addr in
+  let addr'' = stubs_new addr in
+  assert (addr = addr');
+  assert (addr' = addr'');

--- a/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx_aux.cpp
+++ b/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx_aux.cpp
@@ -32,6 +32,6 @@ extern "C" value stubs_new(value vdest)
   socklen_t addr_len;
   caml_unix_get_sockaddr(vdest, &addr, &addr_len);
 
-  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  vaddr = caml_unix_alloc_sockaddr((struct sockaddr *) &addr, addr_len, -1);
   CAMLreturn(vaddr);
 }

--- a/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx_aux.cpp
+++ b/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx_aux.cpp
@@ -1,0 +1,37 @@
+#if !defined(__cplusplus)
+#error "Expected a C++ compiler, got a C compiler"
+#endif
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/socketaddr.h>
+
+/* Test that union sock_addr_union and socklen_param_type still work.
+   struct sockaddr_storage and socklen_t are now preferred.
+ */
+
+extern "C" value stubs_old(value vdest)
+{
+  CAMLparam1(vdest);
+  CAMLlocal1(vaddr);
+
+  union sock_addr_union addr;
+  socklen_param_type addr_len;
+  caml_unix_get_sockaddr(vdest, &addr, &addr_len);
+
+  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  CAMLreturn(vaddr);
+}
+
+extern "C" value stubs_new(value vdest)
+{
+  CAMLparam1(vdest);
+  CAMLlocal1(vaddr);
+
+  struct sockaddr_storage addr;
+  socklen_t addr_len;
+  caml_unix_get_sockaddr(vdest, &addr, &addr_len);
+
+  vaddr = caml_unix_alloc_sockaddr(&addr, addr_len, -1);
+  CAMLreturn(vaddr);
+}


### PR DESCRIPTION
The two `sock_addr_union` and `socklen_param_type` types were introduced when IPv6 was not widely supported. Modernize the network code by deprecating them and replacing them with `struct sockaddr_storage` and `socklen_t`.
`struct sockaddr_storage` and `socklen_t` were specified in [RFC 2553 Basic Socket Interface Extensions for IPv6](https://datatracker.ietf.org/doc/html/rfc2553) (March 1999). They are also specified by [POSIX 2004 (Issue 6)](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/socket.h.html).
`struct sockaddr_storage` is supported since [Windows XP / Windows Server 2003](https://learn.microsoft.com/en-us/windows/win32/winsock/sockaddr-2). `socklen_t` (defined in [`<ws2tcpip.h>`](https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/)) is supported since Windows Vista / Windows Server 2003.

Provide API compatibility with a macro that uses the C11 `_Generic` keyword, and type-punning.
