### PR TITLE
silence duplicated alert messages in auxiliary typechecker functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -607,6 +607,9 @@ Working version
   DragonFly.
   (Michael Neumann, review by Gabriel Scherer and Kate Deplaix)
 
+- #14453: deduplicate some alert messages
+  (Florian Angeletti, review by ???)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -245,13 +245,16 @@ let check_alerts loc attrs s =
     (alerts_of_attrs attrs)
 
 let check_alerts_inclusion ~def ~use loc attrs1 attrs2 s =
-  let m2 = alerts_of_attrs attrs2 in
-  Misc.Stdlib.String.Map.iter
-    (fun kind msg ->
-       if not (Misc.Stdlib.String.Map.mem kind m2) then
-         Location.alert ~def ~use ~kind loc (cat s msg)
-    )
-    (alerts_of_attrs attrs1)
+  match loc with
+  | None -> ()
+  | Some loc ->
+      let m2 = alerts_of_attrs attrs2 in
+      Misc.Stdlib.String.Map.iter
+        (fun kind msg ->
+           if not (Misc.Stdlib.String.Map.mem kind m2) then
+             Location.alert ~def ~use ~kind loc (cat s msg)
+        )
+        (alerts_of_attrs attrs1)
 
 let rec deprecated_mutable_of_attrs = function
   | [] -> None
@@ -266,13 +269,16 @@ let check_deprecated_mutable loc attrs s =
       Location.deprecated loc (Printf.sprintf "mutating field %s" (cat s txt))
 
 let check_deprecated_mutable_inclusion ~def ~use loc attrs1 attrs2 s =
-  match deprecated_mutable_of_attrs attrs1,
-        deprecated_mutable_of_attrs attrs2
-  with
-  | None, _ | Some _, Some _ -> ()
-  | Some txt, None ->
-      Location.deprecated ~def ~use loc
-        (Printf.sprintf "mutating field %s" (cat s txt))
+  match loc with
+  | None -> ()
+  | Some loc ->
+      match deprecated_mutable_of_attrs attrs1,
+            deprecated_mutable_of_attrs attrs2
+      with
+      | None, _ | Some _, Some _ -> ()
+      | Some txt, None ->
+          Location.deprecated ~def ~use loc
+            (Printf.sprintf "mutating field %s" (cat s txt))
 
 let rec attrs_of_sig = function
   | {psig_desc = Psig_attribute a} :: tl ->

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -114,8 +114,8 @@ val mark_deprecated_mutable_used : Parsetree.attributes -> unit
 
 val check_alerts: Location.t -> Parsetree.attributes -> string -> unit
 val check_alerts_inclusion:
-  def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
-  Parsetree.attributes -> string -> unit
+  def:Location.t -> use:Location.t -> Location.t option ->
+  Parsetree.attributes -> Parsetree.attributes -> string -> unit
 val alerts_of_attrs: Parsetree.attributes -> Misc.alerts
 val alerts_of_sig: mark:bool -> Parsetree.signature -> Misc.alerts
 val alerts_of_str: mark:bool -> Parsetree.structure -> Misc.alerts
@@ -123,8 +123,8 @@ val alerts_of_str: mark:bool -> Parsetree.structure -> Misc.alerts
 val check_deprecated_mutable:
     Location.t -> Parsetree.attributes -> string -> unit
 val check_deprecated_mutable_inclusion:
-  def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
-  Parsetree.attributes -> string -> unit
+  def:Location.t -> use:Location.t -> Location.t option ->
+  Parsetree.attributes -> Parsetree.attributes -> string -> unit
 
 val error_of_extension: Parsetree.extension -> Location.error
 

--- a/testsuite/tests/typing-deprecated/alerts.ml
+++ b/testsuite/tests/typing-deprecated/alerts.ml
@@ -303,54 +303,6 @@ module F : Sx -> Sy -> Sx -> Sy -> sig end
 |}]
 module E = F(Y)(Y)(X)(X)(Y)(Y)
 [%%expect {|
-File "_none_", line 1:
-Alert x: x
-module X used
-Line 3, characters 22-52:
-3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Definition
-Line 1, characters 21-31:
-1 | module type Sx = sig val x: int end
-                         ^^^^^^^^^^
-  Expected signature
-
-File "_none_", line 1:
-Alert x: x
-module X used
-Line 3, characters 22-52:
-3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Definition
-Line 1, characters 21-31:
-1 | module type Sx = sig val x: int end
-                         ^^^^^^^^^^
-  Expected signature
-
-File "_none_", line 1:
-Alert x: x
-module X used
-Line 3, characters 22-52:
-3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Definition
-Line 1, characters 21-31:
-1 | module type Sx = sig val x: int end
-                         ^^^^^^^^^^
-  Expected signature
-
-File "_none_", line 1:
-Alert x: x
-module X used
-Line 3, characters 22-52:
-3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Definition
-Line 1, characters 21-31:
-1 | module type Sx = sig val x: int end
-                         ^^^^^^^^^^
-  Expected signature
-
 Line 1, characters 11-30:
 1 | module E = F(Y)(Y)(X)(X)(Y)(Y)
                ^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-deprecated/alerts.ml
+++ b/testsuite/tests/typing-deprecated/alerts.ml
@@ -286,3 +286,105 @@ Warning 47 [attribute-payload]: illegal payload for attribute "alert".
 
 module X : sig val x : int val y : int val z : int end
 |}]
+
+(* Only one alert by location *)
+
+module type Sx = sig val x: int end
+module type Sy = sig val y: int end
+module X = struct let (x[@alert x "module X used" ]) = 0 end
+module Y = struct let y = 0 end
+module F(_:Sx)(_:Sy)(_:Sx)(_:Sy) = struct end
+[%%expect {|
+module type Sx = sig val x : int end
+module type Sy = sig val y : int end
+module X : sig val x : int end
+module Y : sig val y : int end
+module F : Sx -> Sy -> Sx -> Sy -> sig end
+|}]
+module E = F(Y)(Y)(X)(X)(Y)(Y)
+[%%expect {|
+File "_none_", line 1:
+Alert x: x
+module X used
+Line 3, characters 22-52:
+3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Definition
+Line 1, characters 21-31:
+1 | module type Sx = sig val x: int end
+                         ^^^^^^^^^^
+  Expected signature
+
+File "_none_", line 1:
+Alert x: x
+module X used
+Line 3, characters 22-52:
+3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Definition
+Line 1, characters 21-31:
+1 | module type Sx = sig val x: int end
+                         ^^^^^^^^^^
+  Expected signature
+
+File "_none_", line 1:
+Alert x: x
+module X used
+Line 3, characters 22-52:
+3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Definition
+Line 1, characters 21-31:
+1 | module type Sx = sig val x: int end
+                         ^^^^^^^^^^
+  Expected signature
+
+File "_none_", line 1:
+Alert x: x
+module X used
+Line 3, characters 22-52:
+3 | module X = struct let (x[@alert x "module X used" ]) = 0 end
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Definition
+Line 1, characters 21-31:
+1 | module type Sx = sig val x: int end
+                         ^^^^^^^^^^
+  Expected signature
+
+Line 1, characters 11-30:
+1 | module E = F(Y)(Y)(X)(X)(Y)(Y)
+               ^^^^^^^^^^^^^^^^^^^
+Error: This application of the functor "F" is ill-typed.
+       These arguments:
+         Y Y X X Y Y
+       do not match these parameters:
+         (Arg : Sx) (Arg : Sy) (Arg : Sx) (Arg : Sy) -> ...
+       1. Modules do not match:
+            Y : sig val y : int end
+          is not included in
+            Sx
+          The value "x" is required but not provided
+       2. Module Y matches the expected module type Sy
+       3. Module X matches the expected module type Sx
+       4. The following extra argument is provided X : sig val x : int end
+       5. Module Y matches the expected module type Sy
+       6. The following extra argument is provided Y : sig val y : int end
+|}]
+
+module type Sxd = sig val x:int [@@alert first_class] end
+let f x = (x: (module Sxd) :> (module Sx))
+[%%expect {|
+module type Sxd = sig val x : int end
+File "_none_", line 1:
+Alert first_class: x
+Line 1, characters 22-53:
+1 | module type Sxd = sig val x:int [@@alert first_class] end
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Definition
+Line 1, characters 21-31:
+1 | module type Sx = sig val x: int end
+                         ^^^^^^^^^^
+  Expected signature
+
+val f : (module Sxd) -> (module Sx) = <fun>
+|}]

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -20,7 +20,7 @@ open Types
 let class_types env cty1 cty2 =
   Ctype.match_class_types env cty1 cty2
 
-let class_type_declarations ~loc env cty1 cty2 =
+let class_type_declarations ?loc env cty1 cty2 =
   Builtin_attributes.check_alerts_inclusion
     ~def:cty1.clty_loc
     ~use:cty2.clty_loc

--- a/typing/includeclass.mli
+++ b/typing/includeclass.mli
@@ -21,7 +21,7 @@ open Ctype
 val class_types:
         Env.t -> class_type -> class_type -> class_match_failure list
 val class_type_declarations:
-  loc:Location.t ->
+  ?loc:Location.t ->
   Env.t -> class_type_declaration -> class_type_declaration ->
   class_match_failure list
 val class_declarations:

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -90,7 +90,7 @@ let value_descriptions_consistency env vd1 vd2 =
   | (_, Val_prim _) -> raise (Dont_match Not_a_primitive)
   | (_, _) -> Tcoerce_none
 
-let value_descriptions ~loc env name
+let value_descriptions ?loc env name
     (vd1 : Types.value_description)
     (vd2 : Types.value_description) =
   Builtin_attributes.check_alerts_inclusion
@@ -504,7 +504,7 @@ module Record_diffing = struct
         Some (Type err : label_mismatch)
     | () -> None
 
-  let rec equal ~loc env params1 params2
+  let rec equal ?loc env params1 params2
       (labels1 : Types.label_declaration list)
       (labels2 : Types.label_declaration list) =
     match labels1, labels2 with
@@ -524,7 +524,7 @@ module Record_diffing = struct
           | Some _ -> false
           (* add arguments to the parameters, cf. PR#7378 *)
           | None ->
-              equal ~loc env
+              equal ?loc env
                 (ld1.ld_type::params1) (ld2.ld_type::params2)
                 rem1 rem2
         end
@@ -545,7 +545,7 @@ module Record_diffing = struct
            (in inline records) *)
         x.data.ld_type::params1, y.data.ld_type::params2
 
-  let test _loc env (params1,params2)
+  let test env (params1,params2)
       ({pos; data=lbl1}: Diff.left)
       ({data=lbl2; _ }: Diff.right)
     =
@@ -600,27 +600,27 @@ module Record_diffing = struct
             we have [Type_change Delete^D < Delete^D Name_change]. *)
 
   let key (x: Defs.left) = Ident.name x.ld_id
-  let diffing loc env params1 params2 cstrs_1 cstrs_2 =
+  let diffing env params1 params2 cstrs_1 cstrs_2 =
     let module Compute = Diff.Simple(struct
         let key_left = key
         let key_right = key
         let update = update
-        let test = test loc env
+        let test = test env
         let weight = weight
       end)
     in
     Compute.diff (params1,params2) cstrs_1 cstrs_2
 
-  let compare ~loc env params1 params2 l r =
-    if equal ~loc env params1 params2 l r then
+  let compare ?loc env params1 params2 l r =
+    if equal ?loc env params1 params2 l r then
       None
     else
-      Some (diffing loc env params1 params2 l r)
+      Some (diffing env params1 params2 l r)
 
 
-  let compare_with_representation ~loc env params1 params2 l r rep1 rep2 =
-    if not (equal ~loc env params1 params2 l r) then
-      let patch = diffing loc env params1 params2 l r in
+  let compare_with_representation ?loc env params1 params2 l r rep1 rep2 =
+    if not (equal ?loc env params1 params2 l r) then
+      let patch = diffing env params1 params2 l r in
       Some (Record_mismatch (Label_mismatch patch))
     else
      match rep1, rep2 with
@@ -646,7 +646,7 @@ end
 
 module Variant_diffing = struct
 
-  let compare_constructor_arguments ~loc env params1 params2 arg1 arg2 =
+  let compare_constructor_arguments ?loc env params1 params2 arg1 arg2 =
     match arg1, arg2 with
     | Types.Cstr_tuple arg1, Types.Cstr_tuple arg2 ->
         if List.length arg1 <> List.length arg2 then
@@ -660,23 +660,23 @@ module Variant_diffing = struct
     | Types.Cstr_record l1, Types.Cstr_record l2 ->
         Option.map
           (fun rec_err -> Inline_record rec_err)
-          (Record_diffing.compare env ~loc params1 params2 l1 l2)
+          (Record_diffing.compare env ?loc params1 params2 l1 l2)
     | Types.Cstr_record _, _ -> Some (Kind First : constructor_mismatch)
     | _, Types.Cstr_record _ -> Some (Kind Second : constructor_mismatch)
 
-  let compare_constructors ~loc env params1 params2 res1 res2 args1 args2 =
+  let compare_constructors ?loc env params1 params2 res1 res2 args1 args2 =
     match res1, res2 with
     | Some r1, Some r2 ->
         begin match Ctype.equal env true [r1] [r2] with
         | exception Ctype.Equality err -> Some (Type err)
-        | () -> compare_constructor_arguments ~loc env [r1] [r2] args1 args2
+        | () -> compare_constructor_arguments ?loc env [r1] [r2] args1 args2
         end
     | Some _, None -> Some (Explicit_return_type First)
     | None, Some _ -> Some (Explicit_return_type Second)
     | None, None ->
-        compare_constructor_arguments ~loc env params1 params2 args1 args2
+        compare_constructor_arguments ?loc env params1 params2 args1 args2
 
-  let equal ~loc env params1 params2
+  let equal ?loc env params1 params2
       (cstrs1 : Types.constructor_declaration list)
       (cstrs2 : Types.constructor_declaration list) =
     List.length cstrs1 = List.length cstrs2 &&
@@ -692,7 +692,7 @@ module Variant_diffing = struct
             cd1.cd_attributes cd2.cd_attributes
             (Ident.name cd1.cd_id)
           ;
-        match compare_constructors ~loc env params1 params2
+        match compare_constructors ?loc env params1 params2
                 cd1.cd_res cd2.cd_res cd1.cd_args cd2.cd_args with
         | Some _ -> false
         | None -> true
@@ -716,13 +716,13 @@ module Variant_diffing = struct
     | Change (_,_,Diffing_with_keys.Type _) -> 50
     (** See {!Variant_diffing.weight} for an explanation *)
 
-  let test loc env (params1,params2)
+  let test env (params1,params2)
       ({pos; data=cd1}: D.left)
       ({data=cd2; _}: D.right) =
     let name1, name2 = Ident.name cd1.cd_id, Ident.name cd2.cd_id in
     if  name1 <> name2 then
       let types_match =
-        match compare_constructors ~loc env params1 params2
+        match compare_constructors env params1 params2
                 cd1.cd_res cd2.cd_res cd1.cd_args cd2.cd_args with
         | Some _ -> false
         | None -> true
@@ -730,34 +730,34 @@ module Variant_diffing = struct
       Error
         (Diffing_with_keys.Name {types_match; pos; got=name1; expected=name2})
     else
-      match compare_constructors ~loc env params1 params2
+      match compare_constructors env params1 params2
               cd1.cd_res cd2.cd_res cd1.cd_args cd2.cd_args with
       | Some reason ->
           Error (Diffing_with_keys.Type {pos; got=cd1; expected=cd2; reason})
       | None -> Ok ()
 
-  let diffing loc env params1 params2 cstrs_1 cstrs_2 =
+  let diffing env params1 params2 cstrs_1 cstrs_2 =
     let key (x:Defs.left) = Ident.name x.cd_id in
     let module Compute = D.Simple(struct
         let key_left = key
         let key_right = key
-        let test = test loc env
+        let test = test env
         let update = update
         let weight = weight
       end)
     in
     Compute.diff (params1,params2) cstrs_1 cstrs_2
 
-  let compare ~loc env params1 params2 l r =
-    if equal ~loc env params1 params2 l r then
+  let compare ?loc env params1 params2 l r =
+    if equal ?loc env params1 params2 l r then
       None
     else
-      Some (diffing loc env params1 params2 l r)
+      Some (diffing env params1 params2 l r)
 
-  let compare_with_representation ~loc env params1 params2
+  let compare_with_representation ?loc env params1 params2
       cstrs1 cstrs2 rep1 rep2
     =
-    let err = compare ~loc env params1 params2 cstrs1 cstrs2 in
+    let err = compare ?loc env params1 params2 cstrs1 cstrs2 in
     match err, rep1, rep2 with
     | None, Variant_regular, Variant_regular
     | None, Variant_unboxed, Variant_unboxed ->
@@ -947,7 +947,7 @@ let type_declarations_consistency env decl1 decl2 =
     | Some err -> Some (Privacy err)
     | None -> None
 
-let type_declarations ?(equality = false) ~loc env ~mark name
+let type_declarations ?(equality = false) ?loc env ~mark name
       decl1 path decl2 =
   Builtin_attributes.check_alerts_inclusion
     ~def:decl1.type_loc
@@ -995,7 +995,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           mark usage cstrs1;
           if equality then mark Env.Exported cstrs2
         end;
-        Variant_diffing.compare_with_representation ~loc env
+        Variant_diffing.compare_with_representation ?loc env
           decl1.type_params
           decl2.type_params
           cstrs1
@@ -1016,7 +1016,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           mark usage labels1;
           if equality then mark Env.Exported labels2
         end;
-        Record_diffing.compare_with_representation ~loc env
+        Record_diffing.compare_with_representation ?loc env
           decl1.type_params decl2.type_params
           labels1 labels2
           rep1 rep2
@@ -1074,7 +1074,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
 
 (* Inclusion between extension constructors *)
 
-let extension_constructors ~loc env ~mark id ext1 ext2 =
+let extension_constructors ?loc env ~mark id ext1 ext2 =
   if mark then begin
     let usage : Env.constructor_usage =
       if ext2.ext_private = Public then Env.Exported
@@ -1095,7 +1095,7 @@ let extension_constructors ~loc env ~mark id ext1 ext2 =
       Some (Constructor_mismatch (id, ext1, ext2, Type err))
   | () ->
     let r =
-      Variant_diffing.compare_constructors ~loc env
+      Variant_diffing.compare_constructors ?loc env
         ext1.ext_type_params ext2.ext_type_params
         ext1.ext_ret_type ext2.ext_ret_type
         ext1.ext_args ext2.ext_args

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -107,17 +107,17 @@ type type_mismatch =
   | Immediate of Type_immediacy.Violation.t
 
 val value_descriptions:
-  loc:Location.t -> Env.t -> string ->
+  ?loc:Location.t -> Env.t -> string ->
   value_description -> value_description -> module_coercion
 
 val type_declarations:
   ?equality:bool ->
-  loc:Location.t ->
+  ?loc:Location.t ->
   Env.t -> mark:bool -> string ->
   type_declaration -> Path.t -> type_declaration -> type_mismatch option
 
 val extension_constructors:
-  loc:Location.t -> Env.t -> mark:bool -> Ident.t ->
+  ?loc:Location.t -> Env.t -> mark:bool -> Ident.t ->
   extension_constructor -> extension_constructor ->
   extension_constructor_mismatch option
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -239,24 +239,24 @@ module Core_inclusion = struct
 
   (* Inclusion between value descriptions *)
 
-  let value_descriptions ~loc env ~direction subst id vd1 vd2 =
+  let value_descriptions ?loc env ~direction subst id vd1 vd2 =
     if Directionality.mark_as_used direction then
       Env.mark_value_used vd1.val_uid;
     let vd2 = Subst.value_description subst vd2 in
     try
-      Ok (Includecore.value_descriptions ~loc env (Ident.name id) vd1 vd2)
+      Ok (Includecore.value_descriptions ?loc env (Ident.name id) vd1 vd2)
     with Includecore.Dont_match err ->
       Error Error.(Core (Value_descriptions (diff vd1 vd2 err)))
 
   (* Inclusion between type declarations *)
 
-  let type_declarations ~loc env ~direction subst id decl1 decl2 =
+  let type_declarations ?loc env ~direction subst id decl1 decl2 =
     let mark = Directionality.mark_as_used direction in
     if mark then
       Env.mark_type_used decl1.type_uid;
     let decl2 = Subst.type_declaration subst decl2 in
     match
-      Includecore.type_declarations ~loc env ~mark
+      Includecore.type_declarations ?loc env ~mark
         (Ident.name id) decl1 (Path.Pident id) decl2
     with
     | None -> Ok Tcoerce_none
@@ -265,24 +265,24 @@ module Core_inclusion = struct
 
   (* Inclusion between extension constructors *)
 
-  let extension_constructors ~loc env ~direction subst id ext1 ext2 =
+  let extension_constructors ?loc env ~direction subst id ext1 ext2 =
     let mark = Directionality.mark_as_used direction in
     let ext2 = Subst.extension_constructor subst ext2 in
-    match Includecore.extension_constructors ~loc env ~mark id ext1 ext2 with
+    match Includecore.extension_constructors ?loc env ~mark id ext1 ext2 with
     | None -> Ok Tcoerce_none
     | Some err ->
         Error Error.(Core(Extension_constructors(diff ext1 ext2 err)))
 
   (* Inclusion between class declarations *)
 
-  let class_type_declarations ~loc env ~direction:_ subst _id decl1 decl2 =
+  let class_type_declarations ?loc env ~direction:_ subst _id decl1 decl2 =
     let decl2 = Subst.cltype_declaration subst decl2 in
-    match Includeclass.class_type_declarations ~loc env decl1 decl2 with
+    match Includeclass.class_type_declarations ?loc env decl1 decl2 with
       []     -> Ok Tcoerce_none
     | reason ->
         Error Error.(Core(Class_type_declarations(diff decl1 decl2 reason)))
 
-  let class_declarations ~loc:_ env ~direction:_ subst _id decl1 decl2 =
+  let class_declarations ?loc:_ env ~direction:_ subst _id decl1 decl2 =
     let decl2 = Subst.class_declaration subst decl2 in
     match Includeclass.class_declarations env decl1 decl2 with
       []     -> Ok Tcoerce_none
@@ -496,8 +496,8 @@ end
   - the coarse-grain consistency relation [C], which is defined by
    [d1 C d2] if there is an environment [E] such that [E |- d1 <: d2]. *)
 type 'a core_incl =
-  loc:Location.t -> Env.t -> direction:Directionality.t -> Subst.t -> Ident.t ->
-  'a -> 'a -> (module_coercion, Error.sigitem_symptom) result
+  ?loc:Location.t -> Env.t -> direction:Directionality.t -> Subst.t ->
+  Ident.t -> 'a -> 'a -> (module_coercion, Error.sigitem_symptom) result
 
 type core_relation = {
   value_descriptions: Types.value_description core_incl;
@@ -514,14 +514,14 @@ let item_subst id1 item2 subst =
   | Sig_modtype (id2,_,_) -> Subst.add_modtype id2 (Path.Pident id1) subst
   | Sig_value _ | Sig_typext _ | Sig_class _ | Sig_class_type _ -> subst
 
-let rec modtypes ~core ~direction ~loc env subst mty1 mty2 shape =
-  match try_modtypes ~core ~direction ~loc env subst mty1 mty2 shape with
+let rec modtypes ~core ~direction ?loc env subst mty1 mty2 shape =
+  match try_modtypes ~core ~direction ?loc env subst mty1 mty2 shape with
   | Ok _ as ok -> ok
   | Error reason ->
     let mty2 = Subst.modtype Make_local subst mty2 in
     Error Error.(diff mty1 mty2 reason)
 
-and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
+and try_modtypes ~core ~direction ?loc env subst mty1 mty2 orig_shape =
   match mty1, mty2 with
   | (Mty_alias p1, Mty_alias p2) ->
       if (equal_module_paths env p1 subst p2) then
@@ -538,7 +538,7 @@ and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
           begin match expand_module_alias ~strengthen:false env p1 with
           | Error e -> Error (Error.Mt_core e)
           | Ok mty1 ->
-              match strengthened_modtypes ~core ~direction ~loc ~aliasable:true
+              match strengthened_modtypes ~core ~direction ?loc ~aliasable:true
                       env subst mty1 p1 mty2 orig_shape
               with
               | Ok _ as x -> x
@@ -552,21 +552,21 @@ and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
       else
         begin match expand_modtype_path env p1, expand_modtype_path env p2 with
         | Some mty1, Some mty2 ->
-            try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape
+            try_modtypes ~core ~direction ?loc env subst mty1 mty2 orig_shape
         | None, _  | _, None -> Error (Error.Mt_core Abstract_module_type)
         end
   | (Mty_ident p1, _) ->
       let p1 = Env.normalize_modtype_path env p1 in
       begin match expand_modtype_path env p1 with
       | Some p1 ->
-          try_modtypes ~core ~direction ~loc env subst p1 mty2 orig_shape
+          try_modtypes ~core ~direction ?loc env subst p1 mty2 orig_shape
       | None -> Error (Error.Mt_core Abstract_module_type)
       end
   | (_, Mty_ident p2) ->
       let p2 = Env.normalize_modtype_path env (Subst.modtype_path subst p2) in
       begin match expand_modtype_path env p2 with
       | Some p2 ->
-          try_modtypes ~core ~direction ~loc env subst mty1 p2 orig_shape
+          try_modtypes ~core ~direction ?loc env subst mty1 p2 orig_shape
       | None ->
           begin match mty1 with
           | Mty_functor _ ->
@@ -578,7 +578,7 @@ and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
       end
   | (Mty_signature sig1, Mty_signature sig2) ->
       begin match
-        signatures ~core ~direction ~loc env subst sig1 sig2 orig_shape
+        signatures ~core ~direction ?loc env subst sig1 sig2 orig_shape
       with
       | Ok _ as ok -> ok
       | Error e -> Error (Error.Signature e)
@@ -586,7 +586,7 @@ and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
   | Mty_functor (param1, res1), Mty_functor (param2, res2) ->
       let cc_arg, env, subst =
         let direction = Directionality.negate direction in
-        functor_param ~core ~direction ~loc env
+        functor_param ~core ~direction ?loc env
           subst param1 param2
       in
       let var, res_shape =
@@ -604,7 +604,7 @@ and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
             var, Shape.app orig_shape ~arg:shape_var
       in
       let cc_res =
-        modtypes ~core ~direction ~loc env subst res1 res2 res_shape
+        modtypes ~core ~direction ?loc env subst res1 res2 res_shape
       in
       begin match cc_arg, cc_res with
       | Ok Tcoerce_none, Ok (Tcoerce_none, final_res_shape) ->
@@ -643,7 +643,7 @@ and try_modtypes ~core ~direction ~loc env subst mty1 mty2 orig_shape =
 
 (* Functor parameters *)
 
-and functor_param ~core ~direction ~loc env subst param1 param2 =
+and functor_param ~core ~direction ?loc env subst param1 param2 =
   match param1, param2 with
   | Unit, Unit ->
       Ok Tcoerce_none, env, subst
@@ -651,7 +651,7 @@ and functor_param ~core ~direction ~loc env subst param1 param2 =
       let arg2' = Subst.modtype Keep subst arg2 in
       let cc_arg =
         match
-          modtypes ~core ~direction ~loc env Subst.identity arg2' arg1
+          modtypes ~core ~direction ?loc env Subst.identity arg2' arg1
                 Shape.dummy_mod
         with
         | Ok (cc, _) -> Ok cc
@@ -679,27 +679,27 @@ and equate_one_functor_param subst env arg2' name1 name2  =
   | None, None ->
       env, subst
 
-and strengthened_modtypes ~core ~direction ~loc ~aliasable env
+and strengthened_modtypes ~core ~direction ?loc ~aliasable env
     subst mty1 path1 mty2 shape =
   match mty1, mty2 with
   | Mty_ident p1, Mty_ident p2 when equal_modtype_paths env p1 subst p2 ->
       Ok (Tcoerce_none, shape)
   | _, _ ->
       let mty1 = Mtype.strengthen ~aliasable env mty1 path1 in
-      modtypes ~core ~direction ~loc env subst mty1 mty2 shape
+      modtypes ~core ~direction ?loc env subst mty1 mty2 shape
 
-and strengthened_module_decl ~core ~loc ~aliasable ~direction env
+and strengthened_module_decl ~core ?loc ~aliasable ~direction env
     subst md1 path1 md2 shape =
   match md1.md_type, md2.md_type with
   | Mty_ident p1, Mty_ident p2 when equal_modtype_paths env p1 subst p2 ->
       Ok (Tcoerce_none, shape)
   | _, _ ->
       let md1 = Mtype.strengthen_decl ~aliasable env md1 path1 in
-      modtypes ~core ~direction ~loc env subst md1.md_type md2.md_type shape
+      modtypes ~core ~direction ?loc env subst md1.md_type md2.md_type shape
 
 (* Inclusion between signatures *)
 
-and signatures ~core ~direction ~loc env subst sig1 sig2 mod_shape =
+and signatures ~core ~direction ?loc env subst sig1 sig2 mod_shape =
   (* Environment used to check inclusion of components *)
   let new_env =
     Env.add_signature sig1 (Env.in_signature true env) in
@@ -748,7 +748,7 @@ and signatures ~core ~direction ~loc env subst sig1 sig2 mod_shape =
       [] ->
         let open Sign_diff in
         let d =
-          signature_components ~core ~direction ~loc env new_env subst
+          signature_components ~core ~direction ?loc env new_env subst
             mod_shape Shape.Map.empty
             (List.rev paired)
         in
@@ -808,7 +808,7 @@ and signatures ~core ~direction ~loc env subst sig1 sig2 mod_shape =
 
 (* Inclusion between signature components *)
 
-and signature_components ~core ~direction ~loc old_env env subst
+and signature_components ~core ~direction ?loc old_env env subst
     orig_shape shape_map paired =
   match paired with
   | [] -> Sign_diff.{ empty with shape_map }
@@ -818,7 +818,7 @@ and signature_components ~core ~direction ~loc old_env env subst
         match sigi1, sigi2 with
         | Sig_value(id1, valdecl1, _), Sig_value(_id2, valdecl2, _) ->
             let item =
-              core.value_descriptions ~loc ~direction env subst id1
+              core.value_descriptions ?loc ~direction env subst id1
                 valdecl1 valdecl2
             in
             let item = mark_error_as_recoverable item in
@@ -831,7 +831,7 @@ and signature_components ~core ~direction ~loc old_env env subst
             item, paired_uids, shape_map, present_at_runtime
         | Sig_type(id1, tydec1, _, _), Sig_type(_id2, tydec2, _, _) ->
             let item =
-              core.type_declarations ~loc ~direction env subst id1 tydec1 tydec2
+              core.type_declarations ?loc ~direction env subst id1 tydec1 tydec2
             in
             let item = mark_error_as_unrecoverable item in
             (* Right now we don't filter hidden constructors / labels from the
@@ -840,7 +840,7 @@ and signature_components ~core ~direction ~loc old_env env subst
             item, (tydec1.type_uid, tydec2.type_uid), shape_map, false
         | Sig_typext(id1, ext1, _, _), Sig_typext(_id2, ext2, _, _) ->
             let item =
-              core.extension_constructors ~loc ~direction env subst id1
+              core.extension_constructors ?loc ~direction env subst id1
                 ext1 ext2
             in
             let item = mark_error_as_unrecoverable item in
@@ -854,7 +854,7 @@ and signature_components ~core ~direction ~loc old_env env subst
                 Shape.(proj orig_shape (Item.module_ id1))
               in
               let item =
-                module_declarations ~core ~direction ~loc env subst id1
+                module_declarations ~core ~direction ?loc env subst id1
                   mty1 mty2 orig_shape
               in
               let item, shape_map =
@@ -884,7 +884,7 @@ and signature_components ~core ~direction ~loc old_env env subst
             end
         | Sig_modtype(id1, info1, _), Sig_modtype(_id2, info2, _) ->
             let item =
-              modtype_infos ~core ~direction ~loc env  subst id1 info1 info2
+              modtype_infos ~core ~direction ?loc env  subst id1 info1 info2
             in
             let shape_map =
               Shape.Map.add_module_type_proj shape_map id1 orig_shape
@@ -893,7 +893,7 @@ and signature_components ~core ~direction ~loc old_env env subst
             item, (info1.mtd_uid, info2.mtd_uid), shape_map, false
         | Sig_class(id1, decl1, _, _), Sig_class(_id2, decl2, _, _) ->
             let item =
-              core.class_declarations ~loc ~direction env subst id1 decl1 decl2
+              core.class_declarations ?loc ~direction env subst id1 decl1 decl2
             in
             let shape_map =
               Shape.Map.add_class_proj shape_map id1 orig_shape
@@ -902,7 +902,7 @@ and signature_components ~core ~direction ~loc old_env env subst
             item, (decl1.cty_uid, decl2.cty_uid), shape_map, true
         | Sig_class_type(id1, info1, _, _), Sig_class_type(_id2, info2, _, _) ->
             let item =
-              core.class_type_declarations ~loc ~direction env subst id1
+              core.class_type_declarations ?loc ~direction env subst id1
                 info1 info2
             in
             let item = mark_error_as_unrecoverable item in
@@ -949,13 +949,13 @@ and signature_components ~core ~direction ~loc old_env env subst
       in
       let rest =
         if continue then
-          signature_components ~core ~direction ~loc old_env env subst
+          signature_components ~core ~direction ?loc old_env env subst
             orig_shape shape_map rem
         else Sign_diff.{ empty with untypables=rem }
        in
        Sign_diff.merge first rest
 
-and module_declarations ~loc env ~direction subst id1 md1 md2 orig_shape =
+and module_declarations ?loc env ~direction subst id1 md1 md2 orig_shape =
   Builtin_attributes.check_alerts_inclusion
     ~def:md1.md_loc
     ~use:md2.md_loc
@@ -965,12 +965,12 @@ and module_declarations ~loc env ~direction subst id1 md1 md2 orig_shape =
   let p1 = Path.Pident id1 in
   if Directionality.mark_as_used direction then
     Env.mark_module_used md1.md_uid;
-  strengthened_modtypes ~direction ~loc ~aliasable:true env subst
+  strengthened_modtypes ~direction ?loc ~aliasable:true env subst
     md1.md_type p1 md2.md_type orig_shape
 
 (* Inclusion between module type specifications *)
 
-and modtype_infos ~core ~loc env ~direction subst id info1 info2 =
+and modtype_infos ~core ?loc env ~direction subst id info1 info2 =
   Builtin_attributes.check_alerts_inclusion
     ~def:info1.mtd_loc
     ~use:info2.mtd_loc
@@ -983,19 +983,19 @@ and modtype_infos ~core ~loc env ~direction subst id info1 info2 =
       (None, None) -> Ok Tcoerce_none
     | (Some _, None) -> Ok Tcoerce_none
     | (Some mty1, Some mty2) ->
-        check_modtype_equiv ~core ~direction ~loc env mty1 mty2
+        check_modtype_equiv ~core ~direction ?loc env mty1 mty2
     | (None, Some mty2) ->
         let mty1 = Mty_ident(Path.Pident id) in
-        check_modtype_equiv ~core ~direction ~loc env mty1 mty2 in
+        check_modtype_equiv ~core ~direction ?loc env mty1 mty2 in
   match r with
   | Ok _ as ok -> ok
   | Error e -> Error Error.(Module_type_declaration (diff info1 info2 e))
 
-and check_modtype_equiv ~core ~direction ~loc env mty1 mty2 =
+and check_modtype_equiv ~core ~direction ?loc env mty1 mty2 =
   let nested_eq = direction.Directionality.in_eq in
   let direction = Directionality.enter_eq direction in
   let c1 =
-    modtypes ~core ~direction ~loc env Subst.identity mty1 mty2 Shape.dummy_mod
+    modtypes ~core ~direction ?loc env Subst.identity mty1 mty2 Shape.dummy_mod
   in
   let c2 =
     (* For nested module type paths, we check only one side of the equivalence:
@@ -1006,7 +1006,7 @@ and check_modtype_equiv ~core ~direction ~loc env mty1 mty2 =
     else
       let direction = Directionality.negate direction in
       Some (
-        modtypes ~core ~direction ~loc env Subst.identity
+        modtypes ~core ~direction ?loc env Subst.identity
           mty2 mty1 Shape.dummy_mod
       )
   in
@@ -1033,18 +1033,18 @@ let core_inclusion = Core_inclusion.{
 }
 
 let core_consistency =
-  let type_declarations ~loc:_ env ~direction:_ _ _ d1 d2 =
+  let type_declarations ?loc:_ env ~direction:_ _ _ d1 d2 =
     match Includecore.type_declarations_consistency env d1 d2 with
     | None -> Ok Tcoerce_none
     | Some err ->  Error Error.(Core(Type_declarations (diff d1 d2 err)))
   in
-  let value_descriptions ~loc:_ env ~direction:_ _ _ vd1 vd2 =
+  let value_descriptions ?loc:_ env ~direction:_ _ _ vd1 vd2 =
     match Includecore.value_descriptions_consistency env vd1 vd2 with
     | x -> Ok x
     | exception Includecore.Dont_match err ->
         Error Error.(Core (Value_descriptions (diff vd1 vd2 err)))
   in
-  let accept ~loc:_ _env ~direction:_ _subst _id _d1 _d2 = Ok Tcoerce_none in
+  let accept ?loc:_ _env ~direction:_ _subst _id _d1 _d2 = Ok Tcoerce_none in
   {
     type_declarations;
     value_descriptions;
@@ -1213,10 +1213,9 @@ module Functor_inclusion_diff = struct
   let diff {i_env=env; i_subst=subst} (l1,res1) (l2,_) =
     let module Compute = Diff.Left_variadic(struct
         let test st mty1 mty2 =
-          let loc = Location.none in
           let res, _, _ =
             let direction=Directionality.unknown ~mark:false in
-            functor_param ~core:core_inclusion ~direction ~loc st.env
+            functor_param ~core:core_inclusion ~direction st.env
               st.subst mty1 mty2
           in
           res
@@ -1304,7 +1303,6 @@ module Functor_app_diff = struct
     let module Compute = Diff.Right_variadic(struct
         let update = update
         let test (state:Defs.state) (arg,arg_mty) param =
-          let loc = Location.none in
           let res = match (arg:Error.functor_arg_descr), param with
             | (Unit|Empty_struct), Unit -> Ok Tcoerce_none
             | Unit, Named _ | (Anonymous | Named _), Unit ->
@@ -1313,7 +1311,7 @@ module Functor_app_diff = struct
                let direction=Directionality.unknown ~mark:false in
                 match
                   modtypes
-                    ~core:core_inclusion ~direction ~loc
+                    ~core:core_inclusion ~direction
                     state.env state.subst arg_mty param
                     Shape.dummy_mod
                 with
@@ -1345,10 +1343,10 @@ let modtypes_constraint ~shape ~loc env ~mark mty1 mty2 =
   | Ok (cc, shape) -> cc, shape
   | Error reason -> raise (Error (env, Error.(In_Module_type reason)))
 
-let modtypes_consistency ~loc env mty1 mty2 =
+let modtypes_consistency env mty1 mty2 =
   let direction = Directionality.unknown ~mark:false in
   match
-    modtypes ~core:core_consistency ~direction ~loc env Subst.identity
+    modtypes ~core:core_consistency ~direction env Subst.identity
       mty1 mty2 Shape.dummy_mod
   with
   | Ok _ -> ()
@@ -1364,9 +1362,10 @@ let modtypes ~loc env ~mark mty1 mty2 =
   | Error reason -> raise (Error (env, Error.(In_Module_type reason)))
 
 let gen_signatures env ?(subst=Subst.identity) ~direction sig1 sig2 =
+  let loc = Location.none (* whole file location *) in
   match
     signatures
-      ~core:core_inclusion ~direction ~loc:Location.none env
+      ~core:core_inclusion ~direction ~loc env
       subst sig1 sig2 Shape.dummy_mod
   with
   | Ok (cc, _) -> cc
@@ -1422,9 +1421,9 @@ module Check = struct
   open Core_inclusion
 
   let check_only f env subst l r =
-    let loc = Location.none and id = Ident.create_local "*dummy*" in
+    let id = Ident.create_local "*dummy*" in
     let direction = Directionality.unknown ~mark:false in
-    f ~loc env ~direction subst id l r
+    f ?loc:None env ~direction subst id l r
 
   let check_ok f env subst l r = Result.is_ok (check_only f env subst l r)
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -150,7 +150,7 @@ val modtypes:
   module_type -> module_type -> module_coercion
 
 val modtypes_consistency:
-  loc:Location.t -> Env.t -> module_type -> module_type -> unit
+  Env.t -> module_type -> module_type -> unit
 
 (** [modtypes_constraint ~shape ~loc env ~mark exp_modtype constraint_modtype]
     checks that [exp_modtype] is a subtype of [constraint_modtype], and returns

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -817,8 +817,7 @@ let unexpected_functor ~env ~before ~ctx diff =
           "@[This module should not be a functor,@ a@ structure was expected.@]"
   in
   let main =
-    match Includemod.modtypes_consistency ~loc:Location.none env rmty
-            diff.expected.res with
+    match Includemod.modtypes_consistency env rmty diff.expected.res with
     | _ ->
         Fmt.dprintf
           "%t@ @{<hint>Hint@}: Did you forget to apply the functor?"

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2945,8 +2945,7 @@ and type_str_item ~names ~toplevel ~funct_body anchor env shape_map
                let mty' =
                  enrich_module_type anchor name.txt modl.mod_type newenv
                in
-               Includemod.modtypes_consistency ~loc:modl.mod_loc newenv
-                mty' mty.mty_type;
+               Includemod.modtypes_consistency newenv mty' mty.mty_type;
                (id, name, mty, modl, mty', attrs, loc, shape, uid))
             decls sbind in
         let newenv = (* allow aliasing recursive modules from outside *)


### PR DESCRIPTION
This PR makes it possible to silence the alert emitted when checking inclusion between module types, for instance in
```ocaml
module X = struct let (x[@alert x "Module X used"]) = 0 end
module User: sig val x: int end = X
```
> Line 3, characters 34-35:
Alert x: x
Module X used
Line 2, characters 22-51:
  Definition
Line 3, characters 17-27:
  Expected signature

but only when using internal typechecker functions. This is used to avoid duplicating alert messages when  
higher-level error functions check multiple times an inclusion between signature items.

For instance, on trunk, the definition of module `E` in
```
module type Sx = sig val x: int end
module type Sy = sig val y: int end
module Y = struct let y = 0 end
module F(_:Sx)(_:Sy)(_:Sx)(_:Sy) = struct end
module E = F(Y)(Y)(X)(X)(Y)(Y)
```
raises four "Module X used" alerts because those alerts are raised when searching for a patch for the ill-typed functor application. This PR removes this redundancy.