### PR TITLE
`natdynlink`: `dlclose` on error

### DIFF
--- a/Changes
+++ b/Changes
@@ -199,6 +199,10 @@ Working version
   and socklen_param_type for socklen_t.
   (Antonin Décimo, review by Nicolás Ojeda Bär, David Allsopp and Samuel Hym)
 
+- #14391: unload native dynlinked objects when an error occurs and it is safe to
+  do so. (Fixes #14323)
+  (Nicolás Ojeda Bär, review by Vincent Laviron)
+
 ### Tools:
 
 - #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -103,8 +103,6 @@ module Bytecode = struct
       init
       !default_crcs
 
-  let run_shared_startup _ = ()
-
   let with_lock lock f =
     Mutex.lock lock;
     Fun.protect f

--- a/otherlibs/dynlink/dynlink_common.ml
+++ b/otherlibs/dynlink/dynlink_common.ml
@@ -346,8 +346,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
       with_lock (fun ({unsafe_allowed; _ } as global) ->
           global.state <- check filename units global.state
               ~unsafe_allowed
-              ~priv;
-          P.run_shared_startup handle;
+              ~priv
         );
       List.iter
         (fun unit_header ->

--- a/otherlibs/dynlink/dynlink_platform_intf.ml
+++ b/otherlibs/dynlink/dynlink_platform_intf.ml
@@ -58,7 +58,6 @@ module type S = sig
     -> priv:bool
     -> handle * (Unit_header.t list)
 
-  val run_shared_startup : handle -> unit
   val run : Mutex.t -> handle -> unit_header:Unit_header.t -> priv:bool -> unit
 
   val unsafe_get_global_value : bytecode_or_asm_symbol:string -> Obj.t option

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -36,6 +36,8 @@ module Native = struct
 
   external ndl_open : string -> bool -> handle * dynheader
     = "caml_natdynlink_open"
+  external ndl_close : handle -> unit
+    = "caml_natdynlink_close"
   external ndl_register : handle -> string array -> unit
     = "caml_natdynlink_register"
   external ndl_run : handle -> string -> unit = "caml_natdynlink_run"
@@ -111,7 +113,7 @@ module Native = struct
     | exception _ -> None
     | obj -> Some obj
 
-  let finish _handle = ()
+  let finish handle = ndl_close handle
 end
 
 include DC.Make (Native)

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -99,6 +99,7 @@ module Native = struct
         ndl_run handle.ndl_handle "_shared_startup"
 
   let run _lock handle ~unit_header ~priv:_ =
+    run_shared_startup handle;
     List.iter (fun cu ->
         try ndl_run handle.ndl_handle cu
         with exn ->

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -32,15 +32,19 @@ type global_map = {
 }
 
 module Native = struct
-  type handle
+  type ndl_handle
+  type handle = {
+    ndl_handle : ndl_handle;
+    mutable initialized : bool;
+  }
 
-  external ndl_open : string -> bool -> handle * dynheader
+  external ndl_open : string -> bool -> ndl_handle * dynheader
     = "caml_natdynlink_open"
-  external ndl_close : handle -> unit
+  external ndl_close : ndl_handle -> unit
     = "caml_natdynlink_close"
-  external ndl_register : handle -> string array -> unit
+  external ndl_register : ndl_handle -> string array -> unit
     = "caml_natdynlink_register"
-  external ndl_run : handle -> string -> unit = "caml_natdynlink_run"
+  external ndl_run : ndl_handle -> string -> unit = "caml_natdynlink_run"
   external ndl_getmap : unit -> global_map list = "caml_natdynlink_getmap"
   external ndl_globals_inited : unit -> int = "caml_natdynlink_globals_inited"
   external ndl_loadsym : string -> Obj.t = "caml_natdynlink_loadsym"
@@ -80,11 +84,12 @@ module Native = struct
       (ndl_getmap ())
 
   let run_shared_startup handle =
-    ndl_run handle "_shared_startup"
+    handle.initialized <- true;
+    ndl_run handle.ndl_handle "_shared_startup"
 
   let run _lock handle ~unit_header ~priv:_ =
     List.iter (fun cu ->
-        try ndl_run handle cu
+        try ndl_run handle.ndl_handle cu
         with exn ->
           Printexc.raise_with_backtrace
             (DT.Error (Library's_module_initializers_failed exn))
@@ -92,11 +97,13 @@ module Native = struct
       (Unit_header.defined_symbols unit_header)
 
   let load ~filename ~priv =
-    let handle, header =
+    let ndl_handle, header =
       try ndl_open filename (not priv)
       with exn -> raise (DT.Error (Cannot_open_dynamic_library exn))
     in
+    let handle = { ndl_handle; initialized = false } in
     if header.dynu_magic <> Config.cmxs_magic_number then begin
+      ndl_close ndl_handle;
       raise (DT.Error (Not_a_bytecode_file filename))
     end;
     let syms =
@@ -104,16 +111,19 @@ module Native = struct
       List.concat_map Unit_header.defined_symbols header.dynu_units
     in
     try
-      ndl_register handle (Array.of_list syms);
+      ndl_register handle.ndl_handle (Array.of_list syms);
       handle, header.dynu_units
-    with exn -> raise (DT.Error (Cannot_open_dynamic_library exn))
+    with exn ->
+      ndl_close ndl_handle;
+      raise (DT.Error (Cannot_open_dynamic_library exn))
 
   let unsafe_get_global_value ~bytecode_or_asm_symbol =
     match ndl_loadsym bytecode_or_asm_symbol with
     | exception _ -> None
     | obj -> Some obj
 
-  let finish handle = ndl_close handle
+  let finish handle =
+    if not handle.initialized then ndl_close handle.ndl_handle
 end
 
 include DC.Make (Native)

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -33,9 +33,12 @@ type global_map = {
 
 module Native = struct
   type ndl_handle
+  type initialized =
+    | Initialized
+    | Not_yet_initialized of string list
   type handle = {
     ndl_handle : ndl_handle;
-    mutable initialized : bool;
+    mutable initialized : initialized;
   }
 
   external ndl_open : string -> bool -> ndl_handle * dynheader
@@ -84,8 +87,16 @@ module Native = struct
       (ndl_getmap ())
 
   let run_shared_startup handle =
-    handle.initialized <- true;
-    ndl_run handle.ndl_handle "_shared_startup"
+    match handle.initialized with
+    | Initialized -> ()
+    | Not_yet_initialized syms ->
+        handle.initialized <- Initialized;
+        begin try
+          ndl_register handle.ndl_handle (Array.of_list syms);
+        with exn ->
+          raise (DT.Error (Cannot_open_dynamic_library exn))
+        end;
+        ndl_run handle.ndl_handle "_shared_startup"
 
   let run _lock handle ~unit_header ~priv:_ =
     List.iter (fun cu ->
@@ -101,7 +112,6 @@ module Native = struct
       try ndl_open filename (not priv)
       with exn -> raise (DT.Error (Cannot_open_dynamic_library exn))
     in
-    let handle = { ndl_handle; initialized = false } in
     if header.dynu_magic <> Config.cmxs_magic_number then begin
       ndl_close ndl_handle;
       raise (DT.Error (Not_a_bytecode_file filename))
@@ -110,12 +120,8 @@ module Native = struct
       "_shared_startup" ::
       List.concat_map Unit_header.defined_symbols header.dynu_units
     in
-    try
-      ndl_register handle.ndl_handle (Array.of_list syms);
-      handle, header.dynu_units
-    with exn ->
-      ndl_close ndl_handle;
-      raise (DT.Error (Cannot_open_dynamic_library exn))
+    let handle = { ndl_handle; initialized = Not_yet_initialized syms } in
+    handle, header.dynu_units
 
   let unsafe_get_global_value ~bytecode_or_asm_symbol =
     match ndl_loadsym bytecode_or_asm_symbol with
@@ -123,7 +129,9 @@ module Native = struct
     | obj -> Some obj
 
   let finish handle =
-    if not handle.initialized then ndl_close handle.ndl_handle
+    match handle.initialized with
+    | Initialized -> ()
+    | Not_yet_initialized _ -> ndl_close handle.ndl_handle
 end
 
 include DC.Make (Native)

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,25 +1,25 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 104, characters 12-40
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
-Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", lines 84-90, characters 4-47
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
+Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", lines 103-109, characters 4-47
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), lines 352-361, characters 6-13
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), lines 351-360, characters 6-13
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 34, characters 8-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-362, characters 4-7
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-361, characters 4-7
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 87-89, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 104, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 106-108, characters 10-43
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
-Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", lines 84-90, characters 4-47
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
+Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", lines 103-109, characters 4-47
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), lines 352-361, characters 6-13
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), lines 351-360, characters 6-13
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 34, characters 8-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-362, characters 4-7
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-361, characters 4-7
 Re-raised at Stdlib__Fun.protect in file "fun.ml" (inlined), line 39, characters 6-52
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-362, characters 4-7
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", lines 345-361, characters 4-7
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,18 +1,18 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 103, characters 12-40
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 104, characters 12-40
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 103, characters 12-40
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 105-107, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 104, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 106-108, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 92, characters 12-40
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 103, characters 12-40
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
@@ -7,8 +7,8 @@ Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 92, characters 12-40
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 94-96, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 103, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 105-107, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 92, characters 12-40
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
@@ -7,8 +7,8 @@ Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 87-89, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 92, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 94-96, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,9 +3,9 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 170, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 172-174, characters 6-39
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
+Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 168, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 170-172, characters 6-39
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,10 +1,10 @@
 Error: Failure("Plugin error")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 103, characters 12-40
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 105-107, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 104, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 106-108, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 364, characters 26-45
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 26-45
 Called from Test10_main in file "test10_main.ml", lines 49-51, characters 30-7

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,6 +1,6 @@
 Error: Failure("Plugin error")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 92, characters 12-40
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 94-96, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 103, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 105-107, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,6 +1,6 @@
 Error: Failure("Plugin error")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 87-89, characters 10-43
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 92, characters 12-40
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", lines 94-96, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15

--- a/testsuite/tests/lib-dynlink-pr14323/test.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/test.ml
@@ -1,0 +1,8 @@
+(* TEST
+   native-dynlink;
+   output = "test.output";
+   reference = "${test_source_directory}/test.reference";
+   program = "${test_source_directory}/test.sh";
+   run;
+   check-program-output;
+*)

--- a/testsuite/tests/lib-dynlink-pr14323/test.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/test.ml
@@ -1,10 +1,11 @@
 (* TEST
    native-dynlink;
    native-compiler;
+   not-windows;
    output = "test.output";
    reference = "${test_source_directory}/test.reference";
-   program = "bash";
-   arguments = "${test_source_directory}/test.sh ${ocamlsrcdir}";
+   program = "${test_source_directory}/test.sh";
+   arguments = "${ocamlsrcdir}";
    run;
    check-program-output;
 *)

--- a/testsuite/tests/lib-dynlink-pr14323/test.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/test.ml
@@ -3,6 +3,7 @@
    output = "test.output";
    reference = "${test_source_directory}/test.reference";
    program = "${test_source_directory}/test.sh";
+   arguments = "${ocamlsrcdir}";
    run;
    check-program-output;
 *)

--- a/testsuite/tests/lib-dynlink-pr14323/test.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/test.ml
@@ -3,8 +3,8 @@
    native-compiler;
    output = "test.output";
    reference = "${test_source_directory}/test.reference";
-   program = "${test_source_directory}/test.sh";
-   arguments = "${ocamlsrcdir}";
+   program = "bash";
+   arguments = "${test_source_directory}/test.sh ${ocamlsrcdir}";
    run;
    check-program-output;
 *)

--- a/testsuite/tests/lib-dynlink-pr14323/test.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/test.ml
@@ -1,5 +1,6 @@
 (* TEST
    native-dynlink;
+   native-compiler;
    output = "test.output";
    reference = "${test_source_directory}/test.reference";
    program = "${test_source_directory}/test.sh";

--- a/testsuite/tests/lib-dynlink-pr14323/test.reference
+++ b/testsuite/tests/lib-dynlink-pr14323/test.reference
@@ -1,2 +1,3 @@
 Dynlink.loadfile failed. Retrying.
-Too many failures.
+Hello natdynlink!
+OK

--- a/testsuite/tests/lib-dynlink-pr14323/test.reference
+++ b/testsuite/tests/lib-dynlink-pr14323/test.reference
@@ -1,0 +1,2 @@
+Dynlink.loadfile failed. Retrying.
+Too many failures.

--- a/testsuite/tests/lib-dynlink-pr14323/test.sh
+++ b/testsuite/tests/lib-dynlink-pr14323/test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ocamlsrcdir="$1"
 
 ocamlopt=(
-  "$ocamlopt_byte"
+  "$ocamlsrcdir"/ocamlopt.opt
   -nostdlib
   -I "$ocamlsrcdir"/stdlib
   -I "$ocamlsrcdir"/otherlibs/dynlink

--- a/testsuite/tests/lib-dynlink-pr14323/test.sh
+++ b/testsuite/tests/lib-dynlink-pr14323/test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ocamlopt=${ocamlopt_byte}
+
+cat >lib.ml <<EOF
+let s = "Hello natdynlink!"
+EOF
+
+cat >toto.ml <<EOF
+let () =
+  print_endline Lib.s
+EOF
+
+cat >main.ml <<EOF
+let () =
+  let rec loop failed i =
+    if i > 5 then begin
+      print_endline "Too many failures.";
+      exit 1
+    end else
+    match Dynlink.loadfile "toto.cmxs" with
+    | _ ->
+      print_endline "OK";
+      exit 0
+    | exception exn ->
+      if not failed then print_endline "Dynlink.loadfile failed. Retrying.";
+      Unix.sleep 1;
+      loop true (i + 1)
+  in
+  loop false 0
+EOF
+
+# Build toto.cmxs against the original lib.cmi
+
+$ocamlopt -c lib.ml
+$ocamlopt -shared -o toto.cmxs toto.ml
+
+# Update lib.cmi
+
+echo 'let x = 42' >>lib.ml
+$ocamlopt -c lib.ml
+$ocamlopt -o main.exe -I +unix -I +dynlink dynlink.cmxa unix.cmxa lib.cmx main.ml
+
+# At this point, toto.cmxs no longer loads as the lib.cmi that has been recorded
+# in main.exe does not match the one used when building toto.cmxs
+
+./main.exe &
+PID=$!
+
+# Rebuild toto.cmxs against the updated lib.cmi
+
+sleep 1
+$ocamlopt -shared -o toto.cmxs toto.ml
+
+wait $PID || :

--- a/testsuite/tests/lib-dynlink-pr14323/test.sh
+++ b/testsuite/tests/lib-dynlink-pr14323/test.sh
@@ -2,7 +2,17 @@
 
 set -euo pipefail
 
-ocamlopt=${ocamlopt_byte}
+ocamlsrcdir="$1"
+
+ocamlopt=(
+  "$ocamlopt_byte"
+  -nostdlib
+  -I "$ocamlsrcdir"/stdlib
+  -I "$ocamlsrcdir"/otherlibs/dynlink
+  -I "$ocamlsrcdir"/otherlibs/unix
+)
+
+ocamlopt="${ocamlopt[@]}"
 
 cat >lib.ml <<EOF
 let s = "Hello natdynlink!"
@@ -41,7 +51,7 @@ $ocamlopt -shared -o toto.cmxs toto.ml
 
 echo 'let x = 42' >>lib.ml
 $ocamlopt -c lib.ml
-$ocamlopt -o main.exe -I +unix -I +dynlink dynlink.cmxa unix.cmxa lib.cmx main.ml
+$ocamlopt -o main.exe dynlink.cmxa unix.cmxa lib.cmx main.ml
 
 # At this point, toto.cmxs no longer loads as the lib.cmi that has been recorded
 # in main.exe does not match the one used when building toto.cmxs


### PR DESCRIPTION
When an error occurs while dynlinking a `.cmxs` we should call unload the dynamic object, in order to properly clean up after ourselves.

There is a test (that fails on `trunk`) that exhibits the issue of #14323.

Fixes #14323