### PR TITLE
AppVeyor - unpin Cygwin version

### DIFF
--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -143,7 +143,6 @@ set CYGWIN_INSTALL_PACKAGES=
 set CYGWIN_UPGRADE_REQUIRED=%FORCE_CYGWIN_UPGRADE%
 
 for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
-set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,cygwin=3.5.4-1
 call :UpgradeCygwin
 
 "%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh install" || exit /b 1

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -143,7 +143,7 @@ set CYGWIN_INSTALL_PACKAGES=
 set CYGWIN_UPGRADE_REQUIRED=%FORCE_CYGWIN_UPGRADE%
 
 for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
-set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,cygwin=3.6.1-1
+set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,cygwin=3.5.4-1
 call :UpgradeCygwin
 
 "%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh install" || exit /b 1

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -162,6 +162,10 @@ case "$1" in
     if $run_testsuite; then
       # The testsuite is too slow to run on AppVeyor in full. Run the dynlink
       # tests now (to include natdynlink)
+      # GNU Parallel 20250122 introduced a somewhat dubious check on the
+      # characters in $PWD and $OLDPWD - --unsafe disables these "checks"
+      # (as would sed -i -e 's/PWD OLDPWD//' /usr/bin/parallel)
+      export PARALLEL='--unsafe'
       run "test dynlink $PORT" \
           $MAKE -C "$FULL_BUILD_PREFIX-$PORT/testsuite" parallel-lib-dynlink
       # Now reconfigure ocamltest to run in bytecode-only mode


### PR DESCRIPTION
The first commits revert the mitigation for #13717 from #13718 (which was updated in #13954), as it's no longer necessary and is actually adding time to the AppVeyor run as Cygwin gets downgraded to an older release.

The last commit deals with a slightly strange warning which got added in GNU Parallel 20250122 and otherwise causes this obnoxious output:
```
make: Entering directory '/cygdrive/c/projects/🐫реализация-mingw64/testsuite'
parallel: Warning: $PWD can only contain [-\p{L}\p{N}\p{M}_+,.%@:/=() ].
parallel: Warning: Use '--unsafe' to ignore this.
parallel: Warning: $OLDPWD can only contain [-\p{L}\p{N}\p{M}_+,.%@:/=() ].
parallel: Warning: Use '--unsafe' to ignore this.
Running tests from 'tests/lib-dynlink-bytecode' ...
```

(the build is performed in a directory containing an emojus precisely to test UTF-16 surrogate pairs; [it's smoked out bugs in the past](https://cygwin.com/pipermail/cygwin/2024-April/255807.html); I'm not sure why a tool takes it upon itself to get judgemental about the result of [`getcwd`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/getcwd.html) 🤷)