### PR TITLE
Add String.is_empty

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,9 @@ Working version
 
 ### Standard library:
 
+- #14438: Add String.is_empty
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 - #14440: Add String.of_char
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -304,6 +304,7 @@ type t = string
 
 let compare (x: t) (y: t) = Stdlib.compare x y
 external equal : string -> string -> bool = "caml_string_equal" [@@noalloc]
+let is_empty s = Int.equal (length s) 0
 
 (** {1 Iterators} *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -159,6 +159,11 @@ val compare : t -> t -> int
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
+val is_empty : string -> bool
+(** [is_empty s] is [true] if and only if [s] is an empty string.
+
+    @since 5.5 *)
+
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
 (** [starts_with ][~prefix s] is [true] if and only if [s] starts with

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -159,6 +159,11 @@ val compare : t -> t -> int
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
+val is_empty : string -> bool
+(** [is_empty s] is [true] if and only if [s] is an empty string.
+
+    @since 5.5 *)
+
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
 (** [starts_with ][~prefix s] is [true] if and only if [s] starts with

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -258,3 +258,9 @@ let () =
   assert (String.of_char 'a' = "a");
   assert (String.of_char '\x00' = "\x00");
   ()
+
+let () =
+  (* Test String.is_empty *)
+  assert (String.is_empty "life" = false);
+  assert (String.is_empty "" = true);
+  ()


### PR DESCRIPTION
Since we got `List.is_empty` in 5.1, I hope 5.5 can bring you `String.is_empty`. 

This PR is made on top of #14437 to show a use with `drop` in the testsuite (which was there when I ported it over to the compiler).

To clear up the backlog, it can of course be made against master and #14437 be made on top of it.