### PR TITLE
Domain.join preserves the backtrace.

### DIFF
--- a/Changes
+++ b/Changes
@@ -88,6 +88,12 @@ Working version
 
 ### Standard library:
 
+- #14363: Preserve the backtrace at exceptional domain termination. Domain.join
+  on an exceptionally terminated domain re-raises the exception with the
+  backtrace.
+  (KC Sivaramakrishnan, report by Nathan Taylor, review by Gabriel Scherer,
+  David Allsopp)
+
 - #13372: New Format and Printf printf-like functions that accept a
    heterogeneous list as arguments.
   (Leonardo Santos, review by Florian Angeletti and Gabriel Scherer)

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -150,6 +150,8 @@ CAMLextern void caml_print_exception_backtrace(void);
 void caml_init_backtrace(void);
 CAMLextern void caml_init_debug_info(void);
 
+value caml_get_exception_raw_backtrace(value unit);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_BACKTRACE_H */

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -216,6 +216,7 @@ stdlib__Digest.cmi : digest.mli
 stdlib__Domain.cmo : domain.ml \
     stdlib__Sys.cmi \
     stdlib.cmi \
+    stdlib__Printexc.cmi \
     stdlib__Obj.cmi \
     stdlib__Mutex.cmi \
     stdlib__List.cmi \
@@ -226,6 +227,7 @@ stdlib__Domain.cmo : domain.ml \
 stdlib__Domain.cmx : domain.ml \
     stdlib__Sys.cmx \
     stdlib.cmx \
+    stdlib__Printexc.cmx \
     stdlib__Obj.cmx \
     stdlib__Mutex.cmx \
     stdlib__List.cmx \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -73,11 +73,11 @@ STDLIB_MODULE_BASENAMES = \
   mutex \
   condition \
   semaphore \
-  domain \
   camlinternalFormat \
   printf \
   arg \
   printexc \
+  domain \
   fun \
   gc \
   in_channel \

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -25,7 +25,8 @@ module Raw = struct
 
   type 'a state =
     | Running
-    | Finished of ('a, exn) result [@warning "-unused-constructor"]
+    | Finished of ('a, exn * Printexc.raw_backtrace) result
+    [@warning "-unused-constructor"]
 
   type 'a term_sync = {
     (* protected by [mut] *)
@@ -299,7 +300,7 @@ let join { term_sync ; _ } =
   in
   match Mutex.protect term_sync.mut loop with
   | Ok x -> x
-  | Error ex -> raise ex
+  | Error (ex, bt) -> Printexc.raise_with_backtrace ex bt
 
 let count = Raw.get_domain_count
 let recommended_domain_count = Raw.get_recommended_domain_count

--- a/testsuite/tests/backtrace/backtrace_domain_join.ml
+++ b/testsuite/tests/backtrace/backtrace_domain_join.ml
@@ -1,0 +1,28 @@
+(* TEST_BELOW
+(* Blank lines added here to preserve locations. *)
+
+*)
+
+(* A test for backtraces on [Domain.join] *)
+
+let rec bar n =
+  if n = 0 then failwith "bar raised"
+  else foo (n-1) + 1
+
+and foo n =
+  if n = 0 then failwith "foo raised"
+  else bar (n-1) + 1
+
+let f () = foo 10
+
+let _ =
+  match Domain.spawn f |> Domain.join with
+  | v -> ()
+  | exception e ->
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.print_raw_backtrace stdout bt
+
+(* TEST
+ flags = "-g";
+ ocamlrunparam += ",b=1";
+*)

--- a/testsuite/tests/backtrace/backtrace_domain_join.reference
+++ b/testsuite/tests/backtrace/backtrace_domain_join.reference
@@ -1,0 +1,15 @@
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 10, characters 7-16
+Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
+Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 10, characters 7-16
+Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
+Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 10, characters 7-16
+Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
+Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 10, characters 7-16
+Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
+Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 10, characters 7-16
+Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
+Called from Stdlib__Domain.spawn.body in file "domain.ml", line 270, characters 16-20
+Re-raised at Stdlib__Domain.spawn.body in file "domain.ml", line 286, characters 8-17
+Re-raised at Stdlib__Domain.join in file "domain.ml", line 303, characters 22-57
+Called from Backtrace_domain_join in file "backtrace_domain_join.ml", line 19, characters 8-37


### PR DESCRIPTION
In `Domain.join d`, if `d` terminates with an uncaught exception, then the exception is re-raised by `Domain.join` with the backtrace from `d`. This ensure that the backtrace of the terminating domain is not lost.

This was reported by @dijkstracula in https://github.com/ocaml/ocaml/pull/14358. 