### PR TITLE
stdlib: substring search micro-optimisation

### DIFF
--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -316,7 +316,7 @@ module Search = struct
     if l0 > l1 then (l0, p0) else (l1, p1)
 
   let ris_sub_periodic ~sub ~rsub_lp:(l, p) =
-    l < length sub / 2 &&
+    l <= p &&
     let i = ref 0 in
     while !i <= l && Char.equal (get sub !i) (get sub (!i + p))
     do incr i done;

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -242,7 +242,7 @@ module Search = struct
     if l0 > l1 then (l0, p0) else (l1, p1)
 
   let is_sub_periodic ~sub ~sub_lp:(l, p) =
-    l < length sub / 2 &&
+    l <= p &&
     let i = ref 0 in
     while !i <= l && Char.equal (get sub !i) (get sub (!i + p))
     do incr i done;


### PR DESCRIPTION
This PR is a single line optimisation on top of #14381.

To explain the change, the preprocessing phase of the two-way search string algorithm consists in finding a critical factorization of the needle `x`. Such critical factorization splits the string `x` in two part `x` = `uv` such that the local period `local u v` of the factorization is equal to the global period of the needle, `period x`.
Moreover, the critical factorization computed using the maximal suffix in the two-way algorithm is such that

- `length u` < `period x`
- `v` = `yᵏ z` with period `length y = period v`.

However, the period of `v` of the maximal suffix might be shorter than the period of `x`.
To detect this situation, the article use the following lemma:

>  If `length u < length x / 2`, and u is a suffix of y then `period x =period v`. Otherwise, `period x > max (length u) (length v)`

The important part of this condition is in fact "u is a suffix of y" which implies that `length u ≤ length y = period v`. If this condition is satisfied the test `lenght u < length x / 2` is always true, since we have `length u ≤ length y ≤ length v` and thus `2 * length u ≤ length u + length v = length x`.

Thus we can replace the test `length u < length x / 2` by the test `length u < period v`, which catches more cases, for instance `mmmmazazazaz` where the critical factorization `(mmmma,zazazaz)` has a short period (here `2`) with a not so long left factorisation `u="mmmma"`.