### PR TITLE
Fix autoconf test for `diff` flags on macOS

### DIFF
--- a/Changes
+++ b/Changes
@@ -491,7 +491,7 @@ Working version
 
 ### Build system:
 
-- #13705: Cache test results of custom Autoconf tests from aclocal.m4.
+- #13705, #14444: Cache test results of custom Autoconf tests from aclocal.m4.
   (Antonin Décimo, review by David Allsopp and Miod Vallat)
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/configure
+++ b/configure
@@ -23961,7 +23961,7 @@ then :
 else $as_nop
   flags=""
     for flag in ${flags_to_test}; do
-      "$DIFF" $flag /dev/zero /dev/zero >/dev/null 2>&1 && \
+      "$DIFF" $flag /dev/null /dev/null >/dev/null 2>&1 && \
         flags="${flags:+$flags }$flag"
     done
     ocaml_cv_prog_diff_flags="$flags"
@@ -23974,7 +23974,7 @@ if test ${ocaml_cv_prog_diff_supports_color+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  if $DIFF --color=auto $0 $0 > /dev/null 2>&1
+  if $DIFF --color=auto /dev/null /dev/null > /dev/null 2>&1
 then :
   ocaml_cv_prog_diff_supports_color=true
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2854,13 +2854,13 @@ AS_IF([$build_ocamltest],
     [ocaml_cv_prog_diff_flags],
     [flags=""
     for flag in ${flags_to_test}; do
-      "$DIFF" $flag /dev/zero /dev/zero >/dev/null 2>&1 && \
+      "$DIFF" $flag /dev/null /dev/null >/dev/null 2>&1 && \
         flags="${flags:+$flags }$flag"
     done
     ocaml_cv_prog_diff_flags="$flags"])
   AC_CACHE_CHECK([whether $DIFF supports --color={auto,always,never}],
     [ocaml_cv_prog_diff_supports_color],
-    [AS_IF([$DIFF --color=auto $0 $0 > /dev/null 2>&1],
+    [AS_IF([$DIFF --color=auto /dev/null /dev/null > /dev/null 2>&1],
       [ocaml_cv_prog_diff_supports_color=true])])])
 AC_SUBST([DIFF_FLAGS], [$ocaml_cv_prog_diff_flags])
 # Always assign a valid default OCaml value

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -290,38 +290,45 @@ case $NODE_NAME in
     confoptions="--enable-native-toplevel $confoptions";;
 esac
 
-eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
+main_build() {
+  eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
 
-grep -q '^NATIVE_COMPILER=false' Makefile.config && make_native=false
+  grep -q '^NATIVE_COMPILER=false' Makefile.config && make_native=false
 
-if test "$flambda" = "true" && test "$make_native" = "false"; then
-  echo "No need to test flambda in a bytecode-only system; skipping the test."
-  exit 0
-fi
-
-if $bootstrap; then
-  $make $jobs --warn-undefined-variables core
-  $make $jobs --warn-undefined-variables bootstrap
-  if $make_native; then
-    $make $jobs --warn-undefined-variables opt.opt
+  if test "$flambda" = "true" && test "$make_native" = "false"; then
+    echo "No need to test flambda in a bytecode-only system; skipping the test."
+    exit 0
   fi
-else
-  $make $jobs --warn-undefined-variables
-fi
 
+  if $bootstrap; then
+    $make $jobs --warn-undefined-variables core
+    $make $jobs --warn-undefined-variables bootstrap
+    if $make_native; then
+      $make $jobs --warn-undefined-variables opt.opt
+    fi
+  else
+    $make $jobs --warn-undefined-variables
+  fi
 
-if $make_native && $check_make_alldepend; then
-  $make --warn-undefined-variables alldepend
-fi
+  if $make_native && $check_make_alldepend; then
+    $make --warn-undefined-variables alldepend
+  fi
 
-$make --warn-undefined-variables install
-case $confoptions in
-  *--disable-unix-lib*) ;;         # test-in-prefix needs Unix lib
-  *)
-    $make -f Makefile.test -C testsuite/in_prefix test-in-prefix
-    ;;
-esac
-rm -rf "$instdir"
+  $make --warn-undefined-variables install
+  case $confoptions in
+    *--disable-unix-lib*) ;;         # test-in-prefix needs Unix lib
+    *)
+      $make -f Makefile.test -C testsuite/in_prefix test-in-prefix
+      ;;
+  esac
+  rm -rf "$instdir"
+}
+
+# PATH, but without any homebrew additions (tests vanilla macOS in the build,
+# while still allowing full utilities later in the testsuite)
+CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -vF '/homebrew/' | paste -sd: -)
+
+PATH="$CLEAN_PATH" main_build
 
 cd testsuite
 if test -n "$jobs" && test -x /usr/bin/parallel


### PR DESCRIPTION
The caching updates in #13705 included a change to the tests for `diff` which I failed to notice when reviewing it - the test previously compared `$0` (the `configure` script) with itself and this got changed to `/dev/zero`. `diff /dev/zero /dev/zero` exits with code 0 with GNU diffutils, but hangs (quite reasonably) with macOS's default diff.

The fix is simple: compare `/dev/null` instead. I've also adapted a change made for AppVeyor in #13416 to remove the Homebrew `bin` directories when executing the build on the M1 worker in precheck (on Intel silicon, homebrew installs to `/usr/local`, and it didn't seem worth the special-casing just to test it there too). The first commit can be seen hanging on the M1 worker (before I cancelled the job) [in precheck#1099](https://ci.inria.fr/ocaml/job/precheck/1099/flambda=false,label=ocaml-macos-m1/console). The branch with the fix is being tested in [precheck#1100](https://ci.inria.fr/ocaml/job/precheck/1100/).

The first commit is very noisy w.r.t. whitespace - the basic idea is to wrap configuration, build and test-in-prefix in a function so that it can be executed with an altered PATH. The testsuite then runs with the homebrew binaries enabled (in particular, I think that includes GNU parallel).