### PR TITLE
Add String.split_{first,last,all} and String.rsplit_all

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,6 +137,9 @@ Working version
 
 ### Standard library:
 
+- #14437: Add String.split_{first,last,all} and String.rsplit_all
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Florian Angeletti)
+
 - #14436: Add String.replace_{first,last,all}
   (Daniel Bünzli, review by Nicolás Ojeda Bär, Ali Caglayan and
    Florian Angeletti)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -556,6 +556,46 @@ let cut_last_while sat s =
 
 (* Splitting with separators *)
 
+let split_first ~sep =
+  let find_first = find_first ~sub:sep in
+  fun s -> match find_first s with
+  | None -> None
+  | Some i ->
+      Some (subrange ~last:(i - 1) s, subrange ~first:(i + length sep) s)
+
+let split_last ~sep =
+  let find_last = find_last ~sub:sep in
+  fun s -> match find_last s with
+  | None -> None
+  | Some i ->
+      Some (subrange ~last:(i - 1) s, subrange ~first:(i + length sep) s)
+
+let split_all ~sep =
+  let find_all = find_all ~sub:sep in
+  fun ?(drop = fun _ -> false) s ->
+    let first = ref 0 in
+    let add_token i acc =
+      let token = subrange ~first:!first ~last:(i - 1) s in
+      first := i + length sep;
+      if drop token then acc else token :: acc
+    in
+    let tokens = find_all add_token s [] in
+    let last = subrange ~first:!first s in
+    List.rev (if drop last then tokens else last :: tokens)
+
+let rsplit_all ~sep =
+  let rfind_all = rfind_all ~sub:sep in
+  fun ?(drop = fun _ -> false) s ->
+    let last = ref (length s - 1) in
+    let add_token i acc =
+      let token = subrange ~first:(i + length sep) ~last:!last s in
+      last := i - 1;
+      if drop token then acc else token :: acc
+    in
+    let tokens = rfind_all add_token s [] in
+    let last = subrange ~last:!last s in
+    if drop last then tokens else (last :: tokens)
+
 (* duplicated in bytes.ml *)
 let split_on_char sep s =
   let r = ref [] in

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -289,7 +289,77 @@ val cut_last_while : (char -> bool) -> string -> string * string
 
     @since 5.5 *)
 
-(** {2:splitting_sep Splitting with separators} *)
+(** {2:splitting_sep Splitting with separators}
+
+    {b Note.} To split the same [sep] string multiple times, partially
+    applying the [~sep] argument of these functions and using the
+    resulting function repeatedly is more efficient. *)
+
+val split_first :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  string -> (string * string) option
+(** [split_first sep s] is the pair [Some (left, right)] made of the
+    two (possibly empty) substrings of [s] that are delimited by the
+    first match of the separator [sep] in [s] or [None] if [sep] can't
+    be found. Search for [sep] starts at position [0] and uses
+    {!find_first}.
+
+    If [sep] is [""], this is [Some ("", s)].
+
+    The invariant [concat sep [left; right] = s] holds.
+
+    @since 5.5 *)
+
+val split_last :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  string -> (string * string) option
+(** [split_last sep s] is the pair [Some (left, right)] made of the
+    two (possibly empty) substrings of [s] that are delimited by the
+    last match of the separator [sep] in [s] or [None] if [sep] can't
+    be found. Search for [sep] starts at position [length s] and uses
+    {!find_last}.
+
+    If [sep] is [""], this is [Some (s, "")].
+
+    The invariant [concat sep [left; right] = s] holds.
+
+    @since 5.5 *)
+
+val split_all :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  ?drop:(string -> bool) -> string -> string list
+(** [split_all sep s] is the list of all substrings of [s] that are
+    delimited by non-overlapping matches of the separator [sep] or the
+    list [[s]] if [sep] can't be found. Search for [sep] starts at
+    position [0] in increasing indexing order and uses {!find_all}.
+
+    Substrings [sub] for which [drop sub] is [true] are not included
+    in the result. [drop] defaults to [Fun.const false].
+
+    If [sep] is [""], this is [[""; c0; ...; cn; ""]] with [ci]
+    the string [of_char s.[i]].
+
+    The invariant [concat sep (split_all sep s) = s] holds.
+
+    @since 5.5 *)
+
+val rsplit_all :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  ?drop:(string -> bool) -> string -> string list
+(** [rsplit_all sep s] is the list of all substrings of [s] that are
+    delimited by non-overlapping matches of the separator [sep] or
+    [[s]] if [sep] can't be found. Search for [sep] starts at position
+    [length s] in deacreasing indexing order and uses {!rfind_all}.
+
+    Substrings [sub] for which [drop sub] is [true] are not included
+    in the result. [drop] defaults to [Fun.const false].
+
+    If [sep] is [""], this is [[""; c0; ...; cn; ""]] with [ci]
+    the string [of_char s.[i]].
+
+    The invariant [concat sep (rsplit_all sep s) = s] holds.
+
+    @since 5.5 *)
 
 val split_on_char : char -> string -> string list
 (** [split_on_char sep s] is the list of all (possibly empty)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -289,7 +289,77 @@ val cut_last_while : (char -> bool) -> string -> string * string
 
     @since 5.5 *)
 
-(** {2:splitting_sep Splitting with separators} *)
+(** {2:splitting_sep Splitting with separators}
+
+    {b Note.} To split the same [sep] string multiple times, partially
+    applying the [~sep] argument of these functions and using the
+    resulting function repeatedly is more efficient. *)
+
+val split_first :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  string -> (string * string) option
+(** [split_first ~sep s] is the pair [Some (left, right)] made of the
+    two (possibly empty) substrings of [s] that are delimited by the
+    first match of the separator [sep] in [s] or [None] if [sep] can't
+    be found. Search for [sep] starts at position [0] and uses
+    {!find_first}.
+
+    If [sep] is [""], this is [Some ("", s)].
+
+    The invariant [concat sep [left; right] = s] holds.
+
+    @since 5.5 *)
+
+val split_last :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  string -> (string * string) option
+(** [split_last ~sep s] is the pair [Some (left, right)] made of the
+    two (possibly empty) substrings of [s] that are delimited by the
+    last match of the separator [sep] in [s] or [None] if [sep] can't
+    be found. Search for [sep] starts at position [length s] and uses
+    {!find_last}.
+
+    If [sep] is [""], this is [Some (s, "")].
+
+    The invariant [concat sep [left; right] = s] holds.
+
+    @since 5.5 *)
+
+val split_all :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  ?drop:(string -> bool) -> string -> string list
+(** [split_all ~sep s] is the list of all substrings of [s] that are
+    delimited by non-overlapping matches of the separator [sep] or the
+    list [[s]] if [sep] can't be found. Search for [sep] starts at
+    position [0] in increasing indexing order and uses {!find_all}.
+
+    Substrings [sub] for which [drop sub] is [true] are not included
+    in the result. [drop] defaults to [Fun.const false].
+
+    If [sep] is [""], this is [[""; c0; ...; cn; ""]] with [ci]
+    the string [of_char s.[i]].
+
+    The invariant [concat sep (split_all ~sep s) = s] holds.
+
+    @since 5.5 *)
+
+val rsplit_all :
+  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  ?drop:(string -> bool) -> string -> string list
+(** [rsplit_all ~sep s] is the list of all substrings of [s] that are
+    delimited by non-overlapping matches of the separator [sep] or
+    [[s]] if [sep] can't be found. Search for [sep] starts at position
+    [length s] in deacreasing indexing order and uses {!rfind_all}.
+
+    Substrings [sub] for which [drop sub] is [true] are not included
+    in the result. [drop] defaults to [Fun.const false].
+
+    If [sep] is [""], this is [[""; c0; ...; cn; ""]] with [ci]
+    the string [of_char s.[i]].
+
+    The invariant [concat sep (rsplit_all ~sep s) = s] holds.
+
+    @since 5.5 *)
 
 val split_on_char : sep:char -> string -> string list
 (** [split_on_char ~sep s] is the list of all (possibly empty)

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -476,3 +476,97 @@ let () =
   assert (String.replace_all ~start:1 ~sub:"12" ~by:"a" "123112" = "1231a");
   assert (String.replace_all ~sub:"12" ~by:"ab" "123112" = "ab31ab");
   ()
+
+let () =
+  (* Test String.split_first *)
+  assert (String.split_first ~sep:"" "" = Some ("", ""));
+  assert (String.split_first ~sep:"" "a" = Some ("", "a"));
+  assert (String.split_first ~sep:"" "ab" = Some ("", "ab"));
+  assert (String.split_first ~sep:"a" "" = None);
+  assert (String.split_first ~sep:"a" "b" = None);
+  assert (String.split_first ~sep:"a" "ab" = Some ("", "b"));
+  assert (String.split_first ~sep:"a" "ba" = Some ("b", ""));
+  assert (String.split_first ~sep:"ab" "" = None);
+  assert (String.split_first ~sep:"ab" "a" = None);
+  assert (String.split_first ~sep:"ab" "b" = None);
+  assert (String.split_first ~sep:"ab" "ab" = Some ("", ""));
+  assert (String.split_first ~sep:"ab" "aab" = Some ("a", ""));
+  assert (String.split_first ~sep:"ab" "aba" = Some ("", "a"));
+  assert (String.split_first ~sep:"ab" "abab" = Some ("", "ab"));
+  assert (String.split_first ~sep:"ab" "aabb" = Some ("a", "b"));
+  ()
+
+let () =
+  (* Test String.split_last *)
+  assert (String.split_last ~sep:"" "" = Some ("", ""));
+  assert (String.split_last ~sep:"" "a" = Some ("a", ""));
+  assert (String.split_last ~sep:"" "ab" = Some ("ab", ""));
+  assert (String.split_last ~sep:"a" "" = None);
+  assert (String.split_last ~sep:"a" "b" = None);
+  assert (String.split_last ~sep:"a" "ab" = Some ("", "b"));
+  assert (String.split_last ~sep:"a" "ba" = Some ("b", ""));
+  assert (String.split_last ~sep:"ab" "" = None);
+  assert (String.split_last ~sep:"ab" "a" = None);
+  assert (String.split_last ~sep:"ab" "b" = None);
+  assert (String.split_last ~sep:"ab" "ab" = Some ("", ""));
+  assert (String.split_last ~sep:"ab" "aab" = Some ("a", ""));
+  assert (String.split_last ~sep:"ab" "aba" = Some ("", "a"));
+  assert (String.split_last ~sep:"ab" "abab" = Some ("ab", ""));
+  assert (String.split_last ~sep:"ab" "aabb" = Some ("a", "b"));
+  ()
+
+let () =
+  (* Test String.split_all *)
+  assert (String.split_all ~sep:"" "" = [""; ""]);
+  assert (String.split_all ~sep:"" "a" = [""; "a"; ""]);
+  assert (String.split_all ~sep:"" "ab" = [""; "a"; "b"; ""]);
+  assert (String.split_all ~sep:"" "abc" = [""; "a"; "b"; "c"; ""]);
+  assert (String.split_all ~sep:"a" "" = [""]);
+  assert (String.split_all ~sep:"a" "a" = ["";""]);
+  assert (String.split_all ~sep:"a" "ab" = [""; "b"]);
+  assert (String.split_all ~sep:"a" "ba" = ["b"; ""]);
+  assert (String.split_all ~sep:"a" "abc" = [""; "bc"]);
+  assert (String.split_all ~sep:"a" "aba" = [""; "b"; ""]);
+  assert (String.split_all ~sep:"a" "bab" = ["b"; "b"]);
+  assert (String.split_all ~sep:"a" "babbab" = ["b"; "bb"; "b"]);
+  assert (String.split_all ~sep:"ab" "" = [""]);
+  assert (String.split_all ~sep:"ab" "a" = ["a"]);
+  assert (String.split_all ~sep:"ab" "b" = ["b"]);
+  assert (String.split_all ~sep:"ab" "ab" = [""; ""]);
+  assert (String.split_all ~sep:"ab" "aab" = ["a"; ""]);
+  assert (String.split_all ~sep:"ab" "aba" = [""; "a"]);
+  assert (String.split_all ~sep:"ab" "abab" = [""; ""; ""]);
+  assert (String.split_all ~sep:"ab" "aabb" = ["a"; "b"]);
+  assert (String.split_all ~sep:"ab" "aaabbb" = ["aa"; "bb"]);
+  assert (String.split_all ~sep:"aba" "ababa" = [""; "ba"]);
+  assert (String.split_all ~sep:"a" "abaa" = [""; "b"; ""; ""]);
+  assert (String.split_all ~drop:(( = ) "") ~sep:"a" "abaa" = ["b"]);
+  ()
+
+let () =
+  (* Test String.rsplit_all *)
+  assert (String.rsplit_all ~sep:"" "" = [""; ""]);
+  assert (String.rsplit_all ~sep:"" "a" = [""; "a"; ""]);
+  assert (String.rsplit_all ~sep:"" "ab" = [""; "a"; "b"; ""]);
+  assert (String.rsplit_all ~sep:"" "abc" = [""; "a"; "b"; "c"; ""]);
+  assert (String.rsplit_all ~sep:"a" "" = [""]);
+  assert (String.rsplit_all ~sep:"a" "a" = ["";""]);
+  assert (String.rsplit_all ~sep:"a" "ab" = [""; "b"]);
+  assert (String.rsplit_all ~sep:"a" "ba" = ["b"; ""]);
+  assert (String.rsplit_all ~sep:"a" "abc" = [""; "bc"]);
+  assert (String.rsplit_all ~sep:"a" "aba" = [""; "b"; ""]);
+  assert (String.rsplit_all ~sep:"a" "bab" = ["b"; "b"]);
+  assert (String.rsplit_all ~sep:"a" "babbab" = ["b"; "bb"; "b"]);
+  assert (String.rsplit_all ~sep:"ab" "" = [""]);
+  assert (String.rsplit_all ~sep:"ab" "a" = ["a"]);
+  assert (String.rsplit_all ~sep:"ab" "b" = ["b"]);
+  assert (String.rsplit_all ~sep:"ab" "ab" = [""; ""]);
+  assert (String.rsplit_all ~sep:"ab" "aab" = ["a"; ""]);
+  assert (String.rsplit_all ~sep:"ab" "aba" = [""; "a"]);
+  assert (String.rsplit_all ~sep:"ab" "abab" = [""; ""; ""]);
+  assert (String.rsplit_all ~sep:"ab" "aabb" = ["a"; "b"]);
+  assert (String.rsplit_all ~sep:"ab" "aaabbb" = ["aa"; "bb"]);
+  assert (String.rsplit_all ~sep:"aba" "ababa" = ["ab"; ""]);
+  assert (String.rsplit_all ~sep:"a" "abaa" = [""; "b"; ""; ""]);
+  assert (String.rsplit_all ~drop:(( = ) "") ~sep:"a" "abaa" = ["b"]);
+  ()


### PR DESCRIPTION
This PR adds the functions for breaking with separators discussed in https://github.com/ocaml/ocaml/discussions/14137. It is built on top (two last commits) of the PR of search primitives https://github.com/ocaml/ocaml/pull/14381.

**Warning.** The `[r]split_all` functions proposed here add an optional `drop` argument that was not discussed in #14137.

One tidbit that may surprise the proficient JavaScript programmer is the behaviour of `split_all` on the empty string. In JavaScript you have:

```JavaScript
> "abc".split("")
['a', 'b', 'c']
```

While with the function proposed has:

```ocaml
# String.split_all ~sep:"" "abc";;
- : string list = [""; "a"; "b"; "c"; ""]
```

The behaviour we propose is consistent with the definition of empty string matching given by the primitive `String.find_all` (#14381). We can also see that behaviour in action with `String.replace_all` (#14436)

```ocaml
# String.replace_all ~sub:"" ~by:"1" "abc";;
- : string = "1a1b1c1"
```
In this case the result is in fact consistent with JavaScript's `replaceAll`: 

```JavaScript
> "abc".replaceAll("","1")
'1a1b1c1'
```

We argue that it is better to have a consistent way of matching the empty string in all of the functions and despite what you feel maybe be a funny looking result on split all with an empty `sep` we still have for all `sep` and `s`

```ocaml
assert (String.concat sep (String.split_all ~sep s) = s)
```

As [desired](https://github.com/ocaml/ocaml/discussions/14137#discussioncomment-14256055) by @gasche in #14137.











