### PR TITLE
Compute C dependency information as a side-effect of compilation

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -50,7 +50,7 @@ jobs:
           set -x
           ./configure --disable-warn-error --disable-ocamldoc \
               --disable-ocamltest --disable-stdlib-manpages \
-              --disable-dependency-generation --prefix="$PREFIX" || failed=$?
+              --prefix="$PREFIX" || failed=$?
           if ((failed)) ; then set +x
             echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
             cat config.log ; echo '::endgroup::' ; exit $failed

--- a/Makefile
+++ b/Makefile
@@ -3059,6 +3059,7 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	  lib, $(INSTALL_LIBDIR_COMPILERLIBS))
 endif
 
+.PHONY: .depend
 include .depend
 
 # Include the cross-compiler recipes only when relevant

--- a/Makefile
+++ b/Makefile
@@ -1514,7 +1514,7 @@ $(DEPDIR)/runtime/%.npic.$(D): \
 # (without the extension, which is added by the macro)
 define COMPILE_C_FILE
 ifeq "$(COMPUTE_DEPS)" "true"
-ifneq "$(1)" "%"
+ifneq "$(if $(3),%,$(1))" "%"
 # -MG would ensure that the dependencies are generated even if the files listed
 # in $$(runtime_BUILT_HEADERS) haven't been assembled yet. However,
 # this goes subtly wrong if the user has the headers installed,
@@ -1556,6 +1556,8 @@ $(eval $(call COMPILE_C_FILE,runtime/$(UNIX_OR_WIN32)_non_shared.%, \
 $(foreach runtime_OBJECT_TYPE,$(subst %,,$(runtime_OBJECT_TYPES)), \
   $(eval \
     runtime/dynlink$(runtime_OBJECT_TYPE).$(O): $(ROOTDIR)/Makefile.config))
+
+$(eval $(call COMPILE_C_FILE,yacc/%,yacc/%,no-deps))
 
 ## Compilation of runtime assembly files
 
@@ -2276,6 +2278,7 @@ endif
 endif
 
 # Check that the stack limit is reasonable (Unix-only)
+$(eval $(call COMPILE_C_FILE,tools/checkstack,tools/checkstack,no-deps))
 .PHONY: checkstack
 ifeq "$(UNIX_OR_WIN32)" "unix"
 checkstack: tools/checkstack$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -1552,8 +1552,8 @@ ifeq "$(COMPUTE_DEPS)$(3)" "true"
 # MSVC doesn't emit usable dependency information, but if GCC is available
 # then it can instead be called in order to generate the .d file.
 ifneq "$(CC)" "$(DEP_CC)"
-	$$(V_CCDEPS)$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MM -MT $$@ \
-   -MF $(DEPDIR)/$$(@:.$(O)=.$(D))
+	$$(V_CCDEPS)$$(DEP_CC) $(DEP_CPPFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< \
+   -MM -MT $$@ -MF $(DEPDIR)/$$(@:.$(O)=.$(D))
 endif # ifneq "$(CC)" "$(DEP_CC)"
 endif # ifeq "$(COMPUTE_DEPS)$(3)" "true"
 endef

--- a/Makefile
+++ b/Makefile
@@ -1507,36 +1507,64 @@ runtime/%.npic.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
 $(DEPDIR)/runtime/%.npic.$(D): \
   OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
 
-## Compilation of runtime C files
+## Compilation of C files
 
-# The COMPILE_C_FILE macro below receives as argument the pattern
-# that corresponds to the name of the generated object file
-# (without the extension, which is added by the macro)
-define COMPILE_C_FILE
+# There are two scenarios in which a C object may need to be rebuilt:
+# 1. The C source file is newer than the object
+# 2. A file #include'd by the C source file is newer than the object
+#
+# When the C source file is newer than the object, we do not have to care about
+# which included files are newer, we just have to be sure that all the files
+# which may be #include'd definitely exist.
+#
+# GCC and clang can both generate the precise dependency information
+# needed for (2) as part of compiling the C file. We therefore use C dependency
+# information lazily.
+
+# All C files must depend on the _presence_ of the $(runtime_BUILT_HEADERS). If
+# a C file actually uses one of these headers, then the dependency will be
+# recorded in the .d file (and becomes a real dependency, not an order-only
+# dependency).
+runtime_MISSING_BUILT_HEADERS = \
+  $(filter-out $(wildcard $(runtime_BUILT_HEADERS)), $(runtime_BUILT_HEADERS))
+
+# COMPILE_C_FILE generates the compilation rules for C objects
+#   $1 = target pattern for the generated object file (without the .$(O))
+#   $2 = source pattern for the C source file (without the .c)
+#   $3 = optional; if non-empty suppresses the generation of dependency rules
+define DO_COMPILE_C_FILE
 ifeq "$(COMPUTE_DEPS)" "true"
-ifneq "$(if $(3),%,$(1))" "%"
-# -MG would ensure that the dependencies are generated even if the files listed
-# in $$(runtime_BUILT_HEADERS) haven't been assembled yet. However,
-# this goes subtly wrong if the user has the headers installed,
-# as gcc will pick up a dependency on those instead and the local
-# ones will not be generated. For this reason, we don't use -MG and
-# instead include $(runtime_BUILT_HEADERS) in the order only dependencies
-# to ensure that they exist before dependencies are computed.
-$(DEPDIR)/$(1).$(D): runtime/%.c | $(DEPDIR)/runtime $(runtime_BUILT_HEADERS)
-	$$(V_CCDEPS)$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MT \
-	  'runtime/$$*$(subst runtime/%,,$(1)).$(O)' -MF $$@
-endif # ifneq "$(1)" "%"
-$(1).$(O): $(2).c
+# Secondary expansion means we can use @D to depend on the directory being
+# created.
+$(1).$(O): $(2).c \
+  $(if $(3),,| $(DEPDIR)/$$$$(@D) $(runtime_MISSING_BUILT_HEADERS))
 else
 $(1).$(O): $(2).c \
   $(runtime_CONFIGURED_HEADERS) $(runtime_BUILT_HEADERS) \
   $(RUNTIME_HEADERS)
 endif # ifeq "$(COMPUTE_DEPS)" "true"
 	$$(V_CC)$$(CC) $$(OC_CFLAGS) $$(CFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) \
-	  $$(OUTPUTOBJ)$$@ -c $$<
+	  $$(OUTPUTOBJ)$$@ \
+	  $(if $(3),,$(call DEP_FLAGS,$$@,$(DEPDIR)/$$(@:.$(O)=.$(D)))) \
+	  -c $$<
+# This is skipped if either $(COMPUTE_DEPS) is false or $(3) is non-empty
+ifeq "$(COMPUTE_DEPS)$(3)" "true"
+# MSVC doesn't emit usable dependency information, but if GCC is available
+# then it can instead be called in order to generate the .d file.
+ifneq "$(CC)" "$(DEP_CC)"
+	$$(V_CCDEPS)$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MM -MT $$@ \
+   -MF $(DEPDIR)/$$(@:.$(O)=.$(D))
+endif # ifneq "$(CC)" "$(DEP_CC)"
+endif # ifeq "$(COMPUTE_DEPS)$(3)" "true"
 endef
 
-$(DEPDIR)/runtime:
+# The additional call expands the optional $(3) to an empty string
+COMPILE_C_FILE = \
+  $(call DO_COMPILE_C_FILE,$(1),$(2),$\
+                           $(if $(filter-out undefined,$(origin 3)),$(3)))
+
+.PRECIOUS: $(DEPDIR)/%
+$(DEPDIR)/%:
 	$(MKDIR) $@
 
 runtime_OBJECT_TYPES = % %.b %.bd %.bi %.bpic
@@ -1595,19 +1623,9 @@ runtime/%_libasmrunpic.obj: runtime/%.asm
 
 ## Runtime dependencies
 
-runtime_DEP_FILES := $(addsuffix .b, \
-  $(basename $(runtime_BYTECODE_C_SOURCES) runtime/instrtrace))
-ifeq "$(NATIVE_COMPILER)" "true"
-runtime_DEP_FILES += $(addsuffix .n, $(basename $(runtime_NATIVE_C_SOURCES)))
-endif
-runtime_DEP_FILES += $(addsuffix d, $(runtime_DEP_FILES)) \
-             $(addsuffix i, $(runtime_DEP_FILES)) \
-             $(addsuffix pic, $(runtime_DEP_FILES))
-runtime_DEP_FILES := $(addsuffix .$(D), $(runtime_DEP_FILES))
-
-ifeq "$(COMPUTE_DEPS)" "true"
-include $(addprefix $(DEPDIR)/, $(runtime_DEP_FILES))
-endif
+RUNTIME_DEP_FILES := $(wildcard $(DEPDIR)/runtime/*.$(D))
+.PHONY: $(RUNTIME_DEP_FILES)
+include $(RUNTIME_DEP_FILES)
 
 .PHONY: runtime
 runtime: stdlib/libcamlrun.$(A)
@@ -1947,19 +1965,9 @@ ocamltest_SOURCES = $(addprefix ocamltest/, \
 $(eval $(call COMPILE_C_FILE,ocamltest/%.b,ocamltest/%))
 $(eval $(call COMPILE_C_FILE,ocamltest/%.n,ocamltest/%))
 
-ifeq "$(COMPUTE_DEPS)" "true"
-include $(addprefix $(DEPDIR)/, $(ocamltest_C_FILES:.c=.$(D)))
-endif
-
-ocamltest_DEP_FILES = $(addprefix $(DEPDIR)/, $(ocamltest_C_FILES:.c=.$(D)))
-
-$(ocamltest_DEP_FILES): | $(DEPDIR)/ocamltest
-
-$(DEPDIR)/ocamltest:
-	$(MKDIR) $@
-
-$(ocamltest_DEP_FILES): $(DEPDIR)/ocamltest/%.$(D): ocamltest/%.c
-	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
+ocamltest_DEPEND_FILES := $(wildcard $(DEPDIR)/ocamltest/*.$(D))
+.PHONY: $(ocamltest_DEPEND_FILES)
+include $(ocamltest_DEPEND_FILES)
 
 ocamltest/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 
@@ -2037,6 +2045,11 @@ testsuite/tools/test_in_prefi%: CAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 
 testsuite/tools/poisonedruntime$(EXE): testsuite/tools/poisonedruntime.$(O)
 	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
+
+$(eval $(call COMPILE_C_FILE,\
+  testsuite/tools/main_in_c,testsuite/tools/main_in_c,no-deps))
+$(eval $(call COMPILE_C_FILE,\
+  testsuite/tools/poisonedruntime,testsuite/tools/poisonedruntime,no-deps))
 
 ocamltest_BYTECODE_LINKFLAGS = -custom -g
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -72,7 +72,12 @@ OPTIONAL_NATIVE_TOOLS = @optional_native_tools@
 INSTALL_OCAMLNAT = @install_ocamlnat@
 
 # The command to generate C dependency information
-DEP_CC=@DEP_CC@ -MM
+DEP_CC=@DEP_CC@
+ifeq "@compute_deps@-$(CC)" "true-$(DEP_CC)"
+DEP_FLAGS = -MMD -MT $(1) -MF $(2)
+else
+DEP_FLAGS =
+endif
 COMPUTE_DEPS=@compute_deps@
 
 BUILD_PATH_LOGICAL = @srcdir_abs@

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -74,7 +74,7 @@ INSTALL_OCAMLNAT = @install_ocamlnat@
 # The command to generate C dependency information
 DEP_CC=@DEP_CC@
 ifeq "@compute_deps@-$(CC)" "true-$(DEP_CC)"
-DEP_FLAGS = -MMD -MT $(1) -MF $(2)
+DEP_FLAGS = $(addprefix @DEP_CC_PREFIX@,-MMD -MT $(1) -MF $(2))
 else
 DEP_FLAGS =
 endif

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -73,6 +73,7 @@ INSTALL_OCAMLNAT = @install_ocamlnat@
 
 # The command to generate C dependency information
 DEP_CC=@DEP_CC@
+DEP_CPPFLAGS=@DEP_CPPFLAGS@
 ifeq "@compute_deps@-$(CC)" "true-$(DEP_CC)"
 DEP_FLAGS = $(addprefix @DEP_CC_PREFIX@,-MMD -MT $(1) -MF $(2))
 else

--- a/Makefile.common
+++ b/Makefile.common
@@ -537,9 +537,10 @@ OC_COMMON_LINKFLAGS += \
 
 # The rule to compile C files
 
-# This rule is similar to GNU make's implicit rule, except that it is more
-# general (it supports both .o and .obj)
+# Cancel GNU Make's implicit C compilation rule
+%.o: %.c
 
+# These are still here as they are shared with otherlibs/
 ifeq "$(COMPUTE_DEPS)" "true"
 RUNTIME_HEADERS :=
 REQUIRED_HEADERS :=
@@ -548,10 +549,6 @@ RUNTIME_HEADERS := $(wildcard $(ROOTDIR)/runtime/caml/*.tbl) \
                    $(wildcard $(ROOTDIR)/runtime/caml/*.h)
 REQUIRED_HEADERS := $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
-
-%.$(O): %.c $(REQUIRED_HEADERS)
-	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ -c $<
 
 $(DEPDIR):
 	$(MKDIR) $@

--- a/configure
+++ b/configure
@@ -739,9 +739,8 @@ ac_ct_CC_FOR_BUILD
 CC_FOR_BUILD
 flexlink
 ac_ct_RC
-CPP
 ac_ct_DEP_CC
-DEP_CC
+CPP
 LT_SYS_LIBRARY_PATH
 OTOOL64
 OTOOL
@@ -951,6 +950,8 @@ DIFF_FLAGS
 encode_C_literal
 SAK
 SAK_BUILD
+DEP_CC_PREFIX
+DEP_CC
 ocaml_cc_vendor
 CC
 LINEAR_MAGIC_NUMBER
@@ -3463,6 +3464,8 @@ CMXS_MAGIC_NUMBER=Caml1999D037
 CMT_MAGIC_NUMBER=Caml1999T037
 
 LINEAR_MAGIC_NUMBER=Caml1999L037
+
+
 
 
 
@@ -14817,174 +14820,6 @@ printf "%s\n" "$as_me: WARNING: found inconsistent results for .size and .type d
 esac
 
 
-case $host in #(
-  sparc-sun-solaris*) :
-    DEP_CC="false" ;; #(
-  *-pc-windows) :
-    if test -n "$ac_tool_prefix"; then
-  for ac_prog in $DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc
-  do
-    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
-set dummy $ac_tool_prefix$ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_DEP_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$DEP_CC"; then
-  ac_cv_prog_DEP_CC="$DEP_CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_DEP_CC="$ac_tool_prefix$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-DEP_CC=$ac_cv_prog_DEP_CC
-if test -n "$DEP_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DEP_CC" >&5
-printf "%s\n" "$DEP_CC" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-
-
-    test -n "$DEP_CC" && break
-  done
-fi
-if test -z "$DEP_CC"; then
-  ac_ct_DEP_CC=$DEP_CC
-  for ac_prog in $DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_DEP_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$ac_ct_DEP_CC"; then
-  ac_cv_prog_ac_ct_DEP_CC="$ac_ct_DEP_CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_ac_ct_DEP_CC="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-ac_ct_DEP_CC=$ac_cv_prog_ac_ct_DEP_CC
-if test -n "$ac_ct_DEP_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DEP_CC" >&5
-printf "%s\n" "$ac_ct_DEP_CC" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-
-
-  test -n "$ac_ct_DEP_CC" && break
-done
-
-  if test "x$ac_ct_DEP_CC" = x; then
-    DEP_CC="false"
-  else
-    case $cross_compiling:$ac_tool_warned in
-yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
-ac_tool_warned=yes ;;
-esac
-    DEP_CC=$ac_ct_DEP_CC
-  fi
-fi
- ;; #(
-  *) :
-    DEP_CC="$CC" ;;
-esac
-
-case $enable_dependency_generation in #(
-  yes) :
-    if test "$DEP_CC" = "false"
-then :
-  as_fn_error $? "The MSVC ports cannot generate dependency information. Install gcc (or another CC-like compiler)" "$LINENO" 5
-else $as_nop
-  compute_deps=true
-fi ;; #(
-  no) :
-    compute_deps=false ;; #(
-  *) :
-    if test -e .git
-then :
-  if test "$DEP_CC" = "false"
-then :
-  compute_deps=false
-else $as_nop
-  compute_deps=true
-fi
-else $as_nop
-  compute_deps=false
-fi ;;
-esac
-
-case $target in #(
-  # In config/Makefile.mingw*, we had:
-  # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
-  # TOOLPREF=$(TARGET)-
-  # ARCMD=$(TOOLPREF)ar
-  # However autoconf and libtool seem to use ar
-  # So we let them do, at the moment
-  *-pc-windows) :
-
-      mkexe_via_cc_extra_cmd=' && $(call MERGEMANIFESTEXE,$(1))'
-      libext=lib
-      AR=""
-      if test "$target_cpu" = "x86_64"
-then :
-  machine="-machine:AMD64 "
-else $as_nop
-  machine=""
-fi
-      mklib="link -lib -nologo $machine /out:\$(1) \$(2)"
-     ;; #(
-  *) :
-
-    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
-   ;;
-esac
-
 ## Find vendor of the C compiler
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -15178,6 +15013,181 @@ rm -f conftest.err conftest.i conftest.$ac_ext
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cc_vendor" >&5
 printf "%s\n" "$ocaml_cc_vendor" >&6; }
 
+
+DEP_CC_PREFIX=''
+case $host in #(
+  sparc-sun-solaris*) :
+    DEP_CC="false" ;; #(
+  *-pc-windows) :
+    case $ocaml_cc_vendor in #(
+  msvc-*-clang-*) :
+    DEP_CC="$CC"
+      DEP_CC_PREFIX='/clang:' ;; #(
+  *) :
+    if test -n "$ac_tool_prefix"; then
+  for ac_prog in $DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_DEP_CC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$DEP_CC"; then
+  ac_cv_prog_DEP_CC="$DEP_CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_DEP_CC="$ac_tool_prefix$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+DEP_CC=$ac_cv_prog_DEP_CC
+if test -n "$DEP_CC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DEP_CC" >&5
+printf "%s\n" "$DEP_CC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+    test -n "$DEP_CC" && break
+  done
+fi
+if test -z "$DEP_CC"; then
+  ac_ct_DEP_CC=$DEP_CC
+  for ac_prog in $DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_ac_ct_DEP_CC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$ac_ct_DEP_CC"; then
+  ac_cv_prog_ac_ct_DEP_CC="$ac_ct_DEP_CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_DEP_CC="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_DEP_CC=$ac_cv_prog_ac_ct_DEP_CC
+if test -n "$ac_ct_DEP_CC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DEP_CC" >&5
+printf "%s\n" "$ac_ct_DEP_CC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_DEP_CC" && break
+done
+
+  if test "x$ac_ct_DEP_CC" = x; then
+    DEP_CC="false"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    DEP_CC=$ac_ct_DEP_CC
+  fi
+fi
+ ;;
+esac ;; #(
+  *) :
+    DEP_CC="$CC" ;;
+esac
+
+case $enable_dependency_generation in #(
+  yes) :
+    if test "$DEP_CC" = "false"
+then :
+  as_fn_error $? "The MSVC ports cannot generate dependency information. Install gcc (or another CC-like compiler)" "$LINENO" 5
+else $as_nop
+  compute_deps=true
+fi ;; #(
+  no) :
+    compute_deps=false ;; #(
+  *) :
+    if test -e .git
+then :
+  if test "$DEP_CC" = "false"
+then :
+  compute_deps=false
+else $as_nop
+  compute_deps=true
+fi
+else $as_nop
+  compute_deps=false
+fi ;;
+esac
+
+case $target in #(
+  # In config/Makefile.mingw*, we had:
+  # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
+  # TOOLPREF=$(TARGET)-
+  # ARCMD=$(TOOLPREF)ar
+  # However autoconf and libtool seem to use ar
+  # So we let them do, at the moment
+  *-pc-windows) :
+
+      mkexe_via_cc_extra_cmd=' && $(call MERGEMANIFESTEXE,$(1))'
+      libext=lib
+      AR=""
+      if test "$target_cpu" = "x86_64"
+then :
+  machine="-machine:AMD64 "
+else $as_nop
+  machine=""
+fi
+      mklib="link -lib -nologo $machine /out:\$(1) \$(2)"
+     ;; #(
+  *) :
+
+    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
+   ;;
+esac
 
 ## In cross-compilation mode, can we run executables produced?
 # At the moment, it's required, but the fact is used in C99 function detection

--- a/configure
+++ b/configure
@@ -951,6 +951,7 @@ encode_C_literal
 SAK
 SAK_BUILD
 DEP_CC_PREFIX
+DEP_CPPFLAGS
 DEP_CC
 ocaml_cc_vendor
 CC
@@ -3464,6 +3465,7 @@ CMXS_MAGIC_NUMBER=Caml1999D037
 CMT_MAGIC_NUMBER=Caml1999T037
 
 LINEAR_MAGIC_NUMBER=Caml1999L037
+
 
 
 
@@ -15025,7 +15027,7 @@ case $host in #(
       DEP_CC_PREFIX='/clang:' ;; #(
   *) :
     if test -n "$ac_tool_prefix"; then
-  for ac_prog in $DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc
+  for ac_prog in $DEP_CC x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc gcc cc
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
@@ -15074,7 +15076,7 @@ fi
 fi
 if test -z "$DEP_CC"; then
   ac_ct_DEP_CC=$DEP_CC
-  for ac_prog in $DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc
+  for ac_prog in $DEP_CC x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc gcc cc
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
@@ -15133,7 +15135,10 @@ esac
     DEP_CC=$ac_ct_DEP_CC
   fi
 fi
- ;;
+
+        # The C compiler may not be targetting Windows, so explicitly include
+        # the _WIN32 define
+        DEP_CPPFLAGS=-D_WIN32 ;;
 esac ;; #(
   *) :
     DEP_CC="$CC" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,8 @@ AC_SUBST([CMT_MAGIC_NUMBER], [CMT__MAGIC_NUMBER])
 AC_SUBST([LINEAR_MAGIC_NUMBER], [LINEAR__MAGIC_NUMBER])
 AC_SUBST([CC])
 AC_SUBST([ocaml_cc_vendor])
+AC_SUBST([DEP_CC])
+AC_SUBST([DEP_CC_PREFIX])
 AC_SUBST([SAK_BUILD])
 AC_SUBST([SAK])
 AC_SUBST([encode_C_literal])
@@ -839,14 +841,22 @@ popdef([host])dnl
 OCAML_WITH_NONEXECSTACK_NOTE
 OCAML_ASM_SIZE_TYPE_DIRECTIVES
 
+## Find vendor of the C compiler
+OCAML_CC_VENDOR
+
+DEP_CC_PREFIX=''
 AS_CASE([$host],
   [sparc-sun-solaris*],
     [DEP_CC="false"],
   [*-pc-windows],
-    [AC_CHECK_TOOLS(
-      [DEP_CC],
-      [$DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc],
-      [false])],
+    [AS_CASE([$ocaml_cc_vendor],
+      [msvc-*-clang-*],
+      [DEP_CC="$CC"
+      DEP_CC_PREFIX='/clang:'],
+      [AC_CHECK_TOOLS(
+        [DEP_CC],
+        [$DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc],
+        [false])])],
   [DEP_CC="$CC"])
 
 AS_CASE([$enable_dependency_generation],
@@ -882,9 +892,6 @@ AS_CASE([$target],
   [
     mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
   ])
-
-## Find vendor of the C compiler
-OCAML_CC_VENDOR
 
 ## In cross-compilation mode, can we run executables produced?
 # At the moment, it's required, but the fact is used in C99 function detection

--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ AC_SUBST([LINEAR_MAGIC_NUMBER], [LINEAR__MAGIC_NUMBER])
 AC_SUBST([CC])
 AC_SUBST([ocaml_cc_vendor])
 AC_SUBST([DEP_CC])
+AC_SUBST([DEP_CPPFLAGS])
 AC_SUBST([DEP_CC_PREFIX])
 AC_SUBST([SAK_BUILD])
 AC_SUBST([SAK])
@@ -855,8 +856,11 @@ AS_CASE([$host],
       DEP_CC_PREFIX='/clang:'],
       [AC_CHECK_TOOLS(
         [DEP_CC],
-        [$DEP_CC gcc cc x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc],
-        [false])])],
+        [$DEP_CC x86_64-w64-mingw32-gcc i686-w64-mingw32-gcc gcc cc],
+        [false])
+        # The C compiler may not be targetting Windows, so explicitly include
+        # the _WIN32 define
+        DEP_CPPFLAGS=-D_WIN32])],
   [DEP_CC="$CC"])
 
 AS_CASE([$enable_dependency_generation],

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -166,27 +166,43 @@ distclean:: clean
 %.cmx: %.ml
 	$(V_OCAMLOPT)$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
+ifeq "$(COMPUTE_DEPS)" "true"
+%.b.$(O): %.c $(REQUIRED_HEADERS) | $(DEPDIR)
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ $(call DEP_FLAGS,$@,$(DEPDIR)/$(@:.$(O)=.$(D))) -c $<
+# MSVC doesn't emit usable dependency information, but if GCC is available
+# then it can instead be called in order to generate the .d file.
+ifneq "$(CC)" "$(DEP_CC)"
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MM -MT $@ \
+   -MF $(DEPDIR)/$(@:.$(O)=.$(D))
+endif # ifneq "$(CC)" "$(DEP_CC)"
+
+%.n.$(O): %.c $(REQUIRED_HEADERS) | $(DEPDIR)
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) \
+	  $(OC_CPPFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ \
+	  $(call DEP_FLAGS,$@,$(DEPDIR)/$(@:.$(O)=.$(D))) -c $<
+# MSVC doesn't emit usable dependency information, but if GCC is available
+# then it can instead be called in order to generate the .d file.
+ifneq "$(CC)" "$(DEP_CC)"
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MM -MT $@ \
+   -MF $(DEPDIR)/$(@:.$(O)=.$(D))
+endif # ifneq "$(CC)" "$(DEP_CC)"
+else
 %.b.$(O): %.c $(REQUIRED_HEADERS)
 	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ -c $<
 
-%.n.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
-
 %.n.$(O): %.c $(REQUIRED_HEADERS)
 	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) \
 	  $(OC_CPPFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ -c $<
+endif # ifeq "$(COMPUTE_DEPS)" "true"
+
+%.n.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
 
 ifeq "$(COMPUTE_DEPS)" "true"
 ifneq "$(COBJS_BYTECODE)" ""
-include $(addprefix $(DEPDIR)/, $(COBJS_BYTECODE:.$(O)=.$(D)))
-ifeq "$(NATIVE_COMPILER)" "true"
-include $(addprefix $(DEPDIR)/, $(COBJS_NATIVE:.$(O)=.$(D)))
+GENERATED_DEPEND_FILES := $(wildcard $(DEPDIR)/*.$(D))
+.PHONY: $(GENERATED_DEPEND_FILES)
+include $(GENERATED_DEPEND_FILES)
 endif
 endif
-endif
-
-$(DEPDIR)/%.b.$(D): %.c | $(DEPDIR)
-	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.b.$(O)' -MF $@
-
-$(DEPDIR)/%.n.$(D): %.c | $(DEPDIR)
-	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.n.$(O)' -MF $@

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -173,8 +173,8 @@ ifeq "$(COMPUTE_DEPS)" "true"
 # MSVC doesn't emit usable dependency information, but if GCC is available
 # then it can instead be called in order to generate the .d file.
 ifneq "$(CC)" "$(DEP_CC)"
-	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MM -MT $@ \
-   -MF $(DEPDIR)/$(@:.$(O)=.$(D))
+	$(V_CCDEPS)$(DEP_CC) $(DEP_CPPFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) $< \
+   -MM -MT $@ -MF $(DEPDIR)/$(@:.$(O)=.$(D))
 endif # ifneq "$(CC)" "$(DEP_CC)"
 
 %.n.$(O): %.c $(REQUIRED_HEADERS) | $(DEPDIR)

--- a/otherlibs/runtime_events/Makefile
+++ b/otherlibs/runtime_events/Makefile
@@ -29,4 +29,5 @@ runtime_events.cmx: runtime_events.cmi
 depend:
 	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
+.PHONY: .depend
 include .depend

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -28,4 +28,5 @@ str.cmx: str.cmi
 depend:
 	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
+.PHONY: .depend
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -154,4 +154,5 @@ $(foreach object_type, b n, $(eval $(call GEN_RULE,$(object_type))))
 depend:
 	$(V_GEN)$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
+.PHONY: .depend
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -84,12 +84,20 @@ $(LIBNAME).cmxa: $(THREADS_NCOBJS)
 # twice, each time with different options).
 
 ifeq "$(COMPUTE_DEPS)" "true"
-st_stubs.%.$(O): st_stubs.c
+st_stubs.%.$(O): st_stubs.c | $(DEPDIR)
 else
 st_stubs.%.$(O): st_stubs.c $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
 	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ -c $<
+	  $(OUTPUTOBJ)$@ $(call DEP_FLAGS,$@,$(DEPDIR)/$(@:.$(O)=.$(D))) -c $<
+ifeq "$(COMPUTE_DEPS)" "true"
+# MSVC doesn't emit usable dependency information, but if GCC is available
+# then it can instead be called in order to generate the .d file.
+ifneq "$(CC)" "$(DEP_CC)"
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MM -MT $@ \
+   -MF $(DEPDIR)/$(@:.$(O)=.$(D))
+endif # ifneq "$(CC)" "$(DEP_CC)"
+endif # ifeq "$(COMPUTE_DEPS)" "true"
 
 .PHONY: partialclean
 partialclean:
@@ -130,25 +138,15 @@ installopt:
 %.cmx: %.ml
 	$(V_OCAMLOPT)$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
-DEP_FILES := st_stubs.b.$(D)
-ifeq "$(NATIVE_COMPILER)" "true"
-DEP_FILES += st_stubs.n.$(D)
-endif
-
 ifeq "$(COMPUTE_DEPS)" "true"
-include $(addprefix $(DEPDIR)/, $(DEP_FILES))
+GENERATED_DEPEND_FILES := $(wildcard $(DEPDIR)/*.$(D))
+.PHONY: $(GENERATED_DEPEND_FILES)
+include $(GENERATED_DEPEND_FILES)
 endif
 
 %.b.$(D): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
 %.n.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
 %.n.$(D): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
-
-define GEN_RULE
-$(DEPDIR)/%.$(1).$(D): %.c | $(DEPDIR)
-	$$(V_CCDEPS)$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MT '$$*.$(1).$(O)' -MF $$@
-endef
-
-$(foreach object_type, b n, $(eval $(call GEN_RULE,$(object_type))))
 
 .PHONY: depend
 depend:

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -94,8 +94,8 @@ ifeq "$(COMPUTE_DEPS)" "true"
 # MSVC doesn't emit usable dependency information, but if GCC is available
 # then it can instead be called in order to generate the .d file.
 ifneq "$(CC)" "$(DEP_CC)"
-	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MM -MT $@ \
-   -MF $(DEPDIR)/$(@:.$(O)=.$(D))
+	$(V_CCDEPS)$(DEP_CC) $(DEP_CPPFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) $< \
+   -MM -MT $@ -MF $(DEPDIR)/$(@:.$(O)=.$(D))
 endif # ifneq "$(CC)" "$(DEP_CC)"
 endif # ifeq "$(COMPUTE_DEPS)" "true"
 

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -84,4 +84,5 @@ distclean::
 depend:
 	$(OCAMLDEP_CMD) *.mli *.ml > .depend
 
+.PHONY: .depend
 include .depend

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -22,6 +22,10 @@ OCAMLDEP ?= $(BOOT_OCAMLDEP)
 
 include $(ROOTDIR)/Makefile.common
 
+%.$(O): %.c $(REQUIRED_HEADERS)
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
+
 # There are three ways the Standard Library is compiled in bytecode:
 # 1. During coldstart
 #      - using ../boot/ocamlc which runs on ../boot/ocamlrun

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -184,6 +184,7 @@ $(OTHERS:.cmo=.cmx) std_exit.cmx: stdlib.cmx
 clean::
 	rm -f *.cm* *.o *.obj *.a *.lib *.odoc
 
+.PHONY: .depend
 include .depend
 
 STDLIB_NAMESPACE_MODULES = $(subst $(SPACE),|,$(STDLIB_PREFIXED_MODULES))

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -61,7 +61,6 @@ EOF
                  --enable-flambda-invariants \
                  --enable-ocamltest \
                  --enable-native-toplevel \
-                 --disable-dependency-generation \
                  -C $CONFIG_ARG
 }
 
@@ -300,8 +299,7 @@ BasicCompiler () {
   local failed
   trap ReportBuildStatus ERR
 
-  call-configure --disable-dependency-generation \
-                 --disable-debug-runtime \
+  call-configure --disable-debug-runtime \
                  --disable-instrumented-runtime \
                  --enable-ocamltest \
 

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -77,18 +77,16 @@ function set_configuration {
 
   case "$1" in
     cygwin*)
-      args+=('--disable-dependency-generation' '--enable-native-toplevel');;
+      args+=('--enable-native-toplevel');;
     mingw32)
-      args+=('--host=i686-w64-mingw32' '--disable-dependency-generation');;
+      args+=('--host=i686-w64-mingw32');;
     mingw64)
-      args+=('--host=x86_64-w64-mingw32' '--disable-dependency-generation' \
-             '--disable-stdlib-manpages' '--enable-native-toplevel');;
-    msvc32)
-      args+=('--host=i686-pc-windows' '--disable-dependency-generation');;
-    msvc64)
-      # Explicitly test dependency generation on msvc64
-      args+=('--host=x86_64-pc-windows' '--enable-dependency-generation' \
+      args+=('--host=x86_64-w64-mingw32' '--disable-stdlib-manpages' \
              '--enable-native-toplevel');;
+    msvc32)
+      args+=('--host=i686-pc-windows');;
+    msvc64)
+      args+=('--host=x86_64-pc-windows' '--enable-native-toplevel');;
   esac
   if [[ $RELOCATABLE = 'true' ]]; then
     args+=('--with-relative-libdir' \

--- a/tools/ci/inria/light
+++ b/tools/ci/inria/light
@@ -83,7 +83,6 @@ git clean -q -f -d -x
    --disable-shared \
    --disable-debug-runtime \
    --disable-instrumented-runtime \
-   --disable-dependency-generation \
    --disable-ocamldoc \
    --disable-stdlib-manpages
 

--- a/tools/ci/inria/step-by-step-build/script
+++ b/tools/ci/inria/step-by-step-build/script
@@ -23,7 +23,7 @@ instdir="$HOME/ocaml-tmp-install-$$"
 # Make sure the repository is clean
 git clean -q -f -d -x
 
-./configure --prefix "$instdir" --disable-dependency-generation
+./configure --prefix "$instdir"
 make $jobs world
 make $jobs opt
 make $jobs opt.opt


### PR DESCRIPTION
In #9332 (in OCaml 4.12), I removed the C dependency information from our `.depend` files. This was based on what an LLM would now describe as the key insight that, unlike OCaml object files, if a C file has not yet been compiled, then one can simply compile it immediately; dependency information is only needed to determine whether to _recompile_.

The approach taken today is to generate C dependency information on-the-fly as part of the build - with some shenanigans necessary to cope with MSVC, which can't (easily) generate dependency information in a format suitable for GNU make to consume. That means that prior to compiling anything, we call the C compiler many times to generate dependency graph information. This process is repeated when working on the runtime C sources as well.

Sadly this approach misses another key insight which this PR (an early Christmas present for @MisterDA), finally attempts to remedy. At the moment, when the system starts up, _a lot_ of dependency files are generated. Especially on Windows, either forgetting to build with `make -j` or forgetting to configure with `--disable-dependency-generation` can lose a lot of compilation time. This is not a huge concern for the opam packaging, because we disable dependency generation on our release builds, but it turns out that both GCC and Clang are able to emit the required dependency information _as part of compiling the C file_.

This PR performs the necessary dances to use this facility. There is some code duplication in otherlibs still necessary which will of course disappear when those Makefiles are merged into the root Makefile. A nice side-effect of this work is that it's no longer necessary to have all the various defensive `--disable-dependency-generation` in CI, because generating these files as a side-effect of primary compilation is not significant. The configure option remains, because MSVC still doesn't get rich dependency information - although when building with clang-cl, it's possible to pass some cheeky clang-specific options which _do_ generate the dependency information!