### PR TITLE
untypeast: Handle Tpat_open

### DIFF
--- a/Changes
+++ b/Changes
@@ -502,7 +502,7 @@ Working version
    Antonin Décimo)
 
 - #14457: Handle qualified `M.{ x }` patterns in untypeast
-  (Basile Clément, review by ???)
+  (Basile Clément, review by Florian Angeletti)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -501,6 +501,9 @@ Working version
   (Kate Deplaix, review by Gabriel Scherer, Nicolás Ojeda Bär, and
    Antonin Décimo)
 
+- #14457: Handle qualified `M.{ x }` patterns in untypeast (Basile Clément,
+  review by ???)
+
 ### Build system:
 
 - #13705, #14444: Cache test results of custom Autoconf tests from aclocal.m4.

--- a/Changes
+++ b/Changes
@@ -501,8 +501,8 @@ Working version
   (Kate Deplaix, review by Gabriel Scherer, Nicolás Ojeda Bär, and
    Antonin Décimo)
 
-- #14457: Handle qualified `M.{ x }` patterns in untypeast (Basile Clément,
-  review by ???)
+- #14457: Handle qualified `M.{ x }` patterns in untypeast
+  (Basile Clément, review by ???)
 
 ### Build system:
 

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -80,7 +80,7 @@ let module MS = struct module type S  = sig  end end in
     (fun (module M1 : MS.S) ((module M2)  : (module MS.S)) ->
        (((module M1) : (module MS.S)), ((module M2) : (module MS.S))))
 - : unit = ()
-|}]
+|}];;
 
 run {|
   let module M = struct type t = { x : int } end in
@@ -92,8 +92,7 @@ let module M = struct type t = {
                         x: int } end in
   fun x -> let M.{ x }  = let open M in { x } in x
 - : unit = ()
-|}]
-
+|}];;
 
 let run s =
   let pe = Parse.implementation (Lexing.from_string s) in

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -82,6 +82,18 @@ let module MS = struct module type S  = sig  end end in
 - : unit = ()
 |}]
 
+run {|
+  let module M = struct type t = { x : int } end in
+  fun x -> let M.{ x } = M.{ x } in x
+|};;
+
+[%%expect{|
+let module M = struct type t = {
+                        x: int } end in
+  fun x -> let M.{ x }  = let open M in { x } in x
+- : unit = ()
+|}]
+
 
 let run s =
   let pe = Parse.implementation (Lexing.from_string s) in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -298,6 +298,8 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | { pat_extra= (Tpat_constraint ct, _, _attrs) :: rem; _ } ->
         Ppat_constraint (sub.pat sub { pat with pat_extra=rem },
                          sub.typ sub ct)
+    | { pat_extra = (Tpat_open (_path, lid, _env), _, _attrs) :: rem; _ } ->
+        Ppat_open (lid, sub.pat sub { pat with pat_extra=rem })
     | _ ->
     match pat.pat_desc with
       Tpat_any -> Ppat_any


### PR DESCRIPTION
This ensures that a qualified pattern `M.{ x }` is correctly printed as `M.{ x }` and not as `{ x }`, avoiding "Unbound record field" errors.