### PR TITLE
Add FreeBSD frame pointer support

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ Working version
 
 ### Runtime system:
 
+- #14486: Add FreeBSD frame pointers support for AMD64 and ARM64.
+  Document the usage of pmcstat and dtrace for generating profiling
+  information.
+  (Tim McGilchrist, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1019,7 +1019,7 @@ let begin_assembly() =
 
   emit_named_text_section (Compilenv.make_symbol (Some "code_begin"));
   emit_global_label "code_begin";
-  if system = S_macosx then I.nop (); (* PR#4690 *)
+  if system = S_macosx || system = S_freebsd then I.nop (); (* PR#4690 *)
   ()
 
 let end_assembly() =

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -22,6 +22,8 @@ open Format
 
 let macosx = (Config.system = "macosx")
 
+let freebsd = (Config.system = "freebsd")
+
 let top_bits_ignore = (Config.system = "linux")
 
 (* Machine-specific command-line options *)

--- a/asmcomp/arm64/arch.mli
+++ b/asmcomp/arm64/arch.mli
@@ -19,6 +19,7 @@
 (* Specific operations for the ARM processor, 64-bit mode *)
 
 val macosx : bool
+val freebsd : bool
 
 val top_bits_ignore : bool
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -1260,7 +1260,7 @@ let begin_assembly() =
      Alignment is needed to avoid linker warnings for
      shared_startup__code_{begin,end} (e.g. tests/lib-dynlink-pr4839).
    *)
-  if macosx then begin
+  if macosx || freebsd then begin
     `	nop\n`;
     `	.align	3\n`
   end;

--- a/configure
+++ b/configure
@@ -23698,7 +23698,8 @@ fi
 if test x"$enable_frame_pointers" = "xyes"
 then :
   case $target in #(
-  x86_64-*-linux*|x86_64-*-darwin*|aarch64-*-linux*|aarch64-*-darwin*) :
+  x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|aarch64-*-linux*| \
+     aarch64-*-darwin*|aarch64-*-freebsd*) :
     case $ocaml_cc_vendor in #(
   clang-*|gcc-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/configure.ac
+++ b/configure.ac
@@ -2772,7 +2772,8 @@ AS_IF([$native_compiler],
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
   [AS_CASE([$target],
-    [x86_64-*-linux*|x86_64-*-darwin*|aarch64-*-linux*|aarch64-*-darwin*],
+    [x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|aarch64-*-linux*| \
+     aarch64-*-darwin*|aarch64-*-freebsd*],
      [AS_CASE([$ocaml_cc_vendor],
         [clang-*|gcc-*],
          [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/manual/src/cmds/profil.etex
+++ b/manual/src/cmds/profil.etex
@@ -369,6 +369,74 @@ $ codesign -s - -v -f --entitlements =(echo -n
 
 For more details on entitlements and codesign consult Apple's documentation.
 
+\section{s:ocamlprof-freebsd}{Time profiling with FreeBSD pmcstat and dtrace}
+
+FreeBSD provides \texttt{pmcstat}, part of the hwpmc (Hardware Performance Monitoring Counters) framework, and \texttt{dtrace}, a comprehensive dynamic tracing framework ported from Solaris. Both support sampling-based performance profiling broadly equivalent to Linux's \texttt{perf} tool.
+
+The same prerequisites hold for time profiling with FreeBSD \texttt{pmcstat} or \texttt{dtrace} as for Linux \texttt{perf}. Consult ``Background'' (~\ref{s:ocamlprof-time-profiling-background}) from the previous section for an explanation of call graphs and follow the setup from ``Compiling for Profiling'' (~\ref{s:ocamlprof-compiling-perf}).
+
+Frame pointer support for OCaml on FreeBSD AMD64 and ARM64 is available from OCaml 5.5.
+
+The basic \texttt{pmcstat} command for profiling with call graphs is:
+
+\begin{verbatim}
+        pmcstat -S CPU_CYCLES -O profile.pmc -- PROGRAM
+\end{verbatim}
+
+The \texttt{-S CPU\_CYCLES} option selects CPU cycle sampling (use \texttt{pmcstat -L} to list available events on your system). The \texttt{-O profile.pmc} specifies the output file for the raw sampling data.
+
+\subsection{s:ocamlprof-freebsd-report}{Displaying profiling information}
+
+To generate a call graph report from the captured data:
+
+\begin{verbatim}
+        pmcstat -R profile.pmc -z16 -G profile.graph
+\end{verbatim}
+
+The \texttt{-z16} option sets the call graph depth to 16 frames. The \texttt{-G} option outputs a call graph suitable for processing with \texttt{gprof2dot} or similar tools.
+
+For a flat profile showing which functions consumed the most CPU time:
+
+\begin{verbatim}
+        pmcstat -R profile.pmc -g
+\end{verbatim}
+
+To generate output compatible with flame graph tools:
+
+\begin{verbatim}
+        pmcstat -R profile.pmc -F profile.stacks
+\end{verbatim}
+
+To generate flame graphs from pmcstat output, use the \texttt{stackcollapse-pmc.pl} script from the FlameGraph repository:
+
+\begin{verbatim}
+        git clone https://github.com/brendangregg/FlameGraph
+        cd FlameGraph
+        stackcollapse-pmc.pl profile.stacks | flamegraph.pl > flamegraph.svg
+\end{verbatim}
+
+For more information on \texttt{pmcstat}, consult \texttt{pmcstat(8)} and the FreeBSD Handbook chapter on performance monitoring.
+
+The basic \texttt{dtrace} command for time profiling is:
+
+\begin{verbatim}
+        dtrace -x ustackframes=100 -n 'profile-97 /pid == $target && arg1/ {
+            @[ustack()] = count();
+        } tick-60s { exit(0); }' -c PROGRAM -o out.stacks
+\end{verbatim}
+
+The \texttt{-x ustackframes=100} option sets the maximum stack depth. The \texttt{profile-97} probe samples at 97 Hz, and \texttt{arg1} filters for user-level stacks. The \texttt{-c} option runs and traces the specified program.
+
+To generate flame graphs from DTrace output, use the \texttt{stackcollapse.pl} script from the FlameGraph repository:
+
+\begin{verbatim}
+        git clone https://github.com/brendangregg/FlameGraph
+        cd FlameGraph
+        ./stackcollapse.pl out.stacks | ./flamegraph.pl > flamegraph.svg
+\end{verbatim}
+
+For more information on DTrace, consult \texttt{dtrace(1)} and the DTrace Guide.
+
 \section{s:ocamlprof-glossary}{Glossary}
 
 The following terminology is used in this chapter of the manual.


### PR DESCRIPTION
This PR adds support for building OCaml with frame pointers on FreeBSD AMD64 and ARM64 and adds a brief section to the manual about using pmcstats and dtrace for profiling.

The main interesting piece is I needed to add nop padding similar to #4690 to avoid two symbols having the same address which confuses the execinfo function `backtrace_symbol` for looking up backtrace symbols. In particular the first symbol in a module would clash with the `module.entry` symbol breaking the frame-pointer tests.