### PR TITLE
Add String.replace_{first,last,all}

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,6 +137,10 @@ Working version
 
 ### Standard library:
 
+- #14436: Add String.replace_{first,last,all}
+  (Daniel Bünzli, review by Nicolás Ojeda Bär, Ali Caglayan and
+   Florian Angeletti)
+
 - #13343: Add Array.stable_sort_sub
   (François Pottier, review by Gabriel Scherer, Corentin Leruth and Nicolás
    Ojeda Bär)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -423,24 +423,21 @@ let rfind_all ~sub =
     loop f acc sub rsub_lp rsub_periodic s ~start ~slen
 
 let replace_first ~sub:needle =
-  let sub_lp = Search.find_maximal_suffix_and_period ~sub:needle in
-  let sub_periodic = Search.is_sub_periodic ~sub:needle ~sub_lp in
-  fun ~by ?(start = 0) s ->
-    match Search.find ~start ~sub:needle ~sub_lp ~sub_periodic s with
-    | -1 -> s
-    | i ->
+  let find_first = find_first ~sub:needle in
+  fun ~by ?start s ->
+    match find_first ?start s with
+    | None -> s
+    | Some i ->
         let rest_first = i + length needle in
         let rest_len = length s - i - length needle in
         concat by [sub s 0 i; sub s rest_first rest_len]
 
 let replace_last ~sub:needle =
-  let rsub_lp = Search.rfind_maximal_suffix_and_period ~sub:needle in
-  let rsub_periodic = Search.ris_sub_periodic ~sub:needle ~rsub_lp in
+  let find_last = find_last ~sub:needle in
   fun ~by ?start s ->
-    let start = match start with None -> length s | Some s -> s in
-    match Search.rfind ~start ~sub:needle ~rsub_lp ~rsub_periodic s with
-    | -1 -> s
-    | i ->
+    match find_last ?start s with
+    | None -> s
+    | Some i ->
         let rest_first = i + length needle in
         let rest_len = length s - i - length needle in
         concat by [sub s 0 i; sub s rest_first rest_len]

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -422,6 +422,43 @@ let rfind_all ~sub =
     if not (0 <= start && start <= slen) then invalid_start ~start slen else
     loop f acc sub rsub_lp rsub_periodic s ~start ~slen
 
+let replace_first ~sub:needle =
+  let sub_lp = Search.find_maximal_suffix_and_period ~sub:needle in
+  let sub_periodic = Search.is_sub_periodic ~sub:needle ~sub_lp in
+  fun ~by ?(start = 0) s ->
+    match Search.find ~start ~sub:needle ~sub_lp ~sub_periodic s with
+    | -1 -> s
+    | i ->
+        let rest_first = i + length needle in
+        let rest_len = length s - i - length needle in
+        concat by [sub s 0 i; sub s rest_first rest_len]
+
+let replace_last ~sub:needle =
+  let rsub_lp = Search.rfind_maximal_suffix_and_period ~sub:needle in
+  let rsub_periodic = Search.ris_sub_periodic ~sub:needle ~rsub_lp in
+  fun ~by ?start s ->
+    let start = match start with None -> length s | Some s -> s in
+    match Search.rfind ~start ~sub:needle ~rsub_lp ~rsub_periodic s with
+    | -1 -> s
+    | i ->
+        let rest_first = i + length needle in
+        let rest_len = length s - i - length needle in
+        concat by [sub s 0 i; sub s rest_first rest_len]
+
+let replace_all ~sub:needle =
+  let find_all = find_all ~sub:needle in
+  fun ~by ?start s ->
+    let chunk_first = ref 0 in
+    let add_chunk i acc =
+      let acc = sub s !chunk_first (i - !chunk_first) :: acc in
+      chunk_first := i + length needle; acc
+    in
+    match find_all ?start add_chunk s [] with
+    | [] -> s
+    | chunks ->
+        let chunks = sub s !chunk_first (length s - !chunk_first) :: chunks in
+        concat by (List.rev chunks)
+
 (* ASCII transforms *)
 
 let uppercase_ascii s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -531,6 +531,51 @@ val rfind_all :
 
     @since 5.5 *)
 
+(** {1:replacing Replacing substrings}
+
+    {b Note.} To replace the same [sub] string multiple time, partially
+    applying the [~sub] argument of these functions and using the
+    resulting function repeatedly is more efficient. *)
+
+val replace_first :
+  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> string
+(** [replace_first sub by start s] replaces by [by] the first
+    occurrence of [sub] in [s] at or after the index or position
+    [start] (defaults to [0]).
+
+    If [sub] is [""], this inserts [by] at position [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+    @since 5.5  *)
+
+val replace_last :
+  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> string
+(** [replace_last sub by start s] replaces by [by] the last
+    occurrence of [sub] in [s] at or after the index or position
+    [start] (defaults to [String.length s]).
+
+    If [sub] is [""], this inserts [by] at position [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+    @since 5.5  *)
+
+val replace_all :
+  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> string
+(** [replace_all sub by start s] replaces by [by] all non-overlapping
+    occurrences of [sub] in [s] at or after the index or position [start]
+    (defaults to [0]). Occurences are found in increasing indexing order.
+
+    If [sub] is [""], this inserts [by] on all positions from [start] on.
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+    @since 5.5  *)
+
 (** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -531,6 +531,51 @@ val rfind_all :
 
     @since 5.5 *)
 
+(** {1:replacing Replacing substrings}
+
+    {b Note.} To replace the same [sub] string multiple time, partially
+    applying the [~sub] argument of these functions and using the
+    resulting function repeatedly is more efficient. *)
+
+val replace_first :
+  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> string
+(** [replace_first ~sub ~by ~start s] replaces by [by] the first
+    occurrence of [sub] in [s] at or after the index or position
+    [start] (defaults to [0]).
+
+    If [sub] is [""], this inserts [by] at position [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+    @since 5.5  *)
+
+val replace_last :
+  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> string
+(** [replace_last ~sub ~by ~start s] replaces by [by] the last
+    occurrence of [sub] in [s] at or after the index or position
+    [start] (defaults to [String.length s]).
+
+    If [sub] is [""], this inserts [by] at position [start].
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+    @since 5.5  *)
+
+val replace_all :
+  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  ?start:int -> string -> string
+(** [replace_all ~sub ~by ~start s] replaces by [by] all non-overlapping
+    occurrences of [sub] in [s] at or after the index or position [start]
+    (defaults to [0]). Occurences are found in increasing indexing order.
+
+    If [sub] is [""], this inserts [by] on all positions from [start] on.
+
+    @raise Invalid_argument if [start] is not a valid position of [s].
+    @since 5.5  *)
+
 (** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -416,3 +416,63 @@ let () =
   assert (String.includes ~affix:"ab" "aaba" = true);
   assert (String.includes ~affix:"abab" "aababa" = true);
   ()
+
+let () =
+  (* Test String.replace_first *)
+  assert (String.replace_first ~sub:"" ~by:"" "" = "");
+  assert (String.replace_first ~sub:"" ~by:"a" "" = "a");
+  assert (String.replace_first ~sub:"" ~by:"a" "123" = "a123");
+  assert (String.replace_first ~start:1 ~sub:"" ~by:"a" "123" = "1a23");
+  assert (String.replace_first ~start:2 ~sub:"" ~by:"a" "123" = "12a3");
+  assert (String.replace_first ~start:3 ~sub:"" ~by:"a" "123" = "123a");
+  assert (String.replace_first ~sub:"1" ~by:"" "123" = "23");
+  assert (String.replace_first ~sub:"3" ~by:"" "123" = "12");
+  assert (String.replace_first ~sub:"1" ~by:"" "1" = "");
+  assert (String.replace_first ~sub:"12" ~by:"z" "123" = "z3");
+  assert (String.replace_first ~start:2 ~sub:"" ~by:"z" "123" = "12z3");
+  assert (String.replace_first ~start:3 ~sub:"" ~by:"z" "123" = "123z");
+  assert (String.replace_first ~start:3 ~sub:"a" ~by:"z" "123" = "123");
+  assert (String.replace_first ~sub:"aba" ~by:"1" "ababa" = "1ba");
+  assert (String.replace_first ~sub:"aba" ~by:"12" "ababa" = "12ba");
+  ()
+
+let () =
+  (* Test String.replace_last *)
+  assert (String.replace_last ~sub:"" ~by:"" "" = "");
+  assert (String.replace_last ~sub:"" ~by:"a" "" = "a");
+  assert (String.replace_last ~sub:"" ~by:"a" "123" = "123a");
+  assert (String.replace_last ~start:1 ~sub:"" ~by:"a" "123" = "1a23");
+  assert (String.replace_last ~start:2 ~sub:"" ~by:"a" "123" = "12a3");
+  assert (String.replace_last ~start:3 ~sub:"" ~by:"a" "123" = "123a");
+  assert (String.replace_last ~sub:"1" ~by:"" "123" = "23");
+  assert (String.replace_last ~sub:"3" ~by:"" "123" = "12");
+  assert (String.replace_last ~sub:"1" ~by:"" "1" = "");
+  assert (String.replace_last ~sub:"12" ~by:"z" "123" = "z3");
+  assert (String.replace_last ~start:2 ~sub:"" ~by:"z" "123" = "12z3");
+  assert (String.replace_last ~start:3 ~sub:"" ~by:"z" "123" = "123z");
+  assert (String.replace_last ~start:3 ~sub:"a" ~by:"z" "123" = "123");
+  assert (String.replace_last ~sub:"aba" ~by:"1" "ababa" = "ab1");
+  assert (String.replace_last ~sub:"aba" ~by:"12" "ababa" = "ab12");
+  ()
+
+let () =
+  (* Test String.replace_all *)
+  assert (String.replace_all ~sub:"" ~by:"" "" = "");
+  assert (String.replace_all ~sub:"" ~by:"" "1" = "1");
+  assert (String.replace_all ~sub:"" ~by:"" "12" = "12");
+  assert (String.replace_all ~sub:"" ~by:"a" "" = "a");
+  assert (String.replace_all ~sub:"" ~by:"a" "1" = "a1a");
+  assert (String.replace_all ~sub:"" ~by:"a" "12" = "a1a2a");
+  assert (String.replace_all ~sub:"" ~by:"a" "123" = "a1a2a3a");
+  assert (String.replace_all ~start:0 ~sub:"" ~by:"a" "123" = "a1a2a3a");
+  assert (String.replace_all ~start:1 ~sub:"" ~by:"a" "123" = "1a2a3a");
+  assert (String.replace_all ~start:2 ~sub:"" ~by:"a" "123" = "12a3a");
+  assert (String.replace_all ~start:3 ~sub:"" ~by:"a" "123" = "123a");
+  assert (String.replace_all ~sub:"1" ~by:"" "121" = "2");
+  assert (String.replace_all ~sub:"1" ~by:"3" "121" = "323");
+  assert (String.replace_all ~sub:"1" ~by:"" "1" = "");
+  assert (String.replace_all ~sub:"12" ~by:"a" "123" = "a3");
+  assert (String.replace_all ~sub:"12" ~by:"a" "123112" = "a31a");
+  assert (String.replace_all ~start:1 ~sub:"12" ~by:"a" "123112" = "1231a");
+  assert (String.replace_all ~sub:"12" ~by:"ab" "123112" = "ab31ab");
+  ()


### PR DESCRIPTION
This PR adds the functions string replacing functions discussed in https://github.com/ocaml/ocaml/discussions/14137 it is built (two last commits) on top of the PR of search primitives https://github.com/ocaml/ocaml/pull/14381.