### PR TITLE
#install_printer in debugger: improve test

### DIFF
--- a/testsuite/tests/tool-debugger/printer/debuggee.reference
+++ b/testsuite/tests/tool-debugger/printer/debuggee.reference
@@ -3,4 +3,8 @@ Loading program... done.
 Breakpoint: 1
 18   <|b|>for _i = 0 to x do
 _d: (int, Printer.t) Printer.v list = [D<0, Printer.A>; D<42, Printer.B>]
+_d: (int, Printer.t) Printer.v list = [D<0, ~A>; D<42, ~B>]
 x: int = S S O
+_d: (int, Printer.t) Printer.v list =
+  [D<O, ~A>;
+   D<S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S S O, ~B>]

--- a/testsuite/tests/tool-debugger/printer/input_script
+++ b/testsuite/tests/tool-debugger/printer/input_script
@@ -3,7 +3,11 @@ install_printer Printer.print_generic
 break @ Debuggee 18
 run
 p _d
+install_printer Printer.print_t
+print _d
 install_printer Printer.p
 set print_depth 2
 print x
+set print_depth 100
+print _d
 quit


### PR DESCRIPTION
In #13966  "generalized polymorphic #install_printer" was implemented.

This small PR enhances the test that came with that PR a bit. 

It just uses the functionality / code that already existed in [`printer.ml`](https://github.com/ocaml/ocaml/blob/015d4a5da6fdb0b883c7532c9dd85c1bf3d8888e/testsuite/tests/tool-debugger/printer/printer.ml)
 
This small PR should not need a separate `Changes` entry

cc: @gasche @pirbo 