### PR TITLE
Disable the lib-runtime-events/test_create_cursor_failures.ml test when the current user is a superuser

### DIFF
--- a/Changes
+++ b/Changes
@@ -479,6 +479,10 @@ Working version
 - #13224: Clarify barriers and spin macros with delayed expansion.
   (Antonin Décimo, review by David Allsopp and Gabriel Scherer)
 
+- #14435: Add the not-root builtin ocamltest action. This allows to skip
+  tests that fail if the current user is root (superuser).
+  (Kate Deplaix, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 ### Build system:
 
 - #13705: Cache test results of custom Autoconf tests from aclocal.m4.

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -305,6 +305,13 @@ let has_symlink = make
     "symlinks available"
     "symlinks not available")
 
+let not_root = make
+  ~name:"not-root"
+  ~description:"Skip test if the current user is root"
+  (Actions_helpers.pass_or_skip (Unix.getuid () <> 0)
+    "current user is not root"
+    "current user is root")
+
 let setup_build_env = make
   ~name:"setup-build-env"
   ~description:"Create a dedicated directory for the test and populates it"
@@ -426,6 +433,7 @@ let _ =
     arch32;
     arch64;
     has_symlink;
+    not_root;
     setup_build_env;
     setup_simple_build_env;
     run;

--- a/ocamltest/ocamltest_unix.mli
+++ b/ocamltest/ocamltest_unix.mli
@@ -19,3 +19,4 @@ val has_symlink : unit -> bool
 val symlink : ?to_dir:bool -> string -> string -> unit
 val chmod : string -> int -> unit
 val gettimeofday : unit -> float
+val getuid : unit -> int

--- a/ocamltest/ocamltest_unix_real.ml
+++ b/ocamltest/ocamltest_unix_real.ml
@@ -15,6 +15,7 @@
 (* Unix.gettimeofday and Unix.has_symlink never raise *)
 let has_symlink = Unix.has_symlink
 let gettimeofday = Unix.gettimeofday
+let getuid = Unix.getuid
 
 (* Convert Unix_error to Sys_error *)
 let wrap f x =

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
@@ -2,6 +2,7 @@
  include unix;
  include runtime_events;
  hasunix;
+ not-root;
  {
    bytecode;
  }{
@@ -33,6 +34,7 @@ let find_events_pid cursor =
 
 (* force failure of [create_cursor None] *)
 let make_unreadable () =
+  (* NOTE: Only works if the current user isn't root *)
   Unix.chmod (Option.get (Runtime_events.path())) 0o000
 
 let () =


### PR DESCRIPTION
Per https://github.com/ocaml/ocaml/pull/14431#pullrequestreview-3609371312
This should help https://github.com/ocaml/ocaml/pull/14138 as well as people testing OCaml on virtual or dedicated machines where creating a user isn't necessary.