### PR TITLE
Use atomic accesses to read/write the class cache

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -180,6 +180,8 @@ let rec add_pop n cont =
 
 (* Add the constant "unit" in front of a continuation *)
 
+let const_unit = Const_int 0
+
 let add_const_unit = function
     (Kacc _ | Kconst _ | Kgetglobal _ | Kpush_retaddr _) :: _ as cont -> cont
   | cont -> Kconst const_unit :: cont
@@ -1014,7 +1016,7 @@ and comp_expr_list_assign stack_info env exprl sz pos cont = match exprl with
 
 and comp_binary_test stack_info env cond ifso ifnot sz cont =
   let cont_cond =
-    if ifnot = Lconst const_unit then begin
+    if ifnot = lambda_unit then begin
       let (lbl_end, cont1) = label_code cont in
       Kstrictbranchifnot lbl_end :: comp_expr stack_info env ifso sz cont1
     end else

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -374,11 +374,9 @@ type program =
     required_globals : Ident.Set.t;
     code : lambda }
 
-let const_int n = Const_int n
+let const_int n = Lconst (Const_int n)
 
-let const_unit = const_int 0
-
-let dummy_constant = Lconst (const_int (0xBBBB / 2))
+let dummy_constant = const_int (0xBBBB / 2)
 
 let lambda_of_const (c : Asttypes.constant) =
   match c with
@@ -402,7 +400,7 @@ let lfunction' ~kind ~params ~return ~body ~attr ~loc =
 let lfunction ~kind ~params ~return ~body ~attr ~loc =
   Lfunction (lfunction' ~kind ~params ~return ~body ~attr ~loc)
 
-let lambda_unit = Lconst const_unit
+let lambda_unit = const_int 0
 
 let default_function_attribute = {
   inline = Default_inline;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -387,8 +387,7 @@ type program =
 (* Sharing key *)
 val make_key: lambda -> lambda option
 
-val const_unit: structured_constant
-val const_int : int -> structured_constant
+val const_int : int -> lambda
 val lambda_unit: lambda
 
 val lambda_of_const : Asttypes.constant -> lambda

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -237,6 +237,9 @@ let lsequence l1 l2 =
 let lfield v i = Lprim(Pfield (i, Pointer, Mutable),
                        [Lvar v], Loc_unknown)
 
+let lfield_atomic v i =
+  Lprim(Patomic_load, [Lvar v; const_int i], Loc_unknown)
+
 let transl_label l = share (Const_immstring l)
 
 let transl_meth_list lst =
@@ -1208,8 +1211,15 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                    ~loc:Loc_unknown
                    ~body:(def_ids cla cl_init), lam)
   and lset cached i lam =
-    Lprim(Psetfield(i, Pointer, Assignment),
-          [Lvar cached; lam], Loc_unknown)
+    let prim =
+      Primitive.simple
+        ~name:"caml_atomic_exchange_field" ~arity:3 ~alloc:false
+    in
+    Lprim (
+      Pignore,
+      [Lprim (Pccall prim, [Lvar cached; const_int i; lam], Loc_unknown)],
+      Loc_unknown
+    )
   in
   let ldirect () =
     ltable cla
@@ -1239,7 +1249,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache) in
+      Lifthenelse(lfield_atomic cached 0, lambda_unit, lupdate_cache) in
   let lcache (lam, rkind) =
     let lam = Lsequence (lcheck_cache, lam) in
     let lam =
@@ -1258,14 +1268,14 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   lcache (
   make_envs (
   if ids = []
-  then mkappl (lfield cached 0, [lenvs]), Dynamic
+  then mkappl (lfield_atomic cached 0, [lenvs]), Dynamic
   else
     Lprim(Pmakeblock(0, Immutable, None),
         (if concrete then
-          [mkappl (lfield cached 0, [lenvs]);
-           lfield cached 1;
+          [mkappl (lfield_atomic cached 0, [lenvs]);
+           lfield_atomic cached 1;
            lenvs]
-        else [lambda_unit; lfield cached 0; lenvs]),
+        else [lambda_unit; lfield_atomic cached 0; lenvs]),
         Loc_unknown
        ),
     Static)))

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -240,7 +240,7 @@ let lfield v i = Lprim(Pfield (i, Pointer, Mutable),
 let transl_label l = share (Const_immstring l)
 
 let transl_meth_list lst =
-  if lst = [] then Lconst (const_int 0) else
+  if lst = [] then const_int 0 else
   share (Const_block
             (0, List.map (fun lab -> Const_immstring lab) lst))
 
@@ -677,7 +677,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
            Llet (Strict, Pgenval, inh,
                  mkappl(oo_prim "inherits", narrow_args @
                         [path_lam;
-                         Lconst(const_int (if top then 1 else 0))]),
+                         const_int (if top then 1 else 0)]),
                  Llet(StrictOpt, Pgenval, obj_init, lfield inh 0, cl_init)))
       | _ ->
           let core cl_init =
@@ -847,7 +847,7 @@ let rec builtin_meths self env env2 body =
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
     | Lprim(Pfield(n, _, _), [Lvar e], _) when Ident.same e env ->
-        "env", [Lvar env2; Lconst(const_int n)]
+        "env", [Lvar env2; const_int n]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
     | _ -> raise Not_found
@@ -918,7 +918,7 @@ module M = struct
     | "send_env"   -> SendEnv
     | "send_meth"  -> SendMeth
     | _ -> assert false
-    in Lconst(const_int (Obj.magic tag)) :: args
+    in const_int (Obj.magic tag) :: args
 end
 open M
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -70,7 +70,7 @@ let transl_extension_constructor ~scopes env path ext =
     Text_decl _ ->
       Lprim (Pmakeblock (Obj.object_tag, Immutable, None),
         [Lconst (Const_immstring name);
-         Lprim (prim_fresh_oo_id, [Lconst (const_int 0)], loc)],
+         Lprim (prim_fresh_oo_id, [const_int 0], loc)],
         loc)
   | Text_rebind(path, _lid) ->
       transl_extension_path loc env path
@@ -298,7 +298,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
         | _ -> assert false
       end else begin match cstr.cstr_tag with
         Cstr_constant n ->
-          Lconst(const_int n)
+          const_int n
       | Cstr_unboxed ->
           (match ll with [v] -> v | _ -> assert false)
       | Cstr_block n ->
@@ -321,15 +321,15 @@ and transl_exp0 ~in_new_scope ~scopes e =
   | Texp_variant(l, arg) ->
       let tag = Btype.hash_variant l in
       begin match arg with
-        None -> Lconst(const_int tag)
+        None -> const_int tag
       | Some arg ->
           let lam = transl_exp ~scopes arg in
           try
-            Lconst(Const_block(0, [const_int tag;
+            Lconst(Const_block(0, [Const_int tag;
                                    extract_constant lam]))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, None),
-                  [Lconst(const_int tag); lam],
+                  [const_int tag; lam],
                   of_location ~scopes e.exp_loc)
       end
   | Texp_record {fields; representation; extended_expression} ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -229,8 +229,8 @@ let undefined_location loc =
   let (fname, line, char) = Location.get_pos_info loc.Location.loc_start in
   Lconst(Const_block(0,
                      [Const_immstring fname;
-                      const_int line;
-                      const_int char]))
+                      Const_int line;
+                      Const_int char]))
 
 exception Initialization_failure of unsafe_info
 
@@ -255,9 +255,9 @@ let init_shape id modl =
         let init_v =
           match get_desc (Ctype.expand_head env ty) with
             Tarrow(_,_,_,_) ->
-              const_int 0 (* camlinternalMod.Function *)
+              Const_int 0 (* camlinternalMod.Function *)
           | Tconstr(p, _, _) when Path.same p Predef.path_lazy_t ->
-              const_int 1 (* camlinternalMod.Lazy *)
+              Const_int 1 (* camlinternalMod.Lazy *)
           | _ ->
               let info =
                 Unsafe {reason=Unsafe_non_function; loc; path=new_path} in
@@ -286,7 +286,7 @@ let init_shape id modl =
     | Sig_modtype(id, minfo, _) :: rem ->
         init_shape_struct path (Env.add_modtype id minfo env) rem
     | Sig_class _ :: rem ->
-        const_int 2 (* camlinternalMod.Class *)
+        Const_int 2 (* camlinternalMod.Class *)
         :: init_shape_struct path env rem
     | Sig_class_type _ :: rem ->
         init_shape_struct path env rem
@@ -1566,7 +1566,7 @@ let transl_toplevel_definition str =
 (* Compile the initialization code for a packed library *)
 
 let get_component = function
-    None -> Lconst const_unit
+    None -> lambda_unit
   | Some id -> Lprim(Pgetglobal id, [], Loc_unknown)
 
 let transl_package_flambda component_names coercion =

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -717,7 +717,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
            [Lprim(caml_atomic_exchange_field, [ref; 0; v])]
       *)
       let ref_arg, rest = split args in
-      let args = ref_arg :: Lconst (Lambda.const_int 0) :: rest in
+      let args = ref_arg :: Lambda.const_int 0 :: rest in
       Lprim (prim, args, loc)
   | Field ->
       (* the primitive application
@@ -766,7 +766,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
   | Primitive (prim, arity), args when arity = List.length args ->
       Lprim(prim, args, loc)
   | Sys_argv, [] ->
-      Lprim(Pccall prim_sys_argv, [Lconst (const_int 0)], loc)
+      Lprim(Pccall prim_sys_argv, [const_int 0], loc)
   | External prim, args ->
       Lprim(Pccall prim, args, loc)
   | Comparison(comp, knd), ([_;_] as args) ->
@@ -821,7 +821,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       let frame_pointers =
         if !Clflags.native_code && Config.with_frame_pointers then 1 else 0
       in
-      Lconst (const_int frame_pointers)
+      const_int frame_pointers
   | Identity, [arg] -> arg
   | Apply, [func; arg]
   | Revapply, [arg; func] ->

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -761,7 +761,7 @@ let compile_indirect newval =
 let compile_alloc size =
   let alloc prim size =
     Lprim (Pccall prim,
-           [Lconst (Lambda.const_int size)],
+           [Lambda.const_int size],
            no_loc)
   in
   (* if you add new allocation primitives below,

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -145,13 +145,13 @@ let close_const t (const : Lambda.structured_constant)
   | Symbol s, name ->
     Symbol s, name
 
-let lambda_const_bool b : Lambda.structured_constant =
+let lambda_const_bool b : Lambda.lambda =
   if b then
     Lambda.const_int 1
   else
     Lambda.const_int 0
 
-let lambda_const_int i : Lambda.structured_constant =
+let lambda_const_int i : Lambda.lambda =
   Lambda.const_int i
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
@@ -398,12 +398,12 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         | Ostype_cygwin ->
             lambda_const_bool (String.equal Config.target_os_type "Cygwin")
         | Backend_type ->
-            Lambda.const_int 0 (* tag 0 is the same as Native *)
+            lambda_const_int 0 (* tag 0 is the same as Native *)
         end
       in
       close t env
         (Lambda.Llet(Strict, Pgenval, Ident.create_local "dummy",
-                     arg, Lconst const))
+                     arg, const))
   | Lprim (Pfield _, [Lprim (Pgetglobal id, [],_)], _)
       when Ident.same id t.current_unit_id ->
     Misc.fatal_errorf "[Pfield (Pgetglobal ...)] for the current compilation \

--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -331,7 +331,7 @@ let make_class pub_meths class_init =
   init_class table;
   (env_init (Obj.repr 0), class_init, Obj.repr 0)
 
-type init_table = { mutable env_init: t; mutable class_init: table -> t }
+type init_table = { mutable env_init: t [@atomic]; mutable class_init: table -> t [@atomic] }
 [@@warning "-unused-field"]
 
 let make_class_store pub_meths class_init init_table =
@@ -401,7 +401,7 @@ external get_public_method : obj -> tag -> closure
 
 type tables =
   | Empty
-  | Cons of {key : closure; mutable data: tables; mutable next: tables}
+  | Cons of {key : closure; mutable data: tables [@atomic]; mutable next: tables [@atomic]}
 
 let set_data tables v = match tables with
   | Empty -> assert false


### PR DESCRIPTION
Fixes #14131 (hopefully).

The first commit could be dropped; I just found it annoying to write `Lconst (const_int i)` (particularly since `const_int i` is actually equivalent to `Const_int i`) so I made `const_int` add the `Lconst`, and propagated the change.

The main idea behind the fix is to make the fields of the `init_table` record atomic in `CamlinternalOO`. I also made the fields of the `tables` type atomic, even though I haven't found races on it, because I think it's the correct thing to do. (It is quite hard to generate code that uses this feature, but I believe that it would be susceptible to the same issues as the `init_table` record).

Besides, although the types do not show it, `init_tables` can end up stored in the `data` field of the `tables` structure, so I thought being consistent in atomicity would not hurt.

To test this, I wrote the following program (meant to try to reproduce the issue from #14131, with a few debugging things left in):
```ocaml
class c = object
  method c : 'a. 'a -> 'a = fun x ->
    Printf.printf "id %d\n%!" (Domain.self () :> int);
    x
end

class d = object
  inherit c as super
  method c y = super#c y
end

let f () =
  Unix.sleepf (Random.float 1.0);
  let o = object
    inherit d as super
    method c z = super#c z
  end in
  o#c ()

let run () =
  let domains = ref [] in
  for i = 1 to 8 do
    domains := Domain.spawn f :: !domains;
  done;
  List.iter Domain.join !domains

let () =
  Random.self_init ();
  run ()
```

On trunk, running this program with TSan gives me a race warning once in a while (a few percent of the runs), and after this PR I didn't get any warning after several hundred runs.