### PR TITLE
Use memprof status field to distinguish minimal sampling

### DIFF
--- a/Changes
+++ b/Changes
@@ -630,6 +630,11 @@ Working version
   (Gabriel Scherer, review by Stephen Dolan and Nick Barnes,
    report by Olivier Nicole)
 
+- #14384: use the statmemprof status word, rather than a distinguished
+   value of a boxed float, to identify a "not really sampling"
+   profile.
+  (Nick Barnes, review by Gabriel Scherer)
+
 - #14332: Fix missing TSan instrumentation in subexpressions
   (Vincent Laviron, review by Gabriel Scherer and Olivier Nicole)
 


### PR DESCRIPTION
Statmemprof can be used at very low (or zero) frequency `lambda`, logically sampling allocation but in fact never taking a sample. We avoid doing any work for this case (e.g. we don't initialise the PRNGs). With this PR we test for this case using a new status value `CONFIG_STATUS_SAMPLING_MIN`, instead of the distinguished value -Inf for 1/log(1-lambda) (saved in a boxed float). This should (a) be very slightly faster to set the memprof trigger, especially on platforms with expensive float operations and (b) avoid dereferencing the boxed float to test against -Inf, which reduces the fragility of this code (see issue #14300 and the resolutions #14304, #14305, #14306).