### PR TITLE
Rewrite pack prefixes to replace dots by the appropriate separator

### DIFF
--- a/Changes
+++ b/Changes
@@ -547,6 +547,9 @@ Working version
 - #14370: Fix headers for C++ inclusion.
   (Antonin Décimo, review by Gabriel Scherer)
 
+- #14417: Fix issue with nested packs on macOS.
+  (Vincent Laviron, report by Kate Deplaix, review by Gabriel Scherer)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -119,6 +119,11 @@ let current_unit_linkage_name () =
   Linkage_name.create (make_symbol ~unitname:current_unit.ui_symbol None)
 
 let reset ?packname name =
+  let packname =
+    Option.map
+      (Misc.replace_substring ~before:"." ~after:(String.make 1 symbol_separator))
+      packname
+  in
   Hashtbl.clear global_infos_table;
   Set_of_closures_id.Tbl.clear imported_sets_of_closures_table;
   let symbol = symbolname_for_pack packname name in
@@ -192,7 +197,7 @@ let read_library_info filename =
    ultimately end up in the same pack, including through nested packs. *)
 let is_import_from_same_pack ~imported ~current =
   String.equal imported current
-  || String.starts_with ~prefix:(imported ^ ".") current
+  || String.starts_with ~prefix:(concat_symbol imported "") current
 
 let get_global_info global_ident = (
   let modname = Ident.name global_ident in

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -156,15 +156,6 @@ let current_unit_infos () =
 let current_unit_name () =
   current_unit.ui_name
 
-let symbol_in_current_unit name =
-  let prefix = "caml" ^ current_unit.ui_symbol in
-  name = prefix ||
-  (let lp = String.length prefix in
-   String.length name >= 2 + lp
-   && String.sub name 0 lp = prefix
-   && name.[lp] = '_'
-   && name.[lp + 1] = '_')
-
 let read_unit_info filename =
   let ic = open_in_bin filename in
   try

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -121,7 +121,8 @@ let current_unit_linkage_name () =
 let reset ?packname name =
   let packname =
     Option.map
-      (Misc.replace_substring ~before:"." ~after:(String.make 1 symbol_separator))
+      (Misc.replace_substring ~before:"."
+         ~after:(String.make 1 symbol_separator))
       packname
   in
   Hashtbl.clear global_infos_table;

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -67,10 +67,6 @@ val make_symbol: ?unitname:string -> string option -> string
            corresponds to symbol [id] in the compilation unit [u]
            (or the current unit). *)
 
-val symbol_in_current_unit: string -> bool
-        (* Return true if the given asm symbol belongs to the
-           current compilation unit, false otherwise. *)
-
 val is_predefined_exception: Symbol.t -> bool
         (* flambda-only *)
 


### PR DESCRIPTION
Fixes #14415.

This slightly ugly patch interprets dots in pack prefixes as pack separators, so on platforms where the symbol separator isn't a dot it replaces them with the appropriate character.

The second commit is mostly unrelated but caught my eye when reviewing the rest of `Compilenv`.

I think we should consider tha OxCaml approach of having distinct types for compilation units, symbols and linkage names (instead of just `string` everywhere), to avoid confusion in the future, but this would be a large patch and I consider fixing #14415 a priority.

To @tmcgilchrist: this PR introduces the possibility of having an arbitrary number of separators in the assembly symbols. If I'm not mistaken, this should not be a new problem as using packs already created situations where there were two separators, but I haven't checked if the OCaml demanglers in the wild support that. Do you expect this to be a problem ?