### PR TITLE
GHA: migrate to macos-15 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,9 +166,9 @@ jobs:
                config_arg: "CFLAGS='-O0'"},
               {name: 'linux-arm64', os: 'ubuntu-24.04-arm',
                'test-in-prefix': true},
-              {name: 'macos-x86_64', os: 'macos-13',
+              {name: 'macos-x86_64', os: 'macos-15-intel',
                'test-in-prefix': true},
-              {name: 'macos-arm64', os: 'macos-15',
+              {name: 'macos-arm64', os: 'macos-latest',
                'test-in-prefix': true}];
             // # If this is a pull request, see if the PR has the
             // # 'CI: Full matrix' label. This is done using an API request,
@@ -229,7 +229,7 @@ jobs:
           sudo DevToolsSecurity --enable
           spctl developer-mode enable-terminal
           # Select latest supported version
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.os == 'macos-13' && '15.2' || '16.3' }}.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           lldb --version
       - name: configure tree
         run: |

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.reference
@@ -14,11 +14,11 @@ Breakpoint created for regex camlMeander[.$]c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
+Process XXXX launched: 'XXXX' ($ARCH)
 Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
 Target 0: (meander) stopped.
-Process XXXX launched: 'XXXX' ($ARCH)
 (lldb) backtrace
 frame 0: meander`caml_start_program
 frame 1: meander`caml_startup_common
@@ -46,7 +46,7 @@ frame 7: dyld`start
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 4.1
-    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX [opt]
+    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:XX
    2   	#include <caml/callback.h>
    3
    4   	value ocaml_to_c (value unit) {


### PR DESCRIPTION
macos-13 jobs randomly fail to prompt devs to migrate to macos-15.

See also:
- https://github.com/actions/runner-images/issues/13046
- https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#xcode

no change entry needed