### PR TITLE
Check for declaration of getentropy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1849,7 +1849,16 @@ AS_IF([$has_c99_float_ops],
     with --enable-imprecise-c99-float-ops]))])])
 
 ## getentropy
-AC_CHECK_FUNC([getentropy], [AC_DEFINE([HAS_GETENTROPY], [1])])
+AC_CHECK_DECL([getentropy],
+  [AC_DEFINE([HAS_GETENTROPY], [1])],
+  [],
+  dnl  POSIX says this is in <unistd.h>, but who knows when Apple
+  dnl  adds that? It doesn't seem to be there as of macOS 13
+  dnl  headers.
+  [[#include <unistd.h>
+    #ifdef __APPLE__
+    #include <sys/random.h>
+    #endif]])
 
 ## getrusage
 AC_CHECK_FUNC([getrusage], [AC_DEFINE([HAS_GETRUSAGE], [1])])

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -90,6 +90,7 @@ build: [
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
     "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "LDFLAGS=-landroid-shmem" {os-distribution="android"}
     "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
     "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
     "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}


### PR DESCRIPTION
This helps on Termux running on versions of Android that have getentropy in libc, but targetting an API level before getentropy was added (as Termux clang does by default).