### PR TITLE
Fix headers for C⁠+⁠+ inclusion, again, again

### DIFF
--- a/Changes
+++ b/Changes
@@ -435,6 +435,9 @@ Working version
 - #14332: Fix missing TSan instrumentation in subexpressions
   (Vincent Laviron, review by Gabriel Scherer and Olivier Nicole)
 
+- #14370: Fix headers for C++ inclusion.
+  (Antonin Décimo, review by Gabriel Scherer)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -46,7 +46,7 @@ struct filedescr {
     SOCKET socket;
   } fd;                   /* Real windows handle */
   enum { KIND_HANDLE, KIND_SOCKET } kind;
-  _Atomic int crt_fd;     /* C runtime descriptor */
+  atomic_int crt_fd;      /* C runtime descriptor */
   unsigned int flags_fd;  /* See FLAGS_FD_* */
 };
 

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -57,7 +57,7 @@ value caml_addrmap_lookup(struct addrmap* t, value key)
   for (uintnat pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
     CAMLassert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
     if (t->entries[pos].key == key)
-      return t->entries[pos].value;
+      return t->entries[pos].val;
   }
 }
 
@@ -68,7 +68,7 @@ static void addrmap_alloc(struct addrmap* t, uintnat sz)
   t->size = sz;
   for (uintnat i = 0; i < sz; i++) {
     t->entries[i].key = ADDRMAP_INVALID_KEY;
-    t->entries[i].value = ADDRMAP_NOT_PRESENT;
+    t->entries[i].val = ADDRMAP_NOT_PRESENT;
   }
 }
 
@@ -98,7 +98,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
       t->entries[pos].key = key;
     }
     if (t->entries[pos].key == key) {
-      return &t->entries[pos].value;
+      return &t->entries[pos].val;
     }
   }
   /* failed to insert, rehash and try again */
@@ -110,7 +110,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
       if (old_table[i].key != ADDRMAP_INVALID_KEY) {
         value* p = caml_addrmap_insert_pos(t, old_table[i].key);
         CAMLassert(*p == ADDRMAP_NOT_PRESENT);
-        *p = old_table[i].value;
+        *p = old_table[i].val;
       }
     }
     caml_stat_free(old_table);

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -15,11 +15,9 @@
 #ifndef CAML_ADDRMAP_H
 #define CAML_ADDRMAP_H
 
-#include "mlvalues.h"
+#ifdef CAML_INTERNALS
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "mlvalues.h"
 
 /* An addrmap is a value -> value hashmap, where
    the values are blocks */
@@ -99,8 +97,6 @@ Caml_inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
   return caml_addrmap_next(t, (uintnat)(-1));
 }
 
-#ifdef __cplusplus
-}
-#endif
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_ADDRMAP_H */

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -24,7 +24,7 @@ extern "C" {
 /* An addrmap is a value -> value hashmap, where
    the values are blocks */
 
-struct addrmap_entry { value key, value; };
+struct addrmap_entry { value key; value val; };
 struct addrmap {
   struct addrmap_entry* entries;
   uintnat size;
@@ -84,14 +84,14 @@ Caml_inline value caml_addrmap_iter_value(struct addrmap* t,
                                           addrmap_iterator i)
 {
   CAMLassert(caml_addrmap_iter_ok(t, i));
-  return t->entries[i].value;
+  return t->entries[i].val;
 }
 
 Caml_inline value* caml_addrmap_iter_val_pos(struct addrmap* t,
                                              addrmap_iterator i)
 {
   CAMLassert(caml_addrmap_iter_ok(t, i));
-  return &t->entries[i].value;
+  return &t->entries[i].val;
 }
 
 Caml_inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)


### PR DESCRIPTION
1. _changes-meaning_ errors: in `struct addrmap { value key; value value};`, the field `value` hides the `value` typedef.

   Back in #13777, [@xavierleroy wrote](https://github.com/ocaml/ocaml/pull/13777#issuecomment-2662585070):
   > Funny. I tend to agree with the C++ compiler that this C code is needlessly confusing. Naming the field "val" would be more symmetrical with "key", in any case.
   
   This is technically a breaking change since `struct addrmap` isn't protected by `CAML_INTERNALS` but I suppose that there are no external consumers of this API.
   
2. Another wild `_Atomic int` used in a public type, unprotected, but only on Windows! I've replaced it with C++ `atomic<int>`.
   An interesting read: [N2741 _Clarify atomics compatibility between C and C⁠+⁠+_ – Hans-J. Boehm (2021-05-20)](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2741.htm). Until C⁠+⁠+23, the standard didn't recommend `atomic<T>` to be ABI-compatible with `_Atomic(T)`. The C23 standard makes no such recommendation.
   
 I have found these with a new test that I hope to submit shortly.