### PR TITLE
HACKING.adoc: document clean-for-dune

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -500,7 +500,7 @@ compiler sources:
 
 ----
 ./configure # if not already done
-make clean && dune build @libs
+make clean-for-dune && dune build @libs
 ----
 
 which will do a bytecode build of all the distribution (without linking
@@ -511,9 +511,12 @@ than trying to open the incompatible artefacts produced by a Makefile build. In
 particular, you need to repeat the dune build every time you change the interface
 of some compilation unit, so that merlin is aware of the new interface.
 
-You only need to run `configure` once, but you will need to run `make clean`
-every time you want to run `dune` after you built something with `make`;
-otherwise dune will complain that build artefacts are present among the sources.
+You only need to run `configure` once, but you will need to run `make
+clean-for-dune` every time you want to run `dune` after you built
+something with `make`; otherwise dune will complain that build
+artefacts are present among the sources. (Not all build artifacts need
+to be removed, `clean-for-dune` removes less than `clean` or
+`partialclean` and thus Make will rebuild faster.)
 
 Finally, there will be times where the compiler simply cannot be built with an
 older version of itself. One example of this is when a new primitive is added to


### PR DESCRIPTION
When we are hacking on the compiler, if we want both Merlin support (using dune) and being able to run the testsuite (using Make), we have to clean Make build artifacts before we run `dune`, and then rebuild them before running the tests.

`make clean-for-dune` was introduced by @Alizter in #14408 as a specialized target to do this that removes less than `clean` or `partialclean`. The present PR documents it.

Note: In the future we will be able to get rid of this cleaning action completely thanks to the support for the new `(files ...)` stanza in Dune introduced by @nojb in https://github.com/ocaml/dune/pull/12879 . I am planning to switch to using that after the next public release of dune.