### PR TITLE
Fix local opens keyword typo

### DIFF
--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -1287,7 +1287,7 @@ cases of this construction.
 
 \subsubsection*{sss:local-opens}{Local opens}
 \ikwd{let\@\texttt{let}}
-\ikwd{module\@\texttt{open}}
+\ikwd{open\@\texttt{open}}
 
 The expressions @"let" "open" module-path "in" expr@ and
 @module-path'.('expr')'@ are strictly equivalent. These


### PR DESCRIPTION
<img width="533" height="317" alt="image" src="https://github.com/user-attachments/assets/7fe4aef7-9766-4da2-b34d-c8fc3841dacf" />

This typo causes `open` to appear twice in [Index of keywords](https://ocaml.org/manual/5.4/manual077.html#start-section).