### PR TITLE
Remove unnecessary guards on `unistd.h`

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -22,9 +22,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <time.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 
 
 typedef pthread_t st_thread_id;

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -30,9 +30,7 @@
 #include <ws2tcpip.h>
 #include <wspiapi.h>
 #else /* Unix */
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #endif
 
 #ifdef __cplusplus

--- a/otherlibs/unix/envir_unix.c
+++ b/otherlibs/unix/envir_unix.c
@@ -15,9 +15,7 @@
 
 #include <caml/config.h>
 
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <sys/types.h>
 #ifdef HAS_GETAUXVAL
 #include <sys/auxv.h>

--- a/otherlibs/unix/fcntl.c
+++ b/otherlibs/unix/fcntl.c
@@ -16,9 +16,7 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "caml/unixsupport.h"
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
 #ifndef O_NONBLOCK

--- a/otherlibs/unix/ftruncate.c
+++ b/otherlibs/unix/ftruncate.c
@@ -15,17 +15,16 @@
 
 #define CAML_INTERNALS
 
-#include <sys/types.h>
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include <caml/io.h>
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #ifdef HAS_TRUNCATE
+
+#include <sys/types.h>
+#include <unistd.h>
 
 CAMLprim value caml_unix_ftruncate(value fd, value len)
 {

--- a/otherlibs/unix/getgroups.c
+++ b/otherlibs/unix/getgroups.c
@@ -21,9 +21,7 @@
 #ifdef HAS_GETGROUPS
 
 #include <sys/types.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <errno.h>
 #include "caml/unixsupport.h"
 

--- a/otherlibs/unix/initgroups.c
+++ b/otherlibs/unix/initgroups.c
@@ -20,9 +20,7 @@
 #ifdef HAS_INITGROUPS
 
 #include <sys/types.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <errno.h>
 #include <limits.h>
 #include <grp.h>

--- a/otherlibs/unix/lockf_unix.c
+++ b/otherlibs/unix/lockf_unix.c
@@ -87,14 +87,7 @@ CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
 #else
 
 #ifdef HAS_LOCKF
-#ifndef _WIN32
 #include <unistd.h>
-#else
-#define F_ULOCK 0
-#define F_LOCK 1
-#define F_TLOCK 2
-#define F_TEST 3
-#endif
 
 static const int lock_command_table[] = {
   F_ULOCK, F_LOCK, F_TLOCK, F_TEST, F_LOCK, F_TLOCK

--- a/otherlibs/unix/lseek_unix.c
+++ b/otherlibs/unix/lseek_unix.c
@@ -23,13 +23,7 @@
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
 
-#ifndef _WIN32
 #include <unistd.h>
-#else
-#define SEEK_SET 0
-#define SEEK_CUR 1
-#define SEEK_END 2
-#endif
 
 #ifndef EOVERFLOW
 #define EOVERFLOW ERANGE

--- a/otherlibs/unix/lseek_win32.c
+++ b/otherlibs/unix/lseek_win32.c
@@ -18,14 +18,6 @@
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
 
-#ifndef _WIN32
-#include <unistd.h>
-#else
-#define SEEK_SET 0
-#define SEEK_CUR 1
-#define SEEK_END 2
-#endif
-
 static const DWORD seek_command_table[] = {
   FILE_BEGIN, FILE_CURRENT, FILE_END
 };

--- a/otherlibs/unix/mmap_unix.c
+++ b/otherlibs/unix/mmap_unix.c
@@ -29,9 +29,7 @@
 #include "caml/unixsupport.h"
 
 #include <errno.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #ifdef HAS_MMAP
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/otherlibs/unix/nice.c
+++ b/otherlibs/unix/nice.c
@@ -16,9 +16,7 @@
 #include <caml/mlvalues.h>
 #include "caml/unixsupport.h"
 #include <errno.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 
 CAMLprim value caml_unix_nice(value incr)
 {

--- a/otherlibs/unix/open_unix.c
+++ b/otherlibs/unix/open_unix.c
@@ -20,9 +20,7 @@
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
 #include <string.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
 #ifndef O_NONBLOCK

--- a/otherlibs/unix/setgroups.c
+++ b/otherlibs/unix/setgroups.c
@@ -21,9 +21,7 @@
 #ifdef HAS_SETGROUPS
 
 #include <sys/types.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <limits.h>
 #include <grp.h>
 #include "caml/unixsupport.h"

--- a/otherlibs/unix/setsid.c
+++ b/otherlibs/unix/setsid.c
@@ -16,9 +16,7 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "caml/unixsupport.h"
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 
 CAMLprim value caml_unix_setsid(value unit)
 {

--- a/otherlibs/unix/truncate_unix.c
+++ b/otherlibs/unix/truncate_unix.c
@@ -22,11 +22,10 @@
 #include <caml/signals.h>
 #include <caml/io.h>
 #include "caml/unixsupport.h"
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #ifdef HAS_TRUNCATE
+
+#include <unistd.h>
 
 CAMLprim value caml_unix_truncate(value path, value vlen)
 {

--- a/otherlibs/unix/unixsupport_unix.c
+++ b/otherlibs/unix/unixsupport_unix.c
@@ -24,9 +24,7 @@
 #include "caml/unixsupport.h"
 #include "cst2constr.h"
 #include <errno.h>
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
 #ifndef E2BIG

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -25,8 +25,7 @@
 #include "caml/config.h"
 #ifndef _WIN32
 #include <unistd.h>
-#endif
-#ifdef _WIN32
+#else
 #include <io.h>
 #endif
 

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -63,13 +63,11 @@ CAMLexport void caml_debugger_cleanup_fork(void)
 
 #else
 
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #ifndef _WIN32
+#include <unistd.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -25,8 +25,7 @@
 #include "caml/config.h"
 #ifndef _WIN32
 #include <unistd.h>
-#endif
-#ifdef _WIN32
+#else
 #include <io.h>
 #endif
 #include "caml/alloc.h"

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -25,8 +25,7 @@
 #include "caml/config.h"
 #ifndef _WIN32
 #include <unistd.h>
-#endif
-#ifdef _WIN32
+#else
 #include <io.h>
 #include <process.h>
 #endif

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -31,11 +31,9 @@
 #include <io.h> /* for _wopen and close */
 #else
 #include <sys/wait.h>
-#endif
-#include "caml/config.h"
-#ifndef _WIN32
 #include <unistd.h>
 #endif
+#include "caml/config.h"
 #ifdef HAS_TIMES
 #include <sys/times.h>
 #endif


### PR DESCRIPTION
While reviewing something else, I got puzzled by some of the guards on unistd.h which were added in #13556. It's confusing to have `_WIN32` mentioned in files which are supposed to be Unix-only, so I went back through the diff and updated them. In a couple of cases, as an extra hardening, I moved `unistd.h` down past a `HAS_` macro. In lseek\_win32.c, there were a bunch of constants defined which are never used (I expect they got left there from a time where the file was shared between the two implementations).