### PR TITLE
Correct includes in runtime headers

### DIFF
--- a/otherlibs/systhreads/caml/threads.h
+++ b/otherlibs/systhreads/caml/threads.h
@@ -16,7 +16,7 @@
 #ifndef CAML_THREADS_H
 #define CAML_THREADS_H
 
-#include "caml/config.h"
+#include <caml/misc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/otherlibs/unix/caml/socketaddr.h
+++ b/otherlibs/unix/caml/socketaddr.h
@@ -16,7 +16,7 @@
 #ifndef CAML_SOCKETADDR_H
 #define CAML_SOCKETADDR_H
 
-#include "caml/misc.h"
+#include <caml/mlvalues.h>
 
 #ifdef _WIN32
 

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -16,7 +16,7 @@
 #ifndef CAML_UNIXSUPPORT_H
 #define CAML_UNIXSUPPORT_H
 
-#include <caml/misc.h>
+#include <caml/mlvalues.h>
 
 #ifdef _WIN32 /* Windows */
 #define WIN32_LEAN_AND_MEAN

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -20,7 +20,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#include "misc.h"
+#include "mlvalues.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/sizeclasses.h
+++ b/runtime/caml/sizeclasses.h
@@ -4,6 +4,8 @@
 #define SIZECLASS_MAX 128
 #define NUM_SIZECLASSES 32
 
+#include <assert.h>
+#include <limits.h>
 typedef unsigned char sizeclass;
 static_assert(NUM_SIZECLASSES < (1 << (CHAR_BIT * sizeof(sizeclass))), "");
 

--- a/tools/gen_sizeclasses.ml
+++ b/tools/gen_sizeclasses.ml
@@ -94,6 +94,8 @@ let _ =
   printf "#define SIZECLASS_MAX %d\n" max_slot;
   printf "#define NUM_SIZECLASSES %d\n" (List.length sizes);
   printf {|
+#include <assert.h>
+#include <limits.h>
 typedef unsigned char sizeclass;
 static_assert(NUM_SIZECLASSES < (1 << (CHAR_BIT * sizeof(sizeclass))), "");
 


### PR DESCRIPTION
A conversation with @NickBarnes regarding #14421 spurred the idea that we should be testing whether each header can be included "singly". I've separated this out from the test which checks that, as it'd be nicer to open the PR for that as a "test which currently passes". This PR:
- Corrects `threads.h` to include `misc.h` instead of `config.h`. It had `config.h` in order to have the definition of `uintnat`, but it should really include `misc.h` in order to have `CAMLextern` as well.
- Corrects `socketaddr.h`, `unixsupport.h` and `domain_state.h` to use `mlvalues.h` instead of `misc.h` because they all use the `value` type.
- Corrects `sizeclasses.h` to include `<assert.h>` and `<limits.h>` both of which are required by the assertion in the header. There are more things that should be corrected in that header as well (including whether it should even be in the `caml/` directory), but @NickBarnes has separate work for that, so I've included only those two headers here as the minimal change needed to pass my "can this header be `#include`'d on its own" test.

(note that most headers rather fundamentally include `misc.h`, `mlvalues.h` included, and `misc.h` itself rather fundamentally includes `config.h`, so it's only necessary to include one of them)