### PR TITLE
Allow retyping as-patterns that contain existentials (redone)

### DIFF
--- a/Changes
+++ b/Changes
@@ -152,10 +152,10 @@ Working version
   any wellformedness check.
   (Clement Blaudeau and Ryan Tjoa, review by Florian Angeletti)
 
-- #?????: Allow retyping as-patterns that contain existentials
+- #14327: Allow retyping as-patterns that contain existentials
   (completing #14229)
   (Jacques Garrigue and Takafumi Saikawa, reported by Olivier Nicole,
-   review by ??)
+   review by Gabriel Scherer)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -152,6 +152,10 @@ Working version
   any wellformedness check.
   (Clement Blaudeau and Ryan Tjoa, review by Florian Angeletti)
 
+- #?????: Allow retyping as-patterns that contain existentials
+  (completing #14229)
+  (Jacques Garrigue and Takafumi Saikawa, reported by Olivier Nicole,
+   review by ??)
 
 ### Other libraries:
 

--- a/testsuite/tests/typing-gadts/existential_as_pattern.ml
+++ b/testsuite/tests/typing-gadts/existential_as_pattern.ml
@@ -1,0 +1,103 @@
+(* TEST
+ expect;
+*)
+
+(** Test that as-patterns let us re-specialize the type of a constructor packing an existential *)
+
+(* No payload *)
+type 'a t =
+  | Left : [> `Left ] t
+  | Right : [> `Right ] t
+[%%expect {|
+type 'a t = Left : [> `Left ] t | Right : [> `Right ] t
+|}]
+
+let left : [ `Left | `Right ] t -> [ `Left ] t = function
+  | Left as t -> t
+  | Right -> assert false
+[%%expect {|
+val left : [ `Left | `Right ] t -> [ `Left ] t = <fun>
+|}]
+
+(* Concrete payload *)
+type ('a, 'e) t =
+  | Left : 'e -> ([> `Left ], 'e) t
+  | Right : 'e -> ([> `Right ], 'e) t
+[%%expect {|
+type ('a, 'e) t =
+    Left : 'e -> ([> `Left ], 'e) t
+  | Right : 'e -> ([> `Right ], 'e) t
+|}]
+
+let left : ([ `Left | `Right ], 'e) t -> ([ `Left ], 'e) t = function
+  | Left _ as t -> t
+  | Right _ -> assert false
+[%%expect {|
+val left : ([ `Left | `Right ], 'e) t -> ([ `Left ], 'e) t = <fun>
+|}]
+
+(* Pack payload *)
+type 'a t2 = P : ('a, 'e) t -> 'a t2 [@@unboxed]
+[%%expect {|
+type 'a t2 = P : ('a, 'e) t -> 'a t2 [@@unboxed]
+|}]
+
+let left : [ `Left | `Right ] t2 -> [ `Left ] t2 = function
+  | P (Left _ as t) -> P t
+  | P (Right _) -> assert false
+[%%expect {|
+val left : [ `Left | `Right ] t2 -> [ `Left ] t2 = <fun>
+|}]
+
+(* Existential payload - equivalent to packed concrete payload *)
+type 'a t =
+  | Left : 'e -> [> `Left ] t
+  | Right : 'e -> [> `Right ] t
+[%%expect {|
+type 'a t = Left : 'e -> [> `Left ] t | Right : 'e -> [> `Right ] t
+|}]
+
+let left : [ `Left | `Right ] t -> [ `Left ] t = function
+  | Left _ as t -> t
+  | Right _ -> assert false
+[%%expect {|
+val left : [ `Left | `Right ] t -> [ `Left ] t = <fun>
+|}]
+
+(* Some examples require more work *)
+type 'a boxed_int = private int
+
+(* Easy: no existentials *)
+type 'a good_t = Val of 'a | Boxed : unit boxed_int -> 'a good_t | Other
+
+let f = function
+  | Val x -> Val true
+  | (Boxed _ | Other) as y -> y
+[%%expect{|
+type 'a boxed_int = private int
+type 'a good_t = Val of 'a | Boxed : unit boxed_int -> 'a good_t | Other
+val f : 'a good_t -> bool good_t = <fun>
+|}]
+
+(* Requires to unify existentials *)
+type 'a bad_t = Val of 'a | Boxed : 'b boxed_int -> 'a bad_t | Other
+let f = function
+  | Val x -> Val true
+  | (Boxed _ | Other) as y -> y
+[%%expect{|
+type 'a bad_t = Val of 'a | Boxed : 'b boxed_int -> 'a bad_t | Other
+val f : 'a bad_t -> bool bad_t = <fun>
+|}]
+
+(* Used to work, and should still work *)
+type t =
+  | Value_int of int
+  | Value_boxed_int : 'a boxed_int -> t
+
+let f (x : t) : t =
+  match x with
+  | Value_int _ | Value_boxed_int _ as y -> y
+[%%expect{|
+type t = Value_int of int | Value_boxed_int : 'a boxed_int -> t
+val f : t -> t = <fun>
+|}]

--- a/testsuite/tests/typing-gadts/existential_as_pattern.ml
+++ b/testsuite/tests/typing-gadts/existential_as_pattern.ml
@@ -2,7 +2,8 @@
  expect;
 *)
 
-(** Test that as-patterns let us re-specialize the type of a constructor packing an existential *)
+(** Test that as-patterns let us re-specialize the type of a constructor packing
+    an existential *)
 
 (* No payload *)
 type 'a t =
@@ -67,14 +68,27 @@ val left : [ `Left | `Right ] t -> [ `Left ] t = <fun>
 (* Some examples require more work *)
 type 'a boxed_int = private int
 
-(* Easy: no existentials *)
+(* Used to work, and should still work *)
+type t =
+  | Value_int of int
+  | Value_boxed_int : 'a boxed_int -> t
+
+let f (x : t) : t =
+  match x with
+  | Value_int _ | Value_boxed_int _ as y -> y;;
+[%%expect{|
+type 'a boxed_int = private int
+type t = Value_int of int | Value_boxed_int : 'a boxed_int -> t
+val f : t -> t = <fun>
+|}]
+
+(* Expected typing, an easy case: no existentials *)
 type 'a good_t = Val of 'a | Boxed : unit boxed_int -> 'a good_t | Other
 
 let f = function
   | Val x -> Val true
-  | (Boxed _ | Other) as y -> y
+  | (Boxed _ | Other) as y -> y;;
 [%%expect{|
-type 'a boxed_int = private int
 type 'a good_t = Val of 'a | Boxed : unit boxed_int -> 'a good_t | Other
 val f : 'a good_t -> bool good_t = <fun>
 |}]
@@ -83,21 +97,30 @@ val f : 'a good_t -> bool good_t = <fun>
 type 'a bad_t = Val of 'a | Boxed : 'b boxed_int -> 'a bad_t | Other
 let f = function
   | Val x -> Val true
-  | (Boxed _ | Other) as y -> y
+  | (Boxed _ | Other) as y -> y;;
 [%%expect{|
 type 'a bad_t = Val of 'a | Boxed : 'b boxed_int -> 'a bad_t | Other
 val f : 'a bad_t -> bool bad_t = <fun>
 |}]
 
-(* Used to work, and should still work *)
-type t =
+(* Example with an existential at a higher level *)
+type _ t =
   | Value_int of int
-  | Value_boxed_int : 'a boxed_int -> t
+  | Value_snd : ('a,'b option) result -> 'b t;;
 
-let f (x : t) : t =
+(*
+  level(f)
+< level(match x ..) = level(.. as y)
+< level(Value_snd ..) (an existential $a is introduced)
+< level(Ok ..) ($a is used)
+
+(Ok _ | Error None) : ($a,'b option) result
+*)
+let f (x : _ t) =
   match x with
-  | Value_int _ | Value_boxed_int _ as y -> y
+  | (Value_int _ | Value_snd (Ok _ | Error None)) as y -> y
+  | Value_snd (Error (Some _)) -> Value_snd (Error None);;
 [%%expect{|
-type t = Value_int of int | Value_boxed_int : 'a boxed_int -> t
-val f : t -> t = <fun>
+type _ t = Value_int of int | Value_snd : ('a, 'b option) result -> 'b t
+val f : 'a t -> 'b t = <fun>
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -856,9 +856,13 @@ and build_as_type_aux (env : Env.t) p =
       let tyl = List.map (build_as_type env) pl in
       let ty_args, ty_res, _ =
         instance_constructor Keep_existentials_flexible cstr in
-      (* [p] is a valid result of type inference, and [ty_args] is a generic
-         instance where existentials are variables, with non-escaping ones
-         are at generic level.
+      (* [p] is a valid result of type inference, so the levels inside its
+         types are correct (higher than the scopes). [tyl] is obtained
+         from [pl], which is part of [p], so that all the locally abstract
+         types it contains come from [p].
+         [ty_args] is an instance of the constructor type such that its
+         variables, includinding existentials, are mapped to variables at
+         a level higher than any locally abstract type in [pl], hence [tyl].
          This means that [tyl] is an instance of [ty_args],
          and unification should not fail *)
       List.iter2 (fun (p,ty) -> unify_pat env {p with pat_type = ty})


### PR DESCRIPTION
This PR completes PR #14229, so that the existing code does not break and
the nested or-pattern typechecks as well:
```ocaml
type _ t =
  | Value_int of int
  | Value_snd : ('a,'b option) result -> 'b t;;

let f (x : _ t) =
  match x with
  | (Value_int _ | Value_snd (Ok _ | Error None)) as y -> y
  | Value_snd (Error (Some _)) -> Value_snd (Error None);;

val f : 'a t -> 'b t = <fun>
```

Co-authored-by: @garrigue 