### PR TITLE
Define `_WIN32_WINNT` as `0x0602` (8 / Server 2012) in cppflags

### DIFF
--- a/Changes
+++ b/Changes
@@ -606,6 +606,10 @@ OCaml 5.5.0
   -runtime-search used for bytecode executables produced by the compiler.
   (David Allsopp, review by Damien Doligez and Samuel Hym)
 
+- #14484: Set `_WIN32_WINNT` to require Windows 8/Server 2012 Windows header SDK
+  support.
+  (Antonin Décimo, review by David Allsopp)
+
 ### Bug fixes:
 
 - #14036: Fix nontermination of cycle printing in recursive modules with

--- a/configure
+++ b/configure
@@ -15709,6 +15709,14 @@ case $target in #(
     common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64" ;;
 esac
 
+# Require Windows 8 / Server 2012 or later
+case $target in #(
+  *-w64-mingw32*|*-pc-windows) :
+    internal_cppflags="$internal_cppflags -D_WIN32_WINNT=0x602" ;; #(
+  *) :
+     ;;
+esac
+
 # Adjust according to target
 
 # On Windows we do not take $enable_shared because it does not seem

--- a/configure.ac
+++ b/configure.ac
@@ -1147,6 +1147,11 @@ AS_CASE([$target],
   [*-w64-mingw32*|*-pc-windows], [],
   [common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64"])
 
+# Require Windows 8 / Server 2012 or later
+AS_CASE([$target],
+  [*-w64-mingw32*|*-pc-windows],
+    [internal_cppflags="$internal_cppflags -D_WIN32_WINNT=0x602"])
+
 # Adjust according to target
 
 # On Windows we do not take $enable_shared because it does not seem

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -15,8 +15,6 @@
 
 /* Run programs with redirections and timeouts under Windows */
 
-/* GetTickCount64() requires Windows Vista or Server 2008 */
-#define _WIN32_WINNT 0x0600
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/otherlibs/unix/realpath_win32.c
+++ b/otherlibs/unix/realpath_win32.c
@@ -15,11 +15,6 @@
 
 #define CAML_INTERNALS
 
-/*
- * Windows Vista functions enabled
- */
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>

--- a/otherlibs/unix/symlink_win32.c
+++ b/otherlibs/unix/symlink_win32.c
@@ -14,11 +14,6 @@
 
 #define CAML_INTERNALS
 
-/*
- * Windows Vista functions enabled
- */
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>

--- a/otherlibs/unix/winworker.h
+++ b/otherlibs/unix/winworker.h
@@ -16,8 +16,6 @@
 #ifndef _WINWORKER_H
 #define _WINWORKER_H
 
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0400
 #include "caml/unixsupport.h"
 #include <windows.h>
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -17,10 +17,6 @@
 
 /* Win32-specific stuff */
 
-/* FILE_INFO_BY_HANDLE_CLASS, FILE_NAME_INFO, and INIT_ONCE are only
-   available from Windows Vista onwards */
-#define _WIN32_WINNT 0x0600 /* _WIN32_WINNT_VISTA */
-
 #define WIN32_LEAN_AND_MEAN
 #define _CRT_RAND_S
 #include <windows.h>

--- a/yacc/wstr.c
+++ b/yacc/wstr.c
@@ -12,9 +12,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-/* Need at least Windows Vista for WC_ERR_INVALID_CHARS */
-#define _WIN32_WINNT 0x600
-#define WINVER 0x600
 #include <windows.h>
 
 /* See corresponding values in runtime/win32.c */


### PR DESCRIPTION
This sets the minimum supported Windows version as ~Windows Vista or Windows Server 2008~ Windows 8 or Windows Server 2012 for building OCaml.

Defining this macro is required to get the definition of some macros or symbols from the Windows SDK headers. Rather than defining this macro once in each C file that needs it, define it in the internal cppflags and pass it through the C compiler invocation.

The problem was highlighted by a [build failure of FlexDLL](https://github.com/ocaml/flexdll/pull/164#issuecomment-3728974890). As part of the winpthreads removal, functions from the WinAPI that are guarded by a `#if _WIN32_WINNT >= 0x0600` were needed in `<caml/platform.h>`. The macro wasn't defined, or didn't have the right value in a old mingw-w64 environment.
A [message from @dra27](https://github.com/ocaml/ocaml/pull/13450#discussion_r2631094672) in an earlier discussion here suggested to move the definition of `_WIN32_WINNT` to a single point, preferably the internal cppflags (flags for the *C* *p*re*p*rocessor).

I'm still wondering if this define should stay internal, or become public (reported in `bytecomp_cppflags` and `native_cppflags`), for users who include the caml headers.

We could also move to the latest `_WIN32_WINNT_WIN10 0x0A00` (Windows 10) since all earlier versions have been end-of-life'd by Microsoft.

As I understand it, the value of `WINVER` is derived from `_WIN32_WINNT` if the former isn't defined.

See also [Update `WINVER` and `_WIN32_WINNT`](https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-180) (MS docs) and [`mingw-w64-headers/include/sdkddkver.h`](https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-headers/include/sdkddkver.h).
Closes #7418.

cc @dra27, @nojb, @shindere 