### PR TITLE
invert misc and domain includes in memory.h

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -24,8 +24,8 @@
 #include "major_gc.h"
 #include "minor_gc.h"
 #endif /* CAML_INTERNALS */
-#include "domain.h"
 #include "misc.h"
+#include "domain.h"
 #include "mlvalues.h"
 #include "signals.h"
 


### PR DESCRIPTION
in `runtime/caml/memory.h`, a series of includes looks like
```
#include "domain.h"
#include "misc.h"
#include "mlvalues.h"
#include "signals.h"
```

it turns out `domain.h` uses `CAMLalloc_point_here` which is defined in `misc.h`

Would it make more sense then to swap the include order?