### PR TITLE
Reset the type-checker between compilations

### DIFF
--- a/.depend
+++ b/.depend
@@ -7094,6 +7094,7 @@ driver/compmisc.cmo : \
     utils/load_path.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    typing/ctype.cmi \
     utils/config.cmi \
     driver/compenv.cmi \
     utils/clflags.cmi \
@@ -7107,6 +7108,7 @@ driver/compmisc.cmx : \
     utils/load_path.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    typing/ctype.cmx \
     utils/config.cmx \
     driver/compenv.cmx \
     utils/clflags.cmx \

--- a/Changes
+++ b/Changes
@@ -271,8 +271,8 @@ Working version
   (Jacques Garrigue and Takafumi Saikawa, reported by Olivier Nicole,
    review by Gabriel Scherer)
 
-- #14483: Reset type ID counter between compilations to restore reproducibility
-  of debug information between `ocamlc -c foo.mli foo.ml` versus
+- #14483: Reset type ID and level counters between compilations to restore
+  reproducibility of debug information between `ocamlc -c foo.mli foo.ml` versus
   `ocamlc -c foo.mli; ocamlc -c foo.ml`
   (David Allsopp, review by Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -271,6 +271,11 @@ Working version
   (Jacques Garrigue and Takafumi Saikawa, reported by Olivier Nicole,
    review by Gabriel Scherer)
 
+- #14483: Reset type ID counter between compilations to restore reproducibility
+  of debug information between `ocamlc -c foo.mli foo.ml` versus
+  `ocamlc -c foo.mli; ocamlc -c foo.ml`
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Other libraries:
 
 - #13700, #14454: Use POSIX thread-safe getgrnam_r, getgrgid_r, getpwnam_r,

--- a/Changes
+++ b/Changes
@@ -273,7 +273,10 @@ Working version
 
 - #14483: Reset type ID and level counters between compilations to restore
   reproducibility of debug information between `ocamlc -c foo.mli foo.ml` versus
-  `ocamlc -c foo.mli; ocamlc -c foo.ml`
+  `ocamlc -c foo.mli; ocamlc -c foo.ml`. Also hashcons the identifiers used for
+  persistent structures across resets of the type checker. In particular, that
+  means the initialisation of globals in Matching do not become observable in
+  the marshalled output.
   (David Allsopp, review by Gabriel Scherer)
 
 ### Other libraries:

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -69,6 +69,7 @@ let init_path ?(standard_library=Config.standard_library)
 let initial_env () =
   Ident.reinit();
   Types.Uid.reinit();
+  Types.reset();
   let initially_opened_module =
     if !Clflags.nopervasives then
       None

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -70,6 +70,7 @@ let initial_env () =
   Ident.reinit();
   Types.Uid.reinit();
   Types.reset();
+  Ctype.reset();
   let initially_opened_module =
     if !Clflags.nopervasives then
       None

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.ml
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.ml
@@ -1,0 +1,102 @@
+(* TEST
+ include ocamlcommon;
+ include ocamlbytecomp;
+ readonly_files = "test_module.ml test_module.mli";
+ setup-ocamlc.byte-build-env;
+
+ (* First compilation: .mli and .ml separately *)
+ flags = "-g";
+ all_modules = "test_module.mli";
+ compile_only = "true";
+ ocamlc.byte;
+ all_modules = "test_module.ml";
+ ocamlc.byte;
+ src = "test_module.cmo";
+ dst = "test_module_solo.cmo";
+ copy;
+
+
+ (* Second compilation: all files together *)
+ all_modules = "test_module.mli test_module.ml";
+ ocamlc.byte;
+ src = "test_module.cmo";
+ dst = "test_module_with_mli.cmo";
+ copy;
+
+ (* Now run the comparison test *)
+ {
+   compile_only = "false";
+   all_modules = "determinism.ml";
+   program = "${test_build_directory}/determinism.exe";
+   ocamlc.byte;
+   run;
+   check-program-output;
+ }
+*)
+
+(* Test that .cmo files are identical except for debug info
+   when compiled separately vs together with .mli *)
+
+let load_cmo_and_debug filename =
+  let ic = open_in_bin filename in
+  (* Skip magic number *)
+  let _ = really_input_string ic (String.length Config.cmo_magic_number) in
+  (* Read compilation unit *)
+  let compunit_pos = input_binary_int ic in
+  seek_in ic compunit_pos;
+  let cu : Cmo_format.compilation_unit = input_value ic in
+
+  (* Load debug data if present *)
+  let debug_data =
+    if cu.cu_debug > 0 then begin
+      seek_in ic cu.cu_debug;
+      let events : Instruct.debug_event list = input_value ic in
+      let dirs : string list = input_value ic in
+      Some (events, dirs)
+    end else
+      None
+  in
+  close_in ic;
+  (cu, debug_data)
+
+let () =
+  let (cu1, debug1) = load_cmo_and_debug "test_module_solo.cmo" in
+  let (cu2, debug2) = load_cmo_and_debug "test_module_with_mli.cmo" in
+
+  (* Check that all non-debug-content fields are identical *)
+  if cu1.cu_name <> cu2.cu_name
+     || cu1.cu_imports <> cu2.cu_imports
+     || cu1.cu_required_compunits <> cu2.cu_required_compunits
+     || cu1.cu_primitives <> cu2.cu_primitives
+     || cu1.cu_force_link <> cu2.cu_force_link
+     || cu1.cu_debug <> cu2.cu_debug  (* offset should be the same *)
+  then
+    failwith "Non-debug fields differ!";
+
+  (* Check if the files are byte-for-byte identical *)
+  let load_file filename =
+    let ic = open_in_bin filename in
+    let size = in_channel_length ic in
+    let bytes = Bytes.create size in
+    really_input ic bytes 0 size;
+    close_in ic;
+    bytes
+  in
+  let bytes1 = load_file "test_module_solo.cmo" in
+  let bytes2 = load_file "test_module_with_mli.cmo" in
+  if bytes1 = bytes2 then
+    print_endline "CMO files are identical"
+  else
+    print_endline "CMO files differ";
+
+  if cu1.cu_debug > 0 && cu2.cu_debug > 0 then begin
+    let debug_section1 = Bytes.sub bytes1 cu1.cu_debug cu1.cu_debugsize in
+    let debug_section2 = Bytes.sub bytes2 cu2.cu_debug cu2.cu_debugsize in
+    if debug_section1 = debug_section2 then
+      print_endline "Debug events are identical"
+    else
+      print_endline "Debug events differ"
+  end else if cu1.cu_debug = 0 && cu2.cu_debug = 0 then
+    print_endline "No debug data in either file"
+  else
+    print_endline "Debug data presence mismatch"

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.ml
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.ml
@@ -1,7 +1,7 @@
 (* TEST
  include ocamlcommon;
  include ocamlbytecomp;
- readonly_files = "test_module.ml test_module.mli";
+ readonly_files = "test_module.ml test_module.mli trigger_lazy.ml";
  setup-ocamlc.byte-build-env;
 
  (* First compilation: .mli and .ml separately *)
@@ -17,7 +17,7 @@
 
 
  (* Second compilation: all files together *)
- all_modules = "test_module.mli test_module.ml";
+ all_modules = "trigger_lazy.ml test_module.mli test_module.ml";
  ocamlc.byte;
  src = "test_module.cmo";
  dst = "test_module_with_mli.cmo";

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.reference
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.reference
@@ -1,2 +1,2 @@
-CMO files differ
-Debug events differ
+CMO files are identical
+Debug events are identical

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.reference
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.reference
@@ -1,2 +1,2 @@
-CMO files are identical
+CMO files differ
 Debug events are identical

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.reference
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.reference
@@ -1,2 +1,2 @@
-CMO files are identical
-Debug events are identical
+CMO files differ
+Debug events differ

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.reference
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.reference
@@ -1,0 +1,2 @@
+CMO files differ
+Debug events differ

--- a/testsuite/tests/tool-ocamlc-determinism/determinism.reference
+++ b/testsuite/tests/tool-ocamlc-determinism/determinism.reference
@@ -1,2 +1,2 @@
-CMO files differ
+CMO files are identical
 Debug events are identical

--- a/testsuite/tests/tool-ocamlc-determinism/test_module.ml
+++ b/testsuite/tests/tool-ocamlc-determinism/test_module.ml
@@ -1,2 +1,9 @@
 type t = int
 let greeting = "Hello"
+
+type 'a u = 'a CamlinternalLazy.t
+exception Undefined = CamlinternalLazy.Undefined
+external force : 'a u -> 'a = "%lazy_force"
+
+let map f x =
+  lazy (f (force x))

--- a/testsuite/tests/tool-ocamlc-determinism/test_module.ml
+++ b/testsuite/tests/tool-ocamlc-determinism/test_module.ml
@@ -1,0 +1,1 @@
+let greeting = "Hello"

--- a/testsuite/tests/tool-ocamlc-determinism/test_module.ml
+++ b/testsuite/tests/tool-ocamlc-determinism/test_module.ml
@@ -1,1 +1,2 @@
+type t = int
 let greeting = "Hello"

--- a/testsuite/tests/tool-ocamlc-determinism/test_module.mli
+++ b/testsuite/tests/tool-ocamlc-determinism/test_module.mli
@@ -1,0 +1,1 @@
+val greeting : string

--- a/testsuite/tests/tool-ocamlc-determinism/test_module.mli
+++ b/testsuite/tests/tool-ocamlc-determinism/test_module.mli
@@ -1,1 +1,2 @@
+type t
 val greeting : string

--- a/testsuite/tests/tool-ocamlc-determinism/trigger_lazy.ml
+++ b/testsuite/tests/tool-ocamlc-determinism/trigger_lazy.ml
@@ -1,0 +1,2 @@
+let force_lazy = function
+  | lazy x -> x

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -318,6 +318,13 @@ let increase_global_level () =
 let restore_global_level gl =
   global_level := gl
 
+(* Reset all level counters - used between compilation units *)
+let reset () =
+  current_level := 0;
+  nongen_level := 0;
+  global_level := 0;
+  saved_levels := []
+
 (**** Some type creators ****)
 
 (* Re-export generic type creators *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -95,6 +95,9 @@ val create_scope: unit -> int
            the scope continues until the end of the compilation unit
            or toplevel session. *)
 
+val reset: unit -> unit
+        (* Reset all level counters - used between compilation units *)
+
 val newty: type_desc -> type_expr
 val new_scoped_ty: int -> type_desc -> type_expr
 val newvar: ?name:string -> unit -> type_expr

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -754,6 +754,8 @@ let match_row_field ~present ~absent ~either (f : row_field) =
 
 let new_id = Local_store.s_ref (-1)
 
+let reset () = new_id := -1
+
 let create_expr = Transient_expr.create
 
 let proto_newty3 ~level ~scope desc  =

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -769,3 +769,5 @@ val set_univar: type_expr option ref -> type_expr -> unit
 val link_kind: inside:field_kind -> field_kind -> unit
 val link_commu: inside:commutable -> commutable -> unit
 val set_commu_ok: commutable -> unit
+
+val reset : unit -> unit


### PR DESCRIPTION
Three changes aimed at ensuring that `ocamlc -c foo.ml bar.ml baz.ml` is equivalent to `ocamlc -c foo.ml ; ocamlc -c bar.ml; ocamlc -c baz.ml`.  Relevant in the context of https://github.com/ocaml/RFCs/pull/60; this is work of mine from last year following [work from an internship](https://anil.recoil.org/ideas/effects-scheduling-ocaml-compiler) by @lucasma8795 that's been sat in my freezer pending #14383.

Fixes:
1. Reset the type ID counter (`Types.new_id`) - no semantic difference, but the actual numbers leak in debug events.
2. Highly related to the first, reset the levels in `Ctype` - similarly, no semantic difference, but the actual numbers make it into debug events.
3. Reset the pattern match compiler's lambda caches. This is entirely about determinism. If a file in the compilation causes either `Matching.code_force_lazy_block` or `Matching.code_force_lazy` to be forced, these remain forced in subsequent compilations. If that subsequent module refers to `CamlinternalLazy` _and_ itself uses these blocks, the physical string used in the persistent environment is different, which is observable in the marshalled output from an apparent lack of string sharing.

The series is structured in 3 pairs of commits. The first commit in each pair creates or updates a test which compiles a series of test files both separately and in a single compiler-invocation and then compares the results, reporting whether they differ (which they will). The second commit in each pair then resets the appropriate part of the type checker between compilations in order to make the two test cases identical again.

The investigations and debugging in this PR were carried out by @claude. All the files changed in testsuite/ are AI-generated. The changes to the compiler itself are mine, made following investigations carried out by @claude.