### PR TITLE
Enforce !current_level <= generic_level and explain create_scope

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,8 +339,8 @@ Working version
   being treated as equivalent to `let rec x = ...`
   (Vincent Laviron, review by Alistair O'Brien and Florian Angeletti)
 
-- Enforce current_level <= generic_level, and explain create_scope
-  (Jacques Garrigue and Takafumi Saikawa, review by ?)
+- #14331: Enforce current_level <= generic_level, and explain create_scope
+  (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -339,6 +339,9 @@ Working version
   being treated as equivalent to `let rec x = ...`
   (Vincent Laviron, review by Alistair O'Brien and Florian Angeletti)
 
+- Enforce current_level <= generic_level, and explain create_scope
+  (Jacques Garrigue and Takafumi Saikawa, review by ?)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -82,7 +82,18 @@ val increase_global_level: unit -> int
 val restore_global_level: int -> unit
         (* This pair of functions is only used in Typetexp *)
 
-val create_scope : unit -> int
+val create_scope: unit -> int
+        (* Return a level higher than all previous levels.
+           When used as scope in [Ident.create_scoped], this guarantees
+           that the correspondind type cannot escape to a previous
+           environment.
+           Practically, this is done by returning the current level
+           after raising it.
+           Contrary to [with_local_level*], the end of the scope is not
+           specified by [create_scope]. If there is an enclosing
+           [with_local_level*], the scope will end there. Otherwise
+           the scope continues until the end of the compilation unit
+           or toplevel session. *)
 
 val newty: type_desc -> type_expr
 val new_scoped_ty: int -> type_desc -> type_expr


### PR DESCRIPTION
This PR does two things:
* `with_level` used to call `begin_def`, so that in some cases `current_level` was momentarily raised above `generic_level`.
   This PR now ensures that this never happens, neither through `with_local_level` nor `with_level`.
* It also adds the promised explanation of `create_scope` in the mli.

See also: https://github.com/ocaml/ocaml/pull/14327#issuecomment-3470919640

Co-authored-by: @t6s 