### PR TITLE
Fix `-Wundef` errors on `HAVE_` macros from configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -234,8 +234,8 @@ Working version
 
 ### Other libraries:
 
-- #13700: Use POSIX thread-safe getgrnam_r, getgrgid_r, getpwnam_r, getpwuid_r,
-  gmtime_r, localtime_r, getlogin_r, and fix mktime error checking.
+- #13700, #14454: Use POSIX thread-safe getgrnam_r, getgrgid_r, getpwnam_r,
+  getpwuid_r, gmtime_r, localtime_r, getlogin_r, and fix mktime error checking.
   (Antonin Décimo, review by David Allsopp, Stefan Muenzel, and Miod Vallat)
 
 - #14406: Better handling of address length for unix sockets, improving Haiku

--- a/otherlibs/unix/getgr.c
+++ b/otherlibs/unix/getgr.c
@@ -82,7 +82,7 @@ CAMLprim value caml_unix_getgrnam(value name)
     caml_raise_not_found();
   }
   res = alloc_group_entry(entry);
-#if HAVE_GETGRNAM_R
+#ifdef HAVE_GETGRNAM_R
   caml_stat_free(buffer);
 #endif
   return res;
@@ -125,7 +125,7 @@ CAMLprim value caml_unix_getgrgid(value gid)
     caml_raise_not_found();
   }
   res = alloc_group_entry(entry);
-#if HAVE_GETGRGID_R
+#ifdef HAVE_GETGRGID_R
   caml_stat_free(buffer);
 #endif
   return res;

--- a/otherlibs/unix/getlogin.c
+++ b/otherlibs/unix/getlogin.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <errno.h>
 
+/* Arbitrary limit to prevent allocating too much memory */
 #define CAML_LOGIN_NAME_MAX (256 * 4)
 
 CAMLprim value caml_unix_getlogin(value unit)

--- a/otherlibs/unix/getpw.c
+++ b/otherlibs/unix/getpw.c
@@ -88,7 +88,7 @@ CAMLprim value caml_unix_getpwnam(value name)
     caml_raise_not_found();
   }
   res = alloc_passwd_entry(entry);
-#if HAVE_GETPWNAM_R
+#ifdef HAVE_GETPWNAM_R
   caml_stat_free(buffer);
 #endif
   return res;
@@ -131,7 +131,7 @@ CAMLprim value caml_unix_getpwuid(value uid)
     caml_raise_not_found();
   }
   res = alloc_passwd_entry(entry);
-#if HAVE_GETPWUID_R
+#ifdef HAVE_GETPWUID_R
   caml_stat_free(buffer);
 #endif
   return res;


### PR DESCRIPTION
Fix a little oversight from #13700. There are a few places where I used `#if` instead of `#ifdef` on the `HAVE_*` macro, this triggers an error if the macro is not defined and `-Wundef` is used.

    error: 'HAVE_GETGRGID_R' is not defined, evaluates to 0 [-Werror,-Wundef]
    
I also piggy-back a forgotten comment.