### PR TITLE
ocamltest: contain temporary files in a single directory

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -224,6 +224,7 @@ let test_file test_filename =
   let hookname_prefix = Filename.concat test_source_directory test_prefix in
   let test_build_directory_prefix =
     get_test_build_directory_prefix test_directory in
+  Filename.set_temp_dir_name test_build_directory_prefix;
   let clean_test_build_directory () =
     try
       Sys.rm_rf test_build_directory_prefix


### PR DESCRIPTION
I've hacked ocamltest to write its temporary files in a sub-directory of the temporary directory. I think it's a bit easier to locate them this way, when working on a complex test. This is extracted from #14421. cc @dra27, @gasche. No change entry needed.