### PR TITLE
Fix TSan tests after #13416

### DIFF
--- a/testsuite/tests/tsan/array_elt.reference
+++ b/testsuite/tests/tsan/array_elt.reference
@@ -29,11 +29,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlArray_elt$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlArray_elt$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlArray_elt$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -41,11 +41,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_from_c$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlExn_from_c$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_from_c_stack_args.reference
+++ b/testsuite/tests/tsan/exn_from_c_stack_args.reference
@@ -41,11 +41,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c_stack_args$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -40,11 +40,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_in_callback$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlExn_in_callback$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_in_callback$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -40,11 +40,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_reraise$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlExn_reraise$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_reraise$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/perform.reference
+++ b/testsuite/tests/tsan/perform.reference
@@ -36,11 +36,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlPerform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlPerform$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform$race_<implemspecific>
 ==================
@@ -82,11 +83,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlPerform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlPerform$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform$race_<implemspecific>
 ==================
@@ -128,11 +130,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlPerform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlPerform$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform$race_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/raise_through_handler.reference
+++ b/testsuite/tests/tsan/raise_through_handler.reference
@@ -34,11 +34,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlRaise_through_handler$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlRaise_through_handler$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRaise_through_handler$reader_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/record_field.reference
+++ b/testsuite/tests/tsan/record_field.reference
@@ -30,11 +30,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlRecord_field$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlRecord_field$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRecord_field$reader_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/reperform.reference
+++ b/testsuite/tests/tsan/reperform.reference
@@ -36,11 +36,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlReperform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlReperform$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform$race_<implemspecific>
 ==================
@@ -84,11 +85,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlReperform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlReperform$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform$race_<implemspecific>
 ==================
@@ -129,11 +131,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlReperform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlReperform$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform$race_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/unhandled.reference
+++ b/testsuite/tests/tsan/unhandled.reference
@@ -31,11 +31,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlUnhandled$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled$race_<implemspecific>
 ==================
@@ -82,11 +83,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
+    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #3 caml_c_call <implemspecific> (<implemspecific>)
+    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #5 camlUnhandled$entry <implemspecific> (<implemspecific>)
+    #6 caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled$race_<implemspecific>
 ==================


### PR DESCRIPTION
The TSan tests are failing because #13416 modified the stack traces by adding an intermediate call to `caml_plat_thread_create`. We need to update the test reference outputs to reflect that.