### PR TITLE
Add String.find_{first,last}_index, String.find_{first,last} and String.[r]find_all

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,11 @@ Working version
 
 ### Standard library:
 
+- #14381: Add String.find_{first,last}_index, String.find_{first,last},
+  String.[r]find_all.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär, Ali Caglayan and
+   Florian Angeletti)
+
 - #14438: Add String.is_empty
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -804,6 +804,7 @@ stdlib__String.cmo : string.ml \
     stdlib.cmi \
     stdlib__List.cmi \
     stdlib__Int.cmi \
+    stdlib__Char.cmi \
     stdlib__Bytes.cmi \
     stdlib__Array.cmi \
     stdlib__String.cmi
@@ -812,6 +813,7 @@ stdlib__String.cmx : string.ml \
     stdlib.cmx \
     stdlib__List.cmx \
     stdlib__Int.cmx \
+    stdlib__Char.cmx \
     stdlib__Bytes.cmx \
     stdlib__Array.cmx \
     stdlib__String.cmi

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -393,10 +393,8 @@ let find_all f ~sub ?(start = 0) s acc =
     match Search.find ~start ~sub ~sub_lp s with
     | -1 -> acc
     | i ->
-        let acc = f i acc in
-        let start = i + length sub in
-        let start = if start = i then start + 1 else start in
-        loop f acc sub sub_lp s ~start ~slen
+        let start = i + Int.max (length sub) 1 in
+        loop f (f i acc) sub sub_lp s ~start ~slen
   in
   let slen = length s in
   if not (0 <= start && start <= slen) then invalid_start ~start slen else

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -373,54 +373,52 @@ module Search = struct
 end
 
 let find_first ~sub =
-  let search ~sub ~sub_lp ~sub_periodic ?(start = 0) s =
-    match Search.find ~start ~sub_lp ~sub_periodic ~sub s with
-    | -1 -> None | i -> Some i
-  in
   let sub_lp = Search.find_maximal_suffix_and_period ~sub in
   let sub_periodic = Search.is_sub_periodic ~sub ~sub_lp in
-  search ~sub ~sub_lp ~sub_periodic
+  fun ?(start = 0) s ->
+    match Search.find ~start ~sub_lp ~sub_periodic ~sub s with
+    | -1 -> None | i -> Some i
 
 let find_last ~sub =
-  let search ~sub ~rsub_lp ~rsub_periodic ?start s =
+  let rsub_lp = Search.rfind_maximal_suffix_and_period ~sub in
+  let rsub_periodic = Search.ris_sub_periodic ~sub ~rsub_lp in
+  fun ?start s ->
     let start = match start with None -> length s | Some s -> s in
     match Search.rfind ~start ~sub ~rsub_lp ~rsub_periodic s with
     | -1 -> None | i -> Some i
-  in
-  let rsub_lp = Search.rfind_maximal_suffix_and_period ~sub in
-  let rsub_periodic = Search.ris_sub_periodic ~sub ~rsub_lp in
-  search ~sub ~rsub_lp ~rsub_periodic
 
-let find_all f ~sub ?(start = 0) s acc =
-  let rec loop f acc sub sub_lp sub_periodic s ~start ~slen =
-    if start > slen then acc else
-    match Search.find ~start ~sub ~sub_lp ~sub_periodic s with
-    | -1 -> acc
-    | i ->
-        let start = i + Int.max (length sub) 1 in
-        loop f (f i acc) sub sub_lp sub_periodic s ~start ~slen
-  in
-  let slen = length s in
-  if not (0 <= start && start <= slen) then invalid_start ~start slen else
+let find_all ~sub =
   let sub_lp = Search.find_maximal_suffix_and_period ~sub in
   let sub_periodic = Search.is_sub_periodic ~sub ~sub_lp in
-  loop f acc sub sub_lp sub_periodic s ~start ~slen
+  fun f ?(start = 0) s acc ->
+    let rec loop f acc sub sub_lp sub_periodic s ~start ~slen =
+      if start > slen then acc else
+      match Search.find ~start ~sub ~sub_lp ~sub_periodic s with
+      | -1 -> acc
+      | i ->
+          let start = i + Int.max (length sub) 1 in
+          loop f (f i acc) sub sub_lp sub_periodic s ~start ~slen
+    in
+    let slen = length s in
+    if not (0 <= start && start <= slen) then invalid_start ~start slen else
+    loop f acc sub sub_lp sub_periodic s ~start ~slen
 
-let rfind_all f ~sub ?start s acc =
-  let rec loop f acc sub rsub_lp rsub_periodic s ~start ~slen =
-    if start < 0 then acc else
-    match Search.rfind ~start ~sub ~rsub_lp ~rsub_periodic s with
-    | -1 -> acc
-    | i ->
-        let start = i - Int.max (length sub) 1 in
-        loop f (f i acc) sub rsub_lp rsub_periodic s ~start ~slen
-  in
-  let slen = length s in
-  let start = match start with None -> length s | Some s -> s in
-  if not (0 <= start && start <= slen) then invalid_start ~start slen else
+let rfind_all ~sub =
   let rsub_lp = Search.rfind_maximal_suffix_and_period ~sub in
   let rsub_periodic = Search.ris_sub_periodic ~sub ~rsub_lp in
-  loop f acc sub rsub_lp rsub_periodic s ~start ~slen
+  fun f ?start s acc ->
+    let rec loop f acc sub rsub_lp rsub_periodic s ~start ~slen =
+      if start < 0 then acc else
+      match Search.rfind ~start ~sub ~rsub_lp ~rsub_periodic s with
+      | -1 -> acc
+      | i ->
+          let start = i - Int.max (length sub) 1 in
+          loop f (f i acc) sub rsub_lp rsub_periodic s ~start ~slen
+    in
+    let slen = length s in
+    let start = match start with None -> length s | Some s -> s in
+    if not (0 <= start && start <= slen) then invalid_start ~start slen else
+    loop f acc sub rsub_lp rsub_periodic s ~start ~slen
 
 (* ASCII transforms *)
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -242,6 +242,7 @@ module Search = struct
     if l0 > l1 then (l0, p0) else (l1, p1)
 
   let is_sub_periodic ~sub ~sub_lp:(l, p) =
+    l < length sub / 2 &&
     let i = ref 0 in
     while !i <= l && Char.equal (get sub !i) (get sub (!i + p))
     do incr i done;
@@ -270,7 +271,7 @@ module Search = struct
         done;
         -1
       end else begin
-        let p = 1 + Int.max (l + 1) (sublen - l - 1) in
+        let q = 1 + Int.max (l + 1) (sublen - l - 1) in
         while (!j <= smax) do
           let i = ref (l + 1) in
           while (!i < sublen && Char.equal (get sub !i) (get s (!i + !j)))
@@ -280,7 +281,7 @@ module Search = struct
             i := l;
             while (!i >= 0 && Char.equal (get sub !i) (get s (!i + !j)))
             do decr i done;
-            if !i < 0 then raise_notrace Exit else (j := !j + p)
+            if !i < 0 then raise_notrace Exit else (j := !j + q)
           end
         done;
         -1
@@ -315,6 +316,7 @@ module Search = struct
     if l0 > l1 then (l0, p0) else (l1, p1)
 
   let ris_sub_periodic ~sub ~rsub_lp:(l, p) =
+    l < length sub / 2 &&
     let i = ref 0 in
     while !i <= l && Char.equal (get sub !i) (get sub (!i + p))
     do incr i done;
@@ -351,7 +353,7 @@ module Search = struct
         done;
         -1
       end else begin
-        let p = 1 + Int.max (l + 1) (sublen - l - 1) in
+        let q = 1 + Int.max (l + 1) (sublen - l - 1) in
         while (!j <= smax) do
           let i = ref (l + 1) in
           while (!i < sublen && Char.equal (get sub !i) (get s (!i + !j)))
@@ -361,7 +363,7 @@ module Search = struct
             i := l;
             while (!i >= 0 && Char.equal (get sub !i) (get s (!i + !j)))
             do decr i done;
-            if !i < 0 then raise_notrace Exit else (j := !j + p)
+            if !i < 0 then raise_notrace Exit else (j := !j + q)
           end
         done;
         -1

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -372,14 +372,20 @@ module Search = struct
       slen - 1 - (!j + (sublen - 1))
 end
 
-let find_first ~sub ?(start = 0) s =
+let find_first ~sub =
+  let search ~sub_lp ~sub ?(start = 0) s =
+    match Search.find ~start ~sub_lp ~sub s with -1 -> None | i -> Some i
+  in
   let sub_lp = Search.find_maximal_suffix_and_period ~sub in
-  match Search.find ~start ~sub_lp ~sub s with -1 -> None | i -> Some i
+  search ~sub_lp ~sub
 
-let find_last ~sub ?start s =
-  let start = match start with None -> length s | Some s -> s in
+let find_last ~sub =
+  let search ~rsub_lp ~sub ?start s =
+    let start = match start with None -> length s | Some s -> s in
+    match Search.rfind ~start ~rsub_lp ~sub s with -1 -> None | i -> Some i
+  in
   let rsub_lp = Search.rfind_maximal_suffix_and_period ~sub in
-  match Search.rfind ~start ~rsub_lp ~sub s with -1 -> None | i -> Some i
+  search ~rsub_lp ~sub
 
 let find_all f ~sub ?(start = 0) s acc =
   let rec loop f acc sub sub_lp s ~start ~slen =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -117,6 +117,27 @@ let escaped s =
      its argument. *)
   if b == b' then s else bts b'
 
+(* Finding indices *)
+
+let invalid_start ~start len =
+  let i = string_of_int in
+  invalid_arg @@ concat "" ["start: "; i start; " not in range [0;"; i len; "]"]
+
+let find_first_index sat ?(start = 0) s =
+  let len = length s in
+  if not (0 <= start && start <= len) then invalid_start ~start len else
+  let i = ref start in
+  while !i < len && not (sat (unsafe_get s !i)) do incr i done;
+  if !i < len then Some !i else None
+
+let find_last_index sat ?start s =
+  let len = length s in
+  let start = match start with None -> len | Some s -> s in
+  if not (0 <= start && start <= len) then invalid_start ~start len else
+  let i = ref (if start = len then len - 1 else start) in
+  while !i >= 0 && not (sat (unsafe_get s !i)) do decr i done;
+  if !i < 0 then None else Some !i
+
 (* duplicated in bytes.ml *)
 let rec index_rec s lim i c =
   if i >= lim then raise Not_found else
@@ -194,6 +215,8 @@ let rcontains_from s i c =
     invalid_arg "String.rcontains_from / Bytes.rcontains_from"
   else
     try ignore (rindex_rec s i c); true with Not_found -> false
+
+(* ASCII transforms *)
 
 let uppercase_ascii s =
   B.uppercase_ascii (bos s) |> bts

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -451,6 +451,76 @@ val rindex_opt : string -> char -> int option
 
     @since 4.05 *)
 
+(** {1:find_subs Finding substrings} *)
+
+val find_first :
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> int option
+(** [find_first sub start s] is the starting position of the first
+    occurrence of [sub] in [s] at or after the index or position [start]
+    (defaults to [0]).
+
+    If [sub] is [""] the result is [Some start]. The result of the
+    function is always a valid index of [s] except when [sub] is
+    [""] and [start] is [length s].
+
+    If you need to search for [sub] multiple times in [s] it is more
+    efficient to use {!find_all}.
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val find_last :
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> int option
+(** [find_last sub start s] is the starting position of the last
+    occurrence of [sub] in [s] at or before the index or position
+    [start] (defaults to [String.length s]).
+
+    If [sub] is [""] the result is [Some start]. The result of the
+    function is always a valid index of [s] except when [sub] is
+    [""] and [start] is [length s].
+
+    If you need to search for [sub] multiple times in [s] it is more
+    efficient to use {!rfind_all}.
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val find_all :
+  (int -> 'acc -> 'acc) ->
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> 'acc -> 'acc
+(** [find_all f sub start s acc], starting with [acc], folds [f]
+    over all non-overlapping starting positions of [sub] in [s] at or
+    after the index or position [start] (defaults to [0]). The
+    result is [acc] if [sub] could not be found in [s].
+
+    If [sub] is [""], [f] gets invoked on all positions of [s] at or after
+    [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val rfind_all :
+  (int -> 'acc -> 'acc) ->
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> 'acc -> 'acc
+(** [rfind_all f sub start s acc], starting with [acc], folds [f]
+    over all non-overlapping starting positions of [sub] in [s] at or
+    before the index or position [start] (defaults to [String.length
+    s]). The result is [acc] if [sub] could not be found in [s].
+
+    If [sub] is [""], [f] gets invoked on on all positions of [s] at
+    or before [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
 (** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -385,7 +385,27 @@ val iteri : (int -> char -> unit) -> string -> unit
 
     @since 4.00 *)
 
-(** {1:searching Searching} *)
+(** {1:finding_indices Finding indices} *)
+
+val find_first_index : (char -> bool) -> ?start:int -> string -> int option
+(** [find_first_index p start s] is the index of the first character
+    of [s] that satisfies predicate [p] at or after the index or
+    position [start] (defaults to [0]).
+
+    If [start] is [length s], the result is always [None].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val find_last_index : (char -> bool) -> ?start:int -> string -> int option
+(** [find_last_index p start s] is the index of the last character of
+    [s] that satisfies predicate [p] at or before the index or
+    position [start] (defaults to [length s]).
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
 
 val index_from : string -> int -> char -> int
 (** [index_from s i c] is the index of the first occurrence of [c] in
@@ -393,7 +413,6 @@ val index_from : string -> int -> char -> int
 
     @raise Not_found if [c] does not occur in [s] after position [i].
     @raise Invalid_argument if [i] is not a valid position in [s]. *)
-
 
 val index_from_opt : string -> int -> char -> int option
 (** [index_from_opt s i c] is the index of the first occurrence of [c]

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -514,7 +514,7 @@ val rfind_all :
     [start] (defaults to [String.length s]). The result is [acc] if
     [sub] could not be found in [s].
 
-    If [sub] is [""], [f] gets invoked on on all positions of [s] at
+    If [sub] is [""], [f] gets invoked on all positions of [s] at
     or before [start].
 
     @raise Invalid_argument if [start] is not a valid position of [s].

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -451,7 +451,11 @@ val rindex_opt : string -> char -> int option
 
     @since 4.05 *)
 
-(** {1:find_subs Finding substrings} *)
+(** {1:find_subs Finding substrings}
+
+    {b Note.} To find the same [sub] string multiple times, partially
+    applying the [~sub] argument of these functions and using the
+    resulting function repeatedly is more efficient *)
 
 val find_first :
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
@@ -463,10 +467,6 @@ val find_first :
     If [sub] is [""] the result is [Some start]. The result of the
     function is always a valid index of [s] except when [sub] is
     [""] and [start] is [length s].
-
-    If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!find_all} or to partially apply [~sub] and
-    use the resulting function multiple times.
 
     @raise Invalid_argument if [start] is not a valid position of [s].
 
@@ -483,19 +483,15 @@ val find_last :
     function is always a valid index of [s] except when [sub] is
     [""] and [start] is [length s].
 
-    If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!rfind_all} or to partially apply [~sub] and
-    use the resulting function multiple times.
-
     @raise Invalid_argument if [start] is not a valid position of [s].
 
     @since 5.5 *)
 
 val find_all :
-  (int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  (int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
-(** [find_all f sub start s acc], starting with [acc], folds [f] by
+(** [find_all sub f start s acc], starting with [acc], folds [f] by
     increasing index order over all non-overlapping starting positions
     of [sub] in [s] at or after the index or position [start]
     (defaults to [0]). The result is [acc] if [sub] could not be found
@@ -509,10 +505,10 @@ val find_all :
     @since 5.5 *)
 
 val rfind_all :
-  (int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  (int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
-(** [rfind_all f sub start s acc], starting with [acc], folds [f] by
+(** [rfind_all sub f start s acc], starting with [acc], folds [f] by
     decreasing index order over all non-overlapping starting
     positions of [sub] in [s] at or before the index or position
     [start] (defaults to [String.length s]). The result is [acc] if

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -493,10 +493,11 @@ val find_all :
   (int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
   ?start:int -> string -> 'acc -> 'acc
-(** [find_all f sub start s acc], starting with [acc], folds [f]
-    over all non-overlapping starting positions of [sub] in [s] at or
-    after the index or position [start] (defaults to [0]). The
-    result is [acc] if [sub] could not be found in [s].
+(** [find_all f sub start s acc], starting with [acc], folds [f] by
+    increasing index order over all non-overlapping starting positions
+    of [sub] in [s] at or after the index or position [start]
+    (defaults to [0]). The result is [acc] if [sub] could not be found
+    in [s].
 
     If [sub] is [""], [f] gets invoked on all positions of [s] at or after
     [start].
@@ -509,10 +510,11 @@ val rfind_all :
   (int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
   ?start:int -> string -> 'acc -> 'acc
-(** [rfind_all f sub start s acc], starting with [acc], folds [f]
-    over all non-overlapping starting positions of [sub] in [s] at or
-    before the index or position [start] (defaults to [String.length
-    s]). The result is [acc] if [sub] could not be found in [s].
+(** [rfind_all f sub start s acc], starting with [acc], folds [f] by
+    decreasing index order over all non-overlapping starting
+    positions of [sub] in [s] at or before the index or position
+    [start] (defaults to [String.length s]). The result is [acc] if
+    [sub] could not be found in [s].
 
     If [sub] is [""], [f] gets invoked on on all positions of [s] at
     or before [start].

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -465,7 +465,8 @@ val find_first :
     [""] and [start] is [length s].
 
     If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!find_all}.
+    efficient to use {!find_all} or to partially apply [~sub] and
+    use the resulting function multiple times.
 
     @raise Invalid_argument if [start] is not a valid position of [s].
 
@@ -483,7 +484,8 @@ val find_last :
     [""] and [start] is [length s].
 
     If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!rfind_all}.
+    efficient to use {!rfind_all} or to partially apply [~sub] and
+    use the resulting function multiple times.
 
     @raise Invalid_argument if [start] is not a valid position of [s].
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -493,10 +493,11 @@ val find_all :
   f:(int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
   ?start:int -> string -> 'acc -> 'acc
-(** [find_all f ~sub ~start s acc], starting with [acc], folds [f]
-    over all non-overlapping starting positions of [sub] in [s] at or
-    after the index or position [start] (defaults to [0]). The
-    result is [acc] if [sub] could not be found in [s].
+(** [find_all f ~sub ~start s acc], starting with [acc], folds [f] by
+    increasing index order over all non-overlapping starting positions
+    of [sub] in [s] at or after the index or position [start]
+    (defaults to [0]). The result is [acc] if [sub] could not be found
+    in [s].
 
     If [sub] is [""], [f] gets invoked on all positions of [s] at or after
     [start].
@@ -509,10 +510,11 @@ val rfind_all :
   f:(int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
   ?start:int -> string -> 'acc -> 'acc
-(** [rfind_all f ~sub ~start s acc], starting with [acc], folds [f]
-    over all non-overlapping starting positions of [sub] in [s] at or
-    before the index or position [start] (defaults to [String.length
-    s]). The result is [acc] if [sub] could not be found in [s].
+(** [rfind_all f ~sub ~start s acc], starting with [acc], folds [f] by
+    decreasing index order over all non-overlapping starting
+    positions of [sub] in [s] at or before the index or position
+    [start] (defaults to [String.length s]). The result is [acc] if
+    [sub] could not be found in [s].
 
     If [sub] is [""], [f] gets invoked on on all positions of [s] at
     or before [start].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -451,6 +451,76 @@ val rindex_opt : string -> char -> int option
 
     @since 4.05 *)
 
+(** {1:find_subs Finding substrings} *)
+
+val find_first :
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> int option
+(** [find_first ~sub ~start s] is the starting position of the first
+    occurrence of [sub] in [s] at or after the index or position [start]
+    (defaults to [0]).
+
+    If [sub] is [""] the result is [Some start]. The result of the
+    function is always a valid index of [s] except when [sub] is
+    [""] and [start] is [length s].
+
+    If you need to search for [sub] multiple times in [s] it is more
+    efficient to use {!find_all}.
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val find_last :
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> int option
+(** [find_last ~sub ~start s] is the starting position of the last
+    occurrence of [sub] in [s] at or before the index or position
+    [start] (defaults to [String.length s]).
+
+    If [sub] is [""] the result is [Some start]. The result of the
+    function is always a valid index of [s] except when [sub] is
+    [""] and [start] is [length s].
+
+    If you need to search for [sub] multiple times in [s] it is more
+    efficient to use {!rfind_all}.
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val find_all :
+  f:(int -> 'acc -> 'acc) ->
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> 'acc -> 'acc
+(** [find_all f ~sub ~start s acc], starting with [acc], folds [f]
+    over all non-overlapping starting positions of [sub] in [s] at or
+    after the index or position [start] (defaults to [0]). The
+    result is [acc] if [sub] could not be found in [s].
+
+    If [sub] is [""], [f] gets invoked on all positions of [s] at or after
+    [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val rfind_all :
+  f:(int -> 'acc -> 'acc) ->
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> 'acc -> 'acc
+(** [rfind_all f ~sub ~start s acc], starting with [acc], folds [f]
+    over all non-overlapping starting positions of [sub] in [s] at or
+    before the index or position [start] (defaults to [String.length
+    s]). The result is [acc] if [sub] could not be found in [s].
+
+    If [sub] is [""], [f] gets invoked on on all positions of [s] at
+    or before [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
 (** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -451,7 +451,11 @@ val rindex_opt : string -> char -> int option
 
     @since 4.05 *)
 
-(** {1:find_subs Finding substrings} *)
+(** {1:find_subs Finding substrings}
+
+    {b Note.} To find the same [sub] string multiple times, partially
+    applying the [~sub] argument of these functions and using the
+    resulting function repeatedly is more efficient *)
 
 val find_first :
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
@@ -463,10 +467,6 @@ val find_first :
     If [sub] is [""] the result is [Some start]. The result of the
     function is always a valid index of [s] except when [sub] is
     [""] and [start] is [length s].
-
-    If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!find_all} or to partially apply [~sub] and
-    use the resulting function multiple times.
 
     @raise Invalid_argument if [start] is not a valid position of [s].
 
@@ -483,19 +483,15 @@ val find_last :
     function is always a valid index of [s] except when [sub] is
     [""] and [start] is [length s].
 
-    If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!rfind_all} or to partially apply [~sub] and
-    use the resulting function multiple times.
-
     @raise Invalid_argument if [start] is not a valid position of [s].
 
     @since 5.5 *)
 
 val find_all :
-  f:(int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  f:(int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
-(** [find_all f ~sub ~start s acc], starting with [acc], folds [f] by
+(** [find_all ~sub f ~start s acc], starting with [acc], folds [f] by
     increasing index order over all non-overlapping starting positions
     of [sub] in [s] at or after the index or position [start]
     (defaults to [0]). The result is [acc] if [sub] could not be found
@@ -509,10 +505,10 @@ val find_all :
     @since 5.5 *)
 
 val rfind_all :
-  f:(int -> 'acc -> 'acc) ->
   sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  f:(int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
-(** [rfind_all f ~sub ~start s acc], starting with [acc], folds [f] by
+(** [rfind_all ~sub f ~start s acc], starting with [acc], folds [f] by
     decreasing index order over all non-overlapping starting
     positions of [sub] in [s] at or before the index or position
     [start] (defaults to [String.length s]). The result is [acc] if

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -385,7 +385,27 @@ val iteri : f:(int -> char -> unit) -> string -> unit
 
     @since 4.00 *)
 
-(** {1:searching Searching} *)
+(** {1:finding_indices Finding indices} *)
+
+val find_first_index : (char -> bool) -> ?start:int -> string -> int option
+(** [find_first_index p ~start s] is the index of the first character
+    of [s] that satisfies predicate [p] at or after the index or
+    position [start] (defaults to [0]).
+
+    If [start] is [length s], the result is always [None].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
+
+val find_last_index : (char -> bool) -> ?start:int -> string -> int option
+(** [find_last_index p ~start s] is the index of the last character of
+    [s] that satisfies predicate [p] at or before the index or
+    position [start] (defaults to [length s]).
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+
+    @since 5.5 *)
 
 val index_from : string -> int -> char -> int
 (** [index_from s i c] is the index of the first occurrence of [c] in
@@ -393,7 +413,6 @@ val index_from : string -> int -> char -> int
 
     @raise Not_found if [c] does not occur in [s] after position [i].
     @raise Invalid_argument if [i] is not a valid position in [s]. *)
-
 
 val index_from_opt : string -> int -> char -> int option
 (** [index_from_opt s i c] is the index of the first occurrence of [c]

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -514,7 +514,7 @@ val rfind_all :
     [start] (defaults to [String.length s]). The result is [acc] if
     [sub] could not be found in [s].
 
-    If [sub] is [""], [f] gets invoked on on all positions of [s] at
+    If [sub] is [""], [f] gets invoked on all positions of [s] at
     or before [start].
 
     @raise Invalid_argument if [start] is not a valid position of [s].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -465,7 +465,8 @@ val find_first :
     [""] and [start] is [length s].
 
     If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!find_all}.
+    efficient to use {!find_all} or to partially apply [~sub] and
+    use the resulting function multiple times.
 
     @raise Invalid_argument if [start] is not a valid position of [s].
 
@@ -483,7 +484,8 @@ val find_last :
     [""] and [start] is [length s].
 
     If you need to search for [sub] multiple times in [s] it is more
-    efficient to use {!rfind_all}.
+    efficient to use {!rfind_all} or to partially apply [~sub] and
+    use the resulting function multiple times.
 
     @raise Invalid_argument if [start] is not a valid position of [s].
 

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -347,6 +347,9 @@ let () =
   assert (String.find_first ~start:4 ~sub:"abab" "ababab" = None);
   assert (String.find_first ~start:5 ~sub:"abab" "ababab" = None);
   assert (String.find_first ~start:6 ~sub:"abab" "ababab" = None);
+  assert (String.find_first ~start:0 ~sub:"aba" "xbabxbaba" = Some 6);
+  assert (String.find_first ~start:0 ~sub:"xxxxaz" "yyyyazxxxxxaz" = Some 7);
+  assert (String.find_first ~start:0 ~sub:"aaa" "abaacaaad" = Some 5);
   ()
 
 let () =

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -303,3 +303,92 @@ let () =
   assert (String.find_last_index ~start:2 is_letter "-a-" = Some 1);
   assert (String.find_last_index ~start:3 is_letter "-a-" = Some 1);
   ()
+
+let () =
+  (* Test String.find_first *)
+  let is_invalid_arg f = match f () with
+    | exception Invalid_argument _ -> () | _ -> assert false
+  in
+  is_invalid_arg (fun () -> String.find_first ~start:(-1) ~sub:"" "");
+  assert (String.find_first ~start:0 ~sub:"" "" = Some 0);
+  is_invalid_arg (fun () -> String.find_first ~start:1 ~sub:"" "");
+  assert (String.find_first ~start:0 ~sub:"" "ab" = Some 0);
+  assert (String.find_first ~start:1 ~sub:"" "ab" = Some 1);
+  assert (String.find_first ~start:2 ~sub:"" "ab" = Some 2);
+  is_invalid_arg (fun () -> String.find_first ~start:3 ~sub:"" "ab");
+  assert (String.find_first ~start:0 ~sub:"a" "" = None);
+  assert (String.find_first ~start:0 ~sub:"a" "a" = Some 0);
+  assert (String.find_first ~start:1 ~sub:"a" "a" = None);
+  assert (String.find_first ~start:0 ~sub:"a" "ba" = Some 1);
+  assert (String.find_first ~start:1 ~sub:"a" "ba" = Some 1);
+  assert (String.find_first ~start:2 ~sub:"a" "ba" = None);
+  assert (String.find_first ~start:0 ~sub:"ab" "" = None);
+  assert (String.find_first ~start:0 ~sub:"ab" "ab" = Some 0);
+  assert (String.find_first ~start:0 ~sub:"ab" "aab" = Some 1);
+  assert (String.find_first ~start:1 ~sub:"ab" "aab" = Some 1);
+  assert (String.find_first ~start:2 ~sub:"ab" "aab" = None);
+  assert (String.find_first ~start:3 ~sub:"ab" "aab" = None);
+  is_invalid_arg (fun () -> String.find_first ~start:(-1) ~sub:"abaa" "aba");
+  assert (String.find_first ~start:0 ~sub:"abaa" "aba" = None);
+  assert (String.find_first ~start:2 ~sub:"abaa" "aba" = None);
+  assert (String.find_first ~start:3 ~sub:"abaa" "aba" = None);
+  is_invalid_arg (fun () -> String.find_first ~start:4 ~sub:"abaa" "aba");
+  assert (String.find_first ~start:0 ~sub:"aba" "ababa" = Some 0);
+  assert (String.find_first ~start:1 ~sub:"aba" "ababa" = Some 2);
+  assert (String.find_first ~start:2 ~sub:"aba" "ababa" = Some 2);
+  assert (String.find_first ~start:3 ~sub:"aba" "ababa" = None);
+  assert (String.find_first ~start:4 ~sub:"aba" "ababa" = None);
+  assert (String.find_first ~start:5 ~sub:"aba" "ababa" = None);
+  assert (String.find_first ~start:0 ~sub:"abab" "ababab" = Some 0);
+  assert (String.find_first ~start:1 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_first ~start:2 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_first ~start:3 ~sub:"abab" "ababab" = None);
+  assert (String.find_first ~start:4 ~sub:"abab" "ababab" = None);
+  assert (String.find_first ~start:5 ~sub:"abab" "ababab" = None);
+  assert (String.find_first ~start:6 ~sub:"abab" "ababab" = None);
+  ()
+
+let () =
+  (* Test String.find_last *)
+  let is_invalid_arg f = match f () with
+    | exception Invalid_argument _ -> () | _ -> assert false
+  in
+  is_invalid_arg (fun () -> String.find_last ~start:(-1) ~sub:"" "");
+  assert (String.find_last ~start:0 ~sub:"" "" = Some 0);
+  is_invalid_arg (fun () -> String.find_last ~start:1 ~sub:"" "");
+  assert (String.find_last ~start:0 ~sub:"" "ab" = Some 0);
+  assert (String.find_last ~start:1 ~sub:"" "ab" = Some 1);
+  assert (String.find_last ~start:2 ~sub:"" "ab" = Some 2);
+  is_invalid_arg (fun () -> String.find_last ~start:3 ~sub:"" "ab");
+  assert (String.find_last ~start:0 ~sub:"a" "" = None);
+  assert (String.find_last ~start:0 ~sub:"a" "a" = Some 0);
+  assert (String.find_last ~start:1 ~sub:"a" "a" = Some 0);
+  assert (String.find_last ~start:0 ~sub:"a" "ba" = None);
+  assert (String.find_last ~start:1 ~sub:"a" "ba" = Some 1);
+  assert (String.find_last ~start:2 ~sub:"a" "ba" = Some 1);
+  assert (String.find_last ~start:0 ~sub:"ab" "" = None);
+  assert (String.find_last ~start:0 ~sub:"ab" "ab" = Some 0);
+  assert (String.find_last ~start:0 ~sub:"ab" "aab" = None);
+  assert (String.find_last ~start:1 ~sub:"ab" "aab" = Some 1);
+  assert (String.find_last ~start:2 ~sub:"ab" "aab" = Some 1);
+  assert (String.find_last ~start:3 ~sub:"ab" "aab" = Some 1);
+  is_invalid_arg (fun () -> String.find_last ~start:(-1) ~sub:"abaa" "aba");
+  assert (String.find_last ~start:0 ~sub:"abaa" "aba" = None);
+  assert (String.find_last ~start:2 ~sub:"abaa" "aba" = None);
+  assert (String.find_last ~start:3 ~sub:"abaa" "aba" = None);
+  is_invalid_arg (fun () -> String.find_last ~start:4 ~sub:"abaa" "aba");
+  assert (String.find_last ~start:0 ~sub:"aba" "ababa" = Some 0);
+  assert (String.find_last ~start:1 ~sub:"aba" "ababa" = Some 0);
+  assert (String.find_last ~start:2 ~sub:"aba" "ababa" = Some 2);
+  assert (String.find_last ~start:3 ~sub:"aba" "ababa" = Some 2);
+  assert (String.find_last ~start:4 ~sub:"aba" "ababa" = Some 2);
+  assert (String.find_last ~start:5 ~sub:"aba" "ababa" = Some 2);
+  assert (String.find_last ~start:0 ~sub:"abab" "ababab" = Some 0);
+  assert (String.find_last ~start:1 ~sub:"abab" "ababab" = Some 0);
+  assert (String.find_last ~start:2 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_last ~start:3 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_last ~start:4 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_last ~start:5 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_last ~start:6 ~sub:"abab" "ababab" = Some 2);
+  assert (String.find_last ~sub:"ab" "aabb" = Some 1);
+  ()

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -263,4 +263,43 @@ let () =
   (* Test String.is_empty *)
   assert (String.is_empty "life" = false);
   assert (String.is_empty "" = true);
+
+let () =
+  (* Test String.find_{first,last}_index *)
+  let is_letter = Char.Ascii.is_letter in
+  let is_invalid_arg f = match f () with
+    | exception Invalid_argument _ -> () | _ -> assert false
+  in
+  is_invalid_arg (fun () -> String.find_first_index ~start:(-1) is_letter "");
+  is_invalid_arg (fun () -> String.find_last_index ~start:(-1) is_letter "");
+  assert (String.find_first_index ~start:0 is_letter "" = None);
+  assert (String.find_last_index ~start:0 is_letter "" = None);
+  is_invalid_arg (fun () -> String.find_first_index ~start:1 is_letter "");
+  is_invalid_arg (fun () -> String.find_last_index ~start:1 is_letter "");
+  assert (String.find_first_index ~start:0 is_letter "-" = None);
+  assert (String.find_first_index ~start:1 is_letter "-" = None);
+  assert (String.find_last_index ~start:0 is_letter "-" = None);
+  assert (String.find_last_index ~start:1 is_letter "-" = None);
+  assert (String.find_first_index ~start:0 is_letter "a-" = Some 0);
+  assert (String.find_first_index ~start:1 is_letter "a-" = None);
+  assert (String.find_first_index ~start:2 is_letter "a-" = None);
+  assert (String.find_last_index ~start:0 is_letter "a-" = Some 0);
+  assert (String.find_last_index ~start:1 is_letter "a-" = Some 0);
+  assert (String.find_last_index ~start:2 is_letter "a-" = Some 0);
+  assert (String.find_first_index ~start:0 is_letter "a-a" = Some 0);
+  assert (String.find_first_index ~start:1 is_letter "a-a" = Some 2);
+  assert (String.find_first_index ~start:2 is_letter "a-a" = Some 2);
+  assert (String.find_first_index ~start:3 is_letter "a-a" = None);
+  assert (String.find_last_index ~start:0 is_letter "a-a" = Some 0);
+  assert (String.find_last_index ~start:1 is_letter "a-a" = Some 0);
+  assert (String.find_last_index ~start:2 is_letter "a-a" = Some 2);
+  assert (String.find_last_index ~start:3 is_letter "a-a" = Some 2);
+  assert (String.find_first_index ~start:0 is_letter "-a-" = Some 1);
+  assert (String.find_first_index ~start:1 is_letter "-a-" = Some 1);
+  assert (String.find_first_index ~start:2 is_letter "-a-" = None);
+  assert (String.find_first_index ~start:3 is_letter "-a-" = None);
+  assert (String.find_last_index ~start:0 is_letter "-a-" = None);
+  assert (String.find_last_index ~start:1 is_letter "-a-" = Some 1);
+  assert (String.find_last_index ~start:2 is_letter "-a-" = Some 1);
+  assert (String.find_last_index ~start:3 is_letter "-a-" = Some 1);
   ()

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -263,6 +263,7 @@ let () =
   (* Test String.is_empty *)
   assert (String.is_empty "life" = false);
   assert (String.is_empty "" = true);
+  ()
 
 let () =
   (* Test String.find_{first,last}_index *)


### PR DESCRIPTION
This PR adds the string searching primitives discussed in https://github.com/ocaml/ocaml/discussions/14099 and https://github.com/ocaml/ocaml/discussions/14137. Details about the algorithm used for string search can be found in the comments. 

For reverse search we map, on index lookup, the index range of the needle and haystack from `[0;n-1]` to `[n-1;0]`. This means that the algorithm has exactly the same properties and works like the forward search except from the end towards the start. This trick only requires two well-commented adjustment to the start position and the result. So once the forward search has been reviewed bear in mind that it's just a cut-and-paste of it[^1].

The `String.[r]find_all` functions have no tests. These functions will be tested indirectly via the replace and split functions to be added subsequently which use them. These tests will be more pleasant to read (strings vs indices).

The `String.find_{first,last}_index` are independent from sub string search, I just added them to the batch because they share the same `start` interface and `Invalid_argument` error message.

P.S. This is the most difficult PR to review. Once we have these primitives the rest is piece of cake :–)

[^1]: I tried to abstract the `get` but according to what I read on goldbot's asm output for 5.3, I couldn't find a way to have the compiler inline the `get` and I'd rather avoid having a `caml_apply` of the `get`s.
