### PR TITLE
enable `-i-variance` for classes and extension constructors, and describe `-i-variance` in manpages

### DIFF
--- a/Changes
+++ b/Changes
@@ -395,6 +395,10 @@ Working version
    always strip typing environment in cmt files
    (Florian Angeletti, review by David Allsopp)
 
+- #?????: enable -i-variance also for classes and extension constructors,
+  and add description of -i-variance in manpages
+  (Takafumi Saikawa, review by ??)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/Changes
+++ b/Changes
@@ -366,6 +366,9 @@ Working version
   e.g. `< foo : int; .. as $0>` when $0 is introduced by a GADT constructor
   (Stefan Muenzel, review by Jacques Garrigue and Florian Angeletti)
 
+- #14190: `ocaml -e` now also processes `-init` (previously it was ignored).
+  (Emile Trotignon, review by David Allsopp and @ygrek)
+
 - #14225: do not raise unused-constructor warning on private
   constructor in type implementations, for example
   `type safe = private Safe`, which are typically used to
@@ -388,16 +391,14 @@ Working version
   hard-coded path.
   (David Allsopp, review by Damien Doligez and Samuel Hym)
 
-- #14190: `ocaml -e` now also processes `-init` (previously it was ignored).
-  (Emile Trotignon, review by David Allsopp and @ygrek)
+- #14315: enable -i-variance also for classes and extension constructors,
+  and add description of -i-variance in manpages
+  (Takafumi Saikawa, review by Florian Angeletti and Jacques Garrigue)
 
--  #14373: remove the OCAML_BINANNOT_WITHENV environment variable, and
+- #14373: remove the OCAML_BINANNOT_WITHENV environment variable, and
    always strip typing environment in cmt files
    (Florian Angeletti, review by David Allsopp)
 
-- #?????: enable -i-variance also for classes and extension constructors,
-  and add description of -i-variance in manpages
-  (Takafumi Saikawa, review by ??)
 
 ### Internal/compiler-libs changes:
 

--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -69,6 +69,11 @@ Show absolute filenames in error messages.
 .B \-no-absname
 Do not try to show absolute filenames in error messages.
 .TP
+.B \-i-variance
+Cause the compiler to print the computed variance of type parameters for
+every type declaration.  Without this option, variance is printed only for
+private types or types without a manifest (e.g., abstract types).
+.TP
 .BI \-I " directory"
 Add the given directory to the list of directories searched for
 source and compiled files. By default, the current directory is

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -414,6 +414,11 @@ can help in writing an explicit interface (.mli file) for a file: just
 redirect the standard output of the compiler to a .mli file, and edit
 that file to remove all declarations of unexported names.
 .TP
+.B \-i-variance
+Cause the compiler to print the computed variance of type parameters for
+every type declaration.  Without this option, variance is printed only for
+private types or types without a manifest (e.g., abstract types).
+.TP
 .BI \-cmi-file " filename"
 Type-check the source implementation to be compiled against the
 specified interface file (bypasses the normal lookup for .mli and .cmi files).

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -307,6 +307,11 @@ can help in writing an explicit interface (.mli file) for a file:
 just redirect the standard output of the compiler to a .mli file,
 and edit that file to remove all declarations of unexported names.
 .TP
+.B \-i-variance
+Cause the compiler to print the computed variance of type parameters for
+every type declaration.  Without this option, variance is printed only for
+private types or types without a manifest (e.g., abstract types).
+.TP
 .BI \-cmi\-file " filename"
 Type-check the source implementation to be compiled against the
 specified interface file (bypasses the normal lookup for .mli and .cmi files).

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -336,7 +336,7 @@ class type ['node] extension =
 type 'ext node = < >
   constraint 'ext = 'ext node #extension ;;
 [%%expect{|
-class type ['node] extension =
+class type [+!'node] extension =
   object ('a) method clone : 'a method node : 'node end
 type 'a node = <  > constraint 'a = < clone : 'a; node : 'a node; .. >
 |}]

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -808,12 +808,12 @@ and print_out_extension_constructor ppf ext =
         [] -> fprintf ppf "%a" print_lident ext.oext_type_name
       | [ty_param] ->
         fprintf ppf "@[%a@ %a@]"
-          (print_type_parameter ~non_gen:false)
+          type_parameter
           ty_param
           print_lident ext.oext_type_name
       | _ ->
         fprintf ppf "@[(@[%a)@]@ %a@]"
-          (print_list print_type_parameter (fun ppf -> fprintf ppf ",@ "))
+          (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
           ext.oext_type_params
           print_lident ext.oext_type_name
   in
@@ -829,11 +829,11 @@ and print_out_type_extension ppf te =
       [] -> fprintf ppf "%a" print_lident te.otyext_name
     | [param] ->
       fprintf ppf "@[%a@ %a@]"
-        (print_type_parameter ~non_gen:false) param
+        type_parameter param
         print_lident te.otyext_name
     | _ ->
         fprintf ppf "@[(@[%a)@]@ %a@]"
-          (print_list print_type_parameter (fun ppf -> fprintf ppf ",@ "))
+          (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
           te.otyext_params
           print_lident te.otyext_name
   in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1539,15 +1539,19 @@ let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
 (* TODO: move to somewhere (typedecl_variance?) *)
 (* TODO: Typedecl_variance.surface_variance should be integrated *)
 (* TODO: Types.variance should expose its poset structure better *)
-let decode_variance v =
+let decode_variance
+    ?(var_flag=(!Clflags.print_variance))
+    ?(inj_flag=(!Clflags.print_variance)) vi =
   let open Variance in let open Asttypes in
-  if not !Clflags.print_variance then (NoVariance, NoInjectivity) else
-  (match mem May_pos v, mem May_neg v with
+  let v = if not var_flag then NoVariance else
+  match mem May_pos vi, mem May_neg vi with
   | false, false -> Bivariant
   | true, false -> Covariant
   | false, true -> Contravariant
-  | true, true -> NoVariance),
-  (if mem Inj v then Injective else NoInjectivity)
+  | true, true -> NoVariance in
+  let i = if not inj_flag then NoInjectivity else
+  if mem Inj vi then Injective else NoInjectivity in
+  (v, i)
 
 let prepared_tree_of_extension_constructor
    ~env id ext es
@@ -1744,23 +1748,11 @@ let rec tree_of_class_type mode params =
 
 
 let tree_of_class_param param variance =
-  let ot_variance =
-    if not !Clflags.print_variance && is_Tvar param
-    then Asttypes.(NoVariance, NoInjectivity) else variance in
+  let ot_variance = decode_variance variance
+      ~var_flag:(!Clflags.print_variance || not (is_Tvar param)) in
   match tree_of_typexp Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
   | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}
-
-let class_variance =
-  let open Variance in let open Asttypes in
-  List.map (fun v ->
-    let inj = !Clflags.print_variance && Variance.mem Inj v in
-    (match mem May_pos v, mem May_neg v with
-    | false, false -> Bivariant
-    | true, false -> Covariant
-    | false, true -> Contravariant
-    | true, true -> NoVariance),
-    (if inj then Injective else NoInjectivity))
 
 let tree_of_class_declaration id cl rs =
   let params = filter_params cl.cty_params in
@@ -1778,7 +1770,7 @@ let tree_of_class_declaration id cl rs =
   let vir_flag = cl.cty_new = None in
   Osig_class
     (vir_flag, Ident.name id,
-     List.map2 tree_of_class_param params (class_variance cl.cty_variance),
+     List.map2 tree_of_class_param params cl.cty_variance,
      tree_of_class_type Type_scheme params cl.cty_type,
      tree_of_rec rs)
 
@@ -1805,7 +1797,7 @@ let tree_of_cltype_declaration id cl rs =
   in
   Osig_class_type
     (has_virtual_vars || has_virtual_meths, Ident.name id,
-     List.map2 tree_of_class_param params (class_variance cl.clty_variance),
+     List.map2 tree_of_class_param params cl.clty_variance,
      tree_of_class_type Type_scheme params cl.clty_type,
      tree_of_rec rs)
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1542,8 +1542,12 @@ let prepared_tree_of_extension_constructor
   let ty_params = filter_params ext.ext_type_params in
   let type_param =
     function
-    | Otyp_var (_, id) -> id
-    | _ -> "?"
+    | Otyp_var (_ot_non_gen, ot_name) ->
+        {ot_non_gen=false; ot_name; ot_variance=(NoVariance,NoInjectivity)}
+        (* NB: ot_non_gen=false to preserve the original semantics; however,
+           simply using the given ot_non_gen does not break testsuite either *)
+    | _ ->
+        {ot_non_gen=false; ot_name="?"; ot_variance=NoVariance,NoInjectivity}
   in
   let param_scope f =
     match ext.ext_ret_type with

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1535,15 +1535,40 @@ let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
   let args = tree_of_constructor_arguments ext_args in
   (args, ret)
 
+(* TODO: eliminate duplications of this code in this file *)
+(* TODO: move to somewhere (typedecl_variance?) *)
+(* TODO: Typedecl_variance.surface_variance should be integrated *)
+(* TODO: Types.variance should expose its poset structure better *)
+let decode_variance v =
+  let open Variance in let open Asttypes in
+  if not !Clflags.print_variance then (NoVariance, NoInjectivity) else
+  (match mem May_pos v, mem May_neg v with
+  | false, false -> Bivariant
+  | true, false -> Covariant
+  | false, true -> Contravariant
+  | true, true -> NoVariance),
+  (if mem Inj v then Injective else NoInjectivity)
+
 let prepared_tree_of_extension_constructor
-   id ext es
+   ~env id ext es
   =
   let ty_name = Path.name ext.ext_type_path in
   let ty_params = filter_params ext.ext_type_params in
-  let type_param =
+  let ty_variances =
+    let ovariances =
+        Option.bind env (fun env ->
+          try Some (Env.find_type ext.ext_type_path env).type_variance
+          with Not_found -> None)
+    in
+    Option.fold
+      ~none:(List.map (fun _ -> NoVariance, NoInjectivity) ty_params)
+      ~some:(List.map decode_variance)
+      ovariances
+  in
+  let type_param ot_variance =
     function
     | Otyp_var (_ot_non_gen, ot_name) ->
-        {ot_non_gen=false; ot_name; ot_variance=(NoVariance,NoInjectivity)}
+        {ot_non_gen=false; ot_name; ot_variance}
         (* NB: ot_non_gen=false to preserve the original semantics; however,
            simply using the given ot_non_gen does not break testsuite either *)
     | _ ->
@@ -1562,7 +1587,8 @@ let prepared_tree_of_extension_constructor
     param_scope
       (fun () ->
          List.iter (Aliases.add_printed ~non_gen:false) ty_params;
-         List.map (fun ty -> type_param (tree_of_typexp Type ty)) ty_params
+         List.map2 (fun v ty -> type_param v (tree_of_typexp Type ty))
+          ty_variances ty_params
       )
   in
   let name = Ident.name id in
@@ -1587,14 +1613,14 @@ let prepared_tree_of_extension_constructor
   in
     Osig_typext (ext, es)
 
-let tree_of_extension_constructor id ext es =
+let tree_of_extension_constructor ?env id ext es =
   reset_except_conflicts ();
   add_extension_constructor_to_preparation ext;
-  prepared_tree_of_extension_constructor id ext es
+  prepared_tree_of_extension_constructor ~env id ext es
 
-let prepared_extension_constructor id ppf ext =
+let prepared_extension_constructor ?env id ppf ext =
   !Oprint.out_sig_item ppf
-    (prepared_tree_of_extension_constructor id ext Text_first)
+    (prepared_tree_of_extension_constructor ~env id ext Text_first)
 
 (* Print a value declaration *)
 
@@ -1912,7 +1938,7 @@ and tree_of_signature_rec env' sg =
 
 and trees_of_recursive_sigitem_group env
     (syntactic_group: Signature_group.rec_group) =
-  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem x.src in
+  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem env x.src in
   let env = Env.add_signature syntactic_group.pre_ghosts env in
   match syntactic_group.group with
   | Not_rec x -> add_sigitem env x, [display x]
@@ -1921,13 +1947,13 @@ and trees_of_recursive_sigitem_group env
       List.fold_left add_sigitem env items,
       with_hidden_items ids (fun () -> List.map display items)
 
-and tree_of_sigitem = function
+and tree_of_sigitem env = function
   | Sig_value(id, decl, _) ->
       tree_of_value_description id decl
   | Sig_type(id, decl, rs, _) ->
       tree_of_type_declaration id decl rs
   | Sig_typext(id, ext, es, _) ->
-      tree_of_extension_constructor id ext es
+      tree_of_extension_constructor ~env id ext es
   | Sig_module(id, _, md, rs, _) ->
       let ellipsis =
         List.exists (function

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1548,16 +1548,13 @@ let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
   let args = tree_of_constructor_arguments ext_args in
   (args, ret)
 
-let prepared_tree_of_extension_constructor
-   ~env id ext es
-  =
+let prepared_tree_of_extension_constructor id ext es =
   let ty_name = Path.name ext.ext_type_path in
   let ty_params = filter_params ext.ext_type_params in
   let ty_variances =
     let ovariances =
-        Option.bind env (fun env ->
-          try Some (Env.find_type ext.ext_type_path env).type_variance
-          with Not_found -> None)
+      try Some (Env.find_type ext.ext_type_path !printing_env).type_variance
+      with Not_found -> None
     in
     Option.fold
       ~none:(List.map (fun _ -> NoVariance, NoInjectivity) ty_params)
@@ -1612,14 +1609,14 @@ let prepared_tree_of_extension_constructor
   in
     Osig_typext (ext, es)
 
-let tree_of_extension_constructor ?env id ext es =
+let tree_of_extension_constructor id ext es =
   reset_except_conflicts ();
   add_extension_constructor_to_preparation ext;
-  prepared_tree_of_extension_constructor ~env id ext es
+  prepared_tree_of_extension_constructor id ext es
 
-let prepared_extension_constructor ?env id ppf ext =
+let prepared_extension_constructor id ppf ext =
   !Oprint.out_sig_item ppf
-    (prepared_tree_of_extension_constructor ~env id ext Text_first)
+    (prepared_tree_of_extension_constructor id ext Text_first)
 
 (* Print a value declaration *)
 
@@ -1925,7 +1922,7 @@ and tree_of_signature_rec env' sg =
 
 and trees_of_recursive_sigitem_group env
     (syntactic_group: Signature_group.rec_group) =
-  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem env x.src in
+  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem x.src in
   let env = Env.add_signature syntactic_group.pre_ghosts env in
   match syntactic_group.group with
   | Not_rec x -> add_sigitem env x, [display x]
@@ -1934,13 +1931,13 @@ and trees_of_recursive_sigitem_group env
       List.fold_left add_sigitem env items,
       with_hidden_items ids (fun () -> List.map display items)
 
-and tree_of_sigitem env = function
+and tree_of_sigitem = function
   | Sig_value(id, decl, _) ->
       tree_of_value_description id decl
   | Sig_type(id, decl, rs, _) ->
       tree_of_type_declaration id decl rs
   | Sig_typext(id, ext, es, _) ->
-      tree_of_extension_constructor ~env id ext es
+      tree_of_extension_constructor id ext es
   | Sig_module(id, _, md, rs, _) ->
       let ellipsis =
         List.exists (function

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1552,21 +1552,19 @@ let prepared_tree_of_extension_constructor id ext es =
   let ty_name = Path.name ext.ext_type_path in
   let ty_params = filter_params ext.ext_type_params in
   let ty_variances =
-    let ovariances =
-      try Some (Env.find_type ext.ext_type_path !printing_env).type_variance
-      with Not_found -> None
-    in
-    Option.fold
-      ~none:(List.map (fun _ -> NoVariance, NoInjectivity) ty_params)
-      ~some:(List.map syntactic_variance)
-      ovariances
+    try
+      let variances =
+        (Env.find_type ext.ext_type_path !printing_env).type_variance in
+      List.map syntactic_variance variances
+    with Not_found ->
+      List.map (fun _ -> NoVariance, NoInjectivity) ty_params
   in
   let type_param ot_variance =
     function
     | Otyp_var (_ot_non_gen, ot_name) ->
         {ot_non_gen=false; ot_name; ot_variance}
-        (* NB: ot_non_gen=false to preserve the original semantics; however,
-           simply using the given ot_non_gen does not break testsuite either *)
+        (* NB(#14315): simply using the given ot_non_gen here
+           does not break the testsuite *)
     | _ ->
         {ot_non_gen=false; ot_name="?"; ot_variance=NoVariance,NoInjectivity}
   in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1292,17 +1292,17 @@ let filter_params tyl =
    we need to translate the computed variance ([Variance.t])
    back into the corresponding syntactic node ([Asttypes.variance]).
    [Typedecl_variance.transl_variance] is half inverse to this operation. *)
-let untransl_variance
-    ?(var_flag=(!Clflags.print_variance))
-    ?(inj_flag=(!Clflags.print_variance)) vi =
+let syntactic_variance
+    ?(with_variance=(!Clflags.print_variance))
+    ?(with_injectivity=(!Clflags.print_variance)) vi =
   let open Variance in let open Asttypes in
-  let v = if not var_flag then NoVariance else
+  let v = if not with_variance then NoVariance else
   match mem May_pos vi, mem May_neg vi with
   | false, false -> Bivariant
   | true, false -> Covariant
   | false, true -> Contravariant
   | true, true -> NoVariance in
-  let i = if not inj_flag then NoInjectivity else
+  let i = if not with_injectivity then NoInjectivity else
   if mem Inj vi then Injective else NoInjectivity in
   (v, i)
 
@@ -1428,8 +1428,8 @@ let tree_of_type_decl id decl =
       List.map2
         (fun ty v ->
           let is_var = is_Tvar ty in
-          let var_flag = !Clflags.print_variance || abstr || not is_var in
-          let inj_flag =
+          let with_variance = !Clflags.print_variance || abstr || not is_var in
+          let with_injectivity =
             !Clflags.print_variance ||
             (abstr || not is_var) &&
             type_kind_is_abstract decl &&
@@ -1439,7 +1439,7 @@ let tree_of_type_decl id decl =
                 decl.type_private = Private &&
                 Btype.is_constr_row ~allow_ident:true (Btype.row_of_type ty)
           in
-          untransl_variance ~var_flag ~inj_flag v)
+          syntactic_variance ~with_variance ~with_injectivity v)
         decl.type_params decl.type_variance
     in
     (Ident.name id,
@@ -1561,7 +1561,7 @@ let prepared_tree_of_extension_constructor
     in
     Option.fold
       ~none:(List.map (fun _ -> NoVariance, NoInjectivity) ty_params)
-      ~some:(List.map untransl_variance)
+      ~some:(List.map syntactic_variance)
       ovariances
   in
   let type_param ot_variance =
@@ -1743,8 +1743,8 @@ let rec tree_of_class_type mode params =
 
 
 let tree_of_class_param param variance =
-  let ot_variance = untransl_variance variance
-      ~var_flag:(!Clflags.print_variance || not (is_Tvar param)) in
+  let ot_variance = syntactic_variance variance
+      ~with_variance:(!Clflags.print_variance || not (is_Tvar param)) in
   match tree_of_typexp Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
   | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1288,6 +1288,24 @@ let filter_params tyl =
       [] tyl
   in List.rev params
 
+(* When printing the variance of a type parameter,
+   we need to translate the computed variance ([Variance.t])
+   back into the corresponding syntactic node ([Asttypes.variance]).
+   [Typedecl_variance.transl_variance] is half inverse to this operation. *)
+let untransl_variance
+    ?(var_flag=(!Clflags.print_variance))
+    ?(inj_flag=(!Clflags.print_variance)) vi =
+  let open Variance in let open Asttypes in
+  let v = if not var_flag then NoVariance else
+  match mem May_pos vi, mem May_neg vi with
+  | false, false -> Bivariant
+  | true, false -> Covariant
+  | false, true -> Contravariant
+  | true, true -> NoVariance in
+  let i = if not inj_flag then NoInjectivity else
+  if mem Inj vi then Injective else NoInjectivity in
+  (v, i)
+
 let prepare_type_constructor_arguments = function
   | Cstr_tuple l -> List.iter prepare_type l
   | Cstr_record l -> List.iter (fun l -> prepare_type l.ld_type) l
@@ -1410,23 +1428,18 @@ let tree_of_type_decl id decl =
       List.map2
         (fun ty v ->
           let is_var = is_Tvar ty in
-          if !Clflags.print_variance || abstr || not is_var then
-            let inj =
-              !Clflags.print_variance && Variance.mem Inj v ||
-              type_kind_is_abstract decl && Variance.mem Inj v &&
-              match decl.type_manifest with
-              | None -> true
-              | Some ty -> (* only abstract or private row types *)
-                  decl.type_private = Private &&
-                  Btype.is_constr_row ~allow_ident:true (Btype.row_of_type ty)
-            and (co, cn) = Variance.get_upper v in
-            (match co, cn with
-            | false, false -> Bivariant
-            | true, false -> Covariant
-            | false, true -> Contravariant
-            | true, true -> NoVariance),
-            (if inj then Injective else NoInjectivity)
-          else (NoVariance, NoInjectivity))
+          let var_flag = !Clflags.print_variance || abstr || not is_var in
+          let inj_flag =
+            !Clflags.print_variance ||
+            (abstr || not is_var) &&
+            type_kind_is_abstract decl &&
+            match decl.type_manifest with
+            | None -> true
+            | Some ty -> (* only abstract or private row types *)
+                decl.type_private = Private &&
+                Btype.is_constr_row ~allow_ident:true (Btype.row_of_type ty)
+          in
+          untransl_variance ~var_flag ~inj_flag v)
         decl.type_params decl.type_variance
     in
     (Ident.name id,
@@ -1535,24 +1548,6 @@ let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
   let args = tree_of_constructor_arguments ext_args in
   (args, ret)
 
-(* TODO: eliminate duplications of this code in this file *)
-(* TODO: move to somewhere (typedecl_variance?) *)
-(* TODO: Typedecl_variance.surface_variance should be integrated *)
-(* TODO: Types.variance should expose its poset structure better *)
-let decode_variance
-    ?(var_flag=(!Clflags.print_variance))
-    ?(inj_flag=(!Clflags.print_variance)) vi =
-  let open Variance in let open Asttypes in
-  let v = if not var_flag then NoVariance else
-  match mem May_pos vi, mem May_neg vi with
-  | false, false -> Bivariant
-  | true, false -> Covariant
-  | false, true -> Contravariant
-  | true, true -> NoVariance in
-  let i = if not inj_flag then NoInjectivity else
-  if mem Inj vi then Injective else NoInjectivity in
-  (v, i)
-
 let prepared_tree_of_extension_constructor
    ~env id ext es
   =
@@ -1566,7 +1561,7 @@ let prepared_tree_of_extension_constructor
     in
     Option.fold
       ~none:(List.map (fun _ -> NoVariance, NoInjectivity) ty_params)
-      ~some:(List.map decode_variance)
+      ~some:(List.map untransl_variance)
       ovariances
   in
   let type_param ot_variance =
@@ -1748,7 +1743,7 @@ let rec tree_of_class_type mode params =
 
 
 let tree_of_class_param param variance =
-  let ot_variance = decode_variance variance
+  let ot_variance = untransl_variance variance
       ~var_flag:(!Clflags.print_variance || not (is_Tvar param)) in
   match tree_of_typexp Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1715,7 +1715,8 @@ let rec tree_of_class_type mode params =
 
 let tree_of_class_param param variance =
   let ot_variance =
-    if is_Tvar param then Asttypes.(NoVariance, NoInjectivity) else variance in
+    if not !Clflags.print_variance && is_Tvar param
+    then Asttypes.(NoVariance, NoInjectivity) else variance in
   match tree_of_typexp Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
   | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -132,13 +132,13 @@ val add_constructor_to_preparation : constructor_declaration -> unit
 val prepared_constructor : constructor_declaration printer
 
 val tree_of_extension_constructor:
-    ?env:Env.t -> Ident.t -> extension_constructor -> ext_status -> out_sig_item
+    Ident.t -> extension_constructor -> ext_status -> out_sig_item
 val extension_constructor_args_and_ret_type_subtree:
   constructor_arguments -> type_expr option -> out_type list * out_type option
 val add_extension_constructor_to_preparation :
     extension_constructor -> unit
 val prepared_extension_constructor:
-    ?env:Env.t -> Ident.t -> extension_constructor printer
+    Ident.t -> extension_constructor printer
 
 
 (** {1 Declarations }*)

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -132,13 +132,13 @@ val add_constructor_to_preparation : constructor_declaration -> unit
 val prepared_constructor : constructor_declaration printer
 
 val tree_of_extension_constructor:
-    Ident.t -> extension_constructor -> ext_status -> out_sig_item
+    ?env:Env.t -> Ident.t -> extension_constructor -> ext_status -> out_sig_item
 val extension_constructor_args_and_ret_type_subtree:
   constructor_arguments -> type_expr option -> out_type list * out_type option
 val add_extension_constructor_to_preparation :
     extension_constructor -> unit
 val prepared_extension_constructor:
-    Ident.t -> extension_constructor printer
+    ?env:Env.t -> Ident.t -> extension_constructor printer
 
 
 (** {1 Declarations }*)

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -150,13 +150,13 @@ and out_type_decl =
 and out_extension_constructor =
   { oext_name: string;
     oext_type_name: string;
-    oext_type_params: string list;
+    oext_type_params: out_type_param list;
     oext_args: out_type list;
     oext_ret_type: out_type option;
     oext_private: Asttypes.private_flag }
 and out_type_extension =
   { otyext_name: string;
-    otyext_params: string list;
+    otyext_params: out_type_param list;
     otyext_constructors: out_constructor list;
     otyext_private: Asttypes.private_flag }
 and out_val_decl =


### PR DESCRIPTION
This PR is a follow-up to #13820 and #14126:
`-i-variance` command-line option now works also for classes and extension constructors, and
the manpages are updated.