### PR TITLE
Install a C++ compiler for Cygwin in GitHub Actions

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v3
         with:
-          packages: make,${{ matrix.cc != 'gcc' && 'mingw64-x86_64-' || 'gcc-fortran,' }}gcc-core
+          packages: make,${{ matrix.cc != 'gcc' && 'mingw64-x86_64-' || 'gcc-g++,gcc-fortran,' }}gcc-core
           install-dir: 'D:\cygwin'
 
       - name: Save Cygwin cache


### PR DESCRIPTION
Very minor CI follow-up to #14310: tests/lib-unix/unix-sockaddr/sockaddr_cxx.ml needs a C++ compiler