### PR TITLE
chore: add ocp indent check

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# This file contains a list of Git commit hashes that should be ignored by git
+# blame. These are typically mass formatting changes, whitespace fixes, or
+# other commits that don't meaningfully change the code logic but would
+# otherwise obscure the true author of each line.
+#
+# To use this file, configure git with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+
+bd9fa8f4faff174511b6d77a5c76e31f4fe5ed8b

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -16,6 +16,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  formatting:
+    name: Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5
+
+        # To format the tree with dune, we must configure to avoid
+        # errors about unimplemented modules
+      - name: Configure
+        run: bash -xe tools/ci/actions/runner.sh configure
+
+      - name: Check dune formatting
+        run: |
+          opam install dune ocp-indent --yes
+          opam exec -- dune fmt || true
+          git diff --exit-code
+
   hygiene:
     name: Checks
     runs-on: ubuntu-latest

--- a/.ocp-indent-list
+++ b/.ocp-indent-list
@@ -1,0 +1,8 @@
+; This file lists source files that should be formatted with ocp-indent.
+; Only files listed here (or matching patterns specified here) will be
+; automatically indented by ocp-indent.
+;
+; Format: List of [dependencies](deps).
+;
+; [deps]: https://dune.readthedocs.io/en/stable/concepts/dependency-spec.html
+()

--- a/asmcomp/dune
+++ b/asmcomp/dune
@@ -13,33 +13,43 @@
 ;**************************************************************************
 
 (rule
- (targets arch.ml CSE.ml proc.ml reload.ml scheduling.ml selection.ml
-          stackframe.ml)
- (mode    fallback)
- (deps    (:conf ../Makefile.config)
-          (glob_files amd64/*.ml)
-          (glob_files arm64/*.ml)
-          (glob_files power/*.ml)
-          (glob_files riscv/*.ml)
-          (glob_files s390x/*.ml))
- (action  (bash "cp `grep '^ARCH=' %{conf} | cut -d'=' -f2`/*.ml .")))
+ (targets
+  arch.ml
+  CSE.ml
+  proc.ml
+  reload.ml
+  scheduling.ml
+  selection.ml
+  stackframe.ml)
+ (mode fallback)
+ (deps
+  (:conf ../Makefile.config)
+  (glob_files amd64/*.ml)
+  (glob_files arm64/*.ml)
+  (glob_files power/*.ml)
+  (glob_files riscv/*.ml)
+  (glob_files s390x/*.ml))
+ (action
+  (bash "cp `grep '^ARCH=' %{conf} | cut -d'=' -f2`/*.ml .")))
 
 (rule
  (targets emit.ml)
- (mode    fallback)
- (deps    (:conf ../Makefile.config)
-          amd64/emit.mlp
-          arm64/emit.mlp
-          power/emit.mlp
-          riscv/emit.mlp
-          s390x/emit.mlp)
+ (mode fallback)
+ (deps
+  (:conf ../Makefile.config)
+  amd64/emit.mlp
+  arm64/emit.mlp
+  power/emit.mlp
+  riscv/emit.mlp
+  s390x/emit.mlp)
  (action
-   (no-infer
-    (progn
-      (with-stdout-to contains-input-name
-        (bash "echo `grep '^ARCH=' %{conf} | cut -d'=' -f2`/emit.mlp"))
-      (with-stdout-to %{targets}
-        (progn
-          (bash "echo \\# 1 \\\"`cat contains-input-name`\\\"")
-          (bash "%{dep:../tools/cvt_emit.exe} < `cat contains-input-name`"))
-        )))))
+  (no-infer
+   (progn
+    (with-stdout-to
+     contains-input-name
+     (bash "echo `grep '^ARCH=' %{conf} | cut -d'=' -f2`/emit.mlp"))
+    (with-stdout-to
+     %{targets}
+     (progn
+      (bash "echo \\# 1 \\\"`cat contains-input-name`\\\"")
+      (bash "%{dep:../tools/cvt_emit.exe} < `cat contains-input-name`")))))))

--- a/bytecomp/dune
+++ b/bytecomp/dune
@@ -14,7 +14,9 @@
 
 (rule
  (targets opcodes.ml)
- (mode    fallback)
- (deps    (:instr (file ../runtime/caml/instruct.h)))
+ (mode fallback)
+ (deps
+  (:instr
+   (file ../runtime/caml/instruct.h)))
  (action
   (bash "%{dep:../tools/make_opcodes.exe} -opcodes < %{instr} > %{targets}")))

--- a/dune
+++ b/dune
@@ -13,165 +13,383 @@
 ;**************************************************************************
 
 (env
- (dev     (flags (:standard -w +a-4-9-40-41-42-44-45-48-66-67-70)))
- (release (flags (:standard -w +a-4-9-40-41-42-44-45-48-66-67-70))))
+ (dev
+  (flags
+   (:standard -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+ (release
+  (flags
+   (:standard -w +a-4-9-40-41-42-44-45-48-66-67-70))))
 
 ;; Too annoying to get to work. Use (copy_files# ...) instead
 ; (include_subdirs unqualified)
 ; (ignored_subdirs (lex yacc testsuite ocamldoc ocamltest toplevel otherlibs))
 
 (copy_files# utils/*.ml{,i})
+
 (copy_files# parsing/*.ml{,i})
+
 (copy_files# typing/*.ml{,i})
+
 (copy_files# bytecomp/*.ml{,i})
+
 (copy_files# driver/*.ml{,i})
+
 (copy_files# asmcomp/*.ml{,i})
+
 (copy_files# file_formats/*.ml{,i})
+
 (copy_files# lambda/*.ml{,i})
+
 (copy_files# middle_end/*.ml{,i})
+
 (copy_files# middle_end/closure/*.ml{,i})
+
 (copy_files# middle_end/flambda/*.ml{,i})
+
 (copy_files# middle_end/flambda/base_types/*.ml{,i})
 
 (library
  (name ocamlcommon)
  (wrapped false)
- (flags (:standard -principal -nostdlib \ -short-paths))
+ (flags
+  (:standard -principal -nostdlib \ -short-paths))
  (libraries stdlib)
  (modules_without_implementation
-   annot cmo_format outcometree parsetree value_rec_types)
+  annot
+  cmo_format
+  outcometree
+  parsetree
+  value_rec_types)
  (modules
-   ;; UTILS
-   config build_path_prefix_map misc identifiable numbers arg_helper
-   clflags profile terminfo ccomp format_doc warnings consistbl
-   strongly_connected_components targetint load_path
-   int_replace_polymorphic_compare binutils local_store lazy_backtrack diffing
-   diffing_with_keys unit_info compression linkdeps stable_matching
-
-   ;; PARSING
-   location longident docstrings syntaxerr ast_helper camlinternalMenhirLib
-   ast_iterator builtin_attributes parser lexer parse printast pprintast
-   ast_mapper attr_helper ast_invariants depend
-   ; manual update: mli only files
-   asttypes parsetree
-
-   ;; TYPING
-   ident path primitive shape shape_reduce types btype oprint subst predef
-   datarepr cmi_format persistent_env env type_immediacy errortrace
-   typedtree printtyped ctype printtyp rawprinttyp includeclass mtype envaux
-   includecore tast_iterator tast_mapper signature_group cmt_format untypeast
-   includemod signature_matching includemod_errorprinter errortrace_report
-   typetexp patterns printpat parmatch stypes typeopt typedecl value_rec_check
-   typecore
-   typeclass typemod typedecl_variance typedecl_properties typedecl_immediacy
-   typedecl_unboxed typedecl_separability cmt2annot out_type data_types
-   ; manual update: mli only files
-   annot outcometree value_rec_types
-
-   ;; lambda/
-   debuginfo lambda matching printlambda runtimedef tmc simplif switch
-   translattribute translclass translcore translmod translobj translprim
-   value_rec_compiler
-
-   ;; bytecomp/
-   meta opcodes bytesections dll symtable
-
-   ;; some of COMP
-   pparse main_args compenv compmisc makedepend compile_common
-   ; manual update: mli only files
-   cmo_format
-   ; manual update: this is required.
-   instruct
- ))
+  ;; UTILS
+  config
+  build_path_prefix_map
+  misc
+  identifiable
+  numbers
+  arg_helper
+  clflags
+  profile
+  terminfo
+  ccomp
+  format_doc
+  warnings
+  consistbl
+  strongly_connected_components
+  targetint
+  load_path
+  int_replace_polymorphic_compare
+  binutils
+  local_store
+  lazy_backtrack
+  diffing
+  diffing_with_keys
+  unit_info
+  compression
+  linkdeps
+  stable_matching
+  ;; PARSING
+  location
+  longident
+  docstrings
+  syntaxerr
+  ast_helper
+  camlinternalMenhirLib
+  ast_iterator
+  builtin_attributes
+  parser
+  lexer
+  parse
+  printast
+  pprintast
+  ast_mapper
+  attr_helper
+  ast_invariants
+  depend
+  ; manual update: mli only files
+  asttypes
+  parsetree
+  ;; TYPING
+  ident
+  path
+  primitive
+  shape
+  shape_reduce
+  types
+  btype
+  oprint
+  subst
+  predef
+  datarepr
+  cmi_format
+  persistent_env
+  env
+  type_immediacy
+  errortrace
+  typedtree
+  printtyped
+  ctype
+  printtyp
+  rawprinttyp
+  includeclass
+  mtype
+  envaux
+  includecore
+  tast_iterator
+  tast_mapper
+  signature_group
+  cmt_format
+  untypeast
+  includemod
+  signature_matching
+  includemod_errorprinter
+  errortrace_report
+  typetexp
+  patterns
+  printpat
+  parmatch
+  stypes
+  typeopt
+  typedecl
+  value_rec_check
+  typecore
+  typeclass
+  typemod
+  typedecl_variance
+  typedecl_properties
+  typedecl_immediacy
+  typedecl_unboxed
+  typedecl_separability
+  cmt2annot
+  out_type
+  data_types
+  ; manual update: mli only files
+  annot
+  outcometree
+  value_rec_types
+  ;; lambda/
+  debuginfo
+  lambda
+  matching
+  printlambda
+  runtimedef
+  tmc
+  simplif
+  switch
+  translattribute
+  translclass
+  translcore
+  translmod
+  translobj
+  translprim
+  value_rec_compiler
+  ;; bytecomp/
+  meta
+  opcodes
+  bytesections
+  dll
+  symtable
+  ;; some of COMP
+  pparse
+  main_args
+  compenv
+  compmisc
+  makedepend
+  compile_common
+  ; manual update: mli only files
+  cmo_format
+  ; manual update: this is required.
+  instruct))
 
 (library
  (name ocamlbytecomp)
  (wrapped false)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries stdlib ocamlcommon)
  (modules
-    ;; bytecomp/
-    bytegen bytelibrarian bytelink bytepackager emitcode printinstr
-
-    ;; driver/
-    errors compile maindriver
- ))
+  ;; bytecomp/
+  bytegen
+  bytelibrarian
+  bytelink
+  bytepackager
+  emitcode
+  printinstr
+  ;; driver/
+  errors
+  compile
+  maindriver))
 
 (library
  (name ocamlmiddleend)
  (wrapped false)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries stdlib ocamlcommon)
  (modules_without_implementation
-   cmx_format cmxs_format backend_intf inlining_decision_intf
-   simplify_boxed_integer_ops_intf)
+  cmx_format
+  cmxs_format
+  backend_intf
+  inlining_decision_intf
+  simplify_boxed_integer_ops_intf)
  (modules
-   ;; file_formats/
-   cmx_format cmxs_format
-
-   ;; middle_end/
-   backend_intf backend_var backend_var clambda clambda_primitives
-   compilation_unit compilenv convert_primitives internal_variable_names
-   linkage_name printclambda printclambda_primitives semantics_of_primitives
-   symbol variable
-
-   ;; middle_end/closure/
-   closure closure_middle_end
-
-   ;; middle_end/flambda/base_types/
-   closure_element closure_id closure_origin export_id id_types mutable_variable
-   set_of_closures_id set_of_closures_origin static_exception tag
-   var_within_closure
-
-   ;; middle_end/flambda/
-   alias_analysis allocated_const augment_specialised_args build_export_info
-   closure_conversion closure_conversion_aux closure_offsets effect_analysis
-   export_info export_info_for_pack extract_projections find_recursive_functions
-   flambda flambda_invariants flambda_iterators flambda_middle_end
-   flambda_to_clambda flambda_utils freshening import_approx inconstant_idents
-   initialize_symbol_to_let_symbol inline_and_simplify inline_and_simplify_aux
-   inlining_cost inlining_decision inlining_decision_intf inlining_stats
-   inlining_stats_types inlining_transforms invariant_params lift_code
-   lift_constants lift_let_to_initialize_symbol parameter pass_wrapper
-   projection ref_to_variables remove_free_vars_equal_to_args
-   remove_unused_arguments remove_unused_closure_vars
-   remove_unused_program_constructs share_constants simple_value_approx
-   simplify_boxed_integer_ops simplify_boxed_integer_ops_intf simplify_common
-   simplify_primitives traverse_for_exported_symbols un_anf unbox_closures
-   unbox_free_vars_of_closures unbox_specialised_args
- )
-)
+  ;; file_formats/
+  cmx_format
+  cmxs_format
+  ;; middle_end/
+  backend_intf
+  backend_var
+  backend_var
+  clambda
+  clambda_primitives
+  compilation_unit
+  compilenv
+  convert_primitives
+  internal_variable_names
+  linkage_name
+  printclambda
+  printclambda_primitives
+  semantics_of_primitives
+  symbol
+  variable
+  ;; middle_end/closure/
+  closure
+  closure_middle_end
+  ;; middle_end/flambda/base_types/
+  closure_element
+  closure_id
+  closure_origin
+  export_id
+  id_types
+  mutable_variable
+  set_of_closures_id
+  set_of_closures_origin
+  static_exception
+  tag
+  var_within_closure
+  ;; middle_end/flambda/
+  alias_analysis
+  allocated_const
+  augment_specialised_args
+  build_export_info
+  closure_conversion
+  closure_conversion_aux
+  closure_offsets
+  effect_analysis
+  export_info
+  export_info_for_pack
+  extract_projections
+  find_recursive_functions
+  flambda
+  flambda_invariants
+  flambda_iterators
+  flambda_middle_end
+  flambda_to_clambda
+  flambda_utils
+  freshening
+  import_approx
+  inconstant_idents
+  initialize_symbol_to_let_symbol
+  inline_and_simplify
+  inline_and_simplify_aux
+  inlining_cost
+  inlining_decision
+  inlining_decision_intf
+  inlining_stats
+  inlining_stats_types
+  inlining_transforms
+  invariant_params
+  lift_code
+  lift_constants
+  lift_let_to_initialize_symbol
+  parameter
+  pass_wrapper
+  projection
+  ref_to_variables
+  remove_free_vars_equal_to_args
+  remove_unused_arguments
+  remove_unused_closure_vars
+  remove_unused_program_constructs
+  share_constants
+  simple_value_approx
+  simplify_boxed_integer_ops
+  simplify_boxed_integer_ops_intf
+  simplify_common
+  simplify_primitives
+  traverse_for_exported_symbols
+  un_anf
+  unbox_closures
+  unbox_free_vars_of_closures
+  unbox_specialised_args))
 
 (library
  (name ocamloptcomp)
  (wrapped false)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries stdlib ocamlcommon ocamlmiddleend)
  (modules_without_implementation x86_ast emitenv branch_relaxation_intf)
  (modules
-   ;; asmcomp/
-   afl_instrument arch asmgen asmlibrarian asmlink asmpackager branch_relaxation
-   branch_relaxation_intf cmm_helpers cmm cmmgen cmmgen_state coloring comballoc
-   cmm_invariants
-   CSE CSEgen
-   dataflow deadcode domainstate
-   emit emitaux emitenv
-   interf interval
-   linear linearize linscan
-   liveness mach
-   polling printcmm printlinear printmach proc
-   reg reload reloadgen
-   schedgen scheduling selectgen selection spill split
-   strmatch thread_sanitizer x86_ast x86_dsl x86_gas x86_masm x86_proc
-   stackframegen stackframe
-
-   ;; file_formats/
-   linear_format
-
-   ;; driver/
-   optcompile opterrors optmaindriver
- )
-)
+  ;; asmcomp/
+  afl_instrument
+  arch
+  asmgen
+  asmlibrarian
+  asmlink
+  asmpackager
+  branch_relaxation
+  branch_relaxation_intf
+  cmm_helpers
+  cmm
+  cmmgen
+  cmmgen_state
+  coloring
+  comballoc
+  cmm_invariants
+  CSE
+  CSEgen
+  dataflow
+  deadcode
+  domainstate
+  emit
+  emitaux
+  emitenv
+  interf
+  interval
+  linear
+  linearize
+  linscan
+  liveness
+  mach
+  polling
+  printcmm
+  printlinear
+  printmach
+  proc
+  reg
+  reload
+  reloadgen
+  schedgen
+  scheduling
+  selectgen
+  selection
+  spill
+  split
+  strmatch
+  thread_sanitizer
+  x86_ast
+  x86_dsl
+  x86_gas
+  x86_masm
+  x86_proc
+  stackframegen
+  stackframe
+  ;; file_formats/
+  linear_format
+  ;; driver/
+  optcompile
+  opterrors
+  optmaindriver))
 
 ;;;;;;;;;;;;;;
 ;;; ocamlc ;;;
@@ -180,7 +398,8 @@
 (executable
  (name main)
  (modes byte)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries ocamlbytecomp ocamlcommon runtime stdlib)
  (modules main))
 
@@ -194,7 +413,8 @@
 (executable
  (name optmain)
  (modes byte)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries ocamloptcomp ocamlmiddleend ocamlcommon runtime stdlib)
  (modules optmain))
 
@@ -207,26 +427,26 @@
 
 ; mshinwell: The debugger and ocamldoc are currently disabled as Dynlink is
 ; not built correctly.
-(alias
- (name world)
- (deps ocamlc.byte
-       ocamlopt.byte
-;       debugger/ocamldebug.byte
-;       ocamldoc/ocamldoc.byte
-       ocamltest/ocamltest.byte
-       toplevel/ocaml.byte
-       toplevel/expunge.exe
-       ))
 
 (alias
-  (name libs)
-  (deps
-    ocamloptcomp.cma
-    ocamlmiddleend.cma
-    ocamlcommon.cma
-    runtime/runtime.cma
-    stdlib/stdlib.cma
-    ocamlbytecomp.cma
-    ocamltest/ocamltest_core_and_plugin.cma
-    toplevel/ocamltoplevel.cma
-  ))
+ (name world)
+ (deps
+  ocamlc.byte
+  ocamlopt.byte
+  ;       debugger/ocamldebug.byte
+  ;       ocamldoc/ocamldoc.byte
+  ocamltest/ocamltest.byte
+  toplevel/ocaml.byte
+  toplevel/expunge.exe))
+
+(alias
+ (name libs)
+ (deps
+  ocamloptcomp.cma
+  ocamlmiddleend.cma
+  ocamlcommon.cma
+  runtime/runtime.cma
+  stdlib/stdlib.cma
+  ocamlbytecomp.cma
+  ocamltest/ocamltest_core_and_plugin.cma
+  toplevel/ocamltoplevel.cma))

--- a/dune
+++ b/dune
@@ -450,3 +450,20 @@
   ocamlbytecomp.cma
   ocamltest/ocamltest_core_and_plugin.cma
   toplevel/ocamltoplevel.cma))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Auto indent files with `dune build @fmt` ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(subdir
+ run
+ (dynamic_include ../rules/dune.ocp-indent.inc))
+
+(subdir
+ rules
+ (rule
+  (target dune.ocp-indent.inc)
+  (deps
+   (include ../.ocp-indent-list))
+  (action
+   (run ocp-indent-gen-rules -o %{target}))))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,4 @@
 (lang dune 3.19)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
+
+(formatting (enabled_for dune))

--- a/lambda/dune
+++ b/lambda/dune
@@ -14,8 +14,13 @@
 
 (rule
  (targets runtimedef.ml)
- (mode    fallback)
- (deps    (:fail (file ../runtime/caml/fail.h))
-          (:prim (file ../runtime/primitives)))
- (action  (with-stdout-to %{targets}
-            (run ./generate_runtimedef.sh %{fail} %{prim}))))
+ (mode fallback)
+ (deps
+  (:fail
+   (file ../runtime/caml/fail.h))
+  (:prim
+   (file ../runtime/primitives)))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./generate_runtimedef.sh %{fail} %{prim}))))

--- a/ocamldoc/dune
+++ b/ocamldoc/dune
@@ -12,13 +12,15 @@
 ;*                                                                        *
 ;**************************************************************************
 
-(ocamllex  odoc_lexer odoc_ocamlhtml odoc_see_lexer odoc_text_lexer)
+(ocamllex odoc_lexer odoc_ocamlhtml odoc_see_lexer odoc_text_lexer)
+
 (ocamlyacc odoc_parser odoc_text_parser)
 
 (executable
  (name odoc)
  (modes byte)
- (flags (:standard -nostdlib -w -9-32))
+ (flags
+  (:standard -nostdlib -w -9-32))
  (libraries dynlink ocamlcommon stdlib runtime str unix))
 
 (rule

--- a/ocamltest/dune
+++ b/ocamltest/dune
@@ -21,28 +21,37 @@
  (mode fallback))
 
 ;; FIXME: handle UNIX_OR_WIN32 or something similar
+
 (library
  (name ocamltest_core_and_plugin)
  (modes byte)
  (wrapped false)
- (flags (:standard -nostdlib))
+ (flags
+  (:standard -nostdlib))
  (libraries ocamlcommon stdlib unix)
- (modules (:standard \ options main ocamltest_unix_dummy ocamltest_unix_real))
+ (modules
+  (:standard \ options main ocamltest_unix_dummy ocamltest_unix_real))
  (foreign_stubs
   (language c)
   (names run_unix run_stubs)
-  (flags -DCAML_INTERNALS -I%{project_root}/runtime))) ; fixme
+  (flags -DCAML_INTERNALS -I%{project_root}/runtime)))
+
+; fixme
 
 (rule
  (targets empty.ml)
- (deps (source_tree %{project_root}/runtime/caml))
- (action (write-file %{targets} "(* hack *)")))
+ (deps
+  (source_tree %{project_root}/runtime/caml))
+ (action
+  (write-file %{targets} "(* hack *)")))
 
 (executable
  (name main)
  (modes byte)
- (flags (:standard -nostdlib))
+ (flags
+  (:standard -nostdlib))
  (modules options main)
  (libraries ocamltest_core_and_plugin runtime stdlib))
 
-(rule (copy main.exe ocamltest.byte))
+(rule
+ (copy main.exe ocamltest.byte))

--- a/otherlibs/str/dune
+++ b/otherlibs/str/dune
@@ -15,7 +15,8 @@
 (library
  (name str)
  (modes byte)
- (flags (:standard -nostdlib))
+ (flags
+  (:standard -nostdlib))
  (libraries stdlib)
  (foreign_stubs
   (language c)

--- a/otherlibs/unix/dune
+++ b/otherlibs/unix/dune
@@ -16,184 +16,554 @@
  (name unix)
  (wrapped false)
  (modes byte)
- (flags (:standard -nostdlib -nolabels))
+ (flags
+  (:standard -nostdlib -nolabels))
  (libraries stdlib)
  (foreign_stubs
   (language c)
   (flags -I %{project_root}/runtime)
   (names
-   accept access addrofstr alarm bind channels chdir chmod chown chroot close
-   fsync closedir connect cst2constr cstringv dup dup2 envir errmsg execv execve
-   execvp exit fchmod fchown fcntl fork ftruncate getaddrinfo getcwd getegid
-   geteuid getgid getgr getgroups gethost gethostname getlogin getnameinfo
-   getpeername getpid getppid getproto getpw gettimeofday getserv getsockname
-   getuid gmtime initgroups isatty itimer kill link listen lockf lseek mkdir
-   mkfifo mmap mmap_ba nice open opendir pipe putenv read readdir readlink
-   realpath rename rewinddir rmdir select sendrecv setgid setgroups setsid
-   setuid shutdown signals sleep socket socketaddr socketpair sockopt stat
-   strofaddr symlink termios time times truncate umask unixsupport unlink utimes
-   wait write)))
+   accept
+   access
+   addrofstr
+   alarm
+   bind
+   channels
+   chdir
+   chmod
+   chown
+   chroot
+   close
+   fsync
+   closedir
+   connect
+   cst2constr
+   cstringv
+   dup
+   dup2
+   envir
+   errmsg
+   execv
+   execve
+   execvp
+   exit
+   fchmod
+   fchown
+   fcntl
+   fork
+   ftruncate
+   getaddrinfo
+   getcwd
+   getegid
+   geteuid
+   getgid
+   getgr
+   getgroups
+   gethost
+   gethostname
+   getlogin
+   getnameinfo
+   getpeername
+   getpid
+   getppid
+   getproto
+   getpw
+   gettimeofday
+   getserv
+   getsockname
+   getuid
+   gmtime
+   initgroups
+   isatty
+   itimer
+   kill
+   link
+   listen
+   lockf
+   lseek
+   mkdir
+   mkfifo
+   mmap
+   mmap_ba
+   nice
+   open
+   opendir
+   pipe
+   putenv
+   read
+   readdir
+   readlink
+   realpath
+   rename
+   rewinddir
+   rmdir
+   select
+   sendrecv
+   setgid
+   setgroups
+   setsid
+   setuid
+   shutdown
+   signals
+   sleep
+   socket
+   socketaddr
+   socketpair
+   sockopt
+   stat
+   strofaddr
+   symlink
+   termios
+   time
+   times
+   truncate
+   umask
+   unixsupport
+   unlink
+   utimes
+   wait
+   write)))
 
 (rule
- (action (copy accept_unix.c accept.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy bind_unix.c bind.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy channels_unix.c channels.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy close_unix.c close.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy connect_unix.c connect.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy dup_unix.c dup.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy envir_unix.c envir.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy errmsg_unix.c errmsg.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy getpeername_unix.c getpeername.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy getpid_unix.c getpid.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy gettimeofday_unix.c gettimeofday.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy getsockname_unix.c getsockname.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy isatty_unix.c isatty.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy link_unix.c link.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy listen_unix.c listen.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy lockf_unix.c lockf.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy lseek_unix.c lseek.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy mmap_unix.c mmap.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy open_unix.c open.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy pipe_unix.c pipe.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy read_unix.c read.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy readlink_unix.c readlink.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy realpath_unix.c realpath.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy select_unix.c select.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy sendrecv_unix.c sendrecv.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy shutdown_unix.c shutdown.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy sleep_unix.c sleep.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy socket_unix.c socket.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy socketpair_unix.c socketpair.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy sockopt_unix.c sockopt.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy stat_unix.c stat.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy symlink_unix.c symlink.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy times_unix.c times.c)) (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy truncate_unix.c truncate.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy unixsupport_unix.c unixsupport.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule
- (action (copy utimes_unix.c utimes.c))
- (enabled_if (<> %{os_type} "Win32")))
-(rule (action (copy write_unix.c write.c)) (enabled_if (<> %{os_type} "Win32")))
+ (action
+  (copy accept_unix.c accept.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
 
 (rule
- (action (copy accept_win32.c accept.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy bind_win32.c bind.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy bind_unix.c bind.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy channels_win32.c channels.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy close_win32.c close.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy channels_unix.c channels.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy connect_win32.c connect.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy dup_win32.c dup.c)) (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy envir_win32.c envir.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy close_unix.c close.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy errmsg_win32.c errmsg.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy connect_unix.c connect.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy getpeername_win32.c getpeername.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy dup_unix.c dup.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy getpid_win32.c getpid.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy envir_unix.c envir.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy gettimeofday_win32.c gettimeofday.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy errmsg_unix.c errmsg.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy getsockname_win32.c getsockname.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy getpeername_unix.c getpeername.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy isatty_win32.c isatty.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy link_win32.c link.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy getpid_unix.c getpid.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy listen_win32.c listen.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy lockf_win32.c lockf.c)) (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy lseek_win32.c lseek.c)) (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy mmap_win32.c mmap.c)) (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy open_win32.c open.c)) (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy pipe_win32.c pipe.c)) (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy read_win32.c read.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy gettimeofday_unix.c gettimeofday.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy readlink_win32.c readlink.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy getsockname_unix.c getsockname.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy realpath_win32.c realpath.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy isatty_unix.c isatty.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy select_win32.c select.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy link_unix.c link.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy sendrecv_win32.c sendrecv.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy listen_unix.c listen.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy shutdown_win32.c shutdown.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy sleep_win32.c sleep.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy lockf_unix.c lockf.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy socket_win32.c socket.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy lseek_unix.c lseek.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy socketpair_win32.c socketpair.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy mmap_unix.c mmap.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy sockopt_win32.c sockopt.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy stat_win32.c stat.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy open_unix.c open.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy symlink_win32.c symlink.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy times_win32.c times.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy pipe_unix.c pipe.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy truncate_win32.c truncate.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy read_unix.c read.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy unixsupport_win32.c unixsupport.c))
- (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy readlink_unix.c readlink.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
 (rule
- (action (copy utimes_win32.c utimes.c))
- (enabled_if (= %{os_type} "Win32")))
-(rule (action (copy write_win32.c write.c)) (enabled_if (= %{os_type} "Win32")))
+ (action
+  (copy realpath_unix.c realpath.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy select_unix.c select.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy sendrecv_unix.c sendrecv.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy shutdown_unix.c shutdown.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy sleep_unix.c sleep.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy socket_unix.c socket.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy socketpair_unix.c socketpair.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy sockopt_unix.c sockopt.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy stat_unix.c stat.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy symlink_unix.c symlink.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy times_unix.c times.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy truncate_unix.c truncate.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy unixsupport_unix.c unixsupport.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy utimes_unix.c utimes.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy write_unix.c write.c))
+ (enabled_if
+  (<> %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy accept_win32.c accept.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy bind_win32.c bind.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy channels_win32.c channels.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy close_win32.c close.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy connect_win32.c connect.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy dup_win32.c dup.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy envir_win32.c envir.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy errmsg_win32.c errmsg.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy getpeername_win32.c getpeername.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy getpid_win32.c getpid.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy gettimeofday_win32.c gettimeofday.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy getsockname_win32.c getsockname.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy isatty_win32.c isatty.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy link_win32.c link.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy listen_win32.c listen.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy lockf_win32.c lockf.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy lseek_win32.c lseek.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy mmap_win32.c mmap.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy open_win32.c open.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy pipe_win32.c pipe.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy read_win32.c read.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy readlink_win32.c readlink.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy realpath_win32.c realpath.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy select_win32.c select.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy sendrecv_win32.c sendrecv.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy shutdown_win32.c shutdown.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy sleep_win32.c sleep.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy socket_win32.c socket.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy socketpair_win32.c socketpair.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy sockopt_win32.c sockopt.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy stat_win32.c stat.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy symlink_win32.c symlink.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy times_win32.c times.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy truncate_win32.c truncate.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy unixsupport_win32.c unixsupport.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy utimes_win32.c utimes.c))
+ (enabled_if
+  (= %{os_type} "Win32")))
+
+(rule
+ (action
+  (copy write_win32.c write.c))
+ (enabled_if
+  (= %{os_type} "Win32")))

--- a/parsing/dune
+++ b/parsing/dune
@@ -19,29 +19,35 @@
 
 (rule
  (targets camlinternalMenhirLib.ml)
- (mode    fallback)
- (action  (copy# ../boot/menhir/menhirLib.ml %{targets})))
+ (mode fallback)
+ (action
+  (copy# ../boot/menhir/menhirLib.ml %{targets})))
 
 (rule
  (targets camlinternalMenhirLib.mli)
- (mode    fallback)
- (action  (copy# ../boot/menhir/menhirLib.mli %{targets})))
+ (mode fallback)
+ (action
+  (copy# ../boot/menhir/menhirLib.mli %{targets})))
 
 (rule
  (targets parser.ml)
- (mode    fallback)
- (deps    (:dep ../boot/menhir/parser.ml))
+ (mode fallback)
+ (deps
+  (:dep ../boot/menhir/parser.ml))
  (action
-   (with-stdout-to %{targets}
-     (bash "cat %{dep} | sed 's/MenhirLib/CamlinternalMenhirLib/g'"))))
+  (with-stdout-to
+   %{targets}
+   (bash "cat %{dep} | sed 's/MenhirLib/CamlinternalMenhirLib/g'"))))
 
 (rule
  (targets parser.mli)
- (mode    fallback)
- (deps    (:dep ../boot/menhir/parser.mli))
+ (mode fallback)
+ (deps
+  (:dep ../boot/menhir/parser.mli))
  (action
-   (with-stdout-to %{targets}
-     (bash "cat %{dep} | sed 's/MenhirLib/CamlinternalMenhirLib/g'"))))
+  (with-stdout-to
+   %{targets}
+   (bash "cat %{dep} | sed 's/MenhirLib/CamlinternalMenhirLib/g'"))))
 
 (ocamllex
  (modules lexer)

--- a/runtime/caml/dune
+++ b/runtime/caml/dune
@@ -14,16 +14,19 @@
 
 (rule
  (targets jumptbl.h)
- (mode    fallback)
- (deps (:h instruct.h))
+ (mode fallback)
+ (deps
+  (:h instruct.h))
  (action
-   (with-stdout-to %{targets}
-     (bash "cat %{h} | tr -d '\\r' | \
-            sed -n -e '/^  /s/ \\([A-Z]\\)/ \\&\\&lbl_\\1/gp' -e '/^}/q'"))))
+  (with-stdout-to
+   %{targets}
+   (bash
+    "cat %{h} | tr -d '\\r' | sed -n -e '/^  /s/ \\([A-Z]\\)/ \\&\\&lbl_\\1/gp' -e '/^}/q'"))))
 
 (rule
  (targets version.h)
- (mode    fallback)
+ (mode fallback)
  (action
-   (with-stdout-to %{targets}
-     (run %{dep:../../tools/make-version-header.sh} %{dep:../../VERSION}))))
+  (with-stdout-to
+   %{targets}
+   (run %{dep:../../tools/make-version-header.sh} %{dep:../../VERSION}))))

--- a/runtime/dune
+++ b/runtime/dune
@@ -14,61 +14,137 @@
 
 (rule
  (targets primitives prims.c)
- (mode    fallback)
+ (mode fallback)
  (deps
-   ; matches the line structure of files in gen_primitives.sh
-   alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c intern.c
-     interp.c ints.c io.c
-   lexing.c md5.c meta.c memprof.c obj.c parsing.c signals.c str.c sys.c
-     callback.c weak.c
-   finalise.c domain.c platform.c fiber.c memory.c startup_aux.c
-     runtime_events.c sync.c
-   dynlink.c backtrace_byt.c backtrace.c afl.c bigarray.c prng.c)
+  ; matches the line structure of files in gen_primitives.sh
+  alloc.c
+  array.c
+  compare.c
+  extern.c
+  floats.c
+  gc_ctrl.c
+  hash.c
+  intern.c
+  interp.c
+  ints.c
+  io.c
+  lexing.c
+  md5.c
+  meta.c
+  memprof.c
+  obj.c
+  parsing.c
+  signals.c
+  str.c
+  sys.c
+  callback.c
+  weak.c
+  finalise.c
+  domain.c
+  platform.c
+  fiber.c
+  memory.c
+  startup_aux.c
+  runtime_events.c
+  sync.c
+  dynlink.c
+  backtrace_byt.c
+  backtrace.c
+  afl.c
+  bigarray.c
+  prng.c)
  (action
-   (progn
-     (run %{dep:gen_primitives.sh} primitives %{deps})
-     (with-stdout-to prims.c (run %{dep:gen_primsc.sh} primitives %{deps})))))
+  (progn
+   (run %{dep:gen_primitives.sh} primitives %{deps})
+   (with-stdout-to
+    prims.c
+    (run %{dep:gen_primsc.sh} primitives %{deps})))))
 
 (rule
  (targets libcamlrun.a)
- (mode    fallback)
+ (mode fallback)
  (deps
-   ../Makefile.config
-   ../Makefile.build_config
-   ../Makefile.config_if_required
-   ../Makefile.common Makefile
-   (glob_files caml/*.h)
-   ; matches the line structure of files in Makefile/BYTECODE_C_SOURCES
-   interp.c misc.c fix_code.c startup_aux.c startup_byt.c freelist.c
-     major_gc.c
-   minor_gc.c memory.c alloc.c roots_byt.c globroots.c fail_byt.c signals.c
-   signals_byt.c printexc.c backtrace_byt.c backtrace.c compare.c ints.c
-   floats.c str.c array.c io.c extern.c intern.c hash.c sys.c meta.c parsing.c
-     gc_ctrl.c  md5.c obj.c
-   lexing.c callback.c debugger.c weak.c compact.c finalise.c custom.c dynlink.c
-   afl.c unix.c win32.c bigarray.c main.c memprof.c domain.c
-   skiplist.c codefrag.c
- )
+  ../Makefile.config
+  ../Makefile.build_config
+  ../Makefile.config_if_required
+  ../Makefile.common
+  Makefile
+  (glob_files caml/*.h)
+  ; matches the line structure of files in Makefile/BYTECODE_C_SOURCES
+  interp.c
+  misc.c
+  fix_code.c
+  startup_aux.c
+  startup_byt.c
+  freelist.c
+  major_gc.c
+  minor_gc.c
+  memory.c
+  alloc.c
+  roots_byt.c
+  globroots.c
+  fail_byt.c
+  signals.c
+  signals_byt.c
+  printexc.c
+  backtrace_byt.c
+  backtrace.c
+  compare.c
+  ints.c
+  floats.c
+  str.c
+  array.c
+  io.c
+  extern.c
+  intern.c
+  hash.c
+  sys.c
+  meta.c
+  parsing.c
+  gc_ctrl.c
+  md5.c
+  obj.c
+  lexing.c
+  callback.c
+  debugger.c
+  weak.c
+  compact.c
+  finalise.c
+  custom.c
+  dynlink.c
+  afl.c
+  unix.c
+  win32.c
+  bigarray.c
+  main.c
+  memprof.c
+  domain.c
+  skiplist.c
+  codefrag.c)
  (action
-   (progn
-     (bash "touch .depend") ; hack.
-     (run make %{targets} COMPUTE_DEPS=false)
-     (bash "rm .depend"))))
+  (progn
+   (bash "touch .depend") ; hack.
+   (run make %{targets} COMPUTE_DEPS=false)
+   (bash "rm .depend"))))
 
 ;; HACK
+
 (library
-  (name runtime)
-  (modes byte)
-  (wrapped false)
-  (modules runtime)
-  (foreign_archives camlrun)
-  (flags (-nostdlib -nopervasives))
-  (library_flags -cclib "-I runtime"))
+ (name runtime)
+ (modes byte)
+ (wrapped false)
+ (modules runtime)
+ (foreign_archives camlrun)
+ (flags
+  (-nostdlib -nopervasives))
+ (library_flags -cclib "-I runtime"))
 
 (rule
-  (targets libruntime_stubs.a)
-  (action (copy libcamlrun.a %{targets})))
+ (targets libruntime_stubs.a)
+ (action
+  (copy libcamlrun.a %{targets})))
 
 (rule
-  (targets runtime.ml)
-  (action (write-file %{targets} "let linkme = ()")))
+ (targets runtime.ml)
+ (action
+  (write-file %{targets} "let linkme = ()")))

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -16,14 +16,13 @@
  (name stdlib)
  (libraries dune_support)
  (stdlib
-   (exit_module std_exit)
-   (internal_modules Camlinternal*)
-   (modules_before_stdlib
-     camlinternalFormatBasics))
- (flags (:standard -w -9 -nolabels -open New_predef_types))
+  (exit_module std_exit)
+  (internal_modules Camlinternal*)
+  (modules_before_stdlib camlinternalFormatBasics))
+ (flags
+  (:standard -w -9 -nolabels -open New_predef_types))
  (preprocess
-   (per_module
-    ((action
-      (run awk -f %{dep:expand_module_aliases.awk} %{input-file}))
-      stdlib)
-     )))
+  (per_module
+   ((action
+     (run awk -f %{dep:expand_module_aliases.awk} %{input-file}))
+    stdlib))))

--- a/stdlib/dune_support/dune
+++ b/stdlib/dune_support/dune
@@ -1,6 +1,6 @@
 (library
  (name dune_support)
  (modules_without_implementation new_predef_types)
- (flags (:standard -nostdlib -nopervasives))
- (wrapped false)
-)
+ (flags
+  (:standard -nostdlib -nopervasives))
+ (wrapped false))

--- a/tools/dune
+++ b/tools/dune
@@ -13,13 +13,13 @@
 ;**************************************************************************
 
 (executables
- (names   make_opcodes cvt_emit)
+ (names make_opcodes cvt_emit)
  (modules make_opcodes cvt_emit))
 
 (ocamllex
  (modules make_opcodes)
- (mode    fallback))
+ (mode fallback))
 
 (ocamllex
  (modules cvt_emit)
- (mode    fallback))
+ (mode fallback))

--- a/toplevel/dune
+++ b/toplevel/dune
@@ -17,81 +17,92 @@
 (library
  (name ocamltoplevel)
  (wrapped false)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries stdlib ocamlcommon ocamlbytecomp)
  (modules :standard \ topstart expunge))
 
 (executable
  (name topstart)
  (modes byte)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries ocamlbytecomp ocamlcommon ocamltoplevel runtime stdlib)
  (modules topstart))
 
 (executable
  (name expunge)
  (modes byte)
- (flags (:standard -principal -nostdlib))
+ (flags
+  (:standard -principal -nostdlib))
  (libraries ocamlbytecomp ocamlcommon runtime stdlib)
  (modules expunge))
 
 (rule
  (targets ocaml.byte)
- (action (run %{ocaml_where}/expunge %{dep:topstart.exe} %{targets}
-                    ; FIXME: inlined $(STDLIB_MODULES) ... minus Labels ones ...
-                    stdlib__Arg
-                    stdlib__Array
-                    ; stdlib__ArrayLabels
-                    stdlib__Bigarray
-                    stdlib__Buffer
-                    stdlib__Bytes
-                    ; stdlib__BytesLabels
-                    stdlib__Callback
-                    camlinternalFormat
-                    camlinternalFormatBasics
-                    camlinternalLazy
-                    camlinternalMod
-                    camlinternalOO
-                    stdlib__Char
-                    stdlib__Complex
-                    stdlib__Digest
-                    stdlib__Either
-                    stdlib__Ephemeron
-                    stdlib__Filename
-                    stdlib__Float
-                    stdlib__Format
-                    stdlib__Gc
-                    stdlib__Hashtbl
-                    stdlib__Int32
-                    stdlib__Int64
-                    stdlib__Lazy
-                    stdlib__Lexing
-                    stdlib__List
-                    ; stdlib__ListLabels
-                    stdlib__Map
-                    stdlib__Marshal
-                    ; stdlib__MoreLabels
-                    stdlib__Nativeint
-                    stdlib__Obj
-                    stdlib__Oo
-                    stdlib__Option
-                    stdlib__Parsing
-                    stdlib__Printexc
-                    stdlib__Printf
-                    stdlib__Queue
-                    stdlib__Random
-                    stdlib__Result
-                    stdlib__Scanf
-                    stdlib__Seq
-                    stdlib__Set
-                    stdlib__Stack
-                    ; stdlib__StdLabels
-                    stdlib
-                    stdlib__String
-                    ; stdlib__StringLabels
-                    stdlib__Sys
-                    stdlib__Uchar
-                    stdlib__Weak
-                    ; the rest
-                    outcometree topdirs topeval toploop topmain topcommon
- )))
+ (action
+  (run
+   %{ocaml_where}/expunge
+   %{dep:topstart.exe}
+   %{targets}
+   ; FIXME: inlined $(STDLIB_MODULES) ... minus Labels ones ...
+   stdlib__Arg
+   stdlib__Array
+   ; stdlib__ArrayLabels
+   stdlib__Bigarray
+   stdlib__Buffer
+   stdlib__Bytes
+   ; stdlib__BytesLabels
+   stdlib__Callback
+   camlinternalFormat
+   camlinternalFormatBasics
+   camlinternalLazy
+   camlinternalMod
+   camlinternalOO
+   stdlib__Char
+   stdlib__Complex
+   stdlib__Digest
+   stdlib__Either
+   stdlib__Ephemeron
+   stdlib__Filename
+   stdlib__Float
+   stdlib__Format
+   stdlib__Gc
+   stdlib__Hashtbl
+   stdlib__Int32
+   stdlib__Int64
+   stdlib__Lazy
+   stdlib__Lexing
+   stdlib__List
+   ; stdlib__ListLabels
+   stdlib__Map
+   stdlib__Marshal
+   ; stdlib__MoreLabels
+   stdlib__Nativeint
+   stdlib__Obj
+   stdlib__Oo
+   stdlib__Option
+   stdlib__Parsing
+   stdlib__Printexc
+   stdlib__Printf
+   stdlib__Queue
+   stdlib__Random
+   stdlib__Result
+   stdlib__Scanf
+   stdlib__Seq
+   stdlib__Set
+   stdlib__Stack
+   ; stdlib__StdLabels
+   stdlib
+   stdlib__String
+   ; stdlib__StringLabels
+   stdlib__Sys
+   stdlib__Uchar
+   stdlib__Weak
+   ; the rest
+   outcometree
+   topdirs
+   topeval
+   toploop
+   topmain
+   topcommon)))

--- a/utils/dune
+++ b/utils/dune
@@ -14,32 +14,33 @@
 
 (rule
  (targets config.ml)
- (mode    fallback)
- (deps    config.generated.ml config.common.ml)
+ (mode fallback)
+ (deps config.generated.ml config.common.ml)
  (action
-   (with-stdout-to %{targets}
-     (system "cat %{deps}"))))
+  (with-stdout-to
+   %{targets}
+   (system "cat %{deps}"))))
 
 (rule
  (targets domainstate.ml)
- (mode    fallback)
- (deps    (:conf ../Makefile.config)
-          (:c domainstate.ml.c)
-          (:tbl ../runtime/caml/domain_state.tbl))
+ (mode fallback)
+ (deps
+  (:conf ../Makefile.config)
+  (:c domainstate.ml.c)
+  (:tbl ../runtime/caml/domain_state.tbl))
  (action
-   (with-stdout-to %{targets}
-     (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"
-       ))))
+  (with-stdout-to
+   %{targets}
+   (bash "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"))))
 
 (rule
  (targets domainstate.mli)
- (mode    fallback)
- (deps    (:conf ../Makefile.config)
-          (:c domainstate.mli.c)
-          (:tbl ../runtime/caml/domain_state.tbl))
+ (mode fallback)
+ (deps
+  (:conf ../Makefile.config)
+  (:c domainstate.mli.c)
+  (:tbl ../runtime/caml/domain_state.tbl))
  (action
-   (with-stdout-to %{targets}
-     (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"
-       ))))
+  (with-stdout-to
+   %{targets}
+   (bash "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"))))


### PR DESCRIPTION
# Context

After a long discussion on Zulip, there was consensus for formatting new files (selectively) with ocp-indent. 
This PR adds the necessary dune rules to run `ocp-indent` when running `dune fmt`.

# Description

This PR:
1. Configures dune to not use `ocamlformat` by default
2. The first commit runs `dune fmt`, which formats all dune files. This can be removed, but I actually found the new files nicer to read and more uniform
3. The second commit configures `dune fmt` to run `ocp-indent` based on a list of dune dependencies in `.ocp-indent-list`. If the file isn't in this list, it won't get formatted. Currently, the list is empty
4. The final commit adds `.git-blame-ignore-revs` which allows `git blame` to ignore future commits that only make formatting changes. I added the second commit here
5. The final commit adds `dune fmt --check` to the hygiene check. I'm not too sure of the changes here, necessarily the change that installs `opam, dune`, etc in the workflow. How are runner dependencies managed?