### PR TITLE
add `Atomic.retry_compare_and_set`

### DIFF
--- a/Changes
+++ b/Changes
@@ -88,6 +88,9 @@ Working version
 
 ### Standard library:
 
+- #14389: Add `Atomic.retry_compare_and_set`.
+  (Léo Andrès, review by ?)
+
 - #14362: Add String.{drop,take,cut}_{first,last}_while
   (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
 

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -54,3 +54,9 @@ let incr t =
   Loc.incr [%atomic.loc t.contents]
 let decr t =
   Loc.decr [%atomic.loc t.contents]
+
+let rec retry_compare_and_set (f : 'a -> 'a) (v : 'a t) =
+  let old = get v in
+  let new_ = f old in
+  let success = compare_and_set v old new_ in
+  if not success then retry_compare_and_set f v

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -58,6 +58,10 @@ val exchange : 'a t -> 'a -> 'a
     otherwise. *)
 val compare_and_set : 'a t -> 'a -> 'a -> bool
 
+(** [retry_compare_and_set f r] sets [r] to [f (get r)].
+    Note that [f] may be called many times. *)
+val retry_compare_and_set : ('a -> 'a) -> 'a t -> unit
+
 (** [fetch_and_add r n] atomically increments the value of [r] by [n],
     and returns the current value (before the increment). *)
 val fetch_and_add : int t -> int -> int


### PR DESCRIPTION
Hi,

I'm starting to use this pattern more and more often, and I think it would be nice to directly have it in the standard library. It allows to switch from e.g.:

```ocaml
    let span = Mtime_clock.count counter in
    let rec atomic_set () =
      let curr = Atomic.get atomic_span in
      let success =
        Atomic.compare_and_set atomic_span curr (Mtime.Span.add curr span)
      in
      if not success then atomic_set ()
    in
    atomic_set ()
```

To:

```ocaml
    let span = Mtime_clock.count counter in
    Atomic.retry_compare_and_set (fun curr -> Mtime.Span.add curr span) atomic_span
```

I went with the first name that came to my mind (`retry_compare_and_set`), I'd be happy to hear better suggestions.

The documentation seems good enough to me but once again, if you think I should add things to it, I'd be happy to do it.