### PR TITLE
Skip the Linux native-debugger tests on clang

### DIFF
--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -134,6 +134,16 @@ let not_msvc = make
     "not using MSVC / clang-cl"
     "using MSVC / clang-cl")
 
+let is_clang =
+  List.mem "clang" (String.split_on_char '-' Ocamltest_config.c_compiler_vendor)
+
+let not_clang = make
+  ~name:"not-clang"
+  ~description:"Pass if not using clang"
+  (Actions_helpers.pass_or_skip (not is_clang)
+    "not using clang"
+    "using clang")
+
 (* windows _passes_ on Cygwin; target_windows _skips_ for Cygwin *)
 
 let target_windows = make
@@ -405,6 +415,7 @@ let _ =
     windows;
     not_windows;
     not_msvc;
+    not_clang;
     target_windows;
     not_target_windows;
     bsd;

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -33,6 +33,8 @@ let cflags = {@QS@|@common_cflags@|@QS@}
 
 let ccomp_type = {@QS@|@ccomp_type@|@QS@}
 
+let c_compiler_vendor = {@QS@|@ocaml_cc_vendor@|@QS@}
+
 let target_os_type = {@QS@|@target_os_type@|@QS@}
 
 let diff = {@QS@|@DIFF@|@QS@}

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -39,6 +39,9 @@ val cflags : string
 val ccomp_type : string
 (** Type of C compiler (msvc, cc, etc.) *)
 
+val c_compiler_vendor: string
+(** The vendor and version of the C compiler (see {!Config.c_compiler_vendor} *)
+
 val target_os_type : string
 (** The value of Sys.os_type for the target (cf. Config.target_os_type) *)
 

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -2,6 +2,7 @@
    native-compiler;
    no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
+   not-clang; (* Skip, clang is tested on macOS *)
    arch_amd64;
    script = "sh ${test_source_directory}/has_gdb.sh";
    script;

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.ml
@@ -2,6 +2,7 @@
    native-compiler;
    no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
+   not-clang; (* Skip, clang is tested on macOS *)
    arch_arm64;
    script = "sh ${test_source_directory}/has_gdb.sh";
    script;

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.ml
@@ -1,6 +1,7 @@
 (* TEST
    native-compiler;
    linux;
+   not-clang; (* Skip, clang is tested on macOS *)
    no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    arch_riscv;
    script = "sh ${test_source_directory}/has_gdb.sh";

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.ml
@@ -2,6 +2,7 @@
    native-compiler;
    no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
+   not-clang; (* Skip, clang is tested on macOS *)
    arch_amd64;
    script = "sh ${test_source_directory}/has_lldb.sh linux";
    script;

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.ml
@@ -2,6 +2,7 @@
    native-compiler;
    no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
+   not-clang; (* Skip, clang is tested on macOS *)
    arch_arm64;
    script = "sh ${test_source_directory}/has_lldb.sh linux";
    script;


### PR DESCRIPTION
#14314 got the other-configs job one step closer to passing again, but `tests/native-debugger/linux-gdb-amd64.ml` fails with clang (in fact, so does the lldb test when I tried locally). These are smoke tests for the backtraces and macros, so the simplest thing here (having chatted privately with @tmcgilchrist) is just to skip these tests when building with clang on Linux.

I've added a `not-clang` action to ocamltest which uses a pattern already present in the `test-in-prefix` harness and then used that in all the linux versions of these tests.