### PR TITLE
Refactor the PR14323 test (⇒ fix Jenkins)

### DIFF
--- a/testsuite/tests/lib-dynlink-pr14323/main.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/main.ml
@@ -1,0 +1,16 @@
+let () =
+  let rec loop failed i =
+    if i > 5 then begin
+      print_endline "Too many failures.";
+      exit 1
+    end else
+    match Dynlink.loadfile "toto.cmxs" with
+    | _ ->
+      print_endline "OK";
+      exit 0
+    | exception exn ->
+      if not failed then print_endline "Dynlink.loadfile failed. Retrying.";
+      Unix.sleep 1;
+      loop true (i + 1)
+  in
+  loop false 0

--- a/testsuite/tests/lib-dynlink-pr14323/test.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/test.ml
@@ -1,11 +1,9 @@
 (* TEST
    native-dynlink;
    native-compiler;
-   not-windows;
-   output = "test.output";
-   reference = "${test_source_directory}/test.reference";
-   program = "${test_source_directory}/test.sh";
-   arguments = "${ocamlsrcdir}";
-   run;
-   check-program-output;
+   readonly_files = "toto.ml main.ml";
+   output = "${test_build_directory}/script.output";
+   setup-ocamlopt.opt-build-env;
+   script = "sh ${test_source_directory}/test.sh";
+   script;
 *)

--- a/testsuite/tests/lib-dynlink-pr14323/test.reference
+++ b/testsuite/tests/lib-dynlink-pr14323/test.reference
@@ -1,3 +1,0 @@
-Dynlink.loadfile failed. Retrying.
-Hello natdynlink!
-OK

--- a/testsuite/tests/lib-dynlink-pr14323/test.sh
+++ b/testsuite/tests/lib-dynlink-pr14323/test.sh
@@ -1,18 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euo pipefail
+set -eu
 
 ocamlsrcdir="$1"
 
-ocamlopt=(
-  "$ocamlsrcdir"/ocamlopt.opt
-  -nostdlib
-  -I "$ocamlsrcdir"/stdlib
-  -I "$ocamlsrcdir"/otherlibs/dynlink
-  -I "$ocamlsrcdir"/otherlibs/unix
-)
-
-ocamlopt="${ocamlopt[@]}"
+ocamlopt () {
+  "$ocamlsrcdir"/ocamlopt.opt \
+    -nostdlib \
+    -I "$ocamlsrcdir"/stdlib \
+    -I "$ocamlsrcdir"/otherlibs/dynlink \
+    -I "$ocamlsrcdir"/otherlibs/unix \
+    "$@"
+}
 
 cat >lib.ml <<EOF
 let s = "Hello natdynlink!"
@@ -44,14 +43,14 @@ EOF
 
 # Build toto.cmxs against the original lib.cmi
 
-$ocamlopt -c lib.ml
-$ocamlopt -shared -o toto.cmxs toto.ml
+ocamlopt -c lib.ml
+ocamlopt -shared -o toto.cmxs toto.ml
 
 # Update lib.cmi
 
 echo 'let x = 42' >>lib.ml
-$ocamlopt -c lib.ml
-$ocamlopt -o main.exe dynlink.cmxa unix.cmxa lib.cmx main.ml
+ocamlopt -c lib.ml
+ocamlopt -o main.exe dynlink.cmxa unix.cmxa lib.cmx main.ml
 
 # At this point, toto.cmxs no longer loads as the lib.cmi that has been recorded
 # in main.exe does not match the one used when building toto.cmxs
@@ -62,6 +61,6 @@ PID=$!
 # Rebuild toto.cmxs against the updated lib.cmi
 
 sleep 1
-$ocamlopt -shared -o toto.cmxs toto.ml
+ocamlopt -shared -o toto.cmxs toto.ml
 
 wait $PID || :

--- a/testsuite/tests/lib-dynlink-pr14323/toto.ml
+++ b/testsuite/tests/lib-dynlink-pr14323/toto.ml
@@ -1,0 +1,2 @@
+let () =
+  print_endline Lib.s


### PR DESCRIPTION
While the adjustment added in #14398 improved the operation of the test added for #14323 on FreeBSD, the Jenkins FreeBSD doesn't have `bash` at all, so this test has been causing our main CI checks to fail since it was merged. The first commit in this series removes the bash array from the test script driver so that it can just be executed with `sh`. Technically, `set -o pipefail` is now Posix, but in reality there are still a lot of `sh` implementations which don't support it - given that there aren't actually any pipes in the test, I deleted it (out of curiosity, was the test vibed or guided by shellcheck? Curiosity only because it was a remarkably robust implementation for a test!)

Given how different the implementations of natdynlink are, it's a shame not to be running this test on Windows. The second commit therefore refactors the test to run on Windows. While I normally object to using shell scripts for plumbing these tests, it's obviously necessary for this one, given the timing and recompilation needs. However, it did seem a little gratuitous to embed all of the OCaml sources in the shell script, so I moved the "static" files out to their own files!

I have verified that the refactored test still fails if the fix from #14391 is reverted and this branch has gone through [precheck#1085](https://ci.inria.fr/ocaml/job/precheck/1085/).