### PR TITLE
fix(windows): Fix racy socketpair on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -129,6 +129,10 @@ Working version
   (Antonin Décimo, review by Samuel Hym, Gabriel Scherer, Miod Vallat,
   B. Szilvasy, and Nicolás Ojeda Bär)
 
+- #14461: Fix racy socketpair on Windows. Address-in-use errors would sometimes
+  occur when concurrent threads or processes were trying to create socketpairs.
+  (Jessie Grosen, review by Antonin Décimo and Nicolás Ojeda Bär)
+
 ### Code generation and optimizations:
 
 ### Standard library:


### PR DESCRIPTION
Previously socketpair on win32 relied on GetTempFileName to generate a unix socket path. This API uses very little entropy and thus relies on the created file essentially serving as a lock to avoid concurrent calls picking the same temp name. However, since socketpair must delete the file before binding to that path, it essentially relinquishes the lock for that window. This sometimes leads to address-in-use errors when concurrent threads or processes are trying to create socketpairs.

This patch replaces that path name generation with one that uses the process ID and an incrementing socketpair-call-specific ID. This rules out the possibility of concurrent calls to socketpair picking the same temp name. This does not rule out other threads or processes deliberately colliding with the name, but the peerid check later errors if another process collides.

Fixes #14372.

One issue with this implementation is that if an OCaml process is killed _while_ `socketpair` is being executed, the socket file could persist and end up conflicting with future processes' `socketpair` calls if they have the same PID and `socketpair_id` counter value. I think this is a remote enough possibility to be worth ignoring, but other approaches include retrying a few times by incrementing `socketpair_id`, generating `socketpair_id` randomly (with more randomness than `GetTempFileName` would use), or both.

I don't have a great way to consistently regression-test this in a way that feels appropriate for a test suite, but I'm including a reproducer below that usually fails on my machine without the patch but always succeeds with it. You might need to tweak some of the knobs to reproduce it, though. We have also seen no socketpair errors in Semgrep since deploying this change. Please let me know if you have suggestions for how to incorporate it as a test!

This is an alternative to #13450 with a narrower fix. As discussed in #14372, #13450 did not seem to fix the bug in Semgrep's usage and it doesn't fix the reproducer.

Reproducer:
```ocaml
let n_domains = ref 8
let n_socket_pairs = ref 10_000
let keep_sockets_open = ref false

let go i =
  for _ = 0 to !n_socket_pairs do
    let r, w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
    if not !keep_sockets_open then
      (Unix.close r; Unix.close w)
  done

let argspecs =
  [
    ("-d", Arg.Set_int n_domains, "Number of domains");
    ("-s", Arg.Set_int n_socket_pairs, "Number of socketpair calls");
    ("-o", Arg.Set keep_sockets_open, "Keep all the socket pairs open");
  ]
let usage = "socketpair_repro [-d N] [-s N] [-o]"

let join_print_exn i d =
  try
    Domain.join d;
    Printf.printf "Domain %u succeeded\n%!" i
  with e ->
    Printf.printf "Domain %u failed: %s\n%!" i (Printexc.to_string e)

let () =
  Arg.parse argspecs (fun _ -> ()) usage;
  Printf.printf "spawning %u domains, each to create %u socketpairs\n%!" !n_domains !n_socket_pairs;
  let domains = List.init !n_domains (fun i -> Domain.spawn (fun _ -> go i)) in
  List.iteri join_print_exn domains
```