### PR TITLE
feat: `[@@unstable]` features

### DIFF
--- a/.depend
+++ b/.depend
@@ -29,6 +29,7 @@ utils/ccomp.cmx : \
     utils/ccomp.cmi
 utils/ccomp.cmi :
 utils/clflags.cmo : \
+    utils/unstable_feature.cmi \
     utils/profile.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
@@ -36,6 +37,7 @@ utils/clflags.cmo : \
     utils/arg_helper.cmi \
     utils/clflags.cmi
 utils/clflags.cmx : \
+    utils/unstable_feature.cmx \
     utils/profile.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
@@ -43,6 +45,7 @@ utils/clflags.cmx : \
     utils/arg_helper.cmx \
     utils/clflags.cmi
 utils/clflags.cmi : \
+    utils/unstable_feature.cmi \
     utils/profile.cmi \
     utils/misc.cmi
 utils/compression.cmo : \
@@ -210,6 +213,14 @@ utils/terminfo.cmo : \
 utils/terminfo.cmx : \
     utils/terminfo.cmi
 utils/terminfo.cmi :
+utils/unstable_feature.cmo : \
+    utils/format_doc.cmi \
+    utils/unstable_feature.cmi
+utils/unstable_feature.cmx : \
+    utils/format_doc.cmx \
+    utils/unstable_feature.cmi
+utils/unstable_feature.cmi : \
+    utils/format_doc.cmi
 utils/warnings.cmo : \
     utils/misc.cmi \
     utils/format_doc.cmi \
@@ -340,6 +351,7 @@ parsing/attr_helper.cmi : \
     parsing/asttypes.cmi
 parsing/builtin_attributes.cmo : \
     utils/warnings.cmi \
+    utils/unstable_feature.cmi \
     parsing/parsetree.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
@@ -352,6 +364,7 @@ parsing/builtin_attributes.cmo : \
     parsing/builtin_attributes.cmi
 parsing/builtin_attributes.cmx : \
     utils/warnings.cmx \
+    utils/unstable_feature.cmx \
     parsing/parsetree.cmi \
     utils/misc.cmx \
     parsing/longident.cmx \
@@ -2043,6 +2056,7 @@ typing/typedtree.cmi : \
     parsing/asttypes.cmi
 typing/typemod.cmo : \
     utils/warnings.cmi \
+    utils/unstable_feature.cmi \
     parsing/unit_info.cmi \
     typing/typetexp.cmi \
     typing/types.cmi \
@@ -2082,6 +2096,7 @@ typing/typemod.cmo : \
     typing/typemod.cmi
 typing/typemod.cmx : \
     utils/warnings.cmx \
+    utils/unstable_feature.cmx \
     parsing/unit_info.cmx \
     typing/typetexp.cmx \
     typing/types.cmx \

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ utils_SOURCES = $(addprefix utils/, \
   arg_helper.mli arg_helper.ml \
   local_store.mli local_store.ml \
   load_path.mli load_path.ml \
+  unstable_feature.mli unstable_feature.ml \
   clflags.mli clflags.ml \
   profile.mli profile.ml \
   terminfo.mli terminfo.ml \
@@ -2383,6 +2384,7 @@ ocamlprof_SOURCES = \
   arg_helper.mli arg_helper.ml \
   local_store.mli local_store.ml \
   load_path.mli load_path.ml \
+  unstable_feature.mli unstable_feature.ml \
   clflags.mli clflags.ml \
   terminfo.mli terminfo.ml \
   warnings.mli warnings.ml \
@@ -2412,6 +2414,7 @@ ocamlcp_ocamloptp_SOURCES = \
   arg_helper.mli arg_helper.ml \
   local_store.mli local_store.ml \
   load_path.mli load_path.ml \
+  unstable_feature.mli unstable_feature.ml \
   clflags.mli clflags.ml \
   terminfo.mli terminfo.ml \
   location.mli location.ml \
@@ -2448,6 +2451,7 @@ ocamlmktop_SOURCES = \
   arg_helper.mli arg_helper.ml \
   local_store.mli local_store.ml \
   load_path.mli load_path.ml \
+  unstable_feature.mli unstable_feature.ml \
   clflags.mli clflags.ml \
   profile.mli profile.ml \
   ccomp.mli ccomp.ml \

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -387,6 +387,12 @@ let mk_o f =
 let mk_open f =
   "-open", Arg.String f, "<module>  Opens the module <module> before typing"
 
+let mk_Z f =
+  "-Z", Arg.String f,
+  "<features>  Enable unstable features (comma-separated list).\n\
+  \     Unstable features are experimental and may change or be removed.\n\
+  \     Example: -Z feature1,feature2"
+
 let mk_output_obj f =
   "-output-obj", Arg.Unit f, " Output an object file instead of an executable"
 
@@ -827,6 +833,7 @@ module type Common_options = sig
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
+  val _Z : string -> unit
 
   val anonymous : string -> unit
 end
@@ -1110,6 +1117,7 @@ struct
     mk_o F._o;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_Z F._Z;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
     mk_output_complete_exe F._output_complete_exe;
@@ -1204,6 +1212,7 @@ struct
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
     mk_open F._open;
+    mk_Z F._Z;
     mk_ppx F._ppx;
     mk_keywords F._keywords;
     mk_principal F._principal;
@@ -1333,6 +1342,7 @@ struct
     mk_o3 F._o3;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_Z F._Z;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
     mk_p F._p;
@@ -1473,6 +1483,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_o2 F._o2;
     mk_o3 F._o3;
     mk_open F._open;
+    mk_Z F._Z;
     mk_ppx F._ppx;
     mk_principal F._principal;
     mk_no_principal F._no_principal;
@@ -1564,6 +1575,7 @@ struct
     mk_nostdlib F._nostdlib;
     mk_nocwd F._nocwd;
     mk_open F._open;
+    mk_Z F._Z;
     mk_pp F._pp;
     mk_ppx F._ppx;
     mk_principal F._principal;
@@ -1661,6 +1673,10 @@ module Default = struct
     let _nostdlib = set no_std_include
     let _nocwd = set no_cwd
     let _open s = open_modules := (s :: (!open_modules))
+    let _Z s =
+      let features = parse_unstable_features s in
+      List.iter Unstable_feature.Scope.enable features;
+      unstable_features := !unstable_features @ features
     let _principal = set principal
     let _rectypes = set recursive_types
     let _safer_matching = set safer_matching

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -50,6 +50,7 @@ module type Common_options = sig
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
+  val _Z : string -> unit
 
   val anonymous : string -> unit
 end

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -62,6 +62,7 @@ let builtin_attrs =
   ; "deprecated"
   ; "deprecated_mutable"
   ; "explicit_arity"
+  ; "feature"
   ; "immediate"
   ; "immediate64"
   ; "inline"
@@ -76,6 +77,7 @@ let builtin_attrs =
   ; "tail_mod_cons"
   ; "unboxed"
   ; "untagged"
+  ; "unstable"
   ; "unrolled"
   ; "warnerror"
   ; "warning"
@@ -299,6 +301,9 @@ let alerts_of_str ~mark str =
 let warn_payload loc txt msg =
   Location.prerr_warning loc (Warnings.Attribute_payload (txt, msg))
 
+let warn_payloadf loc txt msgf =
+  msgf |> Format.ksprintf (warn_payload loc txt)
+
 let warning_attribute ?(ppwarning = true) =
   let process loc name errflag payload =
     mark_used name;
@@ -416,3 +421,122 @@ let has_boxed attrs = has_attribute "boxed" attrs
 let has_remove_aliases attrs = has_attribute "remove_aliases" attrs
 
 let has_atomic attrs = has_attribute "atomic" attrs
+
+module Unstable = struct
+  type t = Unstable_feature.t
+
+  (* Parses [{ feature = <string>; issue = <int> }] *)
+  let parse_attr_payload ~loc ~name payload : t option =
+    let warn_if_none opt field =
+      if Option.is_none opt
+      then
+        warn_payloadf
+          loc
+          name.txt
+          "unstable attribute requires a '%s' field"
+          field
+    in
+    match payload with
+    | PStr
+        [ { pstr_desc =
+              Pstr_eval ({ pexp_desc = Pexp_record (fields, None) }, _)
+          }
+        ] ->
+      let feature = ref None in
+      let issue = ref None in
+      List.iter
+        (fun (field_id, field_expr) ->
+          match field_id.txt, field_expr.pexp_desc with
+          | ( Longident.Lident "feature"
+            , Pexp_constant { pconst_desc = Pconst_string (s, _, _) } ) ->
+            let name = Unstable_feature.Name.of_string s in
+            feature := name
+          | ( Longident.Lident "issue"
+            , Pexp_constant { pconst_desc = Pconst_integer (i, _) } ) ->
+            issue := Some (int_of_string i)
+          | _ -> ())
+        fields;
+      warn_if_none !feature "feature";
+      warn_if_none !issue "issue";
+      (match !feature, !issue with
+      | Some name, Some issue -> Some { name; issue }
+      | _, _ -> None)
+    | _ ->
+      warn_payload
+        loc
+        name.txt
+        "unstable attribute expects payload: { feature = \"<name>\"; issue = \
+         <int> }";
+      None
+
+  let of_attrs attrs : t option =
+    let open Option.Syntax in
+    let find_unstable_attr attrs =
+      List.find_opt (fun a -> attr_equals_builtin a "unstable") attrs
+    in
+    let* attr = find_unstable_attr attrs in
+    mark_used attr.attr_name;
+    parse_attr_payload ~loc:attr.attr_loc ~name:attr.attr_name attr.attr_payload
+end
+
+module Unstable_features = struct
+  type t = { enabled : Unstable_feature.Name.t list }
+
+  let parse_attr_payload ~loc ~name payload =
+    match string_of_payload payload with
+    | Some s ->
+      let features = Clflags.parse_unstable_features s in
+      if List.is_empty features
+      then (
+        warn_payload
+          loc
+          name.txt
+          "feature attribute expects a non-empty list of features";
+        None)
+      else Some features
+    | None ->
+      warn_payload loc name.txt "feature attribute expects a string payload";
+      None
+
+  let of_attr attr : t option =
+    let open Option.Syntax in
+    let+ enabled =
+      if not (attr_equals_builtin attr "unstable_feature")
+      then None
+      else (
+        mark_used attr.attr_name;
+        parse_attr_payload
+          ~loc:attr.attr_loc
+          ~name:attr.attr_name
+          attr.attr_payload)
+    in
+    { enabled }
+
+  let iter f t = List.iter f t.enabled
+end
+
+let check_unstable_feature loc attrs ident =
+  attrs
+  |> Unstable.of_attrs
+  |> Option.iter (fun { Unstable_feature.name; issue } ->
+         if not (Unstable_feature.Scope.is_enabled name)
+         then
+           Location.raise_errorf
+             ~loc
+             "@[<v>%s uses unstable feature '%a' (issue #%d).@ Enable it with \
+              -Z %a or [%@%@%@unstable_feature \"%a\"]@]"
+             ident
+             Unstable_feature.Name.pp
+             name
+             issue
+             Unstable_feature.Name.pp
+             name
+             Unstable_feature.Name.pp
+             name)
+
+let unstable_feature_attribute attr =
+  attr
+  |> Unstable_features.of_attr
+  |> Option.iter (fun features ->
+         Unstable_features.iter Unstable_feature.Scope.enable features)
+

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -20,6 +20,7 @@
     - ocaml.deprecated
     - ocaml.deprecated_mutable
     - ocaml.explicit_arity
+    - ocaml.feature
     - ocaml.immediate
     - ocaml.immediate64
     - ocaml.inline
@@ -33,6 +34,7 @@
     - ocaml.tailcall
     - ocaml.tail_mod_cons
     - ocaml.unboxed
+    - ocaml.unstable
     - ocaml.untagged
     - ocaml.unrolled
     - ocaml.warnerror
@@ -190,3 +192,20 @@ val has_boxed: Parsetree.attributes -> bool
 val has_remove_aliases: Parsetree.attributes -> bool
 
 val has_atomic: Parsetree.attributes -> bool
+
+(** {3 Unstable features support} *)
+
+(** [check_unstable_feature loc attrs name] checks that the unstable feature
+    associated with [name] (if any) is enabled in the current
+    {!Unstable_feature.Scope}.
+
+    @raises Location.Error at [loc] if the feature is not enabled. *)
+val check_unstable_feature
+  :  Location.t
+  -> Parsetree.attributes
+  -> string
+  -> unit
+
+(** [unstable_feature_attribute attr] enables the unstable features listed in
+    the attribute (if any). *)
+val unstable_feature_attribute : Parsetree.attribute -> unit

--- a/testsuite/tests/typing-unstable/clflags.ml
+++ b/testsuite/tests/typing-unstable/clflags.ml
@@ -1,0 +1,154 @@
+(* TEST
+ flags = "-Z unstable_type,unstable_val,unstable_constr,unstable_label";
+ expect;
+*)
+
+module Unstable_api : sig
+  type t [@@unstable { feature = "unstable_type"; issue = 1111 }]
+  type never_enabled [@@unstable { feature = "dont_enable"; issue = 6666 }]
+
+  val make : unit -> t [@@unstable { feature = "unstable_val"; issue = 2222 }]
+  val stable : unit -> int
+
+  val never_enabled : unit -> int
+    [@@unstable { feature = "dont_enable"; issue = 6666 }]
+
+  type constr =
+    | Stable
+    | Unstable [@unstable { feature = "unstable_constr"; issue = 3333 }]
+    | Never_enabled [@unstable { feature = "dont_enable"; issue = 6666 }]
+
+  type record =
+    { stable : int
+    ; unstable : bool [@unstable { feature = "unstable_label"; issue = 4444 }]
+    ; never_enabled : unit [@unstable { feature = "dont_enable"; issue = 6666 }]
+    }
+
+  val make_record : unit -> record
+end = struct
+  type t = unit
+  type never_enabled = unit
+
+  let make () = ()
+  let stable () = 0
+  let never_enabled () = 1
+
+  type constr =
+    | Stable
+    | Unstable
+    | Never_enabled
+
+  type record =
+    { stable : int
+    ; unstable : bool
+    ; never_enabled : unit
+    }
+
+  let make_record () = { stable = 42; unstable = false; never_enabled = () }
+end
+
+let x = Unstable_api.make ()
+
+[%%expect
+{|
+module Unstable_api :
+  sig
+    type t
+    type never_enabled
+    val make : unit -> t
+    val stable : unit -> int
+    val never_enabled : unit -> int
+    type constr = Stable | Unstable | Never_enabled
+    type record = { stable : int; unstable : bool; never_enabled : unit; }
+    val make_record : unit -> record
+  end
+val x : Unstable_api.t = <abstr>
+|}]
+
+let y = Unstable_api.stable ()
+
+[%%expect {|
+val y : int = 0
+|}]
+
+let z = Unstable_api.never_enabled ()
+
+[%%expect
+{|
+Line 1, characters 8-34:
+1 | let z = Unstable_api.never_enabled ()
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unstable_api.never_enabled uses unstable feature 'dont_enable' (issue #6666).
+       Enable it with -Z dont_enable or [@@@unstable_feature "dont_enable"]
+|}]
+
+type unstable_t = Unstable_api.t
+
+[%%expect {|
+type unstable_t = Unstable_api.t
+|}]
+
+type never_enabled_t = Unstable_api.never_enabled
+
+[%%expect
+{|
+Line 1, characters 23-49:
+1 | type never_enabled_t = Unstable_api.never_enabled
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unstable_api.never_enabled uses unstable feature 'dont_enable' (issue #6666).
+       Enable it with -Z dont_enable or [@@@unstable_feature "dont_enable"]
+|}]
+
+let a = Unstable_api.Stable
+
+[%%expect {|
+val a : Unstable_api.constr = Unstable_api.Stable
+|}]
+
+let b = Unstable_api.Unstable
+
+[%%expect {|
+val b : Unstable_api.constr = Unstable_api.Unstable
+|}]
+
+let c = Unstable_api.Never_enabled
+
+[%%expect
+{|
+Line 1, characters 8-34:
+1 | let c = Unstable_api.Never_enabled
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Never_enabled uses unstable feature 'dont_enable' (issue #6666).
+       Enable it with -Z dont_enable or [@@@unstable_feature "dont_enable"]
+|}]
+
+let r = Unstable_api.make_record ()
+
+[%%expect
+{|
+val r : Unstable_api.record =
+  {Unstable_api.stable = 42; unstable = false; never_enabled = ()}
+|}]
+
+let field = r.Unstable_api.stable
+
+[%%expect {|
+val field : int = 42
+|}]
+
+let field2 = r.Unstable_api.unstable
+
+[%%expect {|
+val field2 : bool = false
+|}]
+
+let field3 = r.Unstable_api.never_enabled
+
+[%%expect
+{|
+Line 1, characters 15-41:
+1 | let field3 = r.Unstable_api.never_enabled
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: never_enabled uses unstable feature 'dont_enable' (issue #6666).
+       Enable it with -Z dont_enable or [@@@unstable_feature "dont_enable"]
+|}]

--- a/testsuite/tests/typing-unstable/scope.ml
+++ b/testsuite/tests/typing-unstable/scope.ml
@@ -1,0 +1,186 @@
+(* TEST
+ expect;
+*)
+
+module Unstable_api : sig
+  [@@@unstable_feature "unstable_type"]
+
+  type t [@@unstable { feature = "unstable_type"; issue = 1111 }]
+  type never_enabled [@@unstable { feature = "dont_enable"; issue = 6666 }]
+
+  val make : unit -> t [@@unstable { feature = "unstable_val"; issue = 2222 }]
+  val stable : unit -> int
+
+  val never_enabled : unit -> int
+    [@@unstable { feature = "dont_enable"; issue = 6666 }]
+
+  type constr =
+    | Stable
+    | Unstable [@unstable { feature = "unstable_constr"; issue = 3333 }]
+    | Never_enabled [@unstable { feature = "dont_enable"; issue = 6666 }]
+
+  type record =
+    { stable : int
+    ; unstable : bool [@unstable { feature = "unstable_label"; issue = 4444 }]
+    ; never_enabled : unit [@unstable { feature = "dont_enable"; issue = 6666 }]
+    }
+
+  val make_record : unit -> record
+end = struct
+  type t = unit
+  type never_enabled = unit
+
+  let make () = ()
+  let stable () = 0
+  let never_enabled () = 1
+
+  type constr =
+    | Stable
+    | Unstable
+    | Never_enabled
+
+  type record =
+    { stable : int
+    ; unstable : bool
+    ; never_enabled : unit
+    }
+
+  let make_record () = { stable = 42; unstable = false; never_enabled = () }
+end
+
+(* Types *)
+
+type disabled_unstable_t = Unstable_api.t
+
+[%%expect
+{|
+module Unstable_api :
+  sig
+    type t
+    type never_enabled
+    val make : unit -> t
+    val stable : unit -> int
+    val never_enabled : unit -> int
+    type constr = Stable | Unstable | Never_enabled
+    type record = { stable : int; unstable : bool; never_enabled : unit; }
+    val make_record : unit -> record
+  end
+Line 49, characters 27-41:
+49 | type disabled_unstable_t = Unstable_api.t
+                                ^^^^^^^^^^^^^^
+Error: Unstable_api.t uses unstable feature 'unstable_type' (issue #1111).
+       Enable it with -Z unstable_type or [@@@unstable_feature "unstable_type"]
+|}]
+
+[@@@unstable_feature "unstable_type"]
+
+type unstable_t = Unstable_api.t
+
+[%%expect {|
+type unstable_t = Unstable_api.t
+|}]
+
+(* Unstable values are accessible from stable ones *)
+
+let should_fail_unstable_val = Unstable_api.make
+
+[%%expect
+{|
+Line 1, characters 31-48:
+1 | let should_fail_unstable_val = Unstable_api.make
+                                   ^^^^^^^^^^^^^^^^^
+Error: Unstable_api.make uses unstable feature 'unstable_val' (issue #2222).
+       Enable it with -Z unstable_val or [@@@unstable_feature "unstable_val"]
+|}]
+
+[@@@unstable_feature "unstable_val"]
+
+let should_work_unstable_val = Unstable_api.make
+
+[%%expect {|
+val should_work_unstable_val : unit -> Unstable_api.t = <fun>
+|}]
+
+module Inner = struct
+  let unstable_make = Unstable_api.make
+end
+
+[%%expect
+{|
+module Inner : sig val unstable_make : unit -> Unstable_api.t end
+|}]
+
+module Outer = struct
+  module Inner = struct
+    let unstable_make = Unstable_api.make
+  end
+end
+
+[%%expect
+{|
+module Outer :
+  sig module Inner : sig val unstable_make : unit -> Unstable_api.t end end
+|}]
+
+(* Constructors and records *)
+
+let r = Unstable_api.make_record ()
+let should_fail_unstable_constr = Unstable_api.Unstable
+let should_fail_unstable_record = r.Unstable_api.unstable_label
+
+[%%expect
+{|
+val r : Unstable_api.record =
+  {Unstable_api.stable = 42; unstable = false; never_enabled = ()}
+Line 2, characters 34-55:
+2 | let should_fail_unstable_constr = Unstable_api.Unstable
+                                      ^^^^^^^^^^^^^^^^^^^^^
+Error: Unstable uses unstable feature 'unstable_constr' (issue #3333).
+       Enable it with -Z unstable_constr or [@@@unstable_feature "unstable_constr"]
+Unexecuted phrases: 1 phrases did not execute due to an error
+|}]
+
+[@@@unstable_feature "unstable_constr,unstable_label"]
+
+let should_work_unstable_constr = Unstable_api.Unstable
+let should_work_unstable_record = r.Unstable_api.unstable
+
+[%%expect
+{|
+val should_work_unstable_constr : Unstable_api.constr = Unstable_api.Unstable
+val should_work_unstable_record : bool = false
+|}]
+
+(* Nested scopes *)
+
+module New_scope = struct
+  [@@@unstable_feature "different_feature"]
+
+  module Nested_unstable : sig
+    val nested : string
+      [@@unstable { feature = "different_feature"; issue = 7777 }]
+  end = struct
+    let nested = "nested"
+  end
+
+  let a = Nested_unstable.nested
+end
+
+let should_fail = New_scope.Nested_unstable.nested
+
+[%%expect
+{|
+module New_scope :
+  sig module Nested_unstable : sig val nested : string end val a : string end
+Line 14, characters 18-50:
+14 | let should_fail = New_scope.Nested_unstable.nested
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: New_scope.Nested_unstable.nested uses unstable feature 'different_feature' (issue #7777).
+       Enable it with -Z different_feature or [@@@unstable_feature "different_feature"]
+|}]
+
+let still_works = New_scope.a
+
+[%%expect {|
+val still_works : string = "nested"
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2728,6 +2728,8 @@ let use_value ~use ~loc path vda =
     let desc = vda.vda_description in
     mark_value_used desc.val_uid;
     Builtin_attributes.check_alerts loc desc.val_attributes
+      (Path.name path);
+    Builtin_attributes.check_unstable_feature loc desc.val_attributes
       (Path.name path)
   end
 
@@ -2736,6 +2738,8 @@ let use_type ~use ~loc path tda =
     let decl = tda.tda_declaration in
     mark_type_used decl.type_uid;
     Builtin_attributes.check_alerts loc decl.type_attributes
+      (Path.name path);
+    Builtin_attributes.check_unstable_feature loc decl.type_attributes
       (Path.name path)
   end
 
@@ -2744,6 +2748,8 @@ let use_modtype ~use ~loc path desc =
   if use then begin
     mark_modtype_used desc.mtdl_uid;
     Builtin_attributes.check_alerts loc desc.mtdl_attributes
+      (Path.name path);
+    Builtin_attributes.check_unstable_feature loc desc.mtdl_attributes
       (Path.name path)
   end
 
@@ -2752,6 +2758,8 @@ let use_class ~use ~loc path clda =
     let desc = clda.clda_declaration in
     mark_class_used desc.cty_uid;
     Builtin_attributes.check_alerts loc desc.cty_attributes
+      (Path.name path);
+    Builtin_attributes.check_unstable_feature loc desc.cty_attributes
       (Path.name path)
   end
 
@@ -2759,6 +2767,8 @@ let use_cltype ~use ~loc path desc =
   if use then begin
     mark_cltype_used desc.clty_uid;
     Builtin_attributes.check_alerts loc desc.clty_attributes
+      (Path.name path);
+    Builtin_attributes.check_unstable_feature loc desc.clty_attributes
       (Path.name path)
   end
 
@@ -2766,6 +2776,7 @@ let use_label ~use ~loc usage env lbl =
   if use then begin
     mark_label_description_used usage env lbl;
     Builtin_attributes.check_alerts loc lbl.lbl_attributes lbl.lbl_name;
+    Builtin_attributes.check_unstable_feature loc lbl.lbl_attributes lbl.lbl_name;
     if is_mutating_label_usage usage then
       Builtin_attributes.check_deprecated_mutable loc lbl.lbl_attributes
         lbl.lbl_name
@@ -2774,7 +2785,8 @@ let use_label ~use ~loc usage env lbl =
 let use_constructor_desc ~use ~loc usage env cstr =
   if use then begin
     mark_constructor_description_used usage env cstr;
-    Builtin_attributes.check_alerts loc cstr.cstr_attributes cstr.cstr_name
+    Builtin_attributes.check_alerts loc cstr.cstr_attributes cstr.cstr_name;
+    Builtin_attributes.check_unstable_feature loc cstr.cstr_attributes cstr.cstr_name
   end
 
 let use_constructor ~use ~loc usage env cda =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1898,23 +1898,25 @@ and transl_signature env sg =
             typedtree, sg, final_env
         | Psig_attribute x ->
             Builtin_attributes.warning_attribute x;
+            Builtin_attributes.unstable_feature_attribute x;
             let (trem,rem, final_env) = transl_sig env srem in
             mksig (Tsig_attribute x) env loc :: trem, rem, final_env
         | Psig_extension (ext, _attrs) ->
             raise (Error_forward (Builtin_attributes.error_of_extension ext))
   in
   let previous_saved_types = Cmt_format.get_saved_types () in
-  Builtin_attributes.warning_scope []
-    (fun () ->
-       let (trem, rem, final_env) = transl_sig (Env.in_signature true env) sg in
-       let rem = Signature_names.simplify final_env names rem in
-       let sg =
-         { sig_items = trem; sig_type = rem; sig_final_env = final_env }
-       in
-       Cmt_format.set_saved_types
-         ((Cmt_format.Partial_signature sg) :: previous_saved_types);
-       sg
-    )
+  Unstable_feature.Scope.with_local (fun () ->
+    Builtin_attributes.warning_scope []
+      (fun () ->
+         let (trem, rem, final_env) = transl_sig (Env.in_signature true env) sg in
+         let rem = Signature_names.simplify final_env names rem in
+         let sg =
+           { sig_items = trem; sig_type = rem; sig_final_env = final_env }
+         in
+         Cmt_format.set_saved_types
+           ((Cmt_format.Partial_signature sg) :: previous_saved_types);
+         sg
+      ))
 
 and transl_modtype_decl env pmtd =
   Builtin_attributes.warning_scope pmtd.pmtd_attributes
@@ -2773,7 +2775,9 @@ and type_structure ?(toplevel = false) ~funct_body anchor env sstr =
     str, sg, names, Shape.str shape_map, final_env
   in
   if toplevel then run ()
-  else Builtin_attributes.warning_scope [] run
+  else
+    Unstable_feature.Scope.with_local (fun () ->
+      Builtin_attributes.warning_scope [] run)
 
 and type_str_item ~names ~toplevel ~funct_body anchor env shape_map
     {pstr_loc = loc; pstr_desc = desc} =
@@ -3104,6 +3108,7 @@ and type_str_item ~names ~toplevel ~funct_body anchor env shape_map
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute x ->
         Builtin_attributes.warning_attribute x;
+        Builtin_attributes.unstable_feature_attribute x;
         Tstr_attribute x, [], shape_map, env
   in
   { str_desc = desc; str_loc = loc; str_env = env }, sg, shape_map, new_env

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -85,6 +85,7 @@ and nopromptcont = ref false            (* -nopromptcont *)
 and init_file = ref (None : string option)   (* -init *)
 and noinit = ref false                  (* -noinit *)
 and open_modules = ref []               (* -open *)
+and unstable_features = ref ([] : Unstable_feature.Name.t list) (* -Z *)
 and use_prims = ref ""                  (* -use-prims ... *)
 and use_runtime = ref ""                (* -use-runtime ... *)
 and plugin = ref false                  (* -plugin ... *)
@@ -767,6 +768,11 @@ let parse_keyword_edition s =
   | [] -> None, []
   | [s] -> parse_version s, []
   | v :: rest -> parse_version v, rest
+
+let parse_unstable_features s =
+  s
+  |> String.split_on_char ','
+  |> List.filter_map Unstable_feature.Name.of_string
 
 module String = Misc.Stdlib.String
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -98,6 +98,8 @@ val nopervasives : bool ref
 val match_context_rows : int ref
 val safer_matching : bool ref
 val open_modules : string list ref
+val unstable_features : Unstable_feature.Name.t list ref
+val parse_unstable_features : string -> Unstable_feature.Name.t list
 val preprocessor : string option ref
 val all_ppx : string list ref
 val absname : bool ref

--- a/utils/unstable_feature.ml
+++ b/utils/unstable_feature.ml
@@ -1,0 +1,52 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*               Alistair O'Brien, University of Cambridge                *)
+(*                                                                        *)
+(*   Copyright 2025 Alistair O'Brien                                      *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Name = struct
+  module T = struct
+    type t = string
+    let compare = String.compare
+  end
+
+  include T
+
+  let of_string s =
+    match s with
+    | "" -> None
+    | s -> Some s
+
+  let pp = Format_doc.pp_print_string
+
+  module Set = Set.Make (T)
+end
+
+type t = { name : Name.t; issue : int }
+
+module Scope = struct
+  type t = Name.Set.t
+
+  let t : t ref = ref Name.Set.empty
+
+  let is_enabled name = Name.Set.mem name !t
+
+  let enable name = t := Name.Set.add name !t
+
+  let disable name = t := Name.Set.remove name !t
+
+  let with_local f =
+    let current_scope = !t in
+    Fun.protect
+      f
+      ~finally:(fun () -> t := current_scope)
+end
+

--- a/utils/unstable_feature.mli
+++ b/utils/unstable_feature.mli
@@ -1,0 +1,50 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*               Alistair O'Brien, University of Cambridge                *)
+(*                                                                        *)
+(*   Copyright 2025 Alistair O'Brien                                      *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Name : sig
+  type t = private string
+
+  val pp : Format_doc.formatter -> t -> unit
+
+  val of_string : string -> t option
+end
+
+(** Unstable features for the OCaml compiler and standard library. *)
+type t =
+  { name : Name.t
+    (** [name] is the unique name associated with the feature *)
+  ; issue : int
+    (** [issue] is the tracking issue associated with the feature *)
+  }
+
+(** {1 Scopes}
+
+    A feature scope defines the set of enabled language features.
+
+    The root scope is defined by features passed to the
+    [-Z <allowed-features>] CLI flag. *)
+
+module Scope : sig
+  val enable : Name.t -> unit
+
+  val disable : Name.t -> unit
+
+  val is_enabled : Name.t -> bool
+
+  (** Temporarily enable and disable features. Calls to [enable], [disable]
+      inside the body of the function argument will be rolled back when the
+      function returns. *)
+  val with_local : (unit -> 'a) -> 'a
+end
+


### PR DESCRIPTION
## Context

Inspired by @giltho's discussion on 'Stdlib2', I decided to try my hand at implementing `[@@unstable]` attributes for OCaml.

```ocaml
module Unstable_api : sig 
  val do_thing : int -> int
  [@@unstable { feature = "something_pretty_unstable"; issue = 42 }]
end = struct 
  let do_thing x = x
end

let _ = Unstable_api.do_thing 1337
```
```sh
Error: Unstable_api.do_thing uses unstable feature 'something_pretty_unstable' (issue #42).
       Enable it with -Z something_pretty_unstable or [@@@unstable_feature "something_pretty_unstable"]
```

The motivating use-case is giving library authors (including `Stdlib` maintainers) a simple way to gate experimental APIs.

## Description

This adds a builtin attribute `unstable` and a top-level builtin attribute `[@@@unstable_feature]`.

When marked as unstable, any use of the marked node will result in an error unless the matching feature is explicitly enabled, either by `-Z feature_name` or via a local `[@@@unstable_feature "feature_name"]`

Most of the implementation uses the existing plumbing for warnings.  

## Testing

```sh
make -C testsuite one DIR=tests/typing-unstable      
```