### PR TITLE
Towards enabling AddressSanitizer on MSVC

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -773,7 +773,11 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #else
 #  if defined(__SANITIZE_ADDRESS__)
 #    undef CAMLno_asan
-#    define CAMLno_asan __attribute__((no_sanitize_address))
+#    if (defined(_MSC_VER) && !defined(__clang__))
+#      define CAMLno_asan __declspec(no_sanitize_address)
+#    else
+#      define CAMLno_asan __attribute__((no_sanitize_address))
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
I tried to add support for MSVC AddressSanitizer to help me debug Windows code, but I failed. I'm hitting ASAN warnings when flexdll runs, and it's quite difficult to enable ASAN for part of the build and not other parts. It seems _very_ difficult to set it up properly when using `/nodefaultlib` or when setting an entry point with `/entry`.

- [AddressSanitizer](https://learn.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-180);
- [MSVC AddressSanitizer language, build, and debugging reference](https://learn.microsoft.com/en-us/cpp/sanitizers/asan-building?view=msvc-180);
- [`/fsanitize` (Enable sanitizers)](https://learn.microsoft.com/en-us/cpp/build/reference/fsanitize?view=msvc-180);
- [ASAN missing symbols when linking with `/nodefaultlib`](https://developercommunity.visualstudio.com/t/asan-missing-symbols-when-linking-with-nodefaultli/1300874) (closed bug report).

I'm currently stuck on this warning reported by ASAN during the build of the compiler:
```console
> .\boot\ocamlrun.exe ./ocamlopt.exe -nostdlib -I ./stdlib -I otherlibs/dynlink -I utils -I parsing -I typing -I bytecomp -I file_formats -I lambda -I middle_end -I middle_end/closure -I middle_end/flambda -I middle_end/flambda/base_types -I asmcomp -I driver -I toplevel -I tools
-I runtime -I otherlibs/dynlink -I otherlibs/str -I otherlibs/systhreads -I otherlibs/unix -I otherlibs/runtime_events -set-runtime-default standard_library_default=C:/ocamlms64/lib/ocaml -g -o ocamlc.opt.exe compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlbytecomp.cmxa  driver/main.cmx -verbose
+ ml64 -nologo -Cp -c -Fo"C:\Users\Antonin\AppData\Local\Temp\camlstartup9f85f5.obj" "C:\Users\Antonin\AppData\Local\Temp\camlstartup8fbdeb.asm"
 Assembling: C:\Users\Antonin\AppData\Local\Temp\camlstartup8fbdeb.asm
+ flexlink -exe -chain msvc64 -merge-manifest -stack 33554432 -use-mt mt -link /ENTRY:wmainCRTStartup  -link /wholearchive:clang_rt.asan_dynamic-x86_64.lib  -o "ocamlc.opt.exe"  "-L./stdlib" "-Lotherlibs/dynlink" "-Lutils" "-Lparsing" "-Ltyping" "-Lbytecomp" "-Lfile_formats" "-Llambda" "-Lmiddle_end" "-Lmiddle_end/closure" "-Lmiddle_end/flambda" "-Lmiddle_end/flambda/base_types" "-Lasmcomp" "-Ldriver" "-Ltoplevel" "-Ltools" "-Lruntime" "-Lotherlibs/dynlink" "-Lotherlibs/str" "-Lotherlibs/systhreads" "-Lotherlibs/unix" "-Lotherlibs/runtime_events"  "C:\Users\Antonin\AppData\Local\Temp\camlstartup9f85f5.obj" "./stdlib\std_exit.obj" "driver/main.obj" "compilerlibs/ocamlbytecomp.lib" "compilerlibs/ocamlcommon.lib" "./stdlib\stdlib.lib" "-lcomprmarsh" "./stdlib\libasmrun.lib"  clang_rt.asan_dynamic-x86_64.lib ws2_32.lib ole32.lib uuid.lib advapi32.lib shell32.lib version.lib shlwapi.lib synchronization.lib
=================================================================
==24372==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x000ada5ff320 at pc 0x7ffa71508831 bp 0x000ada5ff000 sp 0x000ada5fe7a0
WRITE of size 520 at 0x000ada5ff320 thread T0
    #0 0x7ffa71508830 in memset D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\sanitizer_common\sanitizer_common_interceptors_memintrinsics.inc:92
    #1 0x7ffaf06221d8  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800421d8)
    #2 0x7ffaf06203b8  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800403b8)
    #3 0x7ffaf06ba2fe  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800da2fe)
    #4 0x7ffaed99f7b6  (C:\WINDOWS\System32\KERNELBASE.dll+0x18003f7b6)
    #5 0x7ffaedf530e1  (C:\WINDOWS\System32\ucrtbase.dll+0x1800630e1)
    #6 0x7ffaedf534fe  (C:\WINDOWS\System32\ucrtbase.dll+0x1800634fe)
    #7 0x7ffaedf5329d  (C:\WINDOWS\System32\ucrtbase.dll+0x18006329d)
    #8 0x00000080d855 in caml_sys_system_command C:\Users\Antonin\Tarides\ocaml\trunk\runtime\sys.c:556
    #9 0x0000007f8fd3 in caml_c_call (C:\Users\Antonin\Tarides\ocaml\trunk\opt\bin\flexlink.exe+0xa8fd3)
    #10 0x11d00d589faf  (<unknown module>)

Address 0x000ada5ff320 is located in stack of thread T0 at offset 112 in frame
    #0 0x000ada5ff2df  (<unknown module>)

  This frame has 4 object(s):
    [32, 96) 'caml__roots_arg'
    [48, 112) 'caml__roots_str'
    [64, 1088) 'buf' <== Memory access at offset 112 is inside this variable
    [80, 88) 'str' <== Memory access at offset 112 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp, SEH and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800421d8)
Shadow bytes around the buggy address:
  0x000ada5ff080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff280: 00 00 00 00 00 00 f1 f1 f1 f1 00 00 00 00 00 00
=>0x000ada5ff300: 00 00 f2 f2[f2]f2 00 00 00 00 00 00 00 00 f2 f2
  0x000ada5ff380: f2 f2 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000ada5ff580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```

This is my hack on `configure.ac`:

```sh
asan_msvc_cflags='-fsanitize=address -Z7'
asan_msvc_ldflags='/wholearchive:clang_rt.asan_dynamic-x86_64.lib /debug'
asan_msvc_cclibs='clang_rt.asan_dynamic-x86_64.lib'

internal_cflags="$internal_cflags $asan_msvc_cflags"
oc_ldflags="$oc_ldflags $asan_msvc_ldflags"
cclibs="$cclibs $asan_msvc_cclibs"
```

and in `stdlib/Makefile`, when building `header.obj` and `tmpheader.exe`, I `filter-out` the ASAN flags:
```diff
diff --git i/stdlib/Makefile w/stdlib/Makefile
index 22614ad037..4b4cb181ae 100644
--- i/stdlib/Makefile
+++ w/stdlib/Makefile
@@ -117,13 +117,18 @@ else ifeq "$(TOOLCHAIN)" "msvc"
 header.obj: OC_CFLAGS += /GS- /Os
 tmpheader.exe: OC_LDFLAGS += /NOCOFFGRPINFO /subsystem:console
 HEADERLIBS = kernel32.lib
+
+header.obj: header.c $(REQUIRED_HEADERS)
+       $(V_CC)$(CC) $(filter-out -fsanitize=address -Z7, $(OC_CFLAGS)) \
+          $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ -c $<
+tmpheader.exe:
+       $(V_MKEXE)$(filter-out /wholearchive:clang_rt.asan_dynamic-x86_64.lib,$(call MKEXE_VIA_CC,$@,$^ $(HEADERLIBS)))
 else
 HEADERLIBS =
 endif

 .INTERMEDIATE: tmpheader.exe
 tmpheader.exe: header.$(O)
-       $(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^ $(HEADERLIBS))
 # Do not strip the header produced by cl
 ifneq "$(TOOLCHAIN)" "msvc"
        $(STRIP) $@
```
Then I build ocamlyacc manually:
```sh
runtime/ocamlrun.exe flexlink.byte.exe -exe -chain msvc64 -merge-manifest -stack 33554432 -use-mt mt -link /ENTRY:wmainCRTStartup -link /wholearchive:clang_rt.asan_dynamic-x86_64.lib -o yacc/ocamlyacc.exe yacc/wstr.obj yacc/closure.obj yacc/error.obj yacc/lalr.obj yacc/lr0.obj yacc/main.obj yacc/mkpar.obj yacc/output.obj yacc/reader.obj yacc/skeleton.obj yacc/symtab.obj yacc/verbose.obj yacc/warshall.obj -lclang_rt.asan_dynamic-x86_64.lib
```
and this is the diff in `flexdll/Makefile`:
```diff
diff --git i/Makefile w/Makefile
index 418c1cf..2ca62f3 100644
--- i/Makefile
+++ w/Makefile
@@ -68,7 +68,7 @@ endif
 Makefile.winsdk: msvs-detect
        bash ./msvs-detect --output=make > $@

-MSVC_FLAGS = /nologo /MD -D_CRT_SECURE_NO_DEPRECATE /GS- /W3
+MSVC_FLAGS = /nologo /MD -D_CRT_SECURE_NO_DEPRECATE /GS- /W3 /Z7 /fsanitize=address

 ifeq ($(MSVC_DETECT),0)
 # Assume that the environment is correctly set for a single Microsoft C Compiler; don't attempt to guess anything
@@ -141,9 +141,9 @@ endif

 ifeq ($(NATDYNLINK), false)
 #when ocaml is not built with flexlink i.e. -no-shared-libs
-LINKFLAGS = -cclib "$(RES)"
+LINKFLAGS = -cclib "$(RES)" -cclib -fsanitize=address -cclib -Z7 -cclib -debug -verbose
 else
-LINKFLAGS = -cclib "-link $(RES)"
+LINKFLAGS = -cclib "-link $(RES)" -cclib "-link -fsanitize=address" -cclib "-link -Z7" -cclib "-link -debug"
 endif

 support: $(addprefix build_, $(CHAINS))
 ```

I'm submitting this patch because it's a necessary first step, and perhaps it may spark some interest.