### PR TITLE
feat(typing)!: remove support for `let rec (module ...)`

### DIFF
--- a/Changes
+++ b/Changes
@@ -371,6 +371,9 @@ Working version
 - #14331: Enforce current_level <= generic_level, and explain create_scope
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
+* #14388: Remove support for `let rec (module M : S) = e1 in e2`.
+  (Alistair O'Brien, review by Vincent Laviron and Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -30,18 +30,6 @@ Error: Existential types are not allowed in grouped ("let ... and ...") bindings
 
 
 let () =
-  let rec Any x = Any () in
-  ()
-[%%expect {|
-Line 2, characters 10-15:
-2 |   let rec Any x = Any () in
-              ^^^^^
-Error: Existential types are not allowed in recursive bindings,
-       but the constructor "Any" introduces existential types.
-|}]
-
-
-let () =
   let[@attribute] Any x = Any () in
   ()
 [%%expect {|
@@ -105,19 +93,6 @@ Line 2, characters 6-11:
 Error: Existential types are not allowed in grouped ("let ... and ...") bindings,
        but the constructor "Any" introduces existential types.
 |}]
-
-
-let () =
-  let rec Any x = Any () in
-  ()
-[%%expect {|
-Line 2, characters 10-15:
-2 |   let rec Any x = Any () in
-              ^^^^^
-Error: Existential types are not allowed in recursive bindings,
-       but the constructor "Any" introduces existential types.
-|}]
-
 
 let () =
   let[@attribute] Any x = Any () in

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -169,12 +169,17 @@ module type S' = sig val f : int -> int end
 |}];;
 
 (* Even works with recursion, but must be fully explicit *)
-let rec (module M : S') =
-  (module struct let f n = if n <= 0 then 1 else n * M.f (n-1) end : S')
-in M.f 3;;
+let rec (m : (module S')) =
+  let (module M) = m in
+  (module struct
+    let f n = if n <= 0 then 1 else n * M.f (n - 1)
+  end : S')
+in
+let (module M) = m in
+M.f 3
 [%%expect{|
 - : int = 6
-|}];;
+|}]
 
 (* Subtyping *)
 

--- a/testsuite/tests/typing-misc/let_rec_pat.ml
+++ b/testsuite/tests/typing-misc/let_rec_pat.ml
@@ -1,0 +1,150 @@
+(* TEST
+ expect;
+*)
+
+(* This series of tests checks the pattern validation for [let rec] bindings.
+   Only "variable-like" patterns are allowed. See [is_var_pat] for details. *)
+
+(* Valid patterns *)
+
+let rec x = 1 in x
+[%%expect{|
+- : int = 1
+|}];;
+
+let rec (x : int) = 1 in x
+[%%expect{|
+- : int = 1
+|}];;
+
+let rec ((x : int) : int) = 1 in x
+[%%expect{|
+- : int = 1
+|}];;
+
+module M = struct type t = int end;;
+let rec M.((x : t)) = 1 in x
+[%%expect{|
+module M : sig type t = int end
+- : M.t = 1
+|}];;
+
+(* Invalid patterns *)
+
+let rec _ = 1 in ()
+[%%expect{|
+Line 1, characters 8-9:
+1 | let rec _ = 1 in ()
+            ^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec (x as y) = 1 in x
+[%%expect{|
+Line 1, characters 8-16:
+1 | let rec (x as y) = 1 in x
+            ^^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec 42 = 42 in ()
+[%%expect{|
+Line 1, characters 8-10:
+1 | let rec 42 = 42 in ()
+            ^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec (x, y) = (1, 2) in x
+[%%expect{|
+Line 1, characters 8-14:
+1 | let rec (x, y) = (1, 2) in x
+            ^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec Some x = Some 1 in x
+[%%expect{|
+Line 1, characters 8-14:
+1 | let rec Some x = Some 1 in x
+            ^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+type r = { a : int; b : int };;
+let rec { a; b } = { a = 1; b = 2 } in a
+[%%expect{|
+type r = { a : int; b : int; }
+Line 2, characters 8-16:
+2 | let rec { a; b } = { a = 1; b = 2 } in a
+            ^^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec [| x |] = [| 1 |] in x
+[%%expect{|
+Line 1, characters 8-15:
+1 | let rec [| x |] = [| 1 |] in x
+            ^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec (Some x | None as x) = None in ()
+[%%expect{|
+Line 1, characters 8-28:
+1 | let rec (Some x | None as x) = None in ()
+            ^^^^^^^^^^^^^^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec lazy x = lazy 1 in x
+[%%expect{|
+Line 1, characters 8-14:
+1 | let rec lazy x = lazy 1 in x
+            ^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+module type S = sig val f : int -> int end;;
+let rec (module M : S) = (module struct let f n = if n <= 0 then 1 else n * M.f (n - 1) end : S) in M.f 5
+[%%expect{|
+module type S = sig val f : int -> int end
+Line 2, characters 8-22:
+2 | let rec (module M : S) = (module struct let f n = if n <= 0 then 1 else n * M.f (n - 1) end : S) in M.f 5
+            ^^^^^^^^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+type t = [ `A ];;
+let rec #t = `A in ()
+[%%expect{|
+type t = [ `A ]
+Line 2, characters 8-10:
+2 | let rec #t = `A in ()
+            ^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec ((x, y) : int * int) = (1, 2) in x
+[%%expect{|
+Line 1, characters 8-28:
+1 | let rec ((x, y) : int * int) = (1, 2) in x
+            ^^^^^^^^^^^^^^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec M.(Some (x : t)) = Some 1 in x
+[%%expect{|
+Line 1, characters 8-24:
+1 | let rec M.(Some (x : t)) = Some 1 in x
+            ^^^^^^^^^^^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;
+
+let rec x = a and (a, b) = (1, 2) in x
+[%%expect{|
+Line 1, characters 18-24:
+1 | let rec x = a and (a, b) = (1, 2) in x
+                      ^^^^^^
+Error: Only variables are allowed as left-hand side of "let rec"
+|}];;


### PR DESCRIPTION
# Context

**Meta-context**: I've got a patch that splits `type_let` into two separate functions: `type_let` and `type_let_rec`. While crafting the patch, I made the incorrect assumption that only `let rec x = ...` is permitted. This was surprising, and I feel wrongfully led astray by the type checker. 

Currently, OCaml supports `let rec (module M) = e1 in e2`. This is rather irregular since no other forms of patterns are permitted in `let rec`s aside (annotated) from variables.

I think we should remove support for this construct for the following reasons:
1. The feature is undocumented in the manual, and a quick [sherlocode](https://sherlocode.com/?q=let%20rec%20\(module) suggests it is not used (outside the compiler's testsuite).
2. It increases maintenance burden: there is some non-trivial code used for detecting scope escapes in recursive bindings involving module unpacking. 
3. If `Tpat_unpack` were a proper pattern constructor in typedtree, this would be rejected anyway. The current behaviour seems like an unintended consequence of desugaring during typechecking.
4. #14040 will give us proper support for `let module rec M : S = ... in ...`, covering the only plausible use case for this construct. 

# Description 

This PR makes the minimal change required to disable this feature. It deliberately avoids cleaning up any now-dead code. I wanted to get consensus on this change before making further changes.