### PR TITLE
Moved a match outside of an if in typetexp

### DIFF
--- a/Changes
+++ b/Changes
@@ -460,6 +460,10 @@ Working version
 * #14388: Remove support for `let rec (module M : S) = e1 in e2`.
   (Alistair O'Brien, review by Vincent Laviron and Gabriel Scherer)
 
+- #14422: Refactoring an `if match e with p1 -> true | p2 -> false then ...`
+  into a match in typetexp.
+  (Samuel Vivien, review by Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -331,12 +331,9 @@ end = struct
         if flavor = Unification || is_in_scope name then
           let v = new_global_var () in
           let snap = Btype.snapshot () in
-          if try unify env v ty; true
-            with
-                Unify err when is_in_scope name ->
-                  raise (Error(loc, env, Type_mismatch err))
-              | _ -> Btype.backtrack snap; false
-          then match lookup_global_type_variable name with
+          match unify env v ty with
+          | () ->
+            begin match lookup_global_type_variable name with
             | global_var ->
               r := (loc, v, global_var) :: !r;
               unused := false
@@ -347,7 +344,11 @@ end = struct
                                                   get_in_scope_names ())));
               let v2 = new_global_var () in
               r := (loc, v, v2) :: !r;
-              add ~unused name v2)
+              add ~unused name v2
+            end
+          | exception Unify err when is_in_scope name ->
+            raise (Error(loc, env, Type_mismatch err))
+          | exception _ -> Btype.backtrack snap)
       !used_variables;
     used_variables := TyVarMap.empty;
     fun () ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -332,6 +332,9 @@ end = struct
           let v = new_global_var () in
           let snap = Btype.snapshot () in
           match unify env v ty with
+          | exception Unify err when is_in_scope name ->
+            raise (Error(loc, env, Type_mismatch err))
+          | exception _ -> Btype.backtrack snap
           | () ->
             begin match lookup_global_type_variable name with
             | global_var ->
@@ -345,10 +348,7 @@ end = struct
               let v2 = new_global_var () in
               r := (loc, v, v2) :: !r;
               add ~unused name v2
-            end
-          | exception Unify err when is_in_scope name ->
-            raise (Error(loc, env, Type_mismatch err))
-          | exception _ -> Btype.backtrack snap)
+            end)
       !used_variables;
     used_variables := TyVarMap.empty;
     fun () ->


### PR DESCRIPTION
Small simplification of an `if` in typing/typetexp.ml. From a `if try e1; true with _ -> false then e2` pattern to a match exception.