### PR TITLE
opam: Add a missing conflict with another compiler package

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -61,6 +61,9 @@ depends: [
   "flexdll" {>= "0.44" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
+conflicts: [
+  "ocaml-compiler"
+]
 flags: compiler
 build-env: [
   [MSYS2_ARG_CONV_EXCL = "*"]


### PR DESCRIPTION
cc @dra27 @Octachron 

`ocaml-compiler` isn't part of the `ocaml-core-compiler` conflict-class like `ocaml-variants` is, and thus both could be installed at the same time, which makes the installed files overlap.