### PR TITLE
major_gc.c:ephe_mark: minor fix

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -491,12 +491,11 @@ static intnat ephe_mark (intnat budget, uintnat round,
               goto ephemeron_again;
             }
           }
+        } else if (Tag_val (key) == Infix_tag) {
+          key -= Infix_offset_val (key);
         }
-        else {
-          if (Tag_val (key) == Infix_tag) key -= Infix_offset_val (key);
-          if (is_unmarked (key))
-            preserve_data = false;
-        }
+        if (is_unmarked (key))
+          preserve_data = false;
       }
     }
 


### PR DESCRIPTION
The implementation in `trunk` has the main logic
`if (is_unmarked(key)) alive_data = 0`) placed in the `else` branch of the `Tag_val(key) == Forward_tag` test, so it will not be checked on non-shortcut `Forward_tag` value, which is a minor bug.

Change the code to first try to shortcut the Forward or Infix tag, and then in any case check if the key is unmarked.

(noticed while reviewing #14336)

cc @damiendoligez who is touching this area right now