### PR TITLE
Typo in ocamlopt man page (zero instead of letter o)

### DIFF
--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -738,10 +738,10 @@ Display a short usage summary and exit.
 When the Flambda code generator has been enabled at configuration time,
 its behavior may be tuned up with the following additional options:
 .TP
-.B \-02
+.B \-O2
 Perform more optimisation than usual. Compilation times may be lengthened.
 .TP
-.B \-03
+.B \-O3
 Perform even more optimisation than usual, possibly including unrolling
 of recursive functions. Compilation times may be significantly lengthened.
 .TP


### PR DESCRIPTION
Man page for ocamlopt had `-02` and `-03` instead of `-O2` and `-O3` (zeros instead of big letter Os) as optimization flags. This is incorrect, as I've checked by running the program (also the next line has `-O2` as that flag).