### PR TITLE
fix polymorphic variant specification

### DIFF
--- a/manual/src/refman/types.etex
+++ b/manual/src/refman/types.etex
@@ -136,16 +136,13 @@ of @typexpr@ is captured by @"'" ident@, and quantified upon.
 
 \begin{syntax}
 polymorphic-variant-type:
-        '[' tag-spec-first { '|' tag-spec } ']'
+        '[' tag-spec { '|' tag-spec } ']'
       | '[>' [ tag-spec ] { '|' tag-spec } ']'
       | '[<' ['|'] tag-spec-full { '|' tag-spec-full }
              [ '>' {{ '`'tag-name }} ] ']'
 ;
 %\end{syntax} \begin{syntax}
-tag-spec-first:
-        '`'tag-name [ 'of' typexpr ]
-      | [ typexpr ] '|' tag-spec
-;
+
 tag-spec:
         '`'tag-name [ 'of' typexpr ]
       | typexpr


### PR DESCRIPTION
I think there is an issue with the specification of polymorphic variants.

The issue is that `tag-spec-first` (besides for being redundant to `tag-spec`), allows a type of ``[ | `foo ]`` (`|` before the first variant), because of this rule in `tag-spec-first`:  ``[ typexpr ] '|' tag-spec``.

However, when I tried this in utop, it only allows me to put `|`  between two `tag-spec`s in polymorphic variants, and ``[ | `foo ]`` gives a syntax error on `[|`.