### PR TITLE
add a workflow to automatically label stdlib PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# add stdlib label to any changes within `stdlib` directory
+# see https://github.com/actions/labeler for the documentation
+stdlib:
+  - changed-files:
+    - any-glob-to-any-file: stdlib/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+# workflow to automatically adds label to PR
+# see ../labeler.yml if you want more labels to be added automatically
+name: "add-label-to-pr"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v6


### PR DESCRIPTION
Hi,

This PR introduces a workflow to automatically add the `stdlib` label to PRs touching anything under the `stdlib` directory.

The goal is to make it easier to track any PRs related to the stdlib by regularly checking the [list of PRs labeled with stdlib](https://github.com/ocaml/ocaml/pulls?q=is%3Aopen%20is%3Apr%20label%3Astdlib) without having to rely on manually scanning all repository notifications (there are a lot in this repo).

While @nojb has been pretty good at labeling issues by hand, it is easy to miss one, and automating the process should make it more reliable.

This is my first time trying this GitHub action but it seems to be quite popular so I expect it to work properly. If not, it can be easily removed in the future.

I only added the `stdlib` label, but more can be added in the future if people like it.