### PR TITLE
feat: Domains inherit backtrace_enabled

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,10 @@ Working version
 
 ### Runtime system:
 
+- #14416: Spawned domains will record backtraces if the parent domain has
+  enabled it.
+  (Nathan Taylor, review by Gabriel Scherer)
+
 - #13616: Change free list representation in shared heap
   (Sadiq Jaffer, review by Damien Doligez)
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -989,9 +989,10 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   domain_state->parser_trace = 0;
 
-  if (caml_params->backtrace_enabled) {
-    caml_record_backtraces(1);
-  }
+  bool bt_enabled = parent
+    ? parent->backtrace_active
+    : caml_params->backtrace_enabled;
+  caml_record_backtraces(bt_enabled);
 
 #ifndef NATIVE_CODE
   domain_state->external_raise = NULL;

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -74,6 +74,9 @@ val record_backtrace: bool -> unit
     on (if [b = true]) or off (if [b = false]).  Initially, backtraces
     are not recorded, unless the [b] flag is given to the program
     through the [OCAMLRUNPARAM] variable.
+    @before 5.5 Spawned domains' backtraces would not be recorded, even
+    if the parent had called [record_backtrace true].
+
     @since 3.11
 *)
 


### PR DESCRIPTION
Fixes #14411.

Currently, fresh domains will only have backtraces enabled if they are set via OCAMLRUNOPTS.  As a result, the only way to opt into domains recording their backtrace is by setting OCAMLRUNOPTS or explicitly ensuring each child domain calls ocaml_record_backtrace().

The latter is awkward if domains are managed by, for instance, Eio's executor pools, and the former can be awkward if users aren't accustomed to having to set environment variables for functionality that they might otherwise expect (in our case, from parmap-based parallelism).

This patch changes the default behaviour thus: a child domain inherits the setting of its parent. C-cube and I discussed making this a global value (and so therefore calling `Printexc.record_backtrace` would atomiclly modify all domains) but this seemed like both the minimal change and, given that `backtrace_active` is already tracked per-domain, perhaps close to the original intention?

I tested this with a trivial program of my own:

```ocaml
let doit () =
    try failwith "foo" with
    | exn ->
      let stat = Printexc.backtrace_status () in
      let exn = Printexc.to_string exn in
      let bt = Printexc.(get_raw_backtrace () |> raw_backtrace_to_string) in
      Printf.printf "backtrace_status: %b, exn: %s, BT %s\n" stat exn bt

let () =
    Printf.printf "Running on main thread...\n";
    doit ();

    Printexc.record_backtrace true;

    Printf.printf "Running on main thread...\n";
    doit ();

    Printf.printf "Running in child domain...\n";
    Domain.spawn doit |> Domain.join
```

and observe the expected behaviour (lines two and three contain a backtrace -

```
(cli) [ntaylor@smuggo domain_inherit]$ ocamlopt bin/main.ml && ./a.out
Running on main thread...
backtrace_status: false, exn: Failure("foo"), BT
Running on main thread...
backtrace_status: true, exn: Failure("foo"), BT Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Main.doit in file "bin/main.ml", line 2, characters 8-22

Running in child domain...
backtrace_status: true, exn: Failure("foo"), BT Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Main.doit in file "bin/main.ml", line 2, characters 8-22

(cli) [ntaylor@smuggo domain_inherit]$
```

It seems like I could change `backtrace_domain_join.ml` to remove the `ocamlrunparam` setting to make this change part of the test suite, but I was reluctant to change KC's test without him or someone else signing off on it.  Let me know if you have thoughts on that.