### PR TITLE
Fix #14434: polymorphic parameters soundness bug

### DIFF
--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -456,6 +456,12 @@ val g : unit -> ('a. 'a -> 'a) -> unit = <fun>
 let rec f ([] : 'a. 'a list) = ()
 
 [%%expect{|
+Line 1, characters 11-27:
+1 | let rec f ([] : 'a. 'a list) = ()
+               ^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "_::_"
+
 val f : ('a. 'a list) -> unit = <fun>
 |}]
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1186,6 +1186,11 @@ let solve_Ppat_lazy loc env expected_ty =
     (generic_instance expected_ty);
   nv
 
+let maybe_instance_poly ty =
+  match get_desc ty with
+  | Tpoly (ty', tl) -> instance_poly ~keep_names:true tl ty'
+  | _ -> ty
+
 let solve_Ppat_constraint tps loc env sty expected_ty =
   let cty, ty, force =
     with_local_level_generalize_structure
@@ -1194,12 +1199,7 @@ let solve_Ppat_constraint tps loc env sty expected_ty =
   tps.tps_pattern_force <- force :: tps.tps_pattern_force;
   let ty, expected_ty' = instance ty, ty in
   unify_pat_types loc env ty (instance expected_ty);
-  let expected_ty' =
-    match get_desc expected_ty' with
-    | Tpoly (expected_ty', tl) ->
-        instance_poly ~keep_names:true tl expected_ty'
-    | _ -> expected_ty'
-  in
+  let expected_ty' = maybe_instance_poly expected_ty' in
   (cty, ty, expected_ty')
 
 let solve_Ppat_variant loc env tag no_arg expected_ty =
@@ -2607,6 +2607,7 @@ let rec check_counter_example_pat
     | Backtrack_or -> false
     | Refine_or {inside_nonsplit_or} -> inside_nonsplit_or
   in
+  let expected_ty = maybe_instance_poly expected_ty in
   match tp.pat_desc with
     Tpat_any | Tpat_var _ ->
       let k' () = mkp k tp.pat_desc in


### PR DESCRIPTION
Here's a fix for the soundness issue reported by @johnyob in #14434.

Exhaustivity checking tries to re-type unhandled cases, and if they don't typecheck then it considers them impossible. However, the re-typing logic didn't correctly handle the new Tpoly node used by polymorphic parameters.

This meant that (Some x : 'a . 'a option) was incorrectly considered exhaustive, because the Tpoly produced a spurious typechecking error while considering None as an alternative. The fix means that the generated None case is accepted, which means that the original pattern is rejected as nonexhaustive.

(Aside: the non-monotonicity of typechecking here is really weird. I think it's the only place in the compiler where soundness depends on the typechecker *rejecting* something)