### PR TITLE
Fix C dependency generation in otherlibs

### DIFF
--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -172,9 +172,15 @@ distclean:: clean
 
 ifeq "$(COMPUTE_DEPS)" "true"
 ifneq "$(COBJS_BYTECODE)" ""
-include $(addprefix $(DEPDIR)/, $(COBJS_BYTECODE:.b.$(O)=.$(D)))
+include $(addprefix $(DEPDIR)/, $(COBJS_BYTECODE:.$(O)=.$(D)))
+ifeq "$(NATIVE_COMPILER)" "true"
+include $(addprefix $(DEPDIR)/, $(COBJS_NATIVE:.$(O)=.$(D)))
+endif
 endif
 endif
 
-$(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
+$(DEPDIR)/%.b.$(D): %.c | $(DEPDIR)
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.b.$(O)' -MF $@
+
+$(DEPDIR)/%.n.$(D): %.c | $(DEPDIR)
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.n.$(O)' -MF $@


### PR DESCRIPTION
Accidentally regressed in #11828 (5.1.0). This is C dependencies, so it affects _recompilation_ only (i.e. it's an issue for working on otherlibs, nothing else).

cc @MisterDA