### PR TITLE
`unixsupport.h`: fix C++ missing `std::` namespace on `atomic_int`

### DIFF
--- a/Changes
+++ b/Changes
@@ -560,7 +560,7 @@ Working version
 - #14332: Fix missing TSan instrumentation in subexpressions
   (Vincent Laviron, review by Gabriel Scherer and Olivier Nicole)
 
-- #14370: Fix headers for C++ inclusion.
+- #14370, #14429: Fix headers for C++ inclusion.
   (Antonin Décimo, review by Gabriel Scherer)
 
 - #14417: Fix issue with nested packs on macOS.

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -44,6 +44,9 @@ struct filedescr {
     SOCKET socket;
   } fd;                   /* Real windows handle */
   enum { KIND_HANDLE, KIND_SOCKET } kind;
+#ifdef __cplusplus
+  std::
+#endif
   atomic_int crt_fd;      /* C runtime descriptor */
   unsigned int flags_fd;  /* See FLAGS_FD_* */
 };


### PR DESCRIPTION
The `std::` namespace was missing from bdbe619f1655a02c3ce18dcb745a4cf96c672dc2 in #14370.