### PR TITLE
Fix race on dropped cont after C callback

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,7 +80,7 @@ Working version
   (Jack Nørskov Jørgensen, review by Gabriel Scherer,
    Guillaume Munch-Maccagnoni)
 
-- #14337: Fix potential segfault due to the C callback mechanism dropping 
+- #14337: Fix potential segfault due to the C callback mechanism dropping
   continuations without calling `caml_continuation_use`.
   (Max Slater, review by Nick Barnes and Stephen Dolan)
 

--- a/Changes
+++ b/Changes
@@ -80,6 +80,10 @@ Working version
   (Jack Nørskov Jørgensen, review by Gabriel Scherer,
    Guillaume Munch-Maccagnoni)
 
+- #14337: Fix potential segfault due to the C callback mechanism dropping 
+  continuations without calling `caml_continuation_use`.
+  (Max Slater, review by Nick Barnes and Stephen Dolan)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -69,7 +69,7 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
 {
   CAMLassert(Stack_parent(domain_state->current_stack) == NULL);
   if (Is_block(cont)) {
-    struct stack_info* parent_stack = Ptr_val(Op_val(cont)[0]);
+    struct stack_info* parent_stack = Ptr_val(caml_continuation_use(cont));
     Stack_parent(domain_state->current_stack) = parent_stack;
   }
 }

--- a/testsuite/tests/callback/callback_effects_domains_gc.ml
+++ b/testsuite/tests/callback/callback_effects_domains_gc.ml
@@ -1,0 +1,24 @@
+(* TEST
+ native;
+*)
+
+external caml_callback : ('a -> 'b) -> 'a -> 'b = "caml_callback"
+
+let callback_minor () = caml_callback Gc.minor ()
+
+let make_dead_cont () =
+  Effect.Deep.match_with callback_minor () {
+    retc = ignore;
+    exnc = raise;
+    effc = fun _ -> None
+  }
+
+let () =
+  let _ = Domain.spawn (fun () ->
+    while true do Gc.compact () done) in
+  let state = ref "hello" in
+  for _ = 0 to 10_000 do
+    make_dead_cont ();
+    state := "world";
+  done;
+  ignore state


### PR DESCRIPTION
(Upstreaming https://github.com/oxcaml/oxcaml/pull/4609)

`caml_callback` stashes the parent stack in a continuation block for the duration of the callback, then restores it afterward. 
Currently, the following can occur:

- Domain 1 enters `caml_callback`, allocating a cont pointing to its parent stack
- A minor collection promotes the cont
- Domain 1 leaves `caml_callback`, dropping the cont and changing the retaddr on its stack
- Some domain starts doing compaction work and finds the cont unmarked. It traverses the stack, which has an arbitrary retaddr from domain 1. If the frametable indicates it should visit registers, it segfaults trying to dereference gc_regs.

This should instead call `caml_continuation_use`, which avoids the issue by swapping out the stack pointer. This fixes the test I've added, which (usually) segfaults without the change.