### PR TITLE
Add `String.drop_prefix` and `String.drop_suffix`

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,7 +25,7 @@ Working version
 ### Standard library:
 
 - #14487: Add String.drop_{prefix,suffix}
-  (Michael Neumann, review by Léo)
+  (Michael Neumann, review by Léo Andrès)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -25,7 +25,7 @@ Working version
 ### Standard library:
 
 - #14487: Add String.drop_{prefix,suffix}
-  (Michael Neumann, review by ???)
+  (Michael Neumann, review by Léo)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Working version
 
 ### Standard library:
 
+- #14487: Add String.drop_{prefix,suffix}
+  (Michael Neumann, review by ???)
+
 ### Other libraries:
 
 ### Tools:

--- a/Changes
+++ b/Changes
@@ -25,7 +25,7 @@ Working version
 ### Standard library:
 
 - #14487: Add String.drop_{prefix,suffix}
-  (Michael Neumann, review by Léo Andrès)
+  (Michael Neumann, review by Léo Andrès, review/doc by Nicolás Ojeda Bär)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -25,7 +25,7 @@ Working version
 ### Standard library:
 
 - #14487: Add String.drop_{prefix,suffix}
-  (Michael Neumann, review by Léo Andrès, review/doc by Nicolás Ojeda Bär)
+  (Michael Neumann, review by Léo Andrès, Nicolás Ojeda Bär and Gabriel Scherer)
 
 ### Other libraries:
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -512,21 +512,19 @@ let take_last n s = subrange ~first:(length s - n) s
 let drop_last n s = subrange ~last:(length s - n - 1) s
 let cut_last n s = (drop_last n s, take_last n s)
 
-let drop_prefix ~prefix =
-  let len_pre = length prefix in
-  let starts_with_pre = starts_with ~prefix:prefix in
-  fun s ->
-    if starts_with_pre s
-    then Some (sub s len_pre (length s - len_pre))
-    else None
+let drop_prefix ~prefix s =
+  let drop_pre = drop_first (length prefix) in
+  let starts_with_pre = starts_with ~prefix in
+  if starts_with_pre s
+  then Some (drop_pre s)
+  else None
 
-let drop_suffix ~suffix =
-  let len_suf = length suffix in
-  let ends_with_suf = ends_with ~suffix:suffix in
-  fun s ->
-    if ends_with_suf s
-    then Some (sub s 0 (length s - len_suf))
-    else None
+let drop_suffix ~suffix s =
+  let drop_suf = drop_last (length suffix) in
+  let ends_with_suf = ends_with ~suffix in
+  if ends_with_suf s
+  then Some (drop_suf s)
+  else None
 
 (* Splitting with predicates *)
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -513,17 +513,13 @@ let drop_last n s = subrange ~last:(length s - n - 1) s
 let cut_last n s = (drop_last n s, take_last n s)
 
 let drop_prefix ~prefix s =
-  let drop_pre = drop_first (length prefix) in
-  let starts_with_pre = starts_with ~prefix in
-  if starts_with_pre s
-  then Some (drop_pre s)
+  if starts_with ~prefix s
+  then Some (drop_first (length prefix) s)
   else None
 
 let drop_suffix ~suffix s =
-  let drop_suf = drop_last (length suffix) in
-  let ends_with_suf = ends_with ~suffix in
-  if ends_with_suf s
-  then Some (drop_suf s)
+  if ends_with ~suffix s
+  then Some (drop_last (length suffix) s)
   else None
 
 (* Splitting with predicates *)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -512,6 +512,22 @@ let take_last n s = subrange ~first:(length s - n) s
 let drop_last n s = subrange ~last:(length s - n - 1) s
 let cut_last n s = (drop_last n s, take_last n s)
 
+let drop_prefix ~prefix =
+  let len_pre = length prefix in
+  let starts_with_pre = starts_with ~prefix:prefix in
+  fun s ->
+    if starts_with_pre s
+    then Some (sub s len_pre (length s - len_pre))
+    else None
+
+let drop_suffix ~suffix =
+  let len_suf = length suffix in
+  let ends_with_suf = ends_with ~suffix:suffix in
+  fun s ->
+    if ends_with_suf s
+    then Some (sub s 0 (length s - len_suf))
+    else None
+
 (* Splitting with predicates *)
 
 let take_first_while sat s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -241,6 +241,24 @@ val drop_last : int -> string -> string
 
     @since 5.5 *)
 
+val drop_prefix :
+  prefix (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  string -> string option
+(** [drop_prefix ][~prefix s] is [Some s] with [prefix] removed
+    from the beginning of [s] if [s] starts with [prefix].
+    Else, [None] is returned.
+
+    @since 5.6 *)
+
+val drop_suffix :
+  suffix (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  string -> string option
+(** [drop_suffix ][~suffix s] is [Some s] with [suffix] removed
+    from the end of [s] if [s] ends with [suffix].
+    Else, [None] is returned.
+
+    @since 5.6 *)
+
 val cut_first : int -> string -> string * string
 (** [cut_first n v] is [(take_first n v, drop_first n v)].
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -244,18 +244,16 @@ val drop_last : int -> string -> string
 val drop_prefix :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string ->
   string -> string option
-(** [drop_prefix ][~prefix s] is [Some s] with [prefix] removed
-    from the beginning of [s] if [s] starts with [prefix].
-    Else, [None] is returned.
+(** [drop_prefix ][~prefix s] is [Some t] if [s = prefix ^ t].
+    Otherwise, it is [None].
 
     @since 5.6 *)
 
 val drop_suffix :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string ->
   string -> string option
-(** [drop_suffix ][~suffix s] is [Some s] with [suffix] removed
-    from the end of [s] if [s] ends with [suffix].
-    Else, [None] is returned.
+(** [drop_suffix ][~suffix s] is [Some t] if [s = t ^ suffix].
+    Otherwise, it is [None].
 
     @since 5.6 *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -241,6 +241,24 @@ val drop_last : int -> string -> string
 
     @since 5.5 *)
 
+val drop_prefix :
+  prefix (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  string -> string option
+(** [drop_prefix ][~prefix s] is [Some s] with [prefix] removed
+    from the beginning of [s] if [s] starts with [prefix].
+    Else, [None] is returned.
+
+    @since 5.6 *)
+
+val drop_suffix :
+  suffix (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  string -> string option
+(** [drop_suffix ][~suffix s] is [Some s] with [suffix] removed
+    from the end of [s] if [s] ends with [suffix].
+    Else, [None] is returned.
+
+    @since 5.6 *)
+
 val cut_first : int -> string -> string * string
 (** [cut_first n v] is [(take_first n v, drop_first n v)].
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -244,18 +244,16 @@ val drop_last : int -> string -> string
 val drop_prefix :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string ->
   string -> string option
-(** [drop_prefix ][~prefix s] is [Some s] with [prefix] removed
-    from the beginning of [s] if [s] starts with [prefix].
-    Else, [None] is returned.
+(** [drop_prefix ][~prefix s] is [Some t] if [s = prefix ^ t].
+    Otherwise, it is [None].
 
     @since 5.6 *)
 
 val drop_suffix :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string ->
   string -> string option
-(** [drop_suffix ][~suffix s] is [Some s] with [suffix] removed
-    from the end of [s] if [s] ends with [suffix].
-    Else, [None] is returned.
+(** [drop_suffix ][~suffix s] is [Some t] if [s = t ^ suffix].
+    Otherwise, it is [None].
 
     @since 5.6 *)
 

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -191,6 +191,24 @@ let () =
   assert (String.drop_last 2 "" = "");
   assert (String.drop_last 2 "a" = "");
   assert (String.drop_last 2 "ab" = "");
+  (* String.drop_prefix *)
+  assert (String.drop_prefix ~prefix:"foob" "foobarbaz" = Some "arbaz");
+  assert (String.drop_prefix ~prefix:"" "foobarbaz" = Some "foobarbaz");
+  assert (String.drop_prefix ~prefix:"" "" = Some "");
+  assert (String.drop_prefix ~prefix:"foobar" "bar" = None);
+  assert (String.drop_prefix ~prefix:"foo" "" = None);
+  assert (String.drop_prefix ~prefix:"fool" "foobar" = None);
+  assert (String.drop_prefix ~prefix:"baz" "foobarbaz" = None);
+  assert (String.drop_prefix ~prefix:"foo" "foofoofoo" = Some "foofoo");
+  (* String.drop_suffix *)
+  assert (String.drop_suffix ~suffix:"baz" "foobarbaz" = Some "foobar");
+  assert (String.drop_suffix ~suffix:"" "foobarbaz" = Some "foobarbaz");
+  assert (String.drop_suffix ~suffix:"" "" = Some "");
+  assert (String.drop_suffix ~suffix:"bar" "bar" = Some "");
+  assert (String.drop_suffix ~suffix:"foobar" "bar" = None);
+  assert (String.drop_suffix ~suffix:"foo" "" = None);
+  assert (String.drop_suffix ~suffix:"foo" "foobarbaz" = None);
+  assert (String.drop_suffix ~suffix:"foo" "foofoofoo" = Some "foofoo");
   (* String.cut_first *)
   assert (String.cut_first (-1) "" = ("", ""));
   assert (String.cut_first (-1) "a" = ("", "a"));


### PR DESCRIPTION
I'd also like to add `String.drop_suffix` and `String.replace_{prefix,suffix}` after discussion. I generally find them very useful, especially for scripting, e.g.:

* deleting a "> " prefix from quoted lines (Markdown parsing)
* deleting a leading "/" from a URL (to convert URL to a local path)
* deleting a trailing "/index.html" from a URL to get the "pretty" name

Similar functions exist in Ruby (`String#delete_prefix`, `String#delete_suffix`) and Elixir (`String.replace_prefix`, `String.replace_suffix`).

As I am quite new to OCaml, I am happy about any suggestion about improvements :)
