### PR TITLE
Stdlib: add floor division, ceil division, Euclidean division and remainder

### DIFF
--- a/Changes
+++ b/Changes
@@ -201,6 +201,11 @@ Working version
 - #14084: Future-proof Dynarray implementation against a smarter compiler
   (Basile Clément, review by Gabriel Scherer)
 
+- #14432: Add floor division, ceil division, Euclidean division and remainder
+  to the Int, Int32, Int64 and Nativeint modules.
+  (Xavier Leroy, review by Ali Caglayan, Nicolás Ojeda Bär, Gabriel Scherer)
+
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/int.ml
+++ b/stdlib/int.ml
@@ -55,3 +55,26 @@ external seeded_hash_param :
   int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x
 let hash x = seeded_hash_param 10 100 0 x
+
+(* Floor division, ceil division *)
+
+let fdiv n d =
+  let q = div n d in
+  if logxor n d >= 0 (* n and d have same sign *) || n = q * d
+  then q else pred q
+
+let cdiv n d =
+  let q = div n d in
+  if logxor n d < 0 (* n and d have different signs *) || n = q * d
+  then q else succ q
+
+(* Euclidean division and remainder *)
+
+let erem n d =
+  let r = rem n d in
+  if r >= 0 then r else add r (abs d)
+
+let ediv n d =
+  let q = div n d in
+  let r = n - q * d in
+  if r >= 0 then q else if d >= 0 then pred q else succ q

--- a/stdlib/int.ml
+++ b/stdlib/int.ml
@@ -72,7 +72,7 @@ let cdiv n d =
 
 let erem n d =
   let r = rem n d in
-  if r >= 0 then r else add r (abs d)
+  if r >= 0 then r else if d >= 0 then r + d else r - d
 
 let ediv n d =
   let q = div n d in

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -49,7 +49,7 @@ external mul : int -> int -> int = "%mulint"
 
 external div : int -> int -> int = "%divint"
 (** Rounding division.
-    [div x y] is the quotient [x / y] rounded towards zero to an integer.
+    [div x y] is the real quotient [x / y] rounded towards zero to an integer.
     See {!Stdlib.( / )} for details.
 
     @raise Division_by_zero if the second argument is 0.
@@ -65,28 +65,31 @@ external rem : int -> int -> int = "%modint"
 
 val fdiv : int -> int -> int
 (** Floor division.
-    [fdiv x y] is the quotient [x / y] rounded down to an integer.
+    [fdiv x y] is the real quotient [x / y] rounded down to an integer.
     We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
 
     @raise Division_by_zero if the second argument is 0.
+    @since 5.5
 *)
 
 val cdiv : int -> int -> int
 (** Ceil division.
-    [cdiv x y] is the quotient [x / y] rounded up to an integer.
+    [cdiv x y] is the real quotient [x / y] rounded up to an integer.
     We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
 
     @raise Division_by_zero if the second argument is 0.
+    @since 5.5
 *)
 
 val ediv : int -> int -> int
 (** Euclidean division.
-    [ediv x y] is the quotient [x / y] rounded down to an integer if [y > 0]
-    and rounded up to an integer if [y < 0].
-    The remainder [x - ediv x y * y] is always non-negative.
+    [ediv x y] is the real quotient [x / y] rounded down to an integer
+    if [y > 0] and rounded up to an integer if [y < 0].
+    The remainder [erem x y = x - ediv x y * y] is always non-negative.
     Moreover, [ediv x (-y)] = [- ediv x y].
 
     @raise Division_by_zero if the second argument is 0.
+    @since 5.5
 *)
 
 val erem : int -> int -> int
@@ -96,6 +99,7 @@ val erem : int -> int -> int
     unlike the result of [rem x y], which has the sign of [x].
 
     @raise Division_by_zero if the second argument is 0.
+    @since 5.5
 *)
 
 external succ : int -> int = "%succint"

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -48,10 +48,55 @@ external mul : int -> int -> int = "%mulint"
 (** [mul x y] is the multiplication [x * y]. *)
 
 external div : int -> int -> int = "%divint"
-(** [div x y] is the division [x / y]. See {!Stdlib.( / )} for details. *)
+(** Rounding division.
+    [div x y] is the quotient [x / y] rounded towards zero to an integer.
+    See {!Stdlib.( / )} for details.
+
+    @raise Division_by_zero if the second argument is 0.
+*)
 
 external rem : int -> int -> int = "%modint"
-(** [rem x y] is the remainder [x mod y]. See {!Stdlib.( mod )} for details. *)
+(** [rem x y] is the remainder of the rounding division [div x y].
+    We have [rem x y = x - div x y * y].
+    See {!Stdlib.( mod )} for details.
+
+    @raise Division_by_zero if the second argument is 0.
+*)
+
+val fdiv : int -> int -> int
+(** Floor division.
+    [fdiv x y] is the quotient [x / y] rounded down to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+*)
+
+val cdiv : int -> int -> int
+(** Ceil division.
+    [cdiv x y] is the quotient [x / y] rounded up to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+*)
+
+val ediv : int -> int -> int
+(** Euclidean division.
+    [ediv x y] is the quotient [x / y] rounded down to an integer if [y > 0]
+    and rounded up to an integer if [y < 0].
+    The remainder [x - ediv x y * y] is always non-negative.
+    Moreover, [ediv x (-y)] = [- ediv x y].
+
+    @raise Division_by_zero if the second argument is 0.
+*)
+
+val erem : int -> int -> int
+(** Euclidean remainder.  If [y] is not zero, we have
+    [x = ediv x y * y + erem x y] and [0 <= erem x y <= abs y - 1].
+    The result of [erem x y] is always non-negative,
+    unlike the result of [rem x y], which has the sign of [x].
+
+    @raise Division_by_zero if the second argument is 0.
+*)
 
 external succ : int -> int = "%succint"
 (** [succ x] is [add x 1]. *)

--- a/stdlib/int32.ml
+++ b/stdlib/int32.ml
@@ -105,6 +105,29 @@ let unsigned_div n d =
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
 
+(* Floor division, ceil division *)
+
+let fdiv n d =
+  let q = div n d in
+  if logxor n d >= 0l (* n and d have same sign *) || n = mul q d
+  then q else pred q
+
+let cdiv n d =
+  let q = div n d in
+  if logxor n d < 0l (* n and d have different signs *) || n = mul q d
+  then q else succ q
+
+(* Euclidean division and remainder *)
+
+let erem n d =
+  let r = rem n d in
+  if r >= 0l then r else if d >= 0l then add r d else sub r d
+
+let ediv n d =
+  let q = div n d in
+  let r = sub n (mul q d) in
+  if r >= 0l then q else if d >= 0l then pred q else succ q
+
 external seeded_hash_param :
   int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -79,6 +79,45 @@ val unsigned_rem : int32 -> int32 -> int32
 
     @since 4.08 *)
 
+val fdiv : int32 -> int32 -> int32
+(** Floor division.
+    [fdiv x y] is the real quotient [x / y] rounded down to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val cdiv : int32 -> int32 -> int32
+(** Ceil division.
+    [cdiv x y] is the real quotient [x / y] rounded up to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val ediv : int32 -> int32 -> int32
+(** Euclidean division.
+    [ediv x y] is the real quotient [x / y] rounded down to an integer
+    if [y > 0] and rounded up to an integer if [y < 0].
+    The remainder [erem x y = x - ediv x y * y] is always non-negative.
+    Moreover, [ediv x (-y)] = [- ediv x y].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val erem : int32 -> int32 -> int32
+(** Euclidean remainder.  If [y] is not zero, we have
+    [x = ediv x y * y + erem x y] and [0 <= erem x y <= abs y - 1].
+    The result of [erem x y] is always non-negative,
+    unlike the result of [rem x y], which has the sign of [x].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
 val succ : int32 -> int32
 (** Successor.  [Int32.succ x] is [Int32.add x Int32.one]. *)
 

--- a/stdlib/int64.ml
+++ b/stdlib/int64.ml
@@ -102,6 +102,29 @@ let unsigned_div n d =
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
 
+(* Floor division, ceil division *)
+
+let fdiv n d =
+  let q = div n d in
+  if logxor n d >= 0L (* n and d have same sign *) || n = mul q d
+  then q else pred q
+
+let cdiv n d =
+  let q = div n d in
+  if logxor n d < 0L (* n and d have different signs *) || n = mul q d
+  then q else succ q
+
+(* Euclidean division and remainder *)
+
+let erem n d =
+  let r = rem n d in
+  if r >= 0L then r else if d >= 0L then add r d else sub r d
+
+let ediv n d =
+  let q = div n d in
+  let r = sub n (mul q d) in
+  if r >= 0L then q else if d >= 0L then pred q else succ q
+
 external seeded_hash_param :
   int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -79,6 +79,45 @@ val unsigned_rem : int64 -> int64 -> int64
 
     @since 4.08 *)
 
+val fdiv : int64 -> int64 -> int64
+(** Floor division.
+    [fdiv x y] is the real quotient [x / y] rounded down to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val cdiv : int64 -> int64 -> int64
+(** Ceil division.
+    [cdiv x y] is the real quotient [x / y] rounded up to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val ediv : int64 -> int64 -> int64
+(** Euclidean division.
+    [ediv x y] is the real quotient [x / y] rounded down to an integer
+    if [y > 0] and rounded up to an integer if [y < 0].
+    The remainder [erem x y = x - ediv x y * y] is always non-negative.
+    Moreover, [ediv x (-y)] = [- ediv x y].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val erem : int64 -> int64 -> int64
+(** Euclidean remainder.  If [y] is not zero, we have
+    [x = ediv x y * y + erem x y] and [0 <= erem x y <= abs y - 1].
+    The result of [erem x y] is always non-negative,
+    unlike the result of [rem x y], which has the sign of [x].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
 val succ : int64 -> int64
 (** Successor.  [Int64.succ x] is [Int64.add x Int64.one]. *)
 

--- a/stdlib/nativeint.ml
+++ b/stdlib/nativeint.ml
@@ -94,6 +94,29 @@ let unsigned_div n d =
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
 
+(* Floor division, ceil division *)
+
+let fdiv n d =
+  let q = div n d in
+  if logxor n d >= 0n (* n and d have same sign *) || n = mul q d
+  then q else pred q
+
+let cdiv n d =
+  let q = div n d in
+  if logxor n d < 0n (* n and d have different signs *) || n = mul q d
+  then q else succ q
+
+(* Euclidean division and remainder *)
+
+let erem n d =
+  let r = rem n d in
+  if r >= 0n then r else if d >= 0n then add r d else sub r d
+
+let ediv n d =
+  let q = div n d in
+  let r = sub n (mul q d) in
+  if r >= 0n then q else if d >= 0n then pred q else succ q
+
 external seeded_hash_param :
   int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -85,6 +85,45 @@ val unsigned_rem : nativeint -> nativeint -> nativeint
 
     @since 4.08 *)
 
+val fdiv : nativeint -> nativeint -> nativeint
+(** Floor division.
+    [fdiv x y] is the real quotient [x / y] rounded down to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val cdiv : nativeint -> nativeint -> nativeint
+(** Ceil division.
+    [cdiv x y] is the real quotient [x / y] rounded up to an integer.
+    We have [fdiv x y <= div x y <= cdiv x y] and [cdiv x y - fdiv x y <= 1].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val ediv : nativeint -> nativeint -> nativeint
+(** Euclidean division.
+    [ediv x y] is the real quotient [x / y] rounded down to an integer
+    if [y > 0] and rounded up to an integer if [y < 0].
+    The remainder [erem x y = x - ediv x y * y] is always non-negative.
+    Moreover, [ediv x (-y)] = [- ediv x y].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
+val erem : nativeint -> nativeint -> nativeint
+(** Euclidean remainder.  If [y] is not zero, we have
+    [x = ediv x y * y + erem x y] and [0 <= erem x y <= abs y - 1].
+    The result of [erem x y] is always non-negative,
+    unlike the result of [rem x y], which has the sign of [x].
+
+    @raise Division_by_zero if the second argument is 0.
+    @since 5.5
+*)
+
 val succ : nativeint -> nativeint
 (** Successor.
    [Nativeint.succ x] is [Nativeint.add x Nativeint.one]. *)

--- a/testsuite/tests/lib-int/test.ml
+++ b/testsuite/tests/lib-int/test.ml
@@ -18,6 +18,44 @@ let test_arith () =
   assert (Int.abs 5 = 5);
   ()
 
+let test_div () =
+  let divzero f x y =
+    try ignore (f x y); false with Division_by_zero -> true in
+  let check x y =
+    if y = 0 then begin
+      assert (divzero Int.div x y);
+      assert (divzero Int.rem x y);
+      assert (divzero Int.fdiv x y);
+      assert (divzero Int.cdiv x y);
+      assert (divzero Int.ediv x y);
+      assert (divzero Int.erem x y)
+    end else begin
+      let q = Int.div x y
+      and r = Int.rem x y
+      and f = Int.fdiv x y
+      and c = Int.cdiv x y
+      and q' = Int.ediv x y
+      and r' = Int.erem x y in
+      assert (x = Int.add (Int.mul q y) r);
+      assert (Int.abs r <= Int.abs y - 1);
+      assert (x = Int.add (Int.mul q' y) r');
+      assert (0 <= r' && r' <= Int.abs y - 1);
+      assert (f <= q && q <= c);
+      if r = 0 then assert (f = q && q = c);
+      assert (q' = (if y > 0 then f else c))
+    end in
+  for _i = 1 to 1000 do
+    check (Random.int_in_range ~min:Int.min_int ~max:Int.max_int)
+          (Random.int_in_range ~min:Int.min_int ~max:Int.max_int);
+    check (Random.int_in_range ~min:Int.min_int ~max:Int.max_int)
+          (Random.int_in_range ~min:(-10000) ~max:10000)
+  done;
+  let interesting_values =
+    [Int.min_int; -119; -99; -3; -2; -1; 0; 1; 2; 3; 99; 119; Int.max_int] in
+  List.iter
+    (fun x -> List.iter (check x) interesting_values)
+    interesting_values
+
 let test_logops () =
   assert (Int.logand 0xF0F0 0xFFFF = 0xF0F0);
   assert (Int.logor 0xF0FF 0x0F0F = 0xFFFF);
@@ -70,6 +108,7 @@ let test_hash () =
 let tests () =
   test_consts ();
   test_arith ();
+  test_div ();
   test_logops ();
   test_equal ();
   test_compare ();

--- a/testsuite/tests/lib-int64/test.ml
+++ b/testsuite/tests/lib-int64/test.ml
@@ -18,6 +18,44 @@ let test_arith () =
   assert (Int64.abs 5L = 5L);
   ()
 
+let test_div () =
+  let divzero f x y =
+    try ignore (f x y); false with Division_by_zero -> true in
+  let check x y =
+    if y = 0L then begin
+      assert (divzero Int64.div x y);
+      assert (divzero Int64.rem x y);
+      assert (divzero Int64.fdiv x y);
+      assert (divzero Int64.cdiv x y);
+      assert (divzero Int64.ediv x y);
+      assert (divzero Int64.erem x y)
+    end else begin
+      let q = Int64.div x y
+      and r = Int64.rem x y
+      and f = Int64.fdiv x y
+      and c = Int64.cdiv x y
+      and q' = Int64.ediv x y
+      and r' = Int64.erem x y in
+      assert (x = Int64.add (Int64.mul q y) r);
+      assert (Int64.abs r <= Int64.(sub (abs y) 1L));
+      assert (x = Int64.add (Int64.mul q' y) r');
+      assert (0L <= r' && r' <= Int64.(sub (abs y) 1L));
+      assert (f <= q && q <= c);
+      if r = 0L then assert (f = q && q = c);
+      assert (q' = (if y > 0L then f else c))
+    end in
+  for _i = 1 to 1000 do
+    check (Random.bits64()) (Random.bits64());
+    check (Random.bits64())
+          (Random.int64_in_range ~min:(-10000L) ~max:10000L)
+  done;
+  let interesting_values =
+    [Int64.min_int; -119L; -99L; -3L; -2L; -1L; 0L;
+     1L; 2L; 3L; 99L; 119L; Int64.max_int] in
+  List.iter
+    (fun x -> List.iter (check x) interesting_values)
+    interesting_values
+
 let test_logops () =
   assert (Int64.logand 0xF0F0L 0xFFFFL = 0xF0F0L);
   assert (Int64.logor 0xF0FFL 0x0F0FL = 0xFFFFL);
@@ -62,6 +100,7 @@ let test_min_max () =
 let tests () =
   test_consts ();
   test_arith ();
+  test_div ();
   test_logops ();
   test_equal ();
   test_compare ();


### PR DESCRIPTION
This PR adds three integer division functions and one remainder function to the Int, Int32, Int64 and Nativeint standard library modules.  (Only Int is modified at this point; I'll update the other three modules when we agree on everything.)
- `fdiv`: floor division (round down)
- `cdiv`: ceil division (round up)
- `ediv` and `emod`: Euclidean division and remainder.

The initial motivation is to provide a remainder operation that is appropriate for implementing modulo arithmetic, meaning that the remainder is never negative.  The default `mod` operator doesn't work well, since `(4 - 5) mod 3` is `-1` instead of `2` as expected from modulo-3 arithmetic.   In contrast, `emod p q` is guaranteed to be the unique integer in `{0, ..., |q|-1}` that is congruent to `p` modulo `q`.

The `ediv` division that matches `emod` (i.e. `p = ediv p q * q + erem p q`) is a bit surprising: it rounds down if the divisor is positive and up if the divisor is negative,.  So, I thought it would be nice to also provide `fdiv` and `cdiv`, which consistently round down (for `fdiv`) or up (for `cdiv`).  `fdiv` has its fans (e.g. it's Python's `//` operator) and `cdiv` has its uses (e.g. "how many blocks of n bytes to hold N bytes?").

The Zarith bigint library also offers `div`/`rem` (for truncating, round-toward-zero division), `fdiv`, `cdiv`, `ediv` and `erem` (with the semantics outlined above), so with this PR OCaml's stdlib integers will match Zarith on division operators.

For a more extensive discussion of the flavors of division and why Euclidean division is really nice, see R. Boute, "The Euclidean definition of the functions div and mod", https://dl.acm.org/doi/10.1145/128861.128862


