### PR TITLE
Cleanup runtime events file on SIGINT

### DIFF
--- a/Changes
+++ b/Changes
@@ -217,6 +217,9 @@ OCaml 5.5.0
   heaps and for a smooth start at program launch and after a forced major GC.
   (Damien Doligez, review by Stephen Dolan and Nick Barnes)
 
+- #14470: Cleanup runtime events ring buffer file when a process is terminated
+  by an unhandled sigint. (Stephen Sherratt)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -419,3 +419,6 @@ external create_cursor : (string * int) option -> cursor
 external free_cursor : cursor -> unit = "caml_ml_runtime_events_free_cursor"
 external read_poll : cursor -> Callbacks.t -> int option -> int
                                         = "caml_ml_runtime_events_read_poll"
+
+external register_cleanup_runtime_events_sigint_handler : unit -> unit
+  = "caml_register_cleanup_runtime_events_sigint_handler"

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -682,3 +682,10 @@ val read_poll : cursor -> Callbacks.t -> int option -> int
 (** [read_poll cursor callbacks max_option] calls the corresponding functions
     on [callbacks] for up to [max_option] events read off [cursor]'s
     runtime_events and returns the number of events read. *)
+
+val register_cleanup_runtime_events_sigint_handler : unit -> unit
+(** Register a signal handler for SIGINT which deletes runtime event files.
+    This signal handler is registered for SIGINT by default if runtime events
+    are enabled. Registering any other signal handler for SIGINT (including
+    [Signal_default] will replace this handler, but this function can be called
+    to restore the default behaviour. *)

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -357,6 +357,9 @@ CAMLextern value caml_runtime_events_user_write(
 CAMLextern value caml_runtime_events_user_resolve(char* event_name,
    ev_user_ml_type event_type);
 
+/* Register a signal handler for SIGINT which cleans up runtime event files. */
+CAMLextern void caml_register_cleanup_runtime_events_sigint_handler(void);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_RUNTIME_EVENTS_H */

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -870,3 +870,31 @@ CAMLexport value caml_runtime_events_user_resolve(
 
   CAMLreturn (Val_none);
 }
+
+/* Intended as a signal handler. When a signal is received, cleanup temporary
+   files, register the SIG_DFL handler for the received signal, then reraise
+   the signal so that the program exits due to an unhandled signal of the same
+   type as the received signal. */
+static void cleanup_runtime_events_and_reraise_signal(int signal_number)
+{
+  CAML_RUNTIME_EVENTS_DESTROY();
+#ifdef POSIX_SIGNALS
+  struct sigaction act = {0};
+  act.sa_handler = SIG_DFL;
+  sigaction(signal_number, &act, NULL);
+#else
+  signal(signal_number, SIG_DFL);
+#endif
+  raise(signal_number);
+}
+
+void caml_register_cleanup_runtime_events_sigint_handler(void)
+{
+#ifdef POSIX_SIGNALS
+  struct sigaction act = {0};
+  act.sa_handler = cleanup_runtime_events_and_reraise_signal;
+  sigaction(SIGINT, &act, NULL);
+#else
+  signal(SIGINT, cleanup_runtime_events_and_reraise_signal);
+#endif
+}

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -36,6 +36,7 @@
 #include "caml/sys.h"
 #include "caml/memprof.h"
 #include "caml/finalise.h"
+#include "caml/runtime_events.h"
 #include "misc_internals.h"
 
 /* The set of pending signals (received but not yet processed).
@@ -635,6 +636,9 @@ void caml_init_signals(void)
     }
   }
 #endif
+  if (caml_runtime_events_are_active()) {
+    caml_register_cleanup_runtime_events_sigint_handler();
+  }
 }
 
 void caml_terminate_signals(void)


### PR DESCRIPTION
Introduces a signal handler which cleans up any runtime events file before exiting, and use it to handle SIGINT unless the mutator has registered a signal handler other than Signal_default.

Partially addresses https://github.com/ocaml/ocaml/issues/13011