### PR TITLE
Fix the testsuite on _all_ CRLF checkouts

### DIFF
--- a/testsuite/tests/basic-io/wc.ml
+++ b/testsuite/tests/basic-io/wc.ml
@@ -17,6 +17,9 @@ let count_channel in_channel =
     match c with
       '\n' ->
         incr lines; count Outside_word
+    | '\r' ->
+        (* Ignore \r to cater for CRLF vs LF checkouts *)
+        decr chars; count Outside_word
     | ' ' | '\t' ->
         count Outside_word
     | _ ->
@@ -29,7 +32,7 @@ let count_channel in_channel =
       ()
 
 let count_file name =
-  let ic = open_in name in
+  let ic = open_in_bin name in
   count_channel ic;
   close_in ic
 

--- a/testsuite/tests/basic-io/wc.reference
+++ b/testsuite/tests/basic-io/wc.reference
@@ -1,1 +1,1 @@
-1232 characters, 184 words, 58 lines
+1347 characters, 202 words, 61 lines

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -57,7 +57,7 @@
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
 
     # Remove trailing blanks
-    gsub(/[ \t]+$/, "")
+    gsub(/[ \t\r]+$/, "")
 
     if ($0 != "")
       print $0

--- a/testsuite/tests/tool-caml-tex/ellipses.ml
+++ b/testsuite/tests/tool-caml-tex/ellipses.ml
@@ -5,7 +5,6 @@
  script = "${ocamlrun} ${ocamlsrcdir}/tools/ocamltex -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}";
  hasstr;
  hasunix;
- native-compiler;
  shared-libraries;
  script with unix, str;
  check-program-output;

--- a/testsuite/tests/tool-caml-tex/redirections.ml
+++ b/testsuite/tests/tool-caml-tex/redirections.ml
@@ -5,7 +5,6 @@
  script = "${ocamlrun} ${ocamlsrcdir}/tools/ocamltex -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}";
  hasstr;
  hasunix;
- native-compiler;
  {
    shared-libraries;
    script with unix, str;

--- a/testsuite/tests/warnings/mnemonics.mll
+++ b/testsuite/tests/warnings/mnemonics.mll
@@ -6,7 +6,7 @@
 }
 
 let ws = [' ''\t']
-let eol = '\n'
+let eol = '\r'? '\n'
 let to_eol = [^'\n']* eol
 let constr = ['A'-'Z']['a'-'z''A'-'Z''0'-'9''_']*
 let int = ['0'-'9']+
@@ -38,7 +38,9 @@ let ocamlsrcdir = Sys.getenv "ocamlsrcdir"
 let ocamlrun = Sys.getenv "ocamlrun"
 
 let constructors =
-  let ic = open_in Filename.(concat ocamlsrcdir (concat "utils" "warnings.ml")) in
+  let ic =
+    open_in_bin Filename.(concat ocamlsrcdir (concat "utils" "warnings.ml"))
+  in
   Fun.protect ~finally:(fun () -> close_in_noerr ic)
     (fun () ->
        let lexbuf = Lexing.from_channel ic in
@@ -54,7 +56,7 @@ let mnemonics =
                   ocamlrun [concat ocamlsrcdir "ocamlc"; "-warn-help"])
   in
   assert (n = 0);
-  let ic = open_in stdout in
+  let ic = open_in_bin stdout in
   Fun.protect ~finally:(fun () -> close_in_noerr ic)
     (fun () ->
        let lexbuf = Lexing.from_channel ic in
@@ -75,9 +77,11 @@ let () =
       | true, false -> ()
       | false, true -> ()
       | false, false ->
-        Printf.printf "Could not find constructor corresponding to mnemonic %S (%d)\n%!" s n
+        Printf.printf
+          "Could not find constructor corresponding to mnemonic %S (%d)\n%!" s n
       | true, true ->
-        Printf.printf "Found constructor for deprecated warnings %S (%d)\n%!" s n
+        Printf.printf
+          "Found constructor for deprecated warnings %S (%d)\n%!" s n
     ) mnemonics
 
 let _ =

--- a/testsuite/tests/warnings/mnemonics.mll
+++ b/testsuite/tests/warnings/mnemonics.mll
@@ -6,27 +6,28 @@
 }
 
 let ws = [' ''\t']
-let nl = '\n'
+let eol = '\n'
+let to_eol = [^'\n']* eol
 let constr = ['A'-'Z']['a'-'z''A'-'Z''0'-'9''_']*
 let int = ['0'-'9']+
 let mnemo = ['a'-'z']['a'-'z''-']*['a'-'z']
 
 rule seek_let_number_function = parse
-| ws* "let" ws+ "number" ws* "=" ws* "function" ws* '\n'
+| ws* "let" ws+ "number" ws* "=" ws* "function" ws* eol
   { () }
-| [^'\n']* '\n'
+| to_eol
   { seek_let_number_function lexbuf }
 
 and constructors = parse
-| ws* '|' ws* (constr as c) (ws* '_')? ws* "->" ws* (int as n) [^'\n']* '\n'
+| ws* '|' ws* (constr as c) (ws* '_')? ws* "->" ws* (int as n) to_eol
   { (c, int_of_string n) :: constructors lexbuf }
-| ws* ";;" ws* '\n'
+| ws* ";;" ws* eol
   { [] }
 
 and mnemonics = parse
-| ws* (int as n) ws+ '[' (mnemo as s) ']' [^'\n']* '\n'
+| ws* (int as n) ws+ '[' (mnemo as s) ']' to_eol
   { (s, int_of_string n) :: mnemonics lexbuf }
-| [^'\n']* '\n'
+| to_eol
   { mnemonics lexbuf }
 | eof
   { [] }

--- a/tools/ocamltex.ml
+++ b/tools/ocamltex.ml
@@ -587,7 +587,15 @@ let format_input mode s =  match mode with
       | a :: q -> String.concat ~sep:"\n  " ((toplevel_prompt^a)::q)
 
 let process_file file =
-  let ic = try open_in file with _ -> failwith "Cannot read input file" in
+  let ic = try open_in_bin file with _ -> failwith "Cannot read input file" in
+  let input_line ic =
+    let line = input_line ic in
+    let last = String.length line - 1 in
+    if last >= 0 && line.[last] = '\r' then
+      String.sub line 0 last
+    else
+      line
+  in
   let phrase_start = ref 1 and phrase_stop = ref 1 in
   let incr_phrase_start () =
     incr phrase_start;


### PR DESCRIPTION
This is related to #12297, and my continuing quest never to see errors in testsuites to do with line endings, while avoiding thermonuclear sledgehammer approaches in `.gitattributes`. This is one of my many foibles, which started long ago, and includes such time sinks as #9801.

This one is not so bad, and is to do with running the testsuite from a CRLF "Windows" checkout... but _on Linux_. While that may sound like I've hit the mulled wine and mince pies a little early, WSL means that that's not only easy to end up doing, if one is working on OCaml, it's actually quite convenient to be able to quickly run a test from `/mnt/c/Users/DRA...` or from `\\wsl$\home\dra`, etc. It's less convenient when tests fail for unnecessary reasons.

You can try this trivially on Linux by running:
```console
$ file Makefile
Makefile: makefile script, ASCII text
$ git rm --cached -r .
$ git -c core.eol=crlf -c core.autocrlf=false reset --hard
$ file Makefile
Makefile: makefile script, ASCII text, with CRLF line terminators
```
and then build as normal. There are four fairly simple changes required:
1. The native-debugger tests just ignore `\r` characters at the end of a line
2. mnemonics.mll _always_ opens files in binary mode, and just uses the standard `'\r'? '\n'` for end-of-line
3. wc.ml similarly _always_ opens the file in binary mode, and just ignores `\r` characters when computing the character count (that's good enough for this test - it's primarily testing `input_char` over a loop and ensuring that the channels system is behaving itself)
4. ocamltex likewise _always_ opens files in binary mode, but then tweaks its definition of `input_line` to strip a trailing `\r` character (remember that ocamltex is not an installed tool...)

In passing, I fixed some lines in mnemonics.mll that were gratuitously taking advantage of the `typo.long-line=may` attribute that applies to the testsuite directory.