### PR TITLE
Add documentation for constructing Iarray.t from array literals

### DIFF
--- a/Changes
+++ b/Changes
@@ -236,6 +236,9 @@ Working version
 
 ### Manual and documentation:
 
+- #14397: Improve documentation of type-directed disambiguation of array
+  literals (Alicia Michael review by Olivier Nicole and Florian Angeletti)
+
 - #14293: Improve documentation of Runtime_events.Timestamp (Raphaël Proust,
   review by Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -237,7 +237,7 @@ Working version
 ### Manual and documentation:
 
 - #14397: Improve documentation of type-directed disambiguation of array
-  literals (Alicia Michael review by Olivier Nicole and Florian Angeletti)
+  literals (Alicia Michael, review by Olivier Nicole and Florian Angeletti)
 
 - #14293: Improve documentation of Runtime_events.Timestamp (Raphaël Proust,
   review by Gabriel Scherer)

--- a/manual/src/library/builtin.etex
+++ b/manual/src/library/builtin.etex
@@ -90,6 +90,14 @@ type 'a iarray
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
+type floatarray
+\end{ocamldoccode}
+\index{floatarray@\verb`floatarray`}
+\begin{ocamldocdescription}
+  The type of mutable arrays of floats with packed representation.
+\end{ocamldocdescription}
+
+\begin{ocamldoccode}
 type 'a list = [] | :: of 'a * 'a list
 \end{ocamldoccode}
 \index{list@\verb`list`}

--- a/manual/src/library/builtin.etex
+++ b/manual/src/library/builtin.etex
@@ -82,6 +82,14 @@ type 'a array
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}
+type 'a iarray
+\end{ocamldoccode}
+\index{iarray@\verb`iarray`}
+\begin{ocamldocdescription}
+  The type of immutable arrays whose elements have type "'a".
+\end{ocamldocdescription}
+
+\begin{ocamldoccode}
 type 'a list = [] | :: of 'a * 'a list
 \end{ocamldoccode}
 \index{list@\verb`list`}

--- a/manual/src/refman/extensions/arrayliterals.etex
+++ b/manual/src/refman/extensions/arrayliterals.etex
@@ -4,7 +4,7 @@
 (Introduced in OCaml 5.4)
 
 Since OCaml 5.4, array literal syntax @"[|" e1 ';' e2 ';' ... ';' eN "|]"@ can
-be used to denote values of type "floatarray" or "'a iarray" as well as "'a
+be used to denote values of type "floatarray" or "'a Iarray.t" as well as "'a
 array", both in expression and pattern positions. This syntax is also used to
 display "floatarray" and "'a Iarray.t" values in the toplevel.
 
@@ -23,7 +23,7 @@ let _ = ([|42.|] : floatarray);;
 let _ = Float.Array.length [|42.|];;
 \end{caml_example}
 
-Immutable arrays (here "int IArray.t") can be constructed in exactly the same
+Immutable arrays (here "int Iarray.t") can be constructed in exactly the same
 way:
 
 \begin{caml_example}{verbatim}

--- a/manual/src/refman/extensions/arrayliterals.etex
+++ b/manual/src/refman/extensions/arrayliterals.etex
@@ -4,9 +4,9 @@
 (Introduced in OCaml 5.4)
 
 Since OCaml 5.4, array literal syntax @"[|" e1 ';' e2 ';' ... ';' eN "|]"@ can
-be used to denote values of type "floatarray" as well as "'a array", both in
-expression and pattern positions. This syntax is also used to display
-"floatarray" values in the toplevel.
+be used to denote values of type "floatarray" or "'a iarray" as well as "'a
+array", both in expression and pattern positions. This syntax is also used to
+display "floatarray" and "'a iarray" values in the toplevel.
 
 The compiler matches the expected type of the expression or pattern with the
 type of the literal, in a manner analogous to the disambiguation of constructors
@@ -21,6 +21,15 @@ In the following examples, the array literals are assigned type "floatarray":
 let _ : floatarray = [|42.|];;
 let _ = ([|42.|] : floatarray);;
 let _ = Float.Array.length [|42.|];;
+\end{caml_example}
+
+Immutable arrays (here "float iarray") can be constructed in exactly the same way,
+though this representation is not packed:
+
+\begin{caml_example}{verbatim}
+let _ : _ iarray = [|42.|];;
+let _ = ([|42.|] : _ iarray );;
+let _ = Iarray.length [|42.|];;
 \end{caml_example}
 
 The same disambiguation mechanism is used for array literals appearing in

--- a/manual/src/refman/extensions/arrayliterals.etex
+++ b/manual/src/refman/extensions/arrayliterals.etex
@@ -6,7 +6,7 @@
 Since OCaml 5.4, array literal syntax @"[|" e1 ';' e2 ';' ... ';' eN "|]"@ can
 be used to denote values of type "floatarray" or "'a iarray" as well as "'a
 array", both in expression and pattern positions. This syntax is also used to
-display "floatarray" and "'a iarray" values in the toplevel.
+display "floatarray" and "'a Iarray.t" values in the toplevel.
 
 The compiler matches the expected type of the expression or pattern with the
 type of the literal, in a manner analogous to the disambiguation of constructors
@@ -23,13 +23,13 @@ let _ = ([|42.|] : floatarray);;
 let _ = Float.Array.length [|42.|];;
 \end{caml_example}
 
-Immutable arrays (here "float iarray") can be constructed in exactly the same way,
-though this representation is not packed:
+Immutable arrays (here "int IArray.t") can be constructed in exactly the same
+way:
 
 \begin{caml_example}{verbatim}
-let _ : _ iarray = [|42.|];;
-let _ = ([|42.|] : _ iarray );;
-let _ = Iarray.length [|42.|];;
+let _ : _ Iarray.t = [|42|];;
+let _ = ([|42|] : _ Iarray.t );;
+let _ = Iarray.length [|42|];;
 \end{caml_example}
 
 The same disambiguation mechanism is used for array literals appearing in

--- a/stdlib/iarray.mli
+++ b/stdlib/iarray.mli
@@ -23,16 +23,16 @@
   produce all-constant arrays.  The exception is the sorting functions, which
   are given a copying API to replace the in-place one.
 
-  Immutable arrays can be constructed from array literals by type
+  Immutable arrays can be constructed from array literals by type-based
   disambiguation similar to that used for record fields. For example, when
   assigning to a type-annotated binding or parameter binding, or by directly
   type-annotating the literal.
 
   {[
-  let a : _ iarray = [|1;2;3|]
-  let b = let f (a : _ iarray) = a in
+  let a : _ Iarray.t = [|1;2;3|]
+  let b = let f (a : _ Iarray.t) = a in
     f [|1;2;3|]
-  let c = ([|1;2;3|] : _ iarray)
+  let c = ([|1;2;3|] : _ Iarray.t)
   ]}
 
   @since 5.4 *)

--- a/stdlib/iarray.mli
+++ b/stdlib/iarray.mli
@@ -15,17 +15,29 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Immutable array operations.
+
+  This module mirrors the API of [Array], but omits functions that assume
+  mutability; in addition to obviously mutating functions, it omits [copy]
+  along with the functions [make], [create_float], and [make_matrix] that
+  produce all-constant arrays.  The exception is the sorting functions, which
+  are given a copying API to replace the in-place one.
+
+  Immutable arrays can be constructed from array literals by type
+  disambiguation similar to that used for record fields. For example, when
+  assigning to a type-annotated binding or parameter binding, or by directly
+  type-annotating the literal.
+
+  {[
+  let a : _ iarray = [|1;2;3|]
+  let b = let f (a : _ iarray) = a in
+    f [|1;2;3|]
+  let c = ([|1;2;3|] : _ iarray)
+  ]}
+
+  @since 5.4 *)
+
 open! Stdlib
-
-(** Operations on immutable arrays.  This module mirrors the API of [Array], but
-    omits functions that assume mutability; in addition to obviously mutating
-    functions, it omits [copy] along with the functions [make], [create_float],
-    and [make_matrix] that produce all-constant arrays.  The exception is the
-    sorting functions, which are given a copying API to replace the in-place
-    one.
-
-    @since 5.4
-*)
 
 type +'a t = 'a iarray
 (** An alias for the type of immutable arrays. *)


### PR DESCRIPTION
Addresses #14386

Stdlib

- Adds an example for constructing an Iarray.t from a literal to the api doc for Iarray (also move the open to after the doc comment so the table works).

Manual

- Add `floatarray` and `iarray` to builtin types list in core library section (ch 29) (floatarray has been around a while so maybe this omission is intentional ?)
- Provide example using iarray in the type-directed array literal disambiguation extension section (sec 12.25)