### PR TITLE
fix(typing): correct handling of polymorphic patterns (#14434)

### DIFF
--- a/Changes
+++ b/Changes
@@ -426,6 +426,11 @@ OCaml 5.5.0
   the marshalled output.
   (David Allsopp, review by Gabriel Scherer)
 
+- #14480: Typecheck polymorphic patterns correctly before exhaustiveness
+  checking, restoring type soundness.
+  (completing #14434)
+  (Alistair O'Brien, review by ??)
+
 ### Other libraries:
 
 - #13700, #14454: Use POSIX thread-safe getgrnam_r, getgrgid_r, getpwnam_r,

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -456,6 +456,12 @@ val g : unit -> ('a. 'a -> 'a) -> unit = <fun>
 let rec f ([] : 'a. 'a list) = ()
 
 [%%expect{|
+Line 1, characters 11-27:
+1 | let rec f ([] : 'a. 'a list) = ()
+               ^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "_::_"
+
 val f : ('a. 'a list) -> unit = <fun>
 |}]
 
@@ -566,4 +572,35 @@ Error: The syntactic arity of the function doesn't match the type constraint:
           "fun ... gadt_pat -> fun ..."
           where "gadt_pat" is the pattern with the GADT constructor that
           introduces the local type equation on "a".
+|}]
+
+(* Exhaustiveness check works for annotated polymorphic
+   parameters.
+
+   See https://github.com/ocaml/ocaml/issues/14434 *)
+let should_not_be_exhaustive ([ bad ] : 'a. 'a list) = print_endline bad;;
+should_not_be_exhaustive []
+[%%expect{|
+Line 1, characters 30-51:
+1 | let should_not_be_exhaustive ([ bad ] : 'a. 'a list) = print_endline bad;;
+                                  ^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "bad::_::_"
+
+val should_not_be_exhaustive : ('a. 'a list) -> unit = <fun>
+Exception: Match_failure ("", 1, 29).
+|}]
+
+let should_not_be_exhaustive : ('a. 'a list) -> unit =
+  fun [ bad ] -> print_endline bad;;
+should_not_be_exhaustive []
+[%%expect{|
+Line 2, characters 6-13:
+2 |   fun [ bad ] -> print_endline bad;;
+          ^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "bad::_::_"
+
+val should_not_be_exhaustive : ('a. 'a list) -> unit = <fun>
+Exception: Match_failure ("", 2, 6).
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2611,6 +2611,17 @@ let rec check_counter_example_pat
     | Backtrack_or -> false
     | Refine_or {inside_nonsplit_or} -> inside_nonsplit_or
   in
+  (* Patterns must be match on a monotype (generally speaking),
+     therefore should not be [Tpoly].
+
+     The only exception to [Tpat_var] in the setting of `let` and
+     `let rec` bindings. However, the typing of these constructs does not
+     involve [check_counter_example_pat], so encountering [Tpoly] here
+     should not occur in practice.
+
+     TODO: Once [Tpoly] is removed from the typing of `let` and `let rec`,
+     this exception can be eliminated as well.*)
+  assert (not (is_poly_Tpoly tp.pat_type));
   match tp.pat_desc with
     Tpat_any | Tpat_var _ ->
       let k' () = mkp k tp.pat_desc in
@@ -5872,7 +5883,26 @@ and type_function
       *)
       let ty_arg_internal, default_arg =
         match default_arg with
-        | None -> ty_arg_mono, None
+        | None ->
+            (* HACK: In the case of [has_poly], [ty_arg_internal] is a fresh
+               monomorphic variable.
+
+               When calling [split_function_ty] on an unknown type (e.g.
+               [Tvar]), [ty_arg_mono] is [ty_param] when [has_poly] is [true].
+
+               ADR:
+
+               We later unify [ty_param] in [type_poly_pattern] with a
+               polytype, which would [ty_arg_mono] to a polytype!
+               This is not the intended behaviour, since [ty_arg_mono]
+               should be a monotype. We avoid this by introducing an
+               indirection via a fresh [newvar ()] here.
+
+               TODO: Both [split_function_ty] and [filter_arrow] could be
+               improved with a nicer interface that handles
+               'polyvars' (unification variables that must be [Tpoly])
+               abstractly. *)
+            (if has_poly then newvar () else ty_arg_mono), None
         | Some default ->
             assert (is_optional arg_label);
             let ty_default = newvar () in
@@ -5893,13 +5923,72 @@ and type_function
             let default = type_expect env default (mk_expected ty_default) in
             ty_default, Some default
       in
+      (* To type a 'poly pattern' (a pattern with a `Ptyp_poly` polymorphic
+         annotation), we instantiate the polytype and check the pattern against
+         that instance.
+
+         This is sound due to contravariance; for example:
+         {[
+          # let allowed = fun ([ x ] : 'a. 'a list) -> print_endline x;;
+
+          val allowed : ('a. 'a list) -> unit = <fun>
+         ]}
+
+         Also poly patterns may bind variables with generalized (polymorphic)
+         types. This is implemented by entering a new local region when typing
+         patterns (see [map_half_typed_cases]) and then taking the instance
+         of the polytype within this region. *)
+      let instance_tpoly ty =
+        let sch, univars = tpoly_get_poly ty in
+        instance_poly ~keep_names:true univars sch
+      in
+      let type_poly_pattern
+          category
+          ~lev
+          env
+          spat
+          ty_expected
+          ?cont
+          allowed_modules
+        =
+        match spat.ppat_desc with
+        | Ppat_constraint (spat, ({ ptyp_desc = Ptyp_poly _; _ } as sty)) ->
+          assert has_poly;
+          let cty, ty, force =
+            with_local_level_generalize_structure (fun () ->
+                Typetexp.transl_simple_type_delayed env sty)
+          in
+          let ty' = instance ty in
+          (* Unifies [ty_param] (the polytype variable) of the function.
+             This ensures [ty_arg_mono] is equal to [instance_tpoly ty']. *)
+          unify_pat_types spat.ppat_loc env ty' (instance ty_param);
+          unify_pat_types spat.ppat_loc env (instance_tpoly ty') ty_expected;
+          let p, env, force', pvs, mvs =
+            type_pattern
+              category
+              ~lev
+              env
+              spat
+              (instance_tpoly ty')
+              ?cont
+              allowed_modules
+          in
+          let extra = Tpat_constraint cty, loc, spat.ppat_attributes in
+          ( { p with pat_extra = extra :: p.pat_extra }
+          , env
+          , force :: force'
+          , pvs
+          , mvs )
+        | _ ->
+          type_pattern category ~lev env spat ty_expected ?cont allowed_modules
+      in
       let (pat, params, body, newtypes, contains_gadt), partial =
         (* Check everything else in the scope of the parameter. *)
         map_half_typed_cases Value env ty_arg_internal ty_ret pat.ppat_loc
           ~check_if_total:true
           (* We don't make use of [case_data] here so we pass unit. *)
           [ { pattern = pat; has_guard = false; needs_refute = false }, () ]
-          ~type_pattern
+          ~type_pattern:type_poly_pattern
           ~type_body:begin
             fun () pat ~when_env:_ ~ext_env ~cont:_ ~ty_expected ~ty_infer:_
               ~contains_gadt:param_contains_gadt ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3943,6 +3943,289 @@ let check_absent_variant env =
                      (duplicate_type pat.pat_type)
     | _ -> () }
 
+type 'k type_pattern =
+  'k pattern_category
+  -> lev:int
+  -> Env.t
+  -> Parsetree.pattern
+  -> type_expr
+  -> ?cont:Ident.t * Types.value_description
+  -> module_patterns_restriction
+  -> 'k general_pattern
+     * Env.t
+     * (unit -> unit) list
+     * pattern_variable list
+     * module_variables
+
+type ('k, 'case_data, 'ret) type_body =
+  'case_data
+  -> 'k general_pattern (* the typed pattern *)
+  -> when_env:Env.t (* environment with module/pattern variables *)
+  -> ext_env:Env.t (* when_env + continuation var*)
+  -> cont:(Ident.t * Types.value_description) option
+  -> ty_expected:type_expr (* type to check body in scope of *)
+  -> ty_infer:type_expr (* type to infer for body *)
+  -> contains_gadt:bool (* whether the pattern contains a GADT *)
+  -> 'ret
+
+(* Most of the arguments are the same as [type_cases].
+
+   Takes a callback which is responsible for typing the body of the case.
+   The arguments are documented inline in the type signature.
+
+   It takes a callback rather than returning the half-typed cases directly
+   because the typing of the body must take place at an increased level.
+
+   The overall function returns:
+     - The data returned by the callback
+     - Whether the cases' patterns are partial or total
+*)
+let map_half_typed_cases
+    : type k ret case_data.
+      ?additional_checks_for_split_cases:((_ * ret) list -> unit)
+      -> ?conts:_
+      -> k pattern_category
+      -> _
+      -> _
+      -> _
+      -> _
+      -> (untyped_case * case_data) list
+      -> type_pattern:k type_pattern
+      -> type_body:(k, case_data, ret) type_body
+      -> check_if_total:bool (* if false, assume Partial right away *)
+      -> ret list * partial
+  =
+  fun ?additional_checks_for_split_cases
+      ?conts
+      category
+      env
+      ty_arg
+      ty_res
+      loc
+      caselist
+      ~type_pattern
+      ~type_body
+      ~check_if_total ->
+  (* ty_arg is _fully_ generalized *)
+  let patterns = List.map (fun ((x : untyped_case), _) -> x.pattern) caselist in
+  let contains_polyvars = List.exists contains_polymorphic_variant patterns in
+  let erase_either = contains_polyvars && contains_variant_either ty_arg in
+  let may_contain_gadts = List.exists may_contain_gadts patterns in
+  let may_contain_modules = List.exists may_contain_modules patterns in
+  let create_inner_level = may_contain_gadts || may_contain_modules in
+  let ty_arg =
+    if (may_contain_gadts || erase_either) && not !Clflags.principal
+    then duplicate_type ty_arg else ty_arg
+  in
+  let rec is_var spat =
+    match spat.ppat_desc with
+      Ppat_any | Ppat_var _ -> true
+    | Ppat_alias (spat, _) -> is_var spat
+    | _ -> false in
+  let needs_exhaust_check =
+    match caselist with
+      [ ({ needs_refute = true }, _) ] -> true
+    | [ ({ pattern }, _) ] when is_var pattern -> false
+    | _ -> true
+  in
+  let outer_level = get_current_level () in
+  with_local_level_iter_if create_inner_level begin fun () ->
+  let lev = get_current_level () in
+  let allow_modules =
+    if may_contain_modules
+    then
+      (* The corresponding check for scope escape is done together with
+         the check for GADT-induced existentials by
+         [with_local_level_iter_if create_inner_level].
+      *)
+      Modules_allowed { scope = lev }
+    else Modules_rejected
+  in
+  let take_partial_instance =
+    if erase_either
+    then Some false else None
+  in
+  let map_conts f conts caselist = match conts with
+    | None -> List.map (fun c -> f c None) caselist
+    | Some conts -> List.map2 f caselist conts
+  in
+  let half_typed_cases, ty_res, do_copy_types, ty_arg' =
+   (* propagation of the argument *)
+    with_local_level_generalize begin fun () ->
+      let pattern_force = ref [] in
+      let half_typed_cases =
+        map_conts
+        (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) cont ->
+          let htc =
+            with_local_level_generalize_structure_if_principal begin fun () ->
+              let ty_arg =
+                (* propagation of pattern *)
+                with_local_level_generalize_structure
+                  (fun () -> instance ?partial:take_partial_instance ty_arg)
+              in
+              let (pat, ext_env, force, pvs, mvs) =
+                type_pattern ?cont category ~lev env pattern ty_arg
+                  allow_modules
+              in
+              pattern_force := force @ !pattern_force;
+              { typed_pat = pat;
+                pat_type_for_unif = ty_arg;
+                untyped_case;
+                case_data;
+                branch_env = ext_env;
+                pat_vars = pvs;
+                module_vars = mvs;
+                contains_gadt = contains_gadt (as_comp_pattern category pat);
+              }
+            end
+          in
+          (* Ensure that no ambivalent pattern type escapes its branch *)
+          check_scope_escape htc.typed_pat.pat_loc env outer_level
+            htc.pat_type_for_unif;
+          let pat = htc.typed_pat in
+          {htc with typed_pat = { pat with pat_type = instance pat.pat_type }}
+        )
+        conts caselist in
+      let patl =
+        List.map (fun { typed_pat; _ } -> typed_pat) half_typed_cases in
+      let does_contain_gadt =
+        List.exists (fun { contains_gadt; _ } -> contains_gadt) half_typed_cases
+      in
+      let ty_res, do_copy_types =
+        if does_contain_gadt && not !Clflags.principal then
+          duplicate_type ty_res, Env.make_copy_of_types env
+        else ty_res, (fun env -> env)
+      in
+      (* Unify all cases (delayed to keep it order-free) *)
+      let ty_arg' = newvar () in
+      let unify_pats ty =
+        List.iter (fun { typed_pat = pat; pat_type_for_unif = pat_ty; _ } ->
+          unify_pat_types pat.pat_loc env pat_ty ty
+        ) half_typed_cases
+      in
+      unify_pats ty_arg';
+      (* Check for polymorphic variants to close *)
+      if List.exists has_variants patl then begin
+        Parmatch.pressure_variants_in_computation_pattern env
+          (List.map (as_comp_pattern category) patl);
+        List.iter finalize_variants patl
+      end;
+      (* `Contaminating' unifications start here *)
+      List.iter (fun f -> f()) !pattern_force;
+      (* Post-processing and generalization *)
+      if take_partial_instance <> None then unify_pats (instance ty_arg);
+      List.iter (fun { pat_vars; _ } ->
+        iter_pattern_variables_type (enforce_current_level env) pat_vars
+      ) half_typed_cases;
+      (half_typed_cases, ty_res, do_copy_types, ty_arg')
+    end
+  in
+  (* type bodies *)
+  let ty_res' = instance ty_res in
+  (* Why is it needed to keep the level of result raised ?  *)
+  let result = with_local_level_if_principal ~post:ignore begin fun () ->
+    map_conts
+    (fun { typed_pat = pat; branch_env = ext_env;
+           pat_vars = pvs; module_vars = mvs;
+           case_data; contains_gadt; _ } cont
+        ->
+        let ext_env =
+          if contains_gadt then
+            do_copy_types ext_env
+          else
+            ext_env
+        in
+        (* Before handing off the cases to the callback, first set up the the
+           branch environments by adding the variables (and module variables)
+           from the patterns.
+        *)
+        let cont_vars, pvs =
+          List.partition (fun pv -> pv.pv_kind = Continuation_var) pvs in
+        let add_pattern_vars = add_pattern_variables
+            ~check:(fun s -> Warnings.Unused_var_strict s)
+            ~check_as:(fun s -> Warnings.Unused_var s)
+        in
+        let when_env = add_pattern_vars ext_env pvs in
+        let when_env = add_module_variables when_env mvs in
+        let ext_env = add_pattern_vars when_env cont_vars in
+        let ty_expected =
+          if contains_gadt && not !Clflags.principal then
+            (* Take a generic copy of [ty_res] again to allow propagation of
+                type information from preceding branches *)
+            duplicate_type ty_res
+          else ty_res in
+        type_body case_data pat ~when_env ~ext_env ~cont ~ty_expected
+          ~ty_infer:ty_res' ~contains_gadt)
+    conts half_typed_cases
+  end in
+  let do_init = may_contain_gadts || needs_exhaust_check in
+  let ty_arg_check =
+    if do_init then
+      (* Hack: use for_saving to copy variables too *)
+      Subst.type_expr (Subst.for_saving Subst.identity) ty_arg'
+    else ty_arg'
+  in
+  (* Split the cases into val and exn cases so we can do the appropriate checks
+     for exhaustivity and unused variables.
+
+     The caller of this function can define custom checks. For some of these
+     checks, the half-typed case doesn't provide enough info on its own -- for
+     instance, the check for ambiguous bindings in when guards needs to know the
+     case body's expression -- so the code pairs each case with its
+     corresponding element in [result] before handing it off to the caller's
+     custom checks.
+  *)
+  let val_cases_with_result, exn_cases_with_result =
+    match category with
+    | Value ->
+        let val_cases =
+          List.map2
+            (fun htc res ->
+               { htc.untyped_case with pattern = htc.typed_pat }, res)
+            half_typed_cases
+            result
+        in
+        (val_cases : (pattern Parmatch.parmatch_case * ret) list), []
+    | Computation ->
+        split_half_typed_cases env (List.combine half_typed_cases result)
+  in
+  let val_cases = List.map fst val_cases_with_result in
+  let exn_cases = List.map fst exn_cases_with_result in
+  if val_cases = [] && exn_cases <> [] then
+    raise (Error (loc, env, No_value_clauses));
+  let partial =
+    if check_if_total then
+      check_partial ~lev env ty_arg_check loc val_cases
+    else
+      Partial
+  in
+  let unused_check delayed =
+    List.iter (fun { typed_pat; branch_env; _ } ->
+      check_absent_variant branch_env (as_comp_pattern category typed_pat)
+    ) half_typed_cases;
+    with_level_if delayed ~level:lev begin fun () ->
+      check_unused ~lev env ty_arg_check val_cases ;
+      check_unused ~lev env Predef.type_exn exn_cases ;
+    end;
+  in
+  if contains_polyvars then
+    add_delayed_check (fun () -> unused_check true)
+  else
+    (* Check for unused cases, do not delay because of gadts *)
+    unused_check false;
+  begin
+    match additional_checks_for_split_cases with
+    | None -> ()
+    | Some check ->
+        check val_cases_with_result;
+        check exn_cases_with_result;
+  end;
+  (result, partial), [ty_res']
+  end
+  (* Ensure that existential types do not escape *)
+  ~post:(fun ty_res' -> unify_exp_types loc env ty_res' (newvar ()))
+
+
 (* To find reasonable names for let-bound and lambda-bound idents *)
 
 let rec name_pattern default = function
@@ -5616,6 +5899,7 @@ and type_function
           ~check_if_total:true
           (* We don't make use of [case_data] here so we pass unit. *)
           [ { pattern = pat; has_guard = false; needs_refute = false }, () ]
+          ~type_pattern
           ~type_body:begin
             fun () pat ~when_env:_ ~ext_env ~cont:_ ~ty_expected ~ty_infer:_
               ~contains_gadt:param_contains_gadt ->
@@ -6598,258 +6882,6 @@ and type_statement ?explanation env sexp =
     end
   end
 
-(* Most of the arguments are the same as [type_cases].
-
-   Takes a callback which is responsible for typing the body of the case.
-   The arguments are documented inline in the type signature.
-
-   It takes a callback rather than returning the half-typed cases directly
-   because the typing of the body must take place at an increased level.
-
-   The overall function returns:
-     - The data returned by the callback
-     - Whether the cases' patterns are partial or total
-*)
-and map_half_typed_cases
-  : type k ret case_data.
-    ?additional_checks_for_split_cases:((_ * ret) list -> unit) -> ?conts:_
-    -> k pattern_category -> _ -> _ -> _ -> _
-    -> (untyped_case * case_data) list
-    -> type_body:(
-        case_data
-        -> k general_pattern (* the typed pattern *)
-        -> when_env:_ (* environment with module/pattern variables *)
-        -> ext_env:_ (* when_env + continuation var*)
-        -> cont:_
-        -> ty_expected:_ (* type to check body in scope of *)
-        -> ty_infer:_ (* type to infer for body *)
-        -> contains_gadt:_ (* whether the pattern contains a GADT *)
-        -> ret)
-    -> check_if_total:bool (* if false, assume Partial right away *)
-    -> ret list * partial
-  = fun ?additional_checks_for_split_cases ?conts
-    category env ty_arg ty_res loc caselist ~type_body ~check_if_total ->
-  (* ty_arg is _fully_ generalized *)
-  let patterns = List.map (fun ((x : untyped_case), _) -> x.pattern) caselist in
-  let contains_polyvars = List.exists contains_polymorphic_variant patterns in
-  let erase_either = contains_polyvars && contains_variant_either ty_arg in
-  let may_contain_gadts = List.exists may_contain_gadts patterns in
-  let may_contain_modules = List.exists may_contain_modules patterns in
-  let create_inner_level = may_contain_gadts || may_contain_modules in
-  let ty_arg =
-    if (may_contain_gadts || erase_either) && not !Clflags.principal
-    then duplicate_type ty_arg else ty_arg
-  in
-  let rec is_var spat =
-    match spat.ppat_desc with
-      Ppat_any | Ppat_var _ -> true
-    | Ppat_alias (spat, _) -> is_var spat
-    | _ -> false in
-  let needs_exhaust_check =
-    match caselist with
-      [ ({ needs_refute = true }, _) ] -> true
-    | [ ({ pattern }, _) ] when is_var pattern -> false
-    | _ -> true
-  in
-  let outer_level = get_current_level () in
-  with_local_level_iter_if create_inner_level begin fun () ->
-  let lev = get_current_level () in
-  let allow_modules =
-    if may_contain_modules
-    then
-      (* The corresponding check for scope escape is done together with
-         the check for GADT-induced existentials by
-         [with_local_level_iter_if create_inner_level].
-      *)
-      Modules_allowed { scope = lev }
-    else Modules_rejected
-  in
-  let take_partial_instance =
-    if erase_either
-    then Some false else None
-  in
-  let map_conts f conts caselist = match conts with
-    | None -> List.map (fun c -> f c None) caselist
-    | Some conts -> List.map2 f caselist conts
-  in
-  let half_typed_cases, ty_res, do_copy_types, ty_arg' =
-   (* propagation of the argument *)
-    with_local_level_generalize begin fun () ->
-      let pattern_force = ref [] in
-      (*  Format.printf "@[%i %i@ %a@]@." lev (get_current_level())
-          Printtyp.raw_type_expr ty_arg; *)
-      let half_typed_cases =
-        map_conts
-        (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) cont ->
-          let htc =
-            with_local_level_generalize_structure_if_principal begin fun () ->
-              let ty_arg =
-                (* propagation of pattern *)
-                with_local_level_generalize_structure
-                  (fun () -> instance ?partial:take_partial_instance ty_arg)
-              in
-              let (pat, ext_env, force, pvs, mvs) =
-                type_pattern ?cont category ~lev env pattern ty_arg
-                  allow_modules
-              in
-              pattern_force := force @ !pattern_force;
-              { typed_pat = pat;
-                pat_type_for_unif = ty_arg;
-                untyped_case;
-                case_data;
-                branch_env = ext_env;
-                pat_vars = pvs;
-                module_vars = mvs;
-                contains_gadt = contains_gadt (as_comp_pattern category pat);
-              }
-            end
-          in
-          (* Ensure that no ambivalent pattern type escapes its branch *)
-          check_scope_escape htc.typed_pat.pat_loc env outer_level
-            htc.pat_type_for_unif;
-          let pat = htc.typed_pat in
-          {htc with typed_pat = { pat with pat_type = instance pat.pat_type }}
-        )
-        conts caselist in
-      let patl =
-        List.map (fun { typed_pat; _ } -> typed_pat) half_typed_cases in
-      let does_contain_gadt =
-        List.exists (fun { contains_gadt; _ } -> contains_gadt) half_typed_cases
-      in
-      let ty_res, do_copy_types =
-        if does_contain_gadt && not !Clflags.principal then
-          duplicate_type ty_res, Env.make_copy_of_types env
-        else ty_res, (fun env -> env)
-      in
-      (* Unify all cases (delayed to keep it order-free) *)
-      let ty_arg' = newvar () in
-      let unify_pats ty =
-        List.iter (fun { typed_pat = pat; pat_type_for_unif = pat_ty; _ } ->
-          unify_pat_types pat.pat_loc env pat_ty ty
-        ) half_typed_cases
-      in
-      unify_pats ty_arg';
-      (* Check for polymorphic variants to close *)
-      if List.exists has_variants patl then begin
-        Parmatch.pressure_variants_in_computation_pattern env
-          (List.map (as_comp_pattern category) patl);
-        List.iter finalize_variants patl
-      end;
-      (* `Contaminating' unifications start here *)
-      List.iter (fun f -> f()) !pattern_force;
-      (* Post-processing and generalization *)
-      if take_partial_instance <> None then unify_pats (instance ty_arg);
-      List.iter (fun { pat_vars; _ } ->
-        iter_pattern_variables_type (enforce_current_level env) pat_vars
-      ) half_typed_cases;
-      (half_typed_cases, ty_res, do_copy_types, ty_arg')
-    end
-  in
-  (* type bodies *)
-  let ty_res' = instance ty_res in
-  (* Why is it needed to keep the level of result raised ?  *)
-  let result = with_local_level_if_principal ~post:ignore begin fun () ->
-    map_conts
-    (fun { typed_pat = pat; branch_env = ext_env;
-           pat_vars = pvs; module_vars = mvs;
-           case_data; contains_gadt; _ } cont
-        ->
-        let ext_env =
-          if contains_gadt then
-            do_copy_types ext_env
-          else
-            ext_env
-        in
-        (* Before handing off the cases to the callback, first set up the the
-           branch environments by adding the variables (and module variables)
-           from the patterns.
-        *)
-        let cont_vars, pvs =
-          List.partition (fun pv -> pv.pv_kind = Continuation_var) pvs in
-        let add_pattern_vars = add_pattern_variables
-            ~check:(fun s -> Warnings.Unused_var_strict s)
-            ~check_as:(fun s -> Warnings.Unused_var s)
-        in
-        let when_env = add_pattern_vars ext_env pvs in
-        let when_env = add_module_variables when_env mvs in
-        let ext_env = add_pattern_vars when_env cont_vars in
-        let ty_expected =
-          if contains_gadt && not !Clflags.principal then
-            (* Take a generic copy of [ty_res] again to allow propagation of
-                type information from preceding branches *)
-            duplicate_type ty_res
-          else ty_res in
-        type_body case_data pat ~when_env ~ext_env ~cont ~ty_expected
-          ~ty_infer:ty_res' ~contains_gadt)
-    conts half_typed_cases
-  end in
-  let do_init = may_contain_gadts || needs_exhaust_check in
-  let ty_arg_check =
-    if do_init then
-      (* Hack: use for_saving to copy variables too *)
-      Subst.type_expr (Subst.for_saving Subst.identity) ty_arg'
-    else ty_arg'
-  in
-  (* Split the cases into val and exn cases so we can do the appropriate checks
-     for exhaustivity and unused variables.
-
-     The caller of this function can define custom checks. For some of these
-     checks, the half-typed case doesn't provide enough info on its own -- for
-     instance, the check for ambiguous bindings in when guards needs to know the
-     case body's expression -- so the code pairs each case with its
-     corresponding element in [result] before handing it off to the caller's
-     custom checks.
-  *)
-  let val_cases_with_result, exn_cases_with_result =
-    match category with
-    | Value ->
-        let val_cases =
-          List.map2
-            (fun htc res ->
-               { htc.untyped_case with pattern = htc.typed_pat }, res)
-            half_typed_cases
-            result
-        in
-        (val_cases : (pattern Parmatch.parmatch_case * ret) list), []
-    | Computation ->
-        split_half_typed_cases env (List.combine half_typed_cases result)
-  in
-  let val_cases = List.map fst val_cases_with_result in
-  let exn_cases = List.map fst exn_cases_with_result in
-  if val_cases = [] && exn_cases <> [] then
-    raise (Error (loc, env, No_value_clauses));
-  let partial =
-    if check_if_total then
-      check_partial ~lev env ty_arg_check loc val_cases
-    else
-      Partial
-  in
-  let unused_check delayed =
-    List.iter (fun { typed_pat; branch_env; _ } ->
-      check_absent_variant branch_env (as_comp_pattern category typed_pat)
-    ) half_typed_cases;
-    with_level_if delayed ~level:lev begin fun () ->
-      check_unused ~lev env ty_arg_check val_cases ;
-      check_unused ~lev env Predef.type_exn exn_cases ;
-    end;
-  in
-  if contains_polyvars then
-    add_delayed_check (fun () -> unused_check true)
-  else
-    (* Check for unused cases, do not delay because of gadts *)
-    unused_check false;
-  begin
-    match additional_checks_for_split_cases with
-    | None -> ()
-    | Some check ->
-        check val_cases_with_result;
-        check exn_cases_with_result;
-  end;
-  (result, partial), [ty_res']
-  end
-  (* Ensure that existential types do not escape *)
-  ~post:(fun ty_res' -> unify_exp_types loc env ty_res' (newvar ()))
-
 (* Typing of match cases *)
 and type_cases
     : type k . k pattern_category -> _ -> _ -> _ -> ?conts:_ ->
@@ -6867,6 +6899,7 @@ and type_cases
   *)
   map_half_typed_cases ?conts category env ty_arg ty_res loc caselist
     ~check_if_total
+    ~type_pattern
     ~type_body:begin
       fun { pc_guard; pc_rhs } pat ~when_env ~ext_env ~cont ~ty_expected
         ~ty_infer ~contains_gadt:_ ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2621,7 +2621,7 @@ let rec check_counter_example_pat
 
      TODO: Once [Tpoly] is removed from the typing of `let` and `let rec`,
      this exception can be eliminated as well.*)
-  assert (not (is_poly_Tpoly tp.pat_type));
+  assert (not (is_poly_Tpoly expected_ty));
   match tp.pat_desc with
     Tpat_any | Tpat_var _ ->
       let k' () = mkp k tp.pat_desc in


### PR DESCRIPTION
# Context

This PR fixes #14434, a soundness bug in polymorphic parameters:
```ocaml
# let should_not_work ([ bad ] : 'a. 'a list) = print_endline bad;; 

val should_not_work : ('a. 'a list) -> unit = <fun> 

# should_not_work [];; 

Segmentation fault: 11
```

The root cause of the problem is that the pattern `[ bad ]` is typed as `Tpoly`, which isn't handled by exhaustiveness checker. 

This bug does not occur when the type of the function is 'known' externally to the pattern e.g.
```ocaml
# let works : ('a. 'a list) -> unit = fun [ bad ] -> print_endline bad;;

Warning 8 [partial-match]: this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: bad::_::_
val works : ('a. 'a list) -> unit = <fun>
```
This is because `split_function_ty` will instantiate the polymorphic parameter when typing a `fun [ bad ] -> ...` and typecheck the pattern using the monomorphic type. As a result, the exhaustiveness checker only ever sees the monomorphic type (`string list`) and behaves correctly.

# Description

This PR fixes the bug by correctly splitting the typing of polymorphic parameter patterns (so-called poly-patterns) and regular (monomorphic) patterns.

Within `type_poly_pattern`, we correctly handle:
1. the unification of the external 'polyvar' variable `ty_param` that `split_function_ty` introduces, and 
2. typechecking the underlying pattern monomorphically 

This matches the behaviour of the externally annotated example above (`works`) and ensures that poly-patterns never pass a raw `Tpoly` to the exhaustiveness checker. 

# Testing
```sh
make -C testsuite one TEST=tests/typing-poly/poly_params.ml
```