### PR TITLE
Fix detection of `SetThreadDescription` on i686

### DIFF
--- a/Changes
+++ b/Changes
@@ -554,6 +554,11 @@ Working version
 - #14417: Fix issue with nested packs on macOS.
   (Vincent Laviron, report by Kate Deplaix, review by Gabriel Scherer)
 
+- #14423: Fix detection of SetThreadDescription on 32-bit builds, meaning that
+  Thread.set_current_thread_name now works on 32-bit MSVC and uses the correct
+  mechanism on 32-bit mingw-w64.
+  (David Allsopp, review by Antonin Décimo)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/configure
+++ b/configure
@@ -23718,14 +23718,38 @@ fi
 done
 
 ## SetThreadDescription
-
-  for ac_func in SetThreadDescription
-do :
-  ac_fn_c_check_func "$LINENO" "SetThreadDescription" "ac_cv_func_SetThreadDescription"
-if test "x$ac_cv_func_SetThreadDescription" = xyes
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SetThreadDescription" >&5
+printf %s "checking for SetThreadDescription... " >&6; }
+if test ${ac_cv_func_SetThreadDescription+y}
 then :
-  printf "%s\n" "#define HAVE_SETTHREADDESCRIPTION 1" >>confdefs.h
- printf "%s\n" "#define HAS_SETTHREADDESCRIPTION 1" >>confdefs.h
+  printf %s "(cached) " >&6
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <windows.h>
+int
+main (void)
+{
+SetThreadDescription(GetCurrentThread(), L"test");
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_func_SetThreadDescription=yes
+else $as_nop
+  ac_cv_func_SetThreadDescription=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_SetThreadDescription" >&5
+printf "%s\n" "$ac_cv_func_SetThreadDescription" >&6; }
+
+if test x"$ac_cv_func_SetThreadDescription" = 'xyes'
+then :
+  printf "%s\n" "#define HAS_SETTHREADDESCRIPTION 1" >>confdefs.h
 
   ac_fn_check_decl "$LINENO" "SetThreadDescription" "ac_cv_have_decl_SetThreadDescription" "#define WIN32_LEAN_AND_MEAN
       #include <windows.h>
@@ -23737,8 +23761,6 @@ then :
 
 fi
 fi
-
-done
 
 ## Activate the systhread library
 

--- a/configure.ac
+++ b/configure.ac
@@ -2771,8 +2771,16 @@ AC_CHECK_FUNCS(
   [AC_DEFINE([HAS_PRCTL], [1])])
 
 ## SetThreadDescription
-AC_CHECK_FUNCS(
-  [SetThreadDescription],
+AC_CACHE_CHECK([for SetThreadDescription],
+  [ac_cv_func_SetThreadDescription],
+  [AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include <windows.h>]],
+      [[SetThreadDescription(GetCurrentThread(), L"test");]])],
+    [ac_cv_func_SetThreadDescription=yes],
+    [ac_cv_func_SetThreadDescription=no])])
+
+AS_IF([test x"$ac_cv_func_SetThreadDescription" = 'xyes'],
   [AC_DEFINE([HAS_SETTHREADDESCRIPTION], [1])
   AC_CHECK_DECL(
     [SetThreadDescription],


### PR DESCRIPTION
The 32-bit Windows API uses `__stdcall`, so this test in `configure.ac`:
https://github.com/ocaml/ocaml/blob/2f4a5725406cafa35965cadeb7cf3ec5fad0828a/configure.ac#L2773-L2776

tries to link `SetThreadDescription`, and consequently [fails on 32-bit builds](https://github.com/ocaml/ocaml/actions/runs/20301459064/job/58307851827?pr=13416#step:9:291):
```console
checking for SetThreadDescription... (cached) no
```

At present, that should mean that 32-bit MSVC's version of `Thread.set_current_thread_name` is raising an exception and mingw-w64's version is quietly using `pthread_set_name` instead (and is not semantically equivalent to the 64-bit version).

In #13416, that becomes a problem on mingw-w64.