### PR TITLE
#14474, shape occurrences: fix uid lookup for labels

### DIFF
--- a/Changes
+++ b/Changes
@@ -539,8 +539,9 @@ Working version
 - #14457: Handle qualified `M.{ x }` patterns in untypeast
   (Basile Clément, review by Florian Angeletti)
 
-- #14120: Associate Uids to items that don't have a concrete definition
-  (Ulysse Gérard, review by Florian Angeletti)
+- #14120, #14474, #14476: Associate Uids to items that don't have a concrete
+  definition
+  (Ulysse Gérard, review by Florian Angeletti and Gabriel Scherer)
 
 ### Build system:
 

--- a/testsuite/tests/shape-index/index_functor.ml
+++ b/testsuite/tests/shape-index/index_functor.ml
@@ -37,7 +37,16 @@ module G (X : sig type t = int val x : t module M : S end) = struct
 end
 
 type e = ..
-module I (X: sig type s = A | B of { r:unit } type r = { x:unit } type e += E  end) = struct
+module type T = sig
+  type s =
+    | A
+    | B of { r:unit }
+  type r =
+    { x:unit }
+  type e +=
+      | E
+end
+module I (X:T) = struct
   let x = X.A
   let y = X.B { r = () }
   let z = { X.x = () }

--- a/testsuite/tests/shape-index/index_functor.ml
+++ b/testsuite/tests/shape-index/index_functor.ml
@@ -35,3 +35,11 @@ module G (X : sig type t = int val x : t module M : S end) = struct
 
   type u = Id (X).t
 end
+
+type e = ..
+module I (X: sig type s = A | B of { r:unit } type r = { x:unit } type e += E  end) = struct
+  let x = X.A
+  let y = X.B { r = () }
+  let z = { X.x = () }
+  let w = X.E
+end

--- a/testsuite/tests/shape-index/index_functor.reference
+++ b/testsuite/tests/shape-index/index_functor.reference
@@ -1,24 +1,26 @@
 Indexed shapes:
-Resolved: Index_functor.32:
-  X (File "index_functor.ml", line 44, characters 10-11)
+Resolved: Index_functor.33:
+  X (File "index_functor.ml", line 53, characters 10-11)
 Local opaque: [L]Index_functor.9:
-  X.E (File "index_functor.ml", line 44, characters 10-13)
-Resolved: Index_functor.32:
-  X (File "index_functor.ml", line 43, characters 12-13)
+  X.E (File "index_functor.ml", line 53, characters 10-13)
+Resolved: Index_functor.33:
+  X (File "index_functor.ml", line 52, characters 12-13)
 Local opaque: [L]Index_functor.8:
-  X.x (File "index_functor.ml", line 43, characters 12-15)
+  X.x (File "index_functor.ml", line 52, characters 12-15)
 Local opaque: [L]Index_functor.7:
-  r (File "index_functor.ml", line 42, characters 16-17)
-Resolved: Index_functor.32:
-  X (File "index_functor.ml", line 42, characters 10-11)
+  r (File "index_functor.ml", line 51, characters 16-17)
+Resolved: Index_functor.33:
+  X (File "index_functor.ml", line 51, characters 10-11)
 Local opaque: [L]Index_functor.6:
-  X.B (File "index_functor.ml", line 42, characters 10-13)
-Resolved: Index_functor.32:
-  X (File "index_functor.ml", line 41, characters 10-11)
+  X.B (File "index_functor.ml", line 51, characters 10-13)
+Resolved: Index_functor.33:
+  X (File "index_functor.ml", line 50, characters 10-11)
 Local opaque: [L]Index_functor.5:
-  X.A (File "index_functor.ml", line 41, characters 10-13)
+  X.A (File "index_functor.ml", line 50, characters 10-13)
+Resolved: Index_functor.32:
+  T (File "index_functor.ml", line 49, characters 12-13)
 Resolved: Index_functor.19:
-  e (File "index_functor.ml", line 40, characters 71-72)
+  e (File "index_functor.ml", line 46, characters 7-8)
 Resolved: Index_functor.7:
   Id (File "index_functor.ml", line 36, characters 11-13)
 Resolved: Index_functor.13:
@@ -95,15 +97,16 @@ Index_functor.16: Y (File "index_functor.ml", line 30, characters 9-10)
 Index_functor.17: u (File "index_functor.ml", line 36, characters 7-8)
 Index_functor.18: G (File "index_functor.ml", line 26, characters 7-8)
 Index_functor.19: e (File "index_functor.ml", line 39, characters 5-6)
-Index_functor.20: s (File "index_functor.ml", line 40, characters 22-23)
-Index_functor.21: A (File "index_functor.ml", line 40, characters 26-27)
-Index_functor.22: r (File "index_functor.ml", line 40, characters 37-38)
-Index_functor.23: B (File "index_functor.ml", line 40, characters 30-31)
-Index_functor.29: r (File "index_functor.ml", line 40, characters 51-52)
-Index_functor.30: x (File "index_functor.ml", line 40, characters 57-58)
-Index_functor.31: E (File "index_functor.ml", line 40, characters 76-77)
-Index_functor.33: x (File "index_functor.ml", line 41, characters 6-7)
-Index_functor.35: y (File "index_functor.ml", line 42, characters 6-7)
-Index_functor.36: z (File "index_functor.ml", line 43, characters 6-7)
-Index_functor.37: w (File "index_functor.ml", line 44, characters 6-7)
-Index_functor.38: I (File "index_functor.ml", line 40, characters 7-8)
+Index_functor.20: s (File "index_functor.ml", line 41, characters 7-8)
+Index_functor.21: A (File "index_functor.ml", line 42, characters 6-7)
+Index_functor.22: r (File "index_functor.ml", line 43, characters 13-14)
+Index_functor.23: B (File "index_functor.ml", line 43, characters 6-7)
+Index_functor.29: r (File "index_functor.ml", line 44, characters 7-8)
+Index_functor.30: x (File "index_functor.ml", line 45, characters 6-7)
+Index_functor.31: E (File "index_functor.ml", line 47, characters 8-9)
+Index_functor.32: T (File "index_functor.ml", line 40, characters 12-13)
+Index_functor.34: x (File "index_functor.ml", line 50, characters 6-7)
+Index_functor.36: y (File "index_functor.ml", line 51, characters 6-7)
+Index_functor.37: z (File "index_functor.ml", line 52, characters 6-7)
+Index_functor.38: w (File "index_functor.ml", line 53, characters 6-7)
+Index_functor.39: I (File "index_functor.ml", line 49, characters 7-8)

--- a/testsuite/tests/shape-index/index_functor.reference
+++ b/testsuite/tests/shape-index/index_functor.reference
@@ -1,4 +1,24 @@
 Indexed shapes:
+Resolved: Index_functor.32:
+  X (File "index_functor.ml", line 44, characters 10-11)
+Local opaque: [L]Index_functor.9:
+  X.E (File "index_functor.ml", line 44, characters 10-13)
+Resolved: Index_functor.32:
+  X (File "index_functor.ml", line 43, characters 12-13)
+Local opaque: [L]Index_functor.8:
+  X.x (File "index_functor.ml", line 43, characters 12-15)
+Local opaque: [L]Index_functor.7:
+  r (File "index_functor.ml", line 42, characters 16-17)
+Resolved: Index_functor.32:
+  X (File "index_functor.ml", line 42, characters 10-11)
+Local opaque: [L]Index_functor.6:
+  X.B (File "index_functor.ml", line 42, characters 10-13)
+Resolved: Index_functor.32:
+  X (File "index_functor.ml", line 41, characters 10-11)
+Local opaque: [L]Index_functor.5:
+  X.A (File "index_functor.ml", line 41, characters 10-13)
+Resolved: Index_functor.19:
+  e (File "index_functor.ml", line 40, characters 71-72)
 Resolved: Index_functor.7:
   Id (File "index_functor.ml", line 36, characters 11-13)
 Resolved: Index_functor.13:
@@ -51,6 +71,11 @@ Index_functor.10 <-> Index_functor.5
 [L]Index_functor.2 <- Index_functor.8
 [L]Index_functor.3 <- Index_functor.12
 [L]Index_functor.4 <- Index_functor.5
+[L]Index_functor.5 <- Index_functor.21
+[L]Index_functor.6 <- Index_functor.23
+[L]Index_functor.7 <- Index_functor.22
+[L]Index_functor.8 <- Index_functor.30
+[L]Index_functor.9 <- Index_functor.31
 
 Uid of decls:
 Index_functor.1: M (File "index_functor.ml", line 18, characters 39-40)
@@ -69,3 +94,16 @@ Index_functor.15: y (File "index_functor.ml", line 28, characters 6-7)
 Index_functor.16: Y (File "index_functor.ml", line 30, characters 9-10)
 Index_functor.17: u (File "index_functor.ml", line 36, characters 7-8)
 Index_functor.18: G (File "index_functor.ml", line 26, characters 7-8)
+Index_functor.19: e (File "index_functor.ml", line 39, characters 5-6)
+Index_functor.20: s (File "index_functor.ml", line 40, characters 22-23)
+Index_functor.21: A (File "index_functor.ml", line 40, characters 26-27)
+Index_functor.22: r (File "index_functor.ml", line 40, characters 37-38)
+Index_functor.23: B (File "index_functor.ml", line 40, characters 30-31)
+Index_functor.29: r (File "index_functor.ml", line 40, characters 51-52)
+Index_functor.30: x (File "index_functor.ml", line 40, characters 57-58)
+Index_functor.31: E (File "index_functor.ml", line 40, characters 76-77)
+Index_functor.33: x (File "index_functor.ml", line 41, characters 6-7)
+Index_functor.35: y (File "index_functor.ml", line 42, characters 6-7)
+Index_functor.36: z (File "index_functor.ml", line 43, characters 6-7)
+Index_functor.37: w (File "index_functor.ml", line 44, characters 6-7)
+Index_functor.38: I (File "index_functor.ml", line 40, characters 7-8)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1187,19 +1187,18 @@ and find_cstr path name env =
   | Type_record _ | Type_abstract _ | Type_open | Type_external _ ->
       raise Not_found
 
-let find_type_component_uid path env =
+let find_label path name env =
+  let tda = find_type_data path env in
+  match tda.tda_descriptions with
+  | Type_record (labels, _) ->
+      List.find (fun l -> l.lbl_name = name) labels
+  | Type_variant _ | Type_abstract _ | Type_open | Type_external _ ->
+      raise Not_found
+
+let find_path_extra path =
   match path with
   | Pident _ | Pdot _ | Papply _ | Pextra_ty (_,Pext_ty) -> raise Not_found
-  | Pextra_ty (ty, Pcstr_ty name) ->
-     let tda = find_type_data ty env in
-     match tda.tda_descriptions with
-     | Type_variant (cstrs, _) ->
-        let cstr = List.find (fun cstr -> cstr.cstr_name = name) cstrs in
-        cstr.cstr_uid
-     | Type_record (fields,_) ->
-        let field = List.find (fun f -> f.lbl_name = name) fields in
-        field.lbl_uid
-     | _ -> raise Not_found
+  | Pextra_ty (ty, Pcstr_ty name) -> ty, name
 
 let find_modtype_lazy path env =
   match path with
@@ -1437,8 +1436,14 @@ let find_uid (namespace: Shape.Sig_component_kind.t) path env =
       | Extension_constructor ->
          let cda = find_extension_full path env in
          cda.cda_description.cstr_uid
-      | Constructor | Label ->
-         find_type_component_uid path env
+      | Constructor ->
+         let ty, cstr = find_path_extra path in
+         let cstr = find_cstr ty cstr env in
+         cstr.cstr_uid
+      | Label ->
+         let ty, f = find_path_extra path in
+         let l = find_label ty f env in
+         l.lbl_uid
       | Type ->
         let td = find_type path env in
         td.type_uid

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1421,37 +1421,37 @@ let find_module path env =
 let find_module_lazy path env =
   find_module_lazy ~alias:false path env
 
-let find_uid namespace path env =
+let find_uid (namespace: Shape.Sig_component_kind.t) path env =
+  let path = match namespace with
+    | Value | Class -> normalize_value_path None env path
+    | Type | Constructor | Label | Extension_constructor | Class_type ->
+       normalize_type_path None env path
+    | Module -> normalize_module_path None env path
+    | Module_type -> normalize_modtype_path env path
+  in
   try
     Option.some @@ match (namespace : Shape.Sig_component_kind.t) with
       | Value ->
-        let path = normalize_value_path None env path in
         let vd = find_value path env in
         vd.val_uid
       | Extension_constructor ->
          let cda = find_extension_full path env in
          cda.cda_description.cstr_uid
       | Constructor | Label ->
-         let path = normalize_type_path None env path in
          find_type_component_uid path env
       | Type ->
-        let path = normalize_type_path None env path in
         let td = find_type path env in
         td.type_uid
       | Module ->
-        let path = normalize_module_path None env path in
         let md = find_module path env in
         md.md_uid
       | Module_type ->
-        let path = normalize_modtype_path env path in
         let mtd = find_modtype path env in
         mtd.mtd_uid
       | Class ->
-        let path = normalize_value_path None env path in
         let cty = find_class path env in
         cty.cty_uid
       | Class_type ->
-        let path = normalize_type_path None env path in
         let clty = find_cltype path env in
         clty.clty_uid
   with Not_found -> None

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1187,7 +1187,19 @@ and find_cstr path name env =
   | Type_record _ | Type_abstract _ | Type_open | Type_external _ ->
       raise Not_found
 
-
+let find_type_component_uid path env =
+  match path with
+  | Pident _ | Pdot _ | Papply _ | Pextra_ty (_,Pext_ty) -> raise Not_found
+  | Pextra_ty (ty, Pcstr_ty name) ->
+     let tda = find_type_data ty env in
+     match tda.tda_descriptions with
+     | Type_variant (cstrs, _) ->
+        let cstr = List.find (fun cstr -> cstr.cstr_name = name) cstrs in
+        cstr.cstr_uid
+     | Type_record (fields,_) ->
+        let field = List.find (fun f -> f.lbl_name = name) fields in
+        field.lbl_uid
+     | _ -> raise Not_found
 
 let find_modtype_lazy path env =
   match path with
@@ -1416,7 +1428,13 @@ let find_uid namespace path env =
         let path = normalize_value_path None env path in
         let vd = find_value path env in
         vd.val_uid
-      | Type | Extension_constructor | Constructor | Label ->
+      | Extension_constructor ->
+         let cda = find_extension_full path env in
+         cda.cda_description.cstr_uid
+      | Constructor | Label ->
+         let path = normalize_type_path None env path in
+         find_type_component_uid path env
+      | Type ->
         let path = normalize_type_path None env path in
         let td = find_type path env in
         td.type_uid


### PR DESCRIPTION
This PR fixes #14474 by refining the `Env.find_uid` function introduced in #14120 to resolve correctly constructor and field uids for the occurrence index. 

The assertion failure reported in #14474 was due to `find_uid` querying on `shape`-only paths to constructor and fields which reuse `Pextra_ty _` path to encode path to record field and constructor in shape. Those kind of paths are not allowed outside of shapes and thus the `find_type` query in `find_uid` ended reaching an `assert false` in the `type_of_cstr` function  when called on those  non-standard paths.

This PR  extends `Env.find_uid` to handle specifically those extended paths for extension constructors, constructors, and labels avoiding the `assert false` but also making it possible to rename local use of constructor and labels in merlin.

cc @voodoos 