### PR TITLE
Print a message about an wrong magic number in debugger

### DIFF
--- a/Changes
+++ b/Changes
@@ -1480,6 +1480,10 @@ OCaml 5.3.0 (8 January 2025)
   LLDB support for them.
   (Nick Barnes, review by Tim McGilchrist and Gabriel Scherer)
 
+- #14375: More accurate error message in the ocamldebug in case of incorrect or
+  missing magic number.
+  (Alex Asafov, review by Gabriel Scherer)
+
 ### Toplevel:
 
 - #12891: Improved styling for initial prompt

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -70,7 +70,7 @@ let read_symbols' bytecode_file =
     try
       let open Misc.Magic_number in
       let pos_trailer = in_channel_length ic - magic_length in
-      let _ = seek_in ic pos_trailer in
+      let () = seek_in ic pos_trailer in
       match read_current_info ~expected_kind:(Some Exec) ic with
       | Error (Parse_error err) ->
          prerr_string bytecode_file; prerr_string " load error: "; 

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -71,7 +71,11 @@ let read_symbols' bytecode_file =
       let toc = Bytesections.read_toc ic in
       ignore(Bytesections.seek_section toc ic Bytesections.Name.SYMB);
       toc
-    with Bytesections.Bad_magic_number | Not_found ->
+    with 
+      Bytesections.Bad_magic_number ->
+        prerr_string bytecode_file; prerr_endline " file has wrong magic number.";
+        raise Toplevel
+    | Not_found ->
       prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
       raise Toplevel
   in

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -80,7 +80,7 @@ let read_symbols' bytecode_file =
          prerr_string bytecode_file; prerr_string " load error: "; 
          prerr_endline (explain_unexpected_error err);
          raise Toplevel
-      | Ok _ -> seek_in ic 0;
+      | Ok _ -> ();
       let toc = Bytesections.read_toc ic in
       ignore(Bytesections.seek_section toc ic Bytesections.Name.SYMB);
       toc

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -68,14 +68,23 @@ let read_symbols' bytecode_file =
   let ic = open_in_bin bytecode_file in
   let toc =
     try
+      let open Misc.Magic_number in
+      let pos_trailer = in_channel_length ic - magic_length in
+      let _ = seek_in ic pos_trailer in
+      match read_current_info ~expected_kind:(Some Exec) ic with
+      | Error (Parse_error err) ->
+         prerr_string bytecode_file; prerr_string " load error: "; 
+         prerr_endline (explain_parse_error (Some Exec) err);
+         raise Toplevel
+      | Error (Unexpected_error err) ->
+         prerr_string bytecode_file; prerr_string " load error: "; 
+         prerr_endline (explain_unexpected_error err);
+         raise Toplevel
+      | Ok _ -> seek_in ic 0;
       let toc = Bytesections.read_toc ic in
       ignore(Bytesections.seek_section toc ic Bytesections.Name.SYMB);
       toc
-    with 
-      Bytesections.Bad_magic_number ->
-        prerr_string bytecode_file; prerr_endline " file has wrong magic number.";
-        raise Toplevel
-    | Not_found ->
+    with Bytesections.Bad_magic_number | Not_found ->
       prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
       raise Toplevel
   in

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -73,11 +73,11 @@ let read_symbols' bytecode_file =
       let () = seek_in ic pos_trailer in
       match read_current_info ~expected_kind:(Some Exec) ic with
       | Error (Parse_error err) ->
-         prerr_string bytecode_file; prerr_string " load error: "; 
+         prerr_string bytecode_file; prerr_string " load error: ";
          prerr_endline (explain_parse_error (Some Exec) err);
          raise Toplevel
       | Error (Unexpected_error err) ->
-         prerr_string bytecode_file; prerr_string " load error: "; 
+         prerr_string bytecode_file; prerr_string " load error: ";
          prerr_endline (explain_unexpected_error err);
          raise Toplevel
       | Ok _ -> ();


### PR DESCRIPTION
`ocamldebug` prints "is not a bytecode file" both if it doesn't find the magic number and if it's incorrect. To avoid misleading the user, it's best to print a separate message for the case where the magic number is incorrect, so it's clear the file was compiled with a different compiler version.