### PR TITLE
[doc] explain why the relaxed value restriction only works in strictly positive positions

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -999,7 +999,31 @@ let update_level_for tr_exn env level ty =
     update_level env level ty
   with Escape e -> raise_for tr_exn (Escape e)
 
-(* Lower level of type variables inside contravariant branches *)
+(* Lower level of type variables inside contravariant branches.
+
+   Note: this implies that only variables in *strictly positive*
+   positions can be instantiated, not variables in positive positions
+   on the left of an arrow, for example [('_b -> unit) -> unit].
+
+   Generalizing ['_b] in the example above creates a principality
+   issue (the example below comes from Jeremy Yallop): the term
+     (fun x -> x) (fun _ -> ())
+   has type
+     ('_a -> unit)
+   and also the less general type
+     (('_b -> unit) -> unit)
+   If you then consider
+     let f = (fun x -> x) (fun _ -> ())
+   then using the type ('_a -> unit) does not allow generalization,
+   but using the type (('_b -> unit) -> unit) would allow
+   generalization (if we generalized non-strictly-positive positions),
+   typing more programs.
+
+   In other words, the only generalizable type variables are those
+   that occur in hereditarily positive positions, they are in
+   covariant positions but all the type nodes above them are also in
+   covariant position.
+ *)
 
 let rec lower_contravariant env var_level visited contra ty =
   let must_visit =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1019,11 +1019,28 @@ let update_level_for tr_exn env level ty =
    generalization (if we generalized non-strictly-positive positions),
    typing more programs.
 
-   In other words, the only generalizable type variables are those
-   that occur in hereditarily positive positions, they are in
-   covariant positions but all the type nodes above them are also in
-   covariant position.
- *)
+   On the other hand, covariant arguments of datatype constructors
+   will not be lowered when the constructor application is in strictly
+   positive position, even if the corresponding variable occurs
+   weakly-positively in the datatype definition. Indeed, the type
+   expressions in datatype definitions are written explicitly by
+   users, so they cannot generate inference ambiguity as in the
+   example above.
+
+   For example, the following will be generalized as expected:
+   {[
+     type ('a, 'b) cps = CPS of (('a -> 'b) -> 'b)
+     let cps consumer = CPS consumer
+     let test : ('c list, unit) cps = cps (fun k -> k [])
+   ]}
+   In this example the ['c] type variable is found in covariant
+   position within a parameter of a type-constructor application at
+   the root of the type, so it is not lowered. The fact that it occurs
+   on the left of an arrow within the definition of [cps] is not
+   relevant. But if [cps] was a type synoym rather than a datatype,
+   then ['c] would be lowered as we do not track whether an explicit
+   type annotation was present in the term.
+*)
 
 let rec lower_contravariant env var_level visited contra ty =
   let must_visit =


### PR DESCRIPTION
Today with @johnyob and @diremy we were wondering why the relaxed value restriction is only applied in strictly-positive positions, not in double-negated positions like `(('_b -> unit) -> unit)`. After a bit of head-scratching, before I could decide whether to send an email to @garrigue to ask or to open a new "Discussions" thread, I found an answer in a caml-list post by @yallop from April 21st, 2018. The present PR is my best attempt at recreating this explanation as a code comment in ctype.ml.