### PR TITLE
Skip `sockaddr_cxx.ml` in Jenkins

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -167,6 +167,11 @@ init_submodule_winpthreads=false
 memory_model_tests="tests/memory-model/forbidden.ml \
 tests/memory-model/publish.ml"
 
+# Until https://github.com/ocaml/ocaml/issues/14348 is resolved
+# As it happens, the Cygwin worker has a C++ compiler, so it doesn't matter
+# that it runs it.
+export OCAMLTEST_SKIP_TESTS="tests/lib-unix/unix-sockaddr/sockaddr_cxx.ml"
+
 case "${OCAML_ARCH}" in
   bsd|solaris)
     make=gmake


### PR DESCRIPTION
Temporary workaround for Jenkins until #14348 is resolved.

Commit is being tested with #14243 in [precheck#1080](https://ci.inria.fr/ocaml/job/precheck/1080/).