### PR TITLE
Filter arrow with result rather than an exception

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3416,8 +3416,6 @@ type filter_arrow_failure =
       }
   | Not_a_function
 
-exception Filter_arrow_failed of filter_arrow_failure
-
 type filtered_arrow =
   { ty_param : type_expr;
     ty_ret : type_expr;
@@ -3451,21 +3449,21 @@ let filter_arrow env t l ~param_hole =
       | Tvar _ ->
           let t', ty_param, ty_ret = function_type (get_level t) in
           link_type t t';
-          { ty_param; ty_ret }
+          Ok { ty_param; ty_ret }
       | Tarrow(l', ty_param, ty_ret, _) ->
           if l = l' || !Clflags.classic && l = Nolabel && not (is_optional l')
-          then { ty_param; ty_ret }
-          else raise (Filter_arrow_failed (Label_mismatch
-                          { got = l; expected = l'; expected_type = t }))
+          then Ok { ty_param; ty_ret }
+          else Error (Label_mismatch
+                          { got = l; expected = l'; expected_type = t })
       | _ ->
-          raise (Filter_arrow_failed Not_a_function)
+          Error Not_a_function
     end
   | exception Unify_trace trace ->
       let t', _, _ = function_type (get_level t) in
-      raise (Filter_arrow_failed (Unification_error
+      Error (Unification_error
               (expand_to_unification_error
                   env
-                  (Diff { got = t'; expected = t } :: trace))))
+                  (Diff { got = t'; expected = t } :: trace)))
 
 let is_really_poly env ty =
   let snap = Btype.snapshot () in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3444,29 +3444,28 @@ let filter_arrow env t l ~param_hole =
     let t' = newty2 ~level (Tarrow (l, t1, t2, commu_ok)) in
     t', t1, t2
   in
-  let t =
-    try expand_head_trace env t
-    with Unify_trace trace ->
+  match expand_head_trace env t with
+  | t ->
+    begin
+      match get_desc t with
+      | Tvar _ ->
+          let t', ty_param, ty_ret = function_type (get_level t) in
+          link_type t t';
+          { ty_param; ty_ret }
+      | Tarrow(l', ty_param, ty_ret, _) ->
+          if l = l' || !Clflags.classic && l = Nolabel && not (is_optional l')
+          then { ty_param; ty_ret }
+          else raise (Filter_arrow_failed (Label_mismatch
+                          { got = l; expected = l'; expected_type = t }))
+      | _ ->
+          raise (Filter_arrow_failed Not_a_function)
+    end
+  | exception Unify_trace trace ->
       let t', _, _ = function_type (get_level t) in
-      raise (Filter_arrow_failed
-               (Unification_error
-                  (expand_to_unification_error
-                     env
-                     (Diff { got = t'; expected = t } :: trace))))
-  in
-  match get_desc t with
-  | Tvar _ ->
-      let t', ty_param, ty_ret = function_type (get_level t) in
-      link_type t t';
-      { ty_param; ty_ret }
-  | Tarrow(l', ty_param, ty_ret, _) ->
-      if l = l' || !Clflags.classic && l = Nolabel && not (is_optional l')
-      then { ty_param; ty_ret }
-      else raise (Filter_arrow_failed
-                    (Label_mismatch
-                       { got = l; expected = l'; expected_type = t }))
-  | _ ->
-      raise (Filter_arrow_failed Not_a_function)
+      raise (Filter_arrow_failed (Unification_error
+              (expand_to_unification_error
+                  env
+                  (Diff { got = t'; expected = t } :: trace))))
 
 let is_really_poly env ty =
   let snap = Btype.snapshot () in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -308,8 +308,17 @@ type filtered_arrow =
     ty_ret : type_expr;
   }
 
+type filter_arrow_failure =
+  | Unification_error of Errortrace.unification_error
+  | Label_mismatch of
+      { got           : arg_label
+      ; expected      : arg_label
+      ; expected_type : type_expr
+      }
+  | Not_a_function
+
 val filter_arrow: Env.t -> type_expr -> arg_label -> param_hole:bool ->
-        filtered_arrow
+        (filtered_arrow, filter_arrow_failure) result
         (* A special case of unification with [l:'a -> 'b]. If [param_hole] is
            true then ['a] might be initialized with a [Tvar _] hole to be filled
            later by a [Tpoly _].
@@ -340,17 +349,6 @@ val reify_univars : Env.t -> Types.type_expr -> Types.type_expr
         (* Replaces all the variables of a type by a univar. *)
 
 (* Exceptions for special cases of unify *)
-
-type filter_arrow_failure =
-  | Unification_error of Errortrace.unification_error
-  | Label_mismatch of
-      { got           : arg_label
-      ; expected      : arg_label
-      ; expected_type : type_expr
-      }
-  | Not_a_function
-
-exception Filter_arrow_failed of filter_arrow_failure
 
 type filter_method_failure =
   | Unification_error of Errortrace.unification_error


### PR DESCRIPTION
During typing the function `Ctype.filter_arrow` may raise an exception that will always be immediately cached by the caller.
This PR replaces the exception with a result.

For reviewing purposes the first commit moves code around while the second one removes the exception.

Proposed by @gasche  