### PR TITLE
[minor] fix a TSan report in shared_heap.c

### DIFF
--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1595,7 +1595,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
 
 static void verify_large(large_alloc* a, struct mem_stats* s) {
   for (; a; a = a->next) {
-    header_t hd = *(header_t*)((char*)a + LARGE_ALLOC_HEADER_SZ);
+    header_t hd = Hd_hp((char*)a + LARGE_ALLOC_HEADER_SZ);
     CAMLassert (!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
     s->allocated += Wsize_bsize(LARGE_ALLOC_HEADER_SZ) + Whsize_hd(hd);
     s->overhead += Wsize_bsize(LARGE_ALLOC_HEADER_SZ);


### PR DESCRIPTION
Fixes #14334

In trunk `verify_heap` performs a `header_t*` dereference to compute the header of large blocks, which can race against marking work done in another domain. This race is benign (given that the `verify_heap` code only checks that the block is not GARBAGE, and marking preserves this property), and the standard way to ignore it is to use `Hd_hp` which uses `volatile header_t *` dereference.