### PR TITLE
cmt: always strip Env.t in cmt files

### DIFF
--- a/Changes
+++ b/Changes
@@ -351,6 +351,10 @@ Working version
 - #14190: `ocaml -e` now also processes `-init` (previously it was ignored).
   (Emile Trotignon, review by David Allsopp and @ygrek)
 
+-  #14373: remove the OCAML_BINANNOT_WITHENV environment variable, and
+   always strip typing environment in cmt files
+   (Florian Angeletti, review by David Allsopp)
+
 ### Internal/compiler-libs changes:
 
 - #13839, #14008: Reimplement `let open`, `let module` and `let exception` in

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -110,10 +110,6 @@ let iter_on_declarations ~(f: Shape.Uid.t -> item_declaration -> unit) = {
   item_declaration = (fun _sub decl -> iter_on_declaration f decl);
 }
 
-let need_to_clear_env =
-  try ignore (Sys.getenv "OCAML_BINANNOT_WITHENV"); false
-  with Not_found -> true
-
 let keep_only_summary = Env.keep_only_summary
 
 let cenv =
@@ -132,17 +128,14 @@ let clear_part = function
   | Partial_module_type s -> Partial_module_type (cenv.module_type cenv s)
 
 let clear_env binary_annots =
-  if need_to_clear_env then
-    match binary_annots with
-    | Implementation s -> Implementation (cenv.structure cenv s)
-    | Interface s -> Interface (cenv.signature cenv s)
-    | Packed _ -> binary_annots
-    | Partial_implementation array ->
-        Partial_implementation (Array.map clear_part array)
-    | Partial_interface array ->
-        Partial_interface (Array.map clear_part array)
-
-  else binary_annots
+  match binary_annots with
+  | Implementation s -> Implementation (cenv.structure cenv s)
+  | Interface s -> Interface (cenv.signature cenv s)
+  | Packed _ -> binary_annots
+  | Partial_implementation array ->
+      Partial_implementation (Array.map clear_part array)
+  | Partial_interface array ->
+      Partial_interface (Array.map clear_part array)
 
 (* Every typedtree node with a located longident corresponding to user-facing
    syntax should be indexed. *)
@@ -492,11 +485,10 @@ let save_cmt target binary_annots initial_env cmi shape =
            cmt_builddir = Location.rewrite_absolute_path (Sys.getcwd ());
            cmt_loadpath = Load_path.get_paths ();
            cmt_source_digest = source_digest;
-           cmt_initial_env = if need_to_clear_env then
-               keep_only_summary initial_env else initial_env;
+           cmt_initial_env = keep_only_summary initial_env;
            cmt_imports = List.sort compare (Env.imports ());
            cmt_interface_digest = this_crc;
-           cmt_use_summaries = need_to_clear_env;
+           cmt_use_summaries = true;
            cmt_uid_to_decl;
            cmt_impl_shape = shape;
            cmt_ident_occurrences;


### PR DESCRIPTION
This PR proposes to remove the environment variable OCAML_BINANNOT_WITHENV. 

If this variable was set, the typechecker tried to emit cmt files without stripping environment, which 
may result in a crash if any of the usage warnings was enabled. Indeed, non-stripped environment may
contain functions to track the usage of identifiers.

Since the environment variable was undocumented, I think it might make sense to simply remove the option.