### PR TITLE
Add line number breakpoints to ocamldebug

### DIFF
--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -654,11 +654,11 @@ let instr_break ppf lexbuf =
              in
              match column with
              | None ->
-                 event_at_pos module_name (fst (pos_of_line buffer line))
+                 event_at_pos_inclusive module_name (fst (pos_of_line buffer line))
              | Some col ->
-                 event_near_pos module_name (point_of_coord buffer line col)
+                 event_near_pos_inclusive module_name (point_of_coord buffer line col)
            with
-           | Not_found -> (* event_at_pos / event_near pos *)
+           | Not_found -> (* event_at_pos_inclusive / event_near_pos_inclusive *)
                eprintf "Can\'t find any event there.@.";
                raise Toplevel
            | Out_of_range -> (* pos_of_line / point_of_coord *)
@@ -667,7 +667,7 @@ let instr_break ppf lexbuf =
     | BA_pos2 (mdle, position) ->             (* break @ [MODULE] # POSITION *)
         try
           new_breakpoint
-            (event_near_pos (convert_module (module_of_longident mdle))
+            (event_near_pos_inclusive (convert_module (module_of_longident mdle))
                             position)
         with
         | Not_found ->

--- a/debugger/debugger_parser.mly
+++ b/debugger/debugger_parser.mly
@@ -249,6 +249,7 @@ break_argument_eol :
                                                          pos = $1} }
   | INTEGER COLON integer_eol                   { BA_pc {frag = to_int $1;
                                                          pos = $3} }
+  | module_path COLON integer_eol               { BA_pos1 (Some $1, $3, None) }
   | expression end_of_line                      { BA_function $1 }
   | AT opt_longident INTEGER opt_integer_eol    { BA_pos1 ($2, (to_int $3), $4)}
   | AT opt_longident HASH integer_eol           { BA_pos2 ($2, $4) }

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -239,6 +239,57 @@ let event_near_pos md char =
     if pos < 0 then raise Not_found;
     { ev_frag; ev_ev = ev.(pos) }
 
+(* Check if an event is a valid breakpoint target *)
+(* Function entry pseudo-events are valid, other pseudo-events are not *)
+let is_valid_breakpoint_event ev =
+  match ev.ev_kind, ev.ev_info with
+  | Event_pseudo, Event_function -> true   (* Function entry - VALID *)
+  | Event_pseudo, _ -> false               (* Other pseudo - skip *)
+  | _, _ -> true                           (* All non-pseudo - VALID *)
+
+(* Return first valid event (including function entry pseudo-events) at or after position *)
+(* Raise [Not_found] if module is unknown or no valid event is found. *)
+let event_at_pos_inclusive md char =
+  let ev_frag, evl = Hashtbl.find all_events_by_module md in
+  let ev = Array.of_list evl in
+  let rec find_valid_event pos =
+    if pos >= Array.length ev then
+      raise Not_found
+    else if is_valid_breakpoint_event ev.(pos) then
+      { ev_frag; ev_ev = ev.(pos) }
+    else
+      find_valid_event (pos + 1)
+  in
+  try
+    let pos = find_event ev char in
+    find_valid_event pos
+  with Not_found ->
+    raise Not_found
+
+(* Return valid event (including function entry pseudo-events) closest to position *)
+(* Raise [Not_found] if module is unknown or no valid event is found. *)
+let event_near_pos_inclusive md char =
+  let ev_frag, evl = Hashtbl.find all_events_by_module md in
+  (* Filter to only valid breakpoint events *)
+  let valid_events = evl
+    |> List.filter is_valid_breakpoint_event
+    |> Array.of_list
+  in
+  if Array.length valid_events = 0 then
+    raise Not_found;
+  try
+    let pos = find_event valid_events char in
+    (* Desired event is either valid_events.(pos) or valid_events.(pos - 1),
+       whichever is closest *)
+    if pos > 0 && char - (Events.get_pos valid_events.(pos - 1)).Lexing.pos_cnum
+                  <= (Events.get_pos valid_events.(pos)).Lexing.pos_cnum - char
+    then { ev_frag; ev_ev = valid_events.(pos - 1) }
+    else { ev_frag; ev_ev = valid_events.(pos) }
+  with Not_found ->
+    let pos = Array.length valid_events - 1 in
+    if pos < 0 then raise Not_found;
+    { ev_frag; ev_ev = valid_events.(pos) }
+
 (* Flip "event" bit on all instructions *)
 let set_all_events frag =
   Hashtbl.iter

--- a/debugger/symbols.mli
+++ b/debugger/symbols.mli
@@ -67,5 +67,13 @@ val event_at_pos : string -> int -> code_event
 (* --- Raise `Not_found' if no such event. *)
 val event_near_pos : string -> int -> code_event
 
+(* First event (including function entry pseudo-events) after the given position. *)
+(* --- Raise `Not_found' if no such event. *)
+val event_at_pos_inclusive : string -> int -> code_event
+
+(* Closest event (including function entry pseudo-events) from given position. *)
+(* --- Raise `Not_found' if no such event. *)
+val event_near_pos_inclusive : string -> int -> code_event
+
 (* Recompute the current event *)
 val update_current_event : unit -> unit

--- a/testsuite/tests/tool-debugger/line-breakpoints/input_script
+++ b/testsuite/tests/tool-debugger/line-breakpoints/input_script
@@ -1,0 +1,4 @@
+break @ Test_breakpoints 15
+run
+print n
+quit

--- a/testsuite/tests/tool-debugger/line-breakpoints/module_colon_input_script
+++ b/testsuite/tests/tool-debugger/line-breakpoints/module_colon_input_script
@@ -1,0 +1,4 @@
+break Test_module_colon_syntax:15
+run
+print n
+quit

--- a/testsuite/tests/tool-debugger/line-breakpoints/test_breakpoints.ml
+++ b/testsuite/tests/tool-debugger/line-breakpoints/test_breakpoints.ml
@@ -1,0 +1,42 @@
+(* TEST_BELOW
+(* Blank lines added here to preserve locations. *)
+
+
+
+
+
+
+
+
+*)
+
+(* Test program for line number breakpoints *)
+(* Line 14 *)
+let factorial n =                        (* Line 15 - function entry point *)
+  let rec loop acc n =                   (* Line 16 - nested function *)
+    if n <= 1 then acc                   (* Line 17 *)
+    else loop (acc * n) (n - 1)          (* Line 18 *)
+  in
+  loop 1 n                               (* Line 20 *)
+
+let test_simple x =                      (* Line 22 *)
+  x + 1                                  (* Line 23 *)
+
+let main () =                            (* Line 22 *)
+  Printf.printf "factorial 5 = %d\n" (factorial 5);
+  Printf.printf "test_simple 10 = %d\n" (test_simple 10);
+  ()
+
+let () = main ()
+
+(* TEST
+ flags += " -g ";
+ debugger_script = "${test_source_directory}/input_script";
+ debugger;
+ shared-libraries;
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+ ocamldebug;
+ check-program-output;
+*)

--- a/testsuite/tests/tool-debugger/line-breakpoints/test_breakpoints.reference
+++ b/testsuite/tests/tool-debugger/line-breakpoints/test_breakpoints.reference
@@ -1,0 +1,4 @@
+Loading program... done.
+Breakpoint: 1
+16   <|b|>let rec loop acc n =                   (* Line 16 - nested function *)
+n: int = 5

--- a/testsuite/tests/tool-debugger/line-breakpoints/test_module_colon_syntax.ml
+++ b/testsuite/tests/tool-debugger/line-breakpoints/test_module_colon_syntax.ml
@@ -1,0 +1,34 @@
+(* TEST_BELOW
+(* Blank lines added here to preserve locations. *)
+
+
+
+
+
+
+
+
+*)
+
+(* Test program for Module:line breakpoint syntax *)
+(* Line 14 *)
+let factorial n =                        (* Line 15 *)
+  let rec loop acc n =                   (* Line 16 *)
+    if n <= 1 then acc                   (* Line 17 *)
+    else loop (acc * n) (n - 1)          (* Line 18 *)
+  in
+  loop 1 n                               (* Line 20 *)
+
+let () = Printf.printf "Result: %d\n" (factorial 5)
+
+(* TEST
+ flags += " -g ";
+ debugger_script = "${test_source_directory}/module_colon_input_script";
+ debugger;
+ shared-libraries;
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+ ocamldebug;
+ check-program-output;
+*)

--- a/testsuite/tests/tool-debugger/line-breakpoints/test_module_colon_syntax.reference
+++ b/testsuite/tests/tool-debugger/line-breakpoints/test_module_colon_syntax.reference
@@ -1,0 +1,4 @@
+Loading program... done.
+Breakpoint: 1
+16   <|b|>let rec loop acc n =                   (* Line 16 *)
+n: int = 5


### PR DESCRIPTION
Implements line number breakpoint support for ocamldebug, allowing breakpoints to be set at function entry points using line numbers.

Features:
- New Module:line syntax (e.g., "break Foo:42")

Testing:
- Automated tests in testsuite/tests/tool-debugger/line-breakpoints/
