### PR TITLE
Avoid substituting under letrec lambdas in Simplif

### DIFF
--- a/Changes
+++ b/Changes
@@ -1189,6 +1189,10 @@ OCaml 5.4.0 (9 October 2025)
 - #14287: Bugfix for GC root mishandling in memprof.c
   (Stephen Dolan, review by Leo White)
 
+- #14368: Bugfix for Simplif substituting under lambda
+  (Stephen Dolan, review by Vincent Laviron
+   and Gabriel Scherer)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -417,8 +417,8 @@ let simplify_lets lam =
           end
       | _ -> no_opt ()
       end
-  | Lfunction {body} ->
-      count Ident.Map.empty body
+  | Lfunction fn ->
+      count_lfunction fn
   | Llet(_str, _k, v, Lvar w, l2) when optimize ->
       (* v will be replaced by w in l2, so each occurrence of v in l2
          increases w's refcount *)
@@ -432,7 +432,7 @@ let simplify_lets lam =
      count bv l1;
      count bv l2
   | Lletrec(bindings, body) ->
-      List.iter (fun { def } -> count bv def.body) bindings;
+      List.iter (fun { def } -> count_lfunction def) bindings;
       count bv body
   | Lprim(_p, ll, _) -> List.iter (count bv) ll
   | Lswitch(l, sw, _loc) ->
@@ -467,6 +467,9 @@ let simplify_lets lam =
   | Levent(l, _) -> count bv l
   | Lifused(v, l) ->
       if count_var v > 0 then count bv l
+
+  and count_lfunction fn =
+    count Ident.Map.empty fn.body
 
   and count_default bv sw = match sw.sw_failaction with
   | None -> ()

--- a/testsuite/tests/basic-more/simplif_under_lambda.ml
+++ b/testsuite/tests/basic-more/simplif_under_lambda.ml
@@ -1,0 +1,18 @@
+(* TEST *)
+
+let f () =
+  let junk = ref 42 in
+  Gc.finalise_last (fun () -> print_endline "collected") junk;
+  let tuple = Sys.opaque_identity (junk, "ok") in
+  match tuple with
+  | _, ok ->
+     let rec loop () =
+       print_endline ok;
+       if false then loop ()
+     in
+     loop
+
+let () =
+  let fn = f () in
+  Gc.full_major ();
+  fn ()

--- a/testsuite/tests/basic-more/simplif_under_lambda.reference
+++ b/testsuite/tests/basic-more/simplif_under_lambda.reference
@@ -1,0 +1,2 @@
+collected
+ok


### PR DESCRIPTION
This is a port of oxcaml/oxcaml#3832, which fixes a bug in Simplif that I only recently realised is a bug here as well. The issue is that since a recent refactoring of Lletrec, certain `Alias` bindings are substituted under lambdas (because some lambdas are now not guarded by Lfunction, only Lletrec). This was a soundness bug in oxcaml (stack allocations leaked out of their regions), but turns out to also be a less consequential bug in mainline ocaml too: certain allocations can live longer than they should, if the GC keeps a tuple alive solely in order to project from it later.

I've marked @lthls as the reviewer in the Changes file since he reviewed the code. The testcase is different, though, as the original soundness issue doesn't trigger in the absence of stack allocation.