### PR TITLE
Domain.join: do not lose backtrace if an exn is raised

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -216,6 +216,7 @@ stdlib__Digest.cmi : digest.mli
 stdlib__Domain.cmo : domain.ml \
     stdlib__Sys.cmi \
     stdlib.cmi \
+    stdlib__Printexc.cmi \
     stdlib__Obj.cmi \
     stdlib__Mutex.cmi \
     stdlib__List.cmi \
@@ -226,6 +227,7 @@ stdlib__Domain.cmo : domain.ml \
 stdlib__Domain.cmx : domain.ml \
     stdlib__Sys.cmx \
     stdlib.cmx \
+    stdlib__Printexc.cmx \
     stdlib__Obj.cmx \
     stdlib__Mutex.cmx \
     stdlib__List.cmx \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -73,11 +73,11 @@ STDLIB_MODULE_BASENAMES = \
   mutex \
   condition \
   semaphore \
-  domain \
   camlinternalFormat \
   printf \
   arg \
   printexc \
+  domain \
   fun \
   gc \
   in_channel \

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -299,7 +299,7 @@ let join { term_sync ; _ } =
   in
   match Mutex.protect term_sync.mut loop with
   | Ok x -> x
-  | Error ex -> raise ex
+  | Error ex -> Printexc.raise_with_backtrace ex (Printexc.get_raw_backtrace ())
 
 let count = Raw.get_domain_count
 let recommended_domain_count = Raw.get_recommended_domain_count


### PR DESCRIPTION
When an exception from a joined domain is raised, the backtrace is lost. Instead, the backtrace the user gets indicates that it originated from Domain.join, as opposed to where the error occurred inside the domain. We (Semgrep) have started noticing this in CI runs, which makes pinning the root cause of the exception difficult.  This patch simply captures the backtrace before reraising.

Note that this necessitated reordering `Domain` in stdlib/StdlibModules, since that module now takes a dependency on `Printexc`.

NB: I don't believe this warrants an entry in `Changes` but if you disagree I can add one.