### PR TITLE
Unify returns result rather than raising an exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -460,6 +460,10 @@ Working version
 * #14388: Remove support for `let rec (module M : S) = e1 in e2`.
   (Alistair O'Brien, review by Vincent Laviron and Gabriel Scherer)
 
+- #14422: Refactoring an `if match e with p1 -> true | p2 -> false then ...`
+  into a match in typetexp.
+  (Samuel Vivien, review by Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/Changes
+++ b/Changes
@@ -373,6 +373,10 @@ Working version
 - #14413: Introduce and use the C2y countof operator.
   (Antonin Décimo, review by David Allsopp)
 
+- #14425: Use result rather than exception for multiple unification functions.
+  (Samuel Vivien, review by Jacques Garrigue, Gabriel Scherer and
+   Alistair O'Brien)
+
 - #14483: Reset type ID and level counters between compilations to restore
   reproducibility of debug information between `ocamlc -c foo.mli foo.ml` versus
   `ocamlc -c foo.mli; ocamlc -c foo.ml`. Also hashcons the identifiers used for

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -62,15 +62,18 @@ let match_simple_printer_type env ty ~is_old_style =
   in
   match
     Ctype.with_local_level_generalize begin fun () ->
+      let open Result.Syntax in
       let ty_arg = Ctype.newvar() in
-      Ctype.unify env
-        (make_printer_type ty_arg)
-        (Ctype.instance ty);
+      let+ () =
+        Ctype.unify env
+          (make_printer_type ty_arg)
+          (Ctype.instance ty)
+      in
       ty_arg
     end
   with
-  | exception Ctype.Unify _ -> None
-  | ty_arg ->
+  | Error _ -> None
+  | Ok ty_arg ->
       if is_old_style
       then Some (Old ty_arg)
       else Some (Simple ty_arg)
@@ -120,14 +123,16 @@ let match_generic_printer_type env ty =
           let ty_expected =
             List.fold_right type_arrow
               printer_args_ty (printer_type_new ty_target) in
-          Ctype.unify env
-            ty_expected
-            (Ctype.instance ty);
-          args
+          let unify_res =
+            Ctype.unify env
+              ty_expected
+              (Ctype.instance ty)
+          in
+          unify_res, args
         end
       with
-      | exception Ctype.Unify _ -> None
-      | args ->
+      | Error _, _ -> None
+      | Ok (), args ->
           if Ctype.all_distinct_vars env args
           then
             Some (Generic { ty_path; arity = List.length params; })

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -25,6 +25,7 @@ open Errortrace
 open Local_store
 
 module List = Misc.Stdlib.List
+module Result = Misc.Stdlib.Result
 
 module Path = struct
   include Path
@@ -1920,10 +1921,10 @@ let subst ~env ~level ?scope ~priv ~abbrev ?oty ~params ~args body =
     let (params', body') = instance_parameterized_type ?scope params body in
     abbreviations := ref Mnil;
     let uenv = Expression {env; in_subst = true} in
-    try
-      !unify_var' ~check_occur:true uenv body0 body';
+    match
+      Result.bind (!unify_var' ~check_occur:true uenv body0 body') @@ fun () ->
       let _, first_gen_vars, others =
-        Misc.Stdlib.List.fold_left3
+        List.fold_left3
           (fun (previous_gen, first_gen, others) p p' a ->
              match get_desc p with
              | Tvar _ when get_level p = generic_level
@@ -1943,12 +1944,15 @@ let subst ~env ~level ?scope ~priv ~abbrev ?oty ~params ~args body =
          or non-variables cannot avoid the check, since we're not able to show
          they cannot occur.
       *)
-      Misc.Stdlib.List.rev_iter
-        (fun (p,a) -> !unify_var' uenv ~check_occur:false p a) first_gen_vars;
-      Misc.Stdlib.List.rev_iter
-        (fun (p,a) -> !unify_var' uenv ~check_occur:true p a) others;
-      body'
-    with Unify _ ->
+      Result.bind
+        (List.rev_iter_result
+          (fun (p,a) -> !unify_var' uenv ~check_occur:false p a) first_gen_vars)
+        (fun () ->
+          List.rev_iter_result
+            (fun (p,a) -> !unify_var' uenv ~check_occur:true p a) others)
+    with
+    | Ok () -> body'
+    | Error _ ->
       undo_abbrev ();
       raise Cannot_subst
   end
@@ -3971,12 +3975,13 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
 
 let unify uenv ty1 ty2 =
   let snap = Btype.snapshot () in
-  try
+  match
     unify uenv ty1 ty2
   with
-    Unify_trace trace ->
+  | () -> Ok ()
+  | exception Unify_trace trace ->
       undo_compress snap;
-      raise (Unify (expand_to_unification_error (get_env uenv) trace))
+      Error (expand_to_unification_error (get_env uenv) trace)
 
 let unify_gadt (penv : Pattern_env.t) ~pat:ty1 ~expected:ty2 =
   let equated_types = TypePairs.create 0 in
@@ -3987,24 +3992,24 @@ let unify_gadt (penv : Pattern_env.t) ~pat:ty1 ~expected:ty2 =
           assume_injective = true;
           unify_eq_set = TypePairs.create 11; }
     in
-    unify uenv ty1 ty2;
-    equated_types
+    Result.map (fun () -> equated_types) (unify uenv ty1 ty2)
   in
   let no_leak = penv.in_counterexample || closed_type_expr ty2 in
   if no_leak then with_univar_pairs [] do_unify_gadt else
   let snap = Btype.snapshot () in
-  try
+  match
     (* If there are free variables, first try normal unification *)
     let uenv = Expression {env = penv.env; in_subst = false} in
-    with_univar_pairs [] (fun () -> unify uenv ty1 ty2);
-    equated_types
-  with Unify _ ->
+    with_univar_pairs [] (fun () -> unify uenv ty1 ty2)
+  with
+  | Ok () -> Ok equated_types
+  | Error _ ->
     (* If it fails, retry in pattern mode *)
     Btype.backtrack snap;
     with_univar_pairs [] do_unify_gadt
 
 let unify_var ~check_occur uenv t1 t2 =
-  if eq_type t1 t2 then () else
+  if eq_type t1 t2 then Ok () else
   match get_desc t1, get_desc t2 with
     Tvar _, Tconstr _ when check_occur && deep_occur t1 t2 ->
       unify uenv t1 t2
@@ -4017,11 +4022,12 @@ let unify_var ~check_occur uenv t1 t2 =
         update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2;
         reset_trace_gadt_instances reset_tracing;
+        Ok ()
       with Unify_trace trace ->
         reset_trace_gadt_instances reset_tracing;
-        raise (Unify (expand_to_unification_error
+        Error (expand_to_unification_error
                         env
-                        (Diff { got = t1; expected = t2 } :: trace)))
+                        (Diff { got = t1; expected = t2 } :: trace))
       end
   | _ ->
       unify uenv t1 t2
@@ -4032,20 +4038,28 @@ let _ = unify_var' := unify_var
 let unify_var env ty1 ty2 =
   unify_var ~check_occur:true (Expression {env; in_subst = false}) ty1 ty2
 
+let unify_var_exn env ty1 ty2 =
+  match unify_var env ty1 ty2 with
+  | Ok () -> ()
+  | Error err -> raise (Unify err)
+
 let unify_pairs env ty1 ty2 pairs =
   with_univar_pairs pairs (fun () ->
     unify (Expression {env; in_subst = false}) ty1 ty2)
 
-let unify_exn env ty1 ty2 =
+let unify env ty1 ty2 =
   unify_pairs env ty1 ty2 []
 
-let unify env ty1 ty2 =
-  match unify_exn env ty1 ty2 with
-  | () -> Ok ()
-  | exception Unify trace -> Error trace
+let unify_exn env ty1 ty2 =
+  match unify env ty1 ty2 with
+  | Ok () -> ()
+  | Error trace -> raise (Unify trace)
 
 (* Lower the level of a type to the current level *)
-let enforce_current_level env ty = unify_var env (newvar ()) ty
+let enforce_current_level env ty =
+  match unify_var env (newvar ()) ty with
+  | Ok () -> ()
+  | Error err -> raise (Unify err)
 
 
 (**** Special cases of unification ****)
@@ -5758,7 +5772,7 @@ let rec build_subtype env (visited : transient_expr list)
           let nm =
             if c > Equiv || deep_occur ty ty1' then None else Some(p,tl1) in
           set_type_desc t'' (Tobject (ty1', ref nm));
-          (try unify_var env ty t with Unify _ -> assert false);
+          assert (Result.is_ok (unify_var env ty t));
           ( t'', Changed)
       | _ -> raise Not_found
       with Not_found ->
@@ -6212,11 +6226,12 @@ let subtype env ty1 ty2 =
     function () ->
       List.iter
         (function (env, trace0, t1, t2, pairs) ->
-           try unify_pairs env t1 t2 pairs with Unify {trace} ->
-           subtype_error
-             ~env
-             ~trace:trace0
-             ~unification_trace:(List.tl trace))
+           Result.ok_or_else (unify_pairs env t1 t2 pairs)
+             (fun ({trace} : Errortrace.unification_error) ->
+               subtype_error
+                 ~env
+                 ~trace:trace0
+                 ~unification_trace:(List.tl trace)))
         (List.rev constraints))
 
                               (*******************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -24,6 +24,8 @@ open Errortrace
 
 open Local_store
 
+module List = Misc.Stdlib.List
+
 module Path = struct
   include Path
 
@@ -4034,8 +4036,13 @@ let unify_pairs env ty1 ty2 pairs =
   with_univar_pairs pairs (fun () ->
     unify (Expression {env; in_subst = false}) ty1 ty2)
 
-let unify env ty1 ty2 =
+let unify_exn env ty1 ty2 =
   unify_pairs env ty1 ty2 []
+
+let unify env ty1 ty2 =
+  match unify_exn env ty1 ty2 with
+  | () -> Ok ()
+  | exception Unify trace -> Error trace
 
 (* Lower the level of a type to the current level *)
 let enforce_current_level env ty = unify_var env (newvar ()) ty
@@ -4202,10 +4209,7 @@ let filter_arity env t l =
 let is_really_poly env ty =
   let snap = Btype.snapshot () in
   let really_poly =
-    try
-      unify env (newmono (newvar ())) ty;
-      false
-    with Unify _ -> true
+    Result.is_error (unify env (newmono (newvar ())) ty)
   in
   Btype.backtrack snap;
   really_poly
@@ -4339,7 +4343,7 @@ let add_dummy_method env ~scope sign =
   let kind, ty, row =
     filter_method_row env dummy_method Private sign.csig_self_row
   in
-  unify env ty (new_scoped_ty scope (Ttuple []));
+  unify_exn env ty (new_scoped_ty scope (Ttuple []));
   sign.csig_dummy_method <- kind;
   sign.csig_self_row <- row
 
@@ -4378,8 +4382,8 @@ let add_method env label priv virt ty sign =
           | Virtual -> virt
         in
         match unify env ty ty' with
-        | () -> priv, virt
-        | exception Unify trace ->
+        | Ok () -> priv, virt
+        | Error trace ->
             raise (Add_method_failed (Type_mismatch trace))
       end
     | exception Not_found -> begin
@@ -4396,10 +4400,10 @@ let add_method env label priv virt ty sign =
               raise (Add_method_failed Unexpected_method)
         in
         match unify env ty ty' with
-        | () ->
+        | Ok () ->
             sign.csig_self_row <- row;
             priv, virt
-        | exception Unify trace ->
+        | Error trace ->
             raise (Add_method_failed (Type_mismatch trace))
       end
   in
@@ -4432,8 +4436,8 @@ let add_instance_variable ~strict env label mut virt ty sign =
         if strict then begin
           check_mutability mut mut';
           match unify env ty ty' with
-          | () -> ()
-          | exception Unify trace ->
+          | Ok () -> ()
+          | Error trace ->
               raise (Add_instance_variable_failed (Type_mismatch trace))
         end;
         virt
@@ -4453,8 +4457,8 @@ let unify_self_types env sign1 sign2 =
   let self_type1 = sign1.csig_self in
   let self_type2 = sign2.csig_self in
   match unify env self_type1 self_type2 with
-  | () -> ()
-  | exception Unify err -> begin
+  | Ok () -> ()
+  | Error err -> begin
       match err.trace with
       | Errortrace.Diff _ :: Errortrace.Incompatible_fields {name; _} :: rem ->
           let err = Errortrace.unification_error ~trace:rem in
@@ -4554,7 +4558,7 @@ let reveal_private_methods env sign =
              let kind, ty', row =
                filter_method_row env lab Private row
              in
-             unify env ty ty';
+             unify_exn env ty ty';
              let meths = Meths.add lab (Mprivate kind, virt, ty) meths in
              meths, row)
       meths (meths, sign.csig_self_row)
@@ -5034,7 +5038,7 @@ let matches ~expand_error_trace env ty ty' =
   let vars = rigidify ty in
   cleanup_abbrev_memo ();
   match unify env ty ty' with
-  | () ->
+  | Ok () ->
       if not (all_distinct_vars env vars) then begin
         backtrack snap;
         let diff =
@@ -5045,7 +5049,7 @@ let matches ~expand_error_trace env ty ty' =
         raise (Matches_failure (env, unification_error ~trace:[diff]))
       end;
       backtrack snap
-  | exception Unify err ->
+  | Error err ->
       backtrack snap;
       raise (Matches_failure (env, err))
 
@@ -6064,11 +6068,11 @@ and subtype_package env trace lvl1 pack1 lvl2 pack2 constraints =
         (* need to check module subtyping *)
         let snap = Btype.snapshot () in
         let apply_constraint (env,_,t1,t2,_) = unify env t1 t2 in
-        match List.iter apply_constraint constraints' with
-        | exception Unify {trace=unification_trace} ->
+        match List.iter_result apply_constraint constraints' with
+        | Error {trace=unification_trace} ->
             Btype.backtrack snap;
             subtype_error ~env ~trace ~unification_trace
-        | () ->
+        | Ok () ->
             match !package_subtype env pack1 pack2 with
             | Ok () ->
                 Btype.backtrack snap; constraints' @ constraints
@@ -6779,7 +6783,7 @@ let rec collapse_conj env visited ty =
         (fun (_l,fi) ->
           match row_field_repr fi with
             Reither (_c, t1::(_::_ as tl), _m) ->
-              List.iter (unify env t1) tl
+              List.iter (unify_exn env t1) tl
           | _ ->
               ())
         (row_fields row);

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4066,9 +4066,11 @@ let enforce_current_level env ty =
 
 let expand_head_trace env t =
   let reset_tracing = check_trace_gadt_instances env in
-  let t = expand_head_unif env t in
-  reset_trace_gadt_instances reset_tracing;
-  t
+  match expand_head_unif env t with
+  | t ->
+    reset_trace_gadt_instances reset_tracing;
+    Ok t
+  | exception Unify_trace trace -> Error trace
 
 let instance_funct_nondep_inplace env (tfun : Types.tfunctor) mty =
   let env' = Env.add_module (Ident.of_unscoped tfun.id_us) Mp_present mty env in
@@ -4153,10 +4155,10 @@ let arrow_unify_var ~param_hole l t =
 
 let filter_arrow env ~in_apply t l ~param_hole =
   match expand_head_trace env t with
-  | exception Unify_trace trace ->
+  | Error trace ->
       let t', _, _ = function_type l ~param_hole (get_level t) in
       arrow_unification_error ~in_apply env t t' trace
-  | t ->
+  | Ok t ->
     match get_desc t with
     | Tvar _ -> Ok (arrow_unify_var ~param_hole l t)
     | Tarrow(l', ty_param, ty_ret, _) ->
@@ -4190,10 +4192,10 @@ let filter_arrow env ~in_apply t l ~param_hole =
 
 let filter_functor env t l =
   match expand_head_trace env t with
-  | exception Unify_trace trace ->
+  | Error trace ->
       let t', _, _ = function_type l ~param_hole:false (get_level t) in
       arrow_unification_error ~in_apply:true env t t' trace
-  | t ->
+  | Ok t ->
       match get_desc t with
       | Tfunctor (l', id, pack, ct) ->
           if compatible_labels ~in_pattern_mode:false l l'
@@ -4206,10 +4208,10 @@ let filter_functor env t l =
 let filter_arity env t l =
   let param_hole = false in
   match expand_head_trace env t with
-  | exception Unify_trace trace ->
+  | Error trace ->
       let t', _, _ = function_type l ~param_hole (get_level t) in
       arrow_unification_error ~in_apply:false env t t' trace
-  | t ->
+  | Ok t ->
       match get_desc t with
       | Tvar _ ->
           let ft = arrow_unify_var ~param_hole l t in
@@ -4243,8 +4245,7 @@ let rec filter_method_field env name ty =
       ty', ty1
   in
   let ty =
-    try expand_head_trace env ty
-    with Unify_trace trace ->
+    Result.ok_or_else (expand_head_trace env ty) @@ fun trace ->
       let level = get_level ty in
       let ty', _ = method_type ~level in
       raise (Filter_method_failed
@@ -4277,8 +4278,7 @@ let filter_method env name ty =
       (ty', ty_meth)
   in
   let ty =
-    try expand_head_trace env ty
-    with Unify_trace trace ->
+    Result.ok_or_else (expand_head_trace env ty) @@ fun trace ->
       let level = get_level ty in
       let scope = get_scope ty in
       let ty', _ = object_type ~level ~scope in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -338,7 +338,8 @@ val unify: Env.t -> type_expr -> type_expr -> unit Errortrace.unification_result
         (* Unify the two types given. Returns [Error] if not possible.
            May return a [Tags] exception is some cases. *)
 val unify_gadt:
-    Pattern_env.t -> pat:type_expr -> expected:type_expr -> Btype.TypePairs.t
+    Pattern_env.t -> pat:type_expr -> expected:type_expr ->
+        (Btype.TypePairs.t, Errortrace.unification_error) result
         (* [unify_gadt penv ~pat:ty1 ~expected:ty2] unifies [ty1] and [ty2]
            in [Pattern] mode, possible adding local constraints to the
            environment in [penv]. Raises [Unify] if not possible.
@@ -346,9 +347,12 @@ val unify_gadt:
            Type variables in [ty1] are always assumed to be non-leaking
            (safely reifiable); if [penv.in_counterexample = true]
            then both [ty1] and [ty2] are assumed to be non-leaking. *)
-val unify_var: Env.t -> type_expr -> type_expr -> unit
+val unify_var: Env.t -> type_expr -> type_expr ->
+        (unit, Errortrace.unification_error) result
         (* Same as [unify], but allow free univars when first type
            is a variable. *)
+val unify_var_exn: Env.t -> type_expr -> type_expr -> unit
+        (** Same as [unify_var], but with an exception *)
 
 type filtered_arrow =
   { ty_param : type_expr;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -332,8 +332,11 @@ val extract_concrete_typedecl:
 
 val get_new_abstract_name : Env.t -> string -> string
 
-val unify: Env.t -> type_expr -> type_expr -> unit
+val unify_exn: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
+val unify: Env.t -> type_expr -> type_expr -> unit Errortrace.unification_result
+        (* Unify the two types given. Returns [Error] if not possible.
+           May return a [Tags] exception is some cases. *)
 val unify_gadt:
     Pattern_env.t -> pat:type_expr -> expected:type_expr -> Btype.TypePairs.t
         (* [unify_gadt penv ~pat:ty1 ~expected:ty2] unifies [ty1] and [ty2]

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -200,6 +200,8 @@ let swap_trace e = List.map swap_elt e
 
 type unification_error = { trace : unification error } [@@unboxed]
 
+type 'a unification_result = ('a, unification_error) result
+
 type equality_error =
   { trace : comparison error;
     subst : (type_expr * type_expr) list }

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -148,6 +148,8 @@ val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 
 type unification_error = private { trace : unification error } [@@unboxed]
 
+type 'a unification_result = ('a, unification_error) result
+
 type equality_error = private
   { trace : comparison error;
     subst : (type_expr * type_expr) list }

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -129,8 +129,7 @@ let is_unit_param env ty =
 let unifiable env ty1 ty2 =
   let snap = Btype.snapshot () in
   let res =
-    try Ctype.unify env ty1 ty2; true
-    with Ctype.Unify _ -> false
+    Result.is_ok (Ctype.unify env ty1 ty2)
   in
   Btype.backtrack snap;
   res

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -748,7 +748,7 @@ let close_variant env row =
   if not closed || name != orig_name then begin
     let more' = if static then Btype.newgenty Tnil else Btype.newgenvar () in
     (* this unification cannot fail *)
-    Ctype.unify env more
+    Ctype.unify_exn env more
       (Btype.newgenty
          (Tvariant
             (create_row ~fields:[] ~more:more'

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -20,6 +20,8 @@ open Types
 open Typecore
 open Typetexp
 
+module List = Misc.Stdlib.List
+module Result = Misc.Stdlib.Result
 
 type 'a class_info = {
   cls_id : Ident.t;
@@ -275,9 +277,8 @@ let inherit_class_type ~strict loc env sign1 cty2 =
   inherit_class_signature ~strict loc env sign1 sign2
 
 let unify_delayed_method_type loc env label ty expected_ty=
-  match Ctype.unify env ty expected_ty with
-  | () -> ()
-  | exception Ctype.Unify trace ->
+  Result.ok_or_else (Ctype.unify env ty expected_ty)
+    @@ fun trace ->
       Error.log_and_raise loc env (Field_type_mismatch ("method", label, trace))
 
 let type_constraint val_env sty sty' loc =
@@ -285,10 +286,8 @@ let type_constraint val_env sty sty' loc =
   let ty = cty.ctyp_type in
   let cty' = transl_simple_type val_env ~closed:false sty' in
   let ty' = cty'.ctyp_type in
-  begin
-    try Ctype.unify val_env ty ty' with Ctype.Unify err ->
-      Error.log_and_raise loc val_env (Unconsistent_constraint err);
-  end;
+  Result.ok_or_else (Ctype.unify val_env ty ty')
+    (fun err -> Error.log_and_raise loc val_env (Unconsistent_constraint err));
   (cty, cty')
 
 let make_method loc cl_num expr =
@@ -380,11 +379,8 @@ and class_signature virt env pcsig self_scope loc =
 
   let self_cty = transl_simple_type env ~closed:false sty in
   let self_type = self_cty.ctyp_type in
-  begin try
-    Ctype.unify env self_type sign.csig_self
-  with Ctype.Unify _ ->
-    Error.log_and_raise sty.ptyp_loc env (Pattern_type_clash self_type)
-  end;
+  if Result.is_error (Ctype.unify env self_type sign.csig_self) then
+    Error.log_and_raise sty.ptyp_loc env (Pattern_type_clash self_type);
 
   (* Class type fields *)
   let fields =
@@ -432,11 +428,10 @@ and class_type_aux env virt self_scope scty =
         (fun sty ty ->
           let cty' = transl_simple_type env ~closed:false sty in
           let ty' = cty'.ctyp_type in
-          begin
-            try Ctype.unify env ty' ty with Ctype.Unify err ->
-              Error.log_and_raise sty.ptyp_loc env (Parameter_mismatch err)
-            end;
-            cty'
+          Result.ok_or_else (Ctype.unify env ty' ty)
+            (fun err ->
+              Error.log_and_raise sty.ptyp_loc env (Parameter_mismatch err));
+          cty'
         ) styl params
       in
       let typ = Cty_constr (path, params, clty) in
@@ -804,7 +799,7 @@ let rec class_field_first_pass self_loc cl_num final sign self_scope acc cf =
                match get_desc ty with
                | Tvar _ ->
                    let ty' = Ctype.newvar () in
-                   Ctype.unify val_env (Ctype.newmono ty') ty;
+                   Ctype.unify_exn val_env (Ctype.newmono ty') ty;
                    type_approx val_env sbody ty'
                | Tpoly (ty1, tl) ->
                    let ty1' = Ctype.instance_poly tl ty1 in
@@ -1018,11 +1013,9 @@ and class_structure cl_num virt self_scope final val_env met_env loc
   in
 
   (* Check that the binder has a correct type *)
-  begin try Ctype.unify val_env self_pat.pat_type sign.csig_self with
-    Ctype.Unify _ ->
-      Error.log_and_raise spat.ppat_loc val_env
-        (Pattern_type_clash self_pat.pat_type)
-  end;
+  if Result.is_error (Ctype.unify val_env self_pat.pat_type sign.csig_self) then
+    Error.log_and_raise spat.ppat_loc val_env
+      (Pattern_type_clash self_pat.pat_type);
 
   (* Typing of class fields *)
   let (fields, vars) =
@@ -1115,7 +1108,7 @@ and class_expr_aux cl_num final val_env met_env virt self_scope scl =
       List.iter2
         (fun cty' ty ->
           let ty' = cty'.ctyp_type in
-          try Ctype.unify val_env ty' ty with Ctype.Unify err ->
+          Result.ok_or_else (Ctype.unify val_env ty' ty) @@ fun err ->
             Error.log_and_raise cty'.ctyp_loc val_env (Parameter_mismatch err))
         tyl params;
       (* Check for unexpected virtual methods *)
@@ -1629,21 +1622,17 @@ let class_infos define_class kind
   let constr = Ctype.newconstr (Path.Pident obj_id) obj_params in
   begin
     let row = Btype.self_type_row obj_type in
-    Ctype.unify env row (Ctype.newty Tnil);
-    begin try
-      List.iter2 (Ctype.unify env) obj_params obj_params'
-    with Ctype.Unify _ ->
+    Ctype.unify_exn env row (Ctype.newty Tnil);
+    if Result.is_error
+        (List.iter2_result (Ctype.unify env) obj_params obj_params')
+    then
       Error.log_and_raise cl.pci_loc env
-        (Bad_parameters (obj_id, obj_params, obj_params'))
-    end;
+        (Bad_parameters (obj_id, obj_params, obj_params'));
     let ty = Btype.self_type obj_type in
-    begin try
-      Ctype.unify env ty constr
-    with Ctype.Unify _ ->
+    if Result.is_error (Ctype.unify env ty constr) then
       let constr = Ctype.newconstr (Path.Pident obj_id) obj_params in
       Error.log_and_raise cl.pci_loc env
-        (Abbrev_type_clash (constr, ty, Ctype.expand_head env constr))
-    end
+        (Abbrev_type_clash (constr, ty, Ctype.expand_head env constr));
   end;
 
   Ctype.set_object_name (Path.Pident obj_id) params (Btype.self_type typ);
@@ -1652,30 +1641,25 @@ let class_infos define_class kind
   begin
     let (cl_params', cl_type) = Ctype.instance_class params typ in
     let ty = Btype.self_type cl_type in
-    begin try
-      List.iter2 (Ctype.unify env) cl_params cl_params'
-    with Ctype.Unify _ ->
+    if Result.is_error
+        (List.iter2_result (Ctype.unify env) cl_params cl_params')
+    then
       Error.log_and_raise cl.pci_loc env
-        (Bad_class_type_parameters (ty_id, cl_params, cl_params'))
-    end;
-    begin try
-      Ctype.unify env ty cl_ty
-    with Ctype.Unify _ ->
+        (Bad_class_type_parameters (ty_id, cl_params, cl_params'));
+    if Result.is_error (Ctype.unify env ty cl_ty) then
       let ty_expanded = Ctype.object_fields ty in
       Error.log_and_raise cl.pci_loc env
-        (Abbrev_type_clash (ty, ty_expanded, cl_ty))
-    end
+        (Abbrev_type_clash (ty, ty_expanded, cl_ty));
   end;
 
   (* Type of the class constructor *)
-  begin try
-    Ctype.unify env
-      (constructor_type constr obj_type)
-      (Ctype.instance constr_type)
-  with Ctype.Unify err ->
-    Error.log_and_raise cl.pci_loc env
-      (Constructor_type_mismatch (cl.pci_name.txt, err))
-  end;
+  Result.ok_or_else
+    (Ctype.unify env
+       (constructor_type constr obj_type)
+       (Ctype.instance constr_type))
+    (fun err ->
+      Error.log_and_raise cl.pci_loc env
+        (Constructor_type_mismatch (cl.pci_name.txt, err)));
 
   (* Class and class type temporary definitions *)
   let cty_variance =
@@ -1869,7 +1853,7 @@ let check_coercions env { id; id_loc; clty; ty_id; cltydef; obj_id; obj_abbr;
             and obj_params, obj_ty =
               Ctype.instance_parameterized_type obj_abbr.type_params obj_ab
             in
-            List.iter2 (Ctype.unify env) cl_params obj_params;
+            List.iter2 (Ctype.unify_exn env) cl_params obj_params;
             cl_ty, obj_ty
         | _ -> assert false
       in

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1624,7 +1624,7 @@ let class_infos define_class kind
     let row = Btype.self_type_row obj_type in
     Ctype.unify_exn env row (Ctype.newty Tnil);
     if Result.is_error
-        (List.iter2_result (Ctype.unify env) obj_params obj_params')
+        (Misc.Stdlib.List.iter2_result (Ctype.unify env) obj_params obj_params')
     then
       Error.log_and_raise cl.pci_loc env
         (Bad_parameters (obj_id, obj_params, obj_params'));
@@ -1642,7 +1642,7 @@ let class_infos define_class kind
     let (cl_params', cl_type) = Ctype.instance_class params typ in
     let ty = Btype.self_type cl_type in
     if Result.is_error
-        (List.iter2_result (Ctype.unify env) cl_params cl_params')
+        (Misc.Stdlib.List.iter2_result (Ctype.unify env) cl_params cl_params')
     then
       Error.log_and_raise cl.pci_loc env
         (Bad_class_type_parameters (ty_id, cl_params, cl_params'));

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -757,14 +757,15 @@ let unify_pat_types ?sdesc_for_hint loc env ty ty' =
    [penv.in_counterexample = false] (see [unify_gadt] for details) *)
 let nothing_equated = TypePairs.create 0
 let unify_pat_types_return_equated_pairs ~refine loc penv ~pat ~expected =
-  try
+  match
     if refine || penv.Pattern_env.in_counterexample
     then unify_gadt penv ~pat ~expected
-    else (unify_exn !!penv pat expected; nothing_equated)
+    else (Result.map (fun () -> nothing_equated) (unify !!penv pat expected))
   with
-  | Unify err ->
+  | Ok type_pairs -> type_pairs
+  | Error err ->
       Error.log_and_raise loc !!penv (Pattern_type_clash(err, None))
-  | Tags(l1,l2) ->
+  | exception Tags(l1,l2) ->
       Typetexp.Error.log_and_raise loc !!penv (Typetexp.Variant_tags (l1, l2))
 
 (* Unify pattern types in functions that can be called either from
@@ -1009,13 +1010,12 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
           if x1==x2 then
             unify_vars rem1 rem2
           else begin
-            begin try
-              unify_var env (newvar ()) t1;
-              unify_exn env t1 t2
-            with
-            | Unify err ->
-                Error.log_and_raise loc env (Or_pattern_type_clash(x1, err))
-            end;
+            Result.ok_or_else
+              (Result.bind
+                 (unify_var env (newvar ()) t1)
+                 (fun () -> unify env t1 t2))
+              (fun err ->
+                 Error.log_and_raise loc env (Or_pattern_type_clash(x1, err)));
           (x2,x1)::unify_vars rem1 rem2
           end
       | [],[] -> []
@@ -4330,8 +4330,7 @@ type type_function_result_param =
 (** lower the level of function arguments to the level of the application *)
 let lower_args outer_level env ty_fun =
   let lower env ty =
-    try Ctype.unify_var env (newvar2 outer_level) ty
-    with Unify _ -> assert false
+    Result.get_ok (Ctype.unify_var env (newvar2 outer_level) ty)
   in
   let rec lower_args env seen ty_fun =
     let ty = expand_head env ty_fun in
@@ -5626,7 +5625,7 @@ and type_expect_
         end ~before_generalize: begin fun (newenv, _si, exp) ->
           (* Ensure that local definitions do not leak. *)
           (* Required for implicit unpack *)
-          unify_var newenv tv exp.exp_type
+          unify_var_exn newenv tv exp.exp_type
         end
         in
         re {
@@ -6835,7 +6834,7 @@ and type_apply_arg env ~app_loc (lbl, arg) =
               in
               let (ty_arg0', vars0) = tpoly_get_poly ty_arg0 in
               let vars0, ty_arg0' = instance_poly_fixed vars0 ty_arg0' in
-              List.iter2 (fun ty ty' -> unify_var env ty ty') vars vars0;
+              List.iter2 (fun ty ty' -> unify_var_exn env ty ty') vars vars0;
               let arg =
                 type_argument env sarg ty_arg' ty_arg0'
               in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -28,6 +28,7 @@ open Btype
 open Ctype
 
 module Style = Misc.Style
+module Result = Misc.Stdlib.Result
 
 type type_forcing_context =
   | If_conditional
@@ -701,12 +702,13 @@ let type_continuation_pat env expected_ty sp =
 let unify_exp_types ?sexp loc env ty expected_ty =
   (* Format.eprintf "@[%a@ %a@]@." Printtyp.raw_type_expr exp.exp_type
     Printtyp.raw_type_expr expected_ty; *)
-  try
+  match
     unify env ty expected_ty
   with
-    Unify err ->
+  | Ok () -> ()
+  | Error err ->
       Error.log_and_raise loc env (Expr_type_clash(err, None, sexp))
-  | Tags(l1,l2) ->
+  | exception Tags(l1,l2) ->
       Typetexp.Error.log_and_raise loc env (Typetexp.Variant_tags (l1, l2))
 
 (* Getting proper location of already typed expressions.
@@ -743,10 +745,11 @@ let (!!) (penv : Pattern_env.t) = penv.env
 (* If [penv] is available, calling this function requires
    [penv.in_counterexample = false] *)
 let unify_pat_types ?sdesc_for_hint loc env ty ty' =
-  try unify env ty ty' with
-  | Unify err ->
+  match unify env ty ty' with
+  | Ok () -> ()
+  | Error err ->
       Error.log_and_raise loc env (Pattern_type_clash(err, sdesc_for_hint))
-  | Tags(l1,l2) ->
+  | exception Tags(l1,l2) ->
       Typetexp.Error.log_and_raise loc env (Typetexp.Variant_tags (l1, l2))
 
 (* GADT unification inside solve_Ppat_construct and check_counter_example_pat *)
@@ -757,7 +760,7 @@ let unify_pat_types_return_equated_pairs ~refine loc penv ~pat ~expected =
   try
     if refine || penv.Pattern_env.in_counterexample
     then unify_gadt penv ~pat ~expected
-    else (unify !!penv pat expected; nothing_equated)
+    else (unify_exn !!penv pat expected; nothing_equated)
   with
   | Unify err ->
       Error.log_and_raise loc !!penv (Pattern_type_clash(err, None))
@@ -1008,7 +1011,7 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
           else begin
             begin try
               unify_var env (newvar ()) t1;
-              unify env t1 t2
+              unify_exn env t1 t2
             with
             | Unify err ->
                 Error.log_and_raise loc env (Or_pattern_type_clash(x1, err))
@@ -3318,8 +3321,9 @@ let collect_unknown_apply_args env funct ty_fun0 rev_args sargs =
                   then
                     Location.prerr_warning sarg.pexp_loc
                       Warnings.Ignored_extra_argument;
-                  unify env ty_fun
-                    (newty (Tarrow(lbl,ty_param,ty_res,commu_var ())));
+                  Result.get_ok
+                    (unify env ty_fun
+                      (newty (Tarrow(lbl,ty_param,ty_res,commu_var ()))));
                   (`Arrow ty_arg, ty_res)
               | Tarrow (l, ty_param, ty_res, _)
                 when labels_match ~param:l ~arg:lbl ->
@@ -3818,9 +3822,9 @@ let type_approx_constraint env constraint_ ~loc ty_expected =
   match constraint_ with
   | Pconstraint constrain ->
       let ty_constrain = approx_type env constrain in
-      begin try unify env ty_constrain ty_expected with Unify err ->
-        Error.log_and_raise loc env (Expr_type_clash (err, None, None))
-      end;
+      Result.ok_or_else (unify env ty_constrain ty_expected)
+        (fun err ->
+          Error.log_and_raise loc env (Expr_type_clash (err, None, None)));
       ty_constrain
   | Pcoerce (constrain, coerce) ->
       let ty_constrain = match constrain with
@@ -3828,9 +3832,9 @@ let type_approx_constraint env constraint_ ~loc ty_expected =
         | Some sty -> approx_type env sty
       in
       let ty_coerce = approx_type env coerce in
-      begin try unify env ty_coerce ty_expected with Unify err ->
-        Error.log_and_raise loc env (Expr_type_clash (err, None, None))
-      end;
+      Result.ok_or_else (unify env ty_coerce ty_expected)
+        (fun err ->
+          Error.log_and_raise loc env (Expr_type_clash (err, None, None)));
       ty_constrain
 
 let type_approx_constraint_opt env constraint_ ~loc ty_expected =
@@ -3878,9 +3882,9 @@ let rec type_approx env sexp ty_expected =
 and type_tuple_approx (env: Env.t) loc ty_expected l =
   let labeled_tys = List.map (fun (label, _) -> label, newvar ()) l in
   let ty = newty (Ttuple labeled_tys) in
-  begin try unify env ty ty_expected with Unify err ->
-    Error.log_and_raise loc env (Expr_type_clash (err, None, None))
-  end;
+  Result.ok_or_else (unify env ty ty_expected)
+    (fun err ->
+      Error.log_and_raise loc env (Expr_type_clash (err, None, None)));
   List.iter2
     (fun (_, e) (_, ty) -> type_approx env e ty)
     l labeled_tys
@@ -4378,10 +4382,11 @@ let enforce_syntactic_arity ~loc env exp_type result_params body =
                  error to help the error printing code's heuristic to
                  identify the type equation at fault.
               *)
-              (try
-                 unify env tarrow ty;
-                 fatal_error "unification unexpectedly succeeded"
-               with Unify trace -> trace)
+              (match
+                 unify env tarrow ty
+               with
+                 | Ok () -> fatal_error "unification unexpectedly succeeded"
+                 | Error trace -> trace)
           | Label_mismatch _ ->
               fatal_error
                 "Label_mismatch not expected as this point; this should\
@@ -5236,7 +5241,7 @@ and type_expect_
               instance_poly tl ty
           | Tvar _ ->
               let ty' = newvar () in
-              unify env (instance typ) (newty(Tpoly(ty',[])));
+              unify_exn env (instance typ) (newty(Tpoly(ty',[])));
               (* if not !Clflags.nolabels then
                  Location.prerr_warning loc (Warnings.Unknown_method met); *)
               ty'
@@ -5510,12 +5515,11 @@ and type_expect_
             in
             newty (Tarrow(Nolabel, newmono ty_andops, ty_fun, commu_ok))
           in
-          begin try
-            unify env op_type ty_op
-          with Unify err ->
-            Error.log_or_raise let_loc env
-              (Letop_type_clash(slet.pbop_op.txt, err))
-          end;
+          Result.ok_or_else
+            (unify env op_type ty_op)
+            (fun err ->
+              Error.log_or_raise let_loc env
+                (Letop_type_clash(slet.pbop_op.txt, err)));
           (op_path, op_desc, op_type, spat_params, ty_params,
            ty_func_result, ty_result, ty_andops)
         end
@@ -5700,7 +5704,7 @@ and type_coerce
             let snap = snapshot () in
             let ty, _b = enlarge_type env (generic_instance ty') in
             try
-              force (); Ctype.unify env arg_type ty; true
+              force (); Ctype.unify_exn env arg_type ty; true
             with Unify _ ->
               backtrack snap; false
           then ()
@@ -5717,7 +5721,9 @@ and type_coerce
       | _ ->
           let ty, b = enlarge_type env (generic_instance ty') in
           force ();
-          begin try Ctype.unify env arg_type ty with Unify err ->
+          begin match Ctype.unify env arg_type ty with
+          | Ok () -> ()
+          | Error err ->
             let expanded = full_expand ~may_forget_scope:true env ty' in
             Error.log_and_raise loc_arg env
               (Coercion_failure ({ ty = ty'; expanded }, err, b))
@@ -6000,10 +6006,7 @@ and type_function
         | Some default ->
             assert (is_optional arg_label);
             let ty_default = newvar () in
-            begin
-              try unify env (type_option ty_default) ty_arg_mono
-              with Unify _ -> assert false;
-            end;
+            Result.get_ok (unify env (type_option ty_default) ty_arg_mono);
             (* Issue#12668: Retain type-directed disambiguation of
                ?x:(y : Variant.t = Constr)
             *)
@@ -6219,13 +6222,12 @@ and type_moddep_fun ~env ~name ~pack_param ~rest ~arg_label ~first
         (None, Some cpack, pack)
     | Some (id, pack', ety), Some pack_param ->
         let cpack, pack = type_pack pack_param in
-        begin try
-          unify env
-            (newty (Tfunctor (arg_label, id, pack, newvar())))
-            (newty (Tfunctor (arg_label, id, pack', newvar())))
-        with Unify trace ->
-            Error.log_and_raise loc env (Expr_type_clash(trace, None, None))
-        end;
+        Result.ok_or_else
+          (unify env
+             (newty (Tfunctor (arg_label, id, pack, newvar())))
+             (newty (Tfunctor (arg_label, id, pack', newvar()))))
+          (fun trace ->
+              Error.log_and_raise loc env (Expr_type_clash(trace, None, None)));
         (Some (id, ety), Some cpack, pack)
     | Some (id, pack', ety), None ->
         if not (is_principal ty_expected)
@@ -6624,11 +6626,10 @@ and type_label_exp create env loc ty_expected
             with_local_level_generalize_structure_if separate
               (fun () -> instance_label ~fixed:true label)
           in
-          begin try
-            unify env (instance ty_res) (instance ty_expected)
-          with Unify err ->
-            Error.log_and_raise lid.loc env (Label_mismatch(lid.txt, err))
-          end;
+          Result.ok_or_else
+            (unify env (instance ty_res) (instance ty_expected))
+            (fun err ->
+              Error.log_and_raise lid.loc env (Label_mismatch(lid.txt, err)));
           (* Instantiate so that we can generalize internal nodes *)
           let ty_arg = instance ty_arg in
           (vars, ty_arg)
@@ -7837,21 +7838,20 @@ and type_andops env sarg sands expected_ty =
               newty (Tarrow(Nolabel, newmono ty_arg, ty_result, commu_ok)) in
             let ty_op =
               newty (Tarrow(Nolabel, newmono ty_rest, ty_rest_fun, commu_ok)) in
-            begin try
-              unify env op_type ty_op
-            with Unify err ->
-              Error.log_and_raise sop.loc env (Andop_type_clash(sop.txt, err))
-            end;
+            Result.ok_or_else
+              (unify env op_type ty_op)
+              (fun err ->
+                Error.log_and_raise sop.loc env
+                  (Andop_type_clash(sop.txt, err)));
             (op_path, op_desc, op_type, ty_arg, ty_rest, ty_result)
           end
         in
         let let_arg, rest = loop env let_sarg rest ty_rest in
         let exp = type_expect env sexp (mk_expected ty_arg) in
-        begin try
-          unify env (instance ty_result) (instance expected_ty)
-        with Unify err ->
-          Error.log_and_raise loc env (Bindings_type_clash(err))
-        end;
+        Result.ok_or_else
+          (unify env (instance ty_result) (instance expected_ty))
+          (fun err ->
+            Error.log_and_raise loc env (Bindings_type_clash(err)));
         let andop =
           { bop_op_name = sop;
             bop_op_path = op_path;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -24,6 +24,7 @@ open Typetexp
 
 module String = Misc.Stdlib.String
 module List = Misc.Stdlib.List
+module Result = Misc.Stdlib.Result
 
 type native_repr_kind = Unboxed | Untagged
 
@@ -536,8 +537,9 @@ let transl_declaration env sdecl (id, uid) =
       (fun (cty, cty', loc) ->
         let ty = cty.ctyp_type in
         let ty' = cty'.ctyp_type in
-        try Ctype.unify env ty ty' with Ctype.Unify err ->
-          Error.log_and_raise loc (Inconsistent_constraint (env, err)))
+        Result.ok_or_else (Ctype.unify env ty ty')
+          (fun err ->
+            Error.log_and_raise loc (Inconsistent_constraint (env, err))))
       constraints;
   (* Add abstract row *)
     if is_fixed_type sdecl then begin
@@ -1133,12 +1135,10 @@ let check_regularity ~abs_env env loc path decl to_check =
               let (params0, body0, _) = Env.find_type_expansion path' env in
               let (params, body) =
                 Ctype.instance_parameterized_type params0 body0 in
-              begin
-                try List.iter2 (Ctype.unify abs_env) args' params
-                with Ctype.Unify err ->
-                  Error.log_and_raise loc
-                    (Constraint_failed (abs_env, err));
-              end;
+              Result.ok_or_else
+                (List.iter2_result (Ctype.unify abs_env) args' params)
+                (fun err ->
+                  Error.log_and_raise loc (Constraint_failed (abs_env, err)));
               check_regular args
                 (path' :: prev_exp) (Expands_to (ty,body) :: trace)
                 body
@@ -1247,9 +1247,9 @@ let update_type temp_env env id loc =
          but generalize again after unification. *)
       Ctype.with_local_level_generalize begin fun () ->
         let params = List.map (fun _ -> Ctype.newvar ()) decl.type_params in
-        try Ctype.unify env (Ctype.newconstr path params) ty
-        with Ctype.Unify err ->
-          Error.log_and_raise loc (Type_clash (env, err))
+        Result.ok_or_else
+          (Ctype.unify env (Ctype.newconstr path params) ty)
+          (fun err -> Error.log_and_raise loc (Type_clash (env, err)))
       end
 
 let add_types_to_env decls shapes env =
@@ -1451,13 +1451,11 @@ let transl_extension_constructor ~scope env type_path type_params
               res, ret_type
           else (Ctype.newconstr type_path typext_params), None
         in
-        begin
-          try
-            Ctype.unify env cstr_res res
-          with Ctype.Unify err ->
+        Result.ok_or_else
+          (Ctype.unify env cstr_res res)
+          (fun err ->
             Error.log_and_raise lid.loc
-              (Rebind_wrong_type(lid.txt, env, err))
-        end;
+              (Rebind_wrong_type(lid.txt, env, err)));
         (* Remove "_" names from parameters used in the constructor *)
         if not cdescr.cstr_generalized then begin
           let vars = Ctype.free_variables_list args in
@@ -1509,7 +1507,7 @@ let transl_extension_constructor ~scope env type_path type_params
               in
               let decl = Ctype.instance_declaration decl in
               assert (List.length decl.type_params = List.length tl);
-              List.iter2 (Ctype.unify env) decl.type_params tl;
+              List.iter2 (Ctype.unify_exn env) decl.type_params tl;
               let lbls =
                 match decl.type_kind with
                 | Type_record (lbls, Record_extension _) -> lbls
@@ -1989,9 +1987,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     (* Note: constraints must also be enforced in [sig_env] because
        they may contain parameter variables from [tparams]
        that have now be unified in [sig_env]. *)
-    try Ctype.unify env cty.ctyp_type cty'.ctyp_type
-    with Ctype.Unify err ->
-      Error.log_and_raise loc (Inconsistent_constraint (env, err))
+    Result.ok_or_else
+      (Ctype.unify env cty.ctyp_type cty'.ctyp_type)
+      (fun err ->
+        Error.log_and_raise loc (Inconsistent_constraint (env, err)))
   ) constraints;
   let sig_decl_abstract = Btype.type_kind_is_abstract sig_decl in
   let priv =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1611,7 +1611,7 @@ let transl_type_extension extend env loc styext =
       TyVarEnv.reset();
       let ttype_params = make_params env styext.ptyext_params in
       let type_params = List.map (fun (cty, _) -> cty.ctyp_type) ttype_params in
-      List.iter2 (Ctype.unify_var env)
+      List.iter2 (Ctype.unify_var_exn env)
         (Ctype.instance_list type_decl.type_params)
         type_params;
       let constructors =
@@ -1978,10 +1978,11 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let arity_ok = arity = sig_decl.type_arity in
   if arity_ok then
     List.iter2 (fun (cty, _) tparam ->
-      try Ctype.unify_var env cty.ctyp_type tparam
-      with Ctype.Unify err ->
-        Error.log_and_raise cty.ctyp_loc
-          (Inconsistent_constraint (env, err))
+      Result.ok_or_else
+        (Ctype.unify_var env cty.ctyp_type tparam)
+        (fun err ->
+          Error.log_and_raise cty.ctyp_loc
+            (Inconsistent_constraint (env, err)))
     ) tparams sig_decl.type_params;
   List.iter (fun (cty, cty', loc) ->
     (* Note: constraints must also be enforced in [sig_env] because

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3337,8 +3337,7 @@ let type_package env m pack =
   in
   List.iter
     (fun (n, ty) ->
-      try Ctype.unify env ty (Ctype.newvar ())
-      with Ctype.Unify _ ->
+      if Result.is_error (Ctype.unify env ty (Ctype.newvar ())) then
         let lid = Longident.unflatten n |> Option.get in
         Error.log_and_raise modl.mod_loc env (Scoping_pack (lid, ty)))
     fl';

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -558,11 +558,13 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         match decl.type_manifest with
           None -> unify_var
         | Some ty ->
-            if get_level ty = Btype.generic_level then unify_var else unify_exn
+            if get_level ty = Btype.generic_level then unify_var else unify
       in
       List.iter2
         (fun (sty, cty) ty' ->
-           try unify_param env ty' cty.ctyp_type with Unify err ->
+           match unify_param env ty' cty.ctyp_type with
+           | Ok () -> ()
+           | Error err ->
              let err = Errortrace.swap_unification_error err in
              Error.log_and_raise sty.ptyp_loc env (Type_mismatch err)
         )
@@ -586,7 +588,9 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let (params, body) = instance_parameterized_type decl.type_params body in
       List.iter2
         (fun (sty, cty) ty' ->
-           try unify_var env ty' cty.ctyp_type with Unify err ->
+           match unify_var env ty' cty.ctyp_type with
+           | Ok () -> ()
+           | Error err ->
              let err = Errortrace.swap_unification_error err in
              Error.log_and_raise sty.ptyp_loc env (Type_mismatch err)
         )
@@ -608,7 +612,9 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
           check_tyvar_name env alias.loc alias.txt;
           let t = TyVarEnv.lookup_local ~row_context alias.txt in
           let ty = transl_type env ~policy ~aliased:true ~row_context st in
-          begin try unify_var env t ty.ctyp_type with Unify err ->
+          begin match unify_var env t ty.ctyp_type with
+          | Ok () -> ()
+          | Error err ->
             let err = Errortrace.swap_unification_error err in
             Error.log_and_raise alias.loc env (Alias_type_mismatch err)
           end;
@@ -620,7 +626,9 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
               (* Use the whole location, which is used by [Type_mismatch]. *)
               TyVarEnv.remember_used ~check:alias.loc alias.txt t styp.ptyp_loc;
               let ty = transl_type env ~policy ~row_context st in
-              begin try unify_var env t ty.ctyp_type with Unify err ->
+              begin match unify_var env t ty.ctyp_type with
+              | Ok () -> ()
+              | Error err ->
                 let err = Errortrace.swap_unification_error err in
                 Error.log_and_raise alias.loc env (Alias_type_mismatch err)
               end;
@@ -756,7 +764,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let ty_list = TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars in
       let ty_list = List.filter (fun v -> Btype.deep_occur v ty) ty_list in
       let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
-      unify_var env (newvar()) ty';
+      assert (Result.is_ok (unify_var env (newvar()) ty'));
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package ptyp ->
       let pack, (), ptys =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -23,6 +23,8 @@ open Typedtree
 open Types
 open Ctype
 
+module Result = Misc.Stdlib.Result
+
 exception Already_bound
 
 type error =
@@ -357,10 +359,10 @@ end = struct
           let v = new_global_var () in
           let snap = Btype.snapshot () in
           match unify env v ty with
-          | exception Unify err when is_in_scope name ->
+          | Error err when is_in_scope name ->
               Error.log_and_raise loc env (Type_mismatch err)
-          | exception _ -> Btype.backtrack snap
-          | () ->
+          | Error _ | exception _ -> Btype.backtrack snap
+          | Ok () ->
             begin match lookup_global_type_variable name with
             | global_var ->
               r := (loc, v, global_var) :: !r;
@@ -379,8 +381,8 @@ end = struct
     fun () ->
       List.iter
         (function (loc, t1, t2) ->
-         try unify env t1 t2 with Unify err ->
-           Error.log_and_raise loc env (Type_mismatch err))
+         Result.ok_or_else (unify env t1 t2)
+           (fun err -> Error.log_and_raise loc env (Type_mismatch err)))
         !r
 end
 
@@ -556,7 +558,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         match decl.type_manifest with
           None -> unify_var
         | Some ty ->
-            if get_level ty = Btype.generic_level then unify_var else unify
+            if get_level ty = Btype.generic_level then unify_var else unify_exn
       in
       List.iter2
         (fun (sty, cty) ty' ->
@@ -653,8 +655,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
             Error.log_and_raise styp.ptyp_loc env (Variant_tags (l, l'));
           let ty = mkfield l f and ty' = mkfield l f' in
           if is_equal env false [ty] [ty'] then () else
-          try unify env ty ty'
-          with Unify _trace ->
+          if Result.is_error (unify env ty ty') then
             Error.log_and_raise loc env (Constructor_mismatch (ty, ty'))
         with Not_found ->
           hfields := HMap.add h (l, f) !hfields
@@ -819,8 +820,7 @@ and transl_fields env ~policy ~row_context o fields =
     try
       let ty' = HMap.find l !hfields in
       if is_equal env false [ty] [ty'] then () else
-        try unify env ty ty'
-        with Unify _trace ->
+        if Result.is_error (unify env ty ty') then
           Error.log_and_raise loc env (Method_mismatch (l, ty, ty'))
     with Not_found ->
       hfields := HMap.add l ty !hfields in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -331,12 +331,9 @@ end = struct
         if flavor = Unification || is_in_scope name then
           let v = new_global_var () in
           let snap = Btype.snapshot () in
-          if try unify env v ty; true
-            with
-                Unify err when is_in_scope name ->
-                  raise (Error(loc, env, Type_mismatch err))
-              | _ -> Btype.backtrack snap; false
-          then match lookup_global_type_variable name with
+          match unify env v ty with
+          | () ->
+            begin match lookup_global_type_variable name with
             | global_var ->
               r := (loc, v, global_var) :: !r;
               unused := false
@@ -347,7 +344,11 @@ end = struct
                                                   get_in_scope_names ())));
               let v2 = new_global_var () in
               r := (loc, v, v2) :: !r;
-              add ~unused name v2)
+              add ~unused name v2
+            end
+          | exception Unify err when is_in_scope name ->
+            raise (Error(loc, env, Type_mismatch err))
+          | exception _ -> Btype.backtrack snap)
       !used_variables;
     used_variables := TyVarMap.empty;
     fun () ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -332,6 +332,9 @@ end = struct
           let v = new_global_var () in
           let snap = Btype.snapshot () in
           match unify env v ty with
+          | exception Unify err when is_in_scope name ->
+            raise (Error(loc, env, Type_mismatch err))
+          | exception _ -> Btype.backtrack snap
           | () ->
             begin match lookup_global_type_variable name with
             | global_var ->
@@ -345,10 +348,7 @@ end = struct
               let v2 = new_global_var () in
               r := (loc, v, v2) :: !r;
               add ~unused name v2
-            end
-          | exception Unify err when is_in_scope name ->
-            raise (Error(loc, env, Type_mismatch err))
-          | exception _ -> Btype.backtrack snap)
+            end)
       !used_variables;
     used_variables := TyVarMap.empty;
     fun () ->

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -148,12 +148,12 @@ module Stdlib = struct
 
     let iteri2 f l1 l2 = iteri2 0 f l1 l2
 
-    let rec rev_iter f l =
+    let rec rev_iter_result f l =
       match l with
-      | [] -> ()
+      | [] -> Ok ()
       | x :: xs ->
-          rev_iter f xs;
-          f x
+          Result.bind (rev_iter_result f xs)
+            (fun () -> f x)
 
     let rec iter_result f l =
       match l with

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -155,6 +155,19 @@ module Stdlib = struct
           rev_iter f xs;
           f x
 
+    let rec iter_result f l =
+      match l with
+        [] -> Ok ()
+      | a::l ->
+        Result.bind (f a) (fun () -> iter_result f l)
+
+    let rec iter2_result f l1 l2 =
+      match (l1, l2) with
+        ([], []) -> Ok ()
+      | (a1::l1, a2::l2) ->
+        Result.bind (f a1 a2) (fun () -> iter2_result f l1 l2)
+      | (_, _) -> raise (Invalid_argument "iter2_result")
+
     let some_if_all_elements_are_some l =
       let rec aux acc l =
         match l with
@@ -280,6 +293,14 @@ module Stdlib = struct
 
     let print ppf t =
       Format.pp_print_string ppf t
+  end
+
+  module Result = struct
+    include Result
+    let ok_or_else res f =
+      match res with
+      | Ok v -> v
+      | Error err -> f err
   end
 
   external compare : 'a -> 'a -> int = "%compare"

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -156,7 +156,8 @@ module Stdlib : sig
     (** Same as {!List.iter2}, but the function is applied to the index of
         the element as first argument (counting from 0) *)
 
-    val rev_iter : ('a -> unit) -> 'a list -> unit
+    val rev_iter_result : ('a -> (unit, 'b) result) -> 'a list
+        -> (unit, 'b) result
 
     val split_at : int -> 'a t -> 'a t * 'a t
     (** [split_at n l] returns the pair [before, after] where [before] is

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -137,6 +137,16 @@ module Stdlib : sig
         is returned with the [xs] being the contents of those [Some]s, with
         order preserved.  Otherwise return [None]. *)
 
+    val iter_result : ('a -> (unit, 'err) result) -> 'a list ->
+      (unit, 'err) result
+    (** Similar to {!List.iter} called with a function returning an exception,
+        but with a result instead. *)
+
+      val iter2_result : ('a -> 'b -> (unit, 'err) result) -> 'a list ->
+        'b list -> (unit, 'err) result
+    (** Similar to {!List.iter2} called with a function returning an exception,
+        but with a result instead. *)
+
     val map2_prefix : ('a -> 'b -> 'c) -> 'a t -> 'b t -> ('c t * 'b t)
     (** [let r1, r2 = map2_prefix f l1 l2]
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,
@@ -219,6 +229,12 @@ module Stdlib : sig
     val for_all : (char -> bool) -> t -> bool
 
     val to_utf_8_seq : t -> Uchar.t Seq.t
+  end
+
+(** {2 Extensions to the Result module} *)
+  module Result : sig
+    include module type of Result
+    val ok_or_else : ('a, 'b) result -> ('b -> 'a) -> 'a
   end
 
   external compare : 'a -> 'a -> int = "%compare"


### PR DESCRIPTION
I have noticed that almost all calls to `unify` are directly wrapped inside an exception handler. The cases where we don't have a direct exception handler are the exception that most of the time just expect the unification to never fail.

As such I propose to replace the exception by returning a result. As such the type-checker will help prevent in any future evolution any uncaught exception.

In order to stay as close as possible to the actual semantic I introduced a `unify_ex` (and a `unify_var_ex`) that returns an exception for the few cases where we didn't have a direct exception handler. A futur improvement might be to remove this function from the interface of ctype.ml and adding assertions in places we expect that the unification will never fail.


This PR is reviewed on top of #14422