### PR TITLE
Add history for ocaml-system, ocaml and ocaml-config scripts from opam-repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -214,6 +214,9 @@ runtime/caml/sizeclasses.h typo.missing-header
 
 /tools/gdb_ocamlrun.py typo.long-line
 
+/tools/opam/gen_ocaml-system_config.ml.in typo.missing-header
+/tools/opam/gen_ocaml_config.ml.in typo.long-line typo.missing-header typo.white-at-eol
+
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
 testsuite/tests/basic-modules/anonymous.ml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -215,7 +215,7 @@ runtime/caml/sizeclasses.h typo.missing-header
 /tools/gdb_ocamlrun.py typo.long-line
 
 /tools/opam/gen_ocaml-system_config.ml.in typo.missing-header
-/tools/opam/gen_ocaml_config.ml.in typo.long-line typo.missing-header typo.white-at-eol
+/tools/opam/gen_ocaml_config.ml.in typo.long-line typo.missing-header
 
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.

--- a/.gitattributes
+++ b/.gitattributes
@@ -215,7 +215,7 @@ runtime/caml/sizeclasses.h typo.missing-header
 /tools/gdb_ocamlrun.py typo.long-line
 
 /tools/opam/gen_ocaml-system_config.ml.in typo.missing-header
-/tools/opam/gen_ocaml_config.ml.in typo.very-long-line typo.missing-header
+/tools/opam/gen_ocaml_config.ml.in typo.long-line typo.missing-header
 
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.

--- a/.gitattributes
+++ b/.gitattributes
@@ -215,7 +215,7 @@ runtime/caml/sizeclasses.h typo.missing-header
 /tools/gdb_ocamlrun.py typo.long-line
 
 /tools/opam/gen_ocaml-system_config.ml.in typo.missing-header
-/tools/opam/gen_ocaml_config.ml.in typo.long-line typo.missing-header
+/tools/opam/gen_ocaml_config.ml.in typo.very-long-line typo.missing-header
 
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.

--- a/tools/opam/gen_ocaml-system_config.ml.in
+++ b/tools/opam/gen_ocaml-system_config.ml.in
@@ -1,0 +1,17 @@
+let () =
+  let ocamlc = Sys.executable_name ^ "c" in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ %%S %%S ]\n\
+                     variables { path: %%S }\n"
+    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+  close_out oc

--- a/tools/opam/gen_ocaml-system_config.ml.in
+++ b/tools/opam/gen_ocaml-system_config.ml.in
@@ -17,9 +17,27 @@ let () =
        ocamlc Sys.ocaml_version Sys.ocaml_version;
      exit 1)
   else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
   let oc = open_out "%{_:name}%.config" in
   Printf.fprintf oc "opam-version: \"2.0\"\n\
-                     file-depends: [ %%S %%S ]\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
                      variables { path: %%S }\n"
-    ocamlc (Digest.to_hex (Digest.file ocamlc)) (Filename.dirname ocamlc);
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
   close_out oc

--- a/tools/opam/gen_ocaml-system_config.ml.in
+++ b/tools/opam/gen_ocaml-system_config.ml.in
@@ -1,5 +1,13 @@
 let () =
-  let ocamlc = Sys.executable_name ^ "c" in
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
   if Sys.ocaml_version <> "%{_:version}%" then
     (Printf.eprintf
        "ERROR: The compiler found at %%s has version %%s,\n\

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let ocaml_version =
+    let v = Sys.ocaml_version in
+    try String.sub v 0 (String.index v '+') with Not_found -> v
+  in
+  if ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "OCaml version mismatch: %%s, expected %{_:version}%"
+       ocaml_version;
+     exit 1)
+  else
+  let oc = open_out "%{_:name}%.config" in
+  let ocaml = Sys.executable_name in
+  let ocamlc = ocaml^"c" in
+  let libdir =
+    let ic = Unix.open_process_in (ocamlc^" -where") in
+    let r = input_line ic in
+    if Unix.close_process_in ic <> Unix.WEXITED 0 then 
+      failwith "Bad return from 'ocamlc -where'";
+    r
+  in
+  let stubsdir =
+    let ic = open_in (Filename.concat libdir "ld.conf") in
+    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
+    let lines = List.rev (r []) in
+    close_in ic;
+    String.concat ":" lines
+  in
+  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
+  p "opam-version: \"2.0\"";
+  p "variables {";
+  p "  native: %%b"
+    (Sys.file_exists (ocaml^"opt"));
+  p "  native-tools: %%b"
+    (Sys.file_exists (ocamlc^".opt"));
+  p "  native-dynlink: %%b"
+    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+  p "  stubsdir: %%S"
+    stubsdir;
+  p "  preinstalled: %{ocaml-system:installed}%";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "}";
+  close_out oc

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -1,7 +1,11 @@
 let () =
   let ocaml_version =
     let v = Sys.ocaml_version in
-    try String.sub v 0 (String.index v '+') with Not_found -> v
+    let l = String.length v in
+    let plus = try String.index v '+' with Not_found -> l in
+    (* Introduced in 4.11.0; used from 4.12.0 *)
+    let tilde = try String.index v '~' with Not_found -> l in
+    String.sub v 0 (min (min plus tilde) l)
   in
   if ocaml_version <> Sys.argv.(1) then
     (Printf.eprintf
@@ -47,6 +51,6 @@ let () =
   p "  stubsdir: %%S"
     stubsdir;
   p "  preinstalled: %{ocaml-system:installed}%";
-  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"";
   p "}";
   close_out oc

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -20,12 +20,13 @@ let () =
   in
   let ocamlc = ocaml^"c"^suffix in
   let libdir =
-    let ic = Unix.open_process_in (ocamlc^" -where") in
-    set_binary_mode_in ic false;
-    let r = input_line ic in
-    if Unix.close_process_in ic <> Unix.WEXITED 0 then 
-      failwith "Bad return from 'ocamlc -where'";
-    r
+    if Sys.command (ocamlc^" -where > where") = 0 then
+      (* Must be opened in text mode for Windows *)
+      let ic = open_in "where" in
+      let r = input_line ic in
+      close_in ic; r
+    else
+      failwith "Bad return from 'ocamlc -where'"
   in
   let stubsdir =
     let ic = open_in (Filename.concat libdir "ld.conf") in

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -3,13 +3,13 @@ let () =
     let v = Sys.ocaml_version in
     try String.sub v 0 (String.index v '+') with Not_found -> v
   in
-  if ocaml_version <> "%{_:version}%" then
+  if ocaml_version <> Sys.argv.(1) then
     (Printf.eprintf
-       "OCaml version mismatch: %%s, expected %{_:version}%"
-       ocaml_version;
+       "OCaml version mismatch: %%s, expected %s"
+       ocaml_version Sys.argv.(1);
      exit 1)
   else
-  let oc = open_out "%{_:name}%.config" in
+  let oc = open_out (Sys.argv.(2) ^ ".config") in
   let exe = ".exe" in
   let (ocaml, suffix) =
     let s = Sys.executable_name in

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -10,10 +10,18 @@ let () =
      exit 1)
   else
   let oc = open_out "%{_:name}%.config" in
-  let ocaml = Sys.executable_name in
-  let ocamlc = ocaml^"c" in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
   let libdir =
     let ic = Unix.open_process_in (ocamlc^" -where") in
+    set_binary_mode_in ic false;
     let r = input_line ic in
     if Unix.close_process_in ic <> Unix.WEXITED 0 then 
       failwith "Bad return from 'ocamlc -where'";
@@ -30,9 +38,9 @@ let () =
   p "opam-version: \"2.0\"";
   p "variables {";
   p "  native: %%b"
-    (Sys.file_exists (ocaml^"opt"));
+    (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"));
+    (Sys.file_exists (ocamlc^".opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -1,16 +1,8 @@
 let () =
-  let ocaml_version =
-    let v = Sys.ocaml_version in
-    let l = String.length v in
-    let plus = try String.index v '+' with Not_found -> l in
-    (* Introduced in 4.11.0; used from 4.12.0 *)
-    let tilde = try String.index v '~' with Not_found -> l in
-    String.sub v 0 (min (min plus tilde) l)
-  in
-  if ocaml_version <> Sys.argv.(1) then
+  if Sys.ocaml_version <> Sys.argv.(1) then
     (Printf.eprintf
        "OCaml version mismatch: %%s, expected %s"
-       ocaml_version Sys.argv.(1);
+       Sys.ocaml_version Sys.argv.(1);
      exit 1)
   else
   let oc = open_out (Sys.argv.(2) ^ ".config") in
@@ -51,6 +43,6 @@ let () =
   p "  stubsdir: %%S"
     stubsdir;
   p "  preinstalled: %{ocaml-system:installed}%";
-  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
   p "}";
   close_out oc

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -40,6 +40,12 @@ let () =
     let sep = if Sys.os_type = "Win32" then ";" else ":" in
     String.concat sep lines
   in
+  let has_native_dynlink =
+    let check_dir libdir =
+      Sys.file_exists (Filename.concat libdir "dynlink.cmxa")
+    in
+    List.exists check_dir [Filename.concat libdir "dynlink"; libdir]
+  in
   let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
   p "opam-version: \"2.0\"";
   p "variables {";
@@ -50,7 +56,7 @@ let () =
        (ex. '...\bin\ocamlc.exe') so we use [ocaml] to check *)
     (Sys.file_exists (ocaml^"c.opt"^suffix));
   p "  native-dynlink: %%b"
-    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+    has_native_dynlink;
   p "  stubsdir: %%S"
     stubsdir;
   p "  preinstalled: %{ocaml-system:installed}%";

--- a/tools/opam/gen_ocaml_config.ml.in
+++ b/tools/opam/gen_ocaml_config.ml.in
@@ -1,8 +1,16 @@
 let () =
-  if Sys.ocaml_version <> Sys.argv.(1) then
+  let ocaml_version =
+    let v = Sys.ocaml_version in
+    let l = String.length v in
+    let plus = try String.index v '+' with Not_found -> l in
+    (* Introduced in 4.11.0; used from 4.12.0 *)
+    let tilde = try String.index v '~' with Not_found -> l in
+    String.sub v 0 (min (min plus tilde) l)
+  in
+  if ocaml_version <> Sys.argv.(1) then
     (Printf.eprintf
        "OCaml version mismatch: %%s, expected %s"
-       Sys.ocaml_version Sys.argv.(1);
+       ocaml_version Sys.argv.(1);
      exit 1)
   else
   let oc = open_out (Sys.argv.(2) ^ ".config") in
@@ -29,7 +37,8 @@ let () =
     let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
     let lines = List.rev (r []) in
     close_in ic;
-    String.concat ":" lines
+    let sep = if Sys.os_type = "Win32" then ";" else ":" in
+    String.concat sep lines
   in
   let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
   p "opam-version: \"2.0\"";
@@ -37,12 +46,14 @@ let () =
   p "  native: %%b"
     (Sys.file_exists (ocaml^"opt"^suffix));
   p "  native-tools: %%b"
-    (Sys.file_exists (ocamlc^".opt"^suffix));
+    (* The variable [ocamlc] already has a suffix on Windows
+       (ex. '...\bin\ocamlc.exe') so we use [ocaml] to check *)
+    (Sys.file_exists (ocaml^"c.opt"^suffix));
   p "  native-dynlink: %%b"
     (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
   p "  stubsdir: %%S"
     stubsdir;
   p "  preinstalled: %{ocaml-system:installed}%";
-  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"";
   p "}";
   close_out oc

--- a/tools/opam/ocaml-config.install
+++ b/tools/opam/ocaml-config.install
@@ -1,0 +1,1 @@
+share: ["gen_ocaml_config.ml"]


### PR DESCRIPTION
This extracts the historical parts of #14250. For the HEAD commit, note that:
- `tools/opam/ocaml-config.install` is identical to [ocaml/opam-source-archives@eb91a0d/patches/ocaml-config/ocaml-config.install](https://github.com/ocaml/opam-source-archives/blob/eb91a0daf73d30d17a312fe28363e22fc5a566b8/patches/ocaml-config/ocaml-config.install)
- `tools/opam/gen_ocaml-system_config.ml.in` is identical to [ocaml/opam-source-archives@eb91a0d/patches/ocaml-system/gen_ocaml_config.ml.in](https://github.com/ocaml/opam-source-archives/blob/eb91a0daf73d30d17a312fe28363e22fc5a566b8/patches/ocaml-system/gen_ocaml_config.ml.in)
- `tools/opam/gen_ocaml_config.ml.in` is identical to [ocaml/opam-source-archives@eb91a0d/patches/ocaml-config/gen_ocaml_config.ml.in.3](https://github.com/ocaml/opam-source-archives/blob/eb91a0daf73d30d17a312fe28363e22fc5a566b8/patches/ocaml-config/gen_ocaml_config.ml.in.3)

#14250 can then be rebased on top of this and just be updates and proposed changes.