### PR TITLE
Ignore Emacs' per-directory variable configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ META
 /ocamlnat
 /_opam
 
+# Ignore Emacs' .dir-locals.el file, used to configure directory-specific
+# variables
+/.dir-locals.el
+
 # specific files and patterns in sub-directories
 
 /asmcomp/emit.ml


### PR DESCRIPTION
Ignore Emacs' .dir-locals.el file, used to configure
directory-specific variables