### PR TITLE
Add missing `getuid` dummy impl in ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -490,9 +490,10 @@ Working version
 - #13224: Clarify barriers and spin macros with delayed expansion.
   (Antonin Décimo, review by David Allsopp and Gabriel Scherer)
 
-- #14435: Add the not-root builtin ocamltest action. This allows to skip
+- #14435, #14455: Add the not-root builtin ocamltest action. This allows to skip
   tests that fail if the current user is root (superuser).
-  (Kate Deplaix, review by Gabriel Scherer and Nicolás Ojeda Bär)
+  (Kate Deplaix, review by Gabriel Scherer, Nicolás Ojeda Bär, and
+   Antonin Décimo)
 
 ### Build system:
 

--- a/ocamltest/ocamltest_unix_dummy.ml
+++ b/ocamltest/ocamltest_unix_dummy.ml
@@ -17,3 +17,4 @@ let has_symlink () = false
 let symlink ?to_dir:_ _ _ = invalid_arg "symlink not available"
 let chmod _ _ = invalid_arg "chmod not available"
 let gettimeofday () = invalid_arg "gettimeofday not available"
+let getuid () = invalid_arg "getuid not available"


### PR DESCRIPTION
Fix #14435. This would trigger a failure in `minimal` (https://github.com/MisterDA/ocaml/actions/runs/20722677624/job/59490807388), triggered with the `CI: Full Matrix` label:

```
File "/home/runner/work/ocaml/ocaml/ocamltest/ocamltest_unix.ml", line 1:
Error: The implementation ocamltest/ocamltest_unix.ml
       does not match the interface ocamltest/ocamltest_unix.mli: 
       The value getuid is required but not provided
       File "/home/runner/work/ocaml/ocaml/ocamltest/ocamltest_unix.mli", line 22, characters 0-24:
         Expected declaration
```