### PR TITLE
Add String.includes

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,6 +137,9 @@ Working version
 
 ### Standard library:
 
+- #14439: Add String.includes
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Olivier Nicole)
+
 - #10177: Seq.(delay : (unit -> 'a t) -> 'a t)
   (Gabriel Scherer, review by Jeremy Yallop and François Pottier)
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -454,6 +454,11 @@ let ends_with ~suffix s =
     else aux (i + 1)
   in diff >= 0 && aux 0
 
+let includes ~affix:sub =
+  let sub_lp = Search.find_maximal_suffix_and_period ~sub in
+  let sub_periodic = Search.is_sub_periodic ~sub ~sub_lp in
+  fun s -> Search.find ~start:0 ~sub ~sub_lp ~sub_periodic s <> -1
+
 external seeded_hash : int -> string -> int = "caml_string_hash" [@@noalloc]
 let hash x = seeded_hash 0 x
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -179,9 +179,7 @@ val ends_with :
 
 val includes :
   affix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [includes affix s] is [true] if and only if there exists an index
-    [i] of [s] such that for all indices [k] of [affix], [affix.[k] =
-    s.[i + k]].
+(** [includes affix s] is [true] if and only if [affix] occurs in [s].
 
     {b Note.} To test the same [affix] string multiple times, partially
     applying the [~affix] argument and using the resulting function repeatedly

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -177,6 +177,18 @@ val ends_with :
 
     @since 4.13 *)
 
+val includes :
+  affix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+(** [includes affix s] is [true] if and only if there exists an index
+    [i] of [s] such that for all indices [k] of [affix], [affix.[k] =
+    s.[i + k]].
+
+    {b Note.} To test the same [affix] string multiple times, partially
+    applying the [~affix] argument and using the resulting function repeatedly
+    is more efficient.
+
+    @since 5.5 *)
+
 val contains_from : string -> int -> char -> bool
 (** [contains_from s start c] is [true] if and only if [c] appears in [s]
     after position [start].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -177,6 +177,18 @@ val ends_with :
 
     @since 4.13 *)
 
+val includes :
+  affix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+(** [includes ~affix s] is [true] if and only if there exists an index
+    [i] of [s] such that for all indices [k] of [affix], [affix.[k] =
+    s.[i + k]].
+
+    {b Note.} To test the same [affix] string multiple times, partially
+    applying the [~affix] argument and using the resulting function repeatedly
+    is more efficient.
+
+    @since 5.5 *)
+
 val contains_from : string -> int -> char -> bool
 (** [contains_from s start c] is [true] if and only if [c] appears in [s]
     after position [start].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -179,9 +179,7 @@ val ends_with :
 
 val includes :
   affix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [includes ~affix s] is [true] if and only if there exists an index
-    [i] of [s] such that for all indices [k] of [affix], [affix.[k] =
-    s.[i + k]].
+(** [includes ~affix s] is [true] if and only if [affix] occurs in [s].
 
     {b Note.} To test the same [affix] string multiple times, partially
     applying the [~affix] argument and using the resulting function repeatedly

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -396,3 +396,23 @@ let () =
   assert (String.find_last ~start:6 ~sub:"abab" "ababab" = Some 2);
   assert (String.find_last ~sub:"ab" "aabb" = Some 1);
   ()
+
+let () =
+  (* Test String.includes *)
+  assert (String.includes ~affix:"" "" = true);
+  assert (String.includes ~affix:"" "a" = true);
+  assert (String.includes ~affix:"" "ab" = true);
+  assert (String.includes ~affix:"a" "" = false);
+  assert (String.includes ~affix:"a" "a" = true);
+  assert (String.includes ~affix:"a" "ab" = true);
+  assert (String.includes ~affix:"a" "ba" = true);
+  assert (String.includes ~affix:"a" "bab" = true);
+  assert (String.includes ~affix:"ab" "" =  false);
+  assert (String.includes ~affix:"ab" "a" = false);
+  assert (String.includes ~affix:"ab" "ab" = true);
+  assert (String.includes ~affix:"ab" "aab" = true);
+  assert (String.includes ~affix:"aab" "ab" = false);
+  assert (String.includes ~affix:"ab" "aba" = true);
+  assert (String.includes ~affix:"ab" "aaba" = true);
+  assert (String.includes ~affix:"abab" "aababa" = true);
+  ()


### PR DESCRIPTION
This PR is built (two last commits) on top of the PR of search primitives https://github.com/ocaml/ocaml/pull/14381. It propose a function which was **not** discussed in #14137:

OCaml 4.13 gaves us `String.starts_with ~prefix` and `String.ends_with ~suffix`. We hope OCaml 5.5 can close the triptych with `String.includes ~affix`[^1]. 


[^1]: My first gut name would have been `String.contains` but that name is already taken.