### PR TITLE
Make `<caml/osdeps.h>` self-standing

### DIFF
--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -18,10 +18,10 @@
 #ifndef CAML_OSDEPS_H
 #define CAML_OSDEPS_H
 
-#ifdef CAML_INTERNALS
-
 #include "misc.h"
 #include "memory.h"
+
+#ifdef CAML_INTERNALS
 
 /* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
    [flags] indicates whether [fd] is a socket


### PR DESCRIPTION
The `CAMLalloc` family of macros are defined in `<caml/misc.h>`. The `caml_stat_free` function is defined in `<caml/memory.h>`.

The headers were included below `#ifdef CAML_INTERNALS`, but both the macro and the function were referenced outside of the scope of `CAML_INTERNALS`, requiring users of `<caml/osdeps.h>` to include the headers manually. The current style, if I'm not mistaken, is that public headers should be self-standing, so move the inclusion of the depended headers up.

Fix 6612bfeb129a6576475d66a7cd9a35942126d9b7 (see also 48264c3a3b3e1a9b5a982c4f35e7adb0c06ff8bf) (mea culpa). This commit was included in 5.4. It's possible that this commit broke user stubs that included `<caml/osdeps.h>` but not `<caml/memory.h>`. The `<caml/misc.h>` header is likely to have been included.