### PR TITLE
Fix Obj.dup on closures

### DIFF
--- a/Changes
+++ b/Changes
@@ -78,6 +78,9 @@ Working version
 
 ### Bug fixes:
 
+- #14492: Fix Obj.dup on closures.
+  (Mark Shinwell and Nick Barnes, review by Gabriel Scherer)
+
 OCaml 5.5.0
 -----------
 

--- a/Changes
+++ b/Changes
@@ -79,7 +79,7 @@ Working version
 ### Bug fixes:
 
 - #14492: Fix Obj.dup on closures.
-  (Mark Shinwell and Nick Barnes, review by Gabriel Scherer)
+  (Mark Shinwell and Nick Barnes, review by Gabriel Scherer and Damien Doligez)
 
 OCaml 5.5.0
 -----------

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -130,39 +130,37 @@ CAMLprim value caml_obj_block(value tag, value size)
   return res;
 }
 
-CAMLprim value caml_obj_dup(value arg);
-
 CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
 {
   CAMLparam2 (new_tag_v, arg);
   CAMLlocal1 (res);
 
-  mlsize_t sz = Wosize_val(arg);
   tag_t new_tag = (tag_t)Long_val(new_tag_v);
   tag_t existing_tag = Tag_val(arg);
 
-  if (existing_tag == Infix_tag) {
-    if (new_tag != Infix_tag) {
-      caml_failwith("Cannot change tag of an existing closure.");
+  if (new_tag != existing_tag) {
+    if (new_tag == Infix_tag) {
+      caml_failwith ("Cannot change non-infix block to infix.");
     }
+    if (existing_tag == Infix_tag) {
+      caml_failwith ("Cannot change infix block to non-infix.");
+    }
+    /* Could also check for:
+       - changing non-scannable to scannable
+       - changing closure to non-closure scannnable
+       and maybe others, but we leave these as discipline for the caller. */
+  }
+
+  if (existing_tag == Infix_tag) {
     mlsize_t infix_offset = Infix_offset_val(arg);
-    CAMLassert (infix_offset > 0); /* infinite regress! */
-    res = caml_obj_dup(arg - infix_offset);
+    CAMLassert (infix_offset > 0);
+    arg -= infix_offset;
+    CAMLassert (Tag_val(arg) == Closure_tag);
+    res = caml_obj_with_tag(Val_long(Closure_tag), arg);
     CAMLreturn (res + infix_offset);
   }
 
-  if (new_tag != existing_tag) {
-    if (existing_tag == Closure_tag) {
-      caml_failwith("Cannot change tag of an existing closure.");
-    }
-    if ((new_tag == Closure_tag) ||
-        (new_tag == Infix_tag)) {
-      caml_failwith("Cannot make a closure from a non-closure.");
-    }
-    if (Scannable_tag(new_tag) && !Scannable_tag(existing_tag)) {
-      caml_failwith("Cannot change non-scannable object to scannable.");
-    }
-  }
+  mlsize_t sz = Wosize_val(arg);
 
   if (sz == 0) CAMLreturn (Atom(new_tag));
 

--- a/testsuite/tests/lib-obj/with_tag.ml
+++ b/testsuite/tests/lib-obj/with_tag.ml
@@ -26,5 +26,38 @@ let () =
   assert (allocs (fun () -> Obj.with_tag 1 (Obj.repr (A ("hello", 10.)))) = 0);
   assert (allocs (fun () -> Obj.with_tag 1 (Obj.repr (ref 10))) = 2)
 
+(* check forbidden cases *)
+
+let () =
+  let [@opaque] rec f n = if n < 0 then 0 else g (n-1)
+  and [@opaque]     g n = if n < 0 then 0 else f (n-1)
+
+  in
+  let non_infix_to_infix () =
+    ignore (Obj.with_tag (Obj.tag (Obj.repr f)) (Obj.repr g))
+  in
+  let infix_to_non_infix () =
+    ignore (Obj.with_tag (Obj.tag (Obj.repr g)) (Obj.repr f))
+  in
+  (* Other illegalities left as discipline for the caller *)
+  let check_fail f m =
+    match f () with
+    | () -> print_endline (m ^ ": did not fail")
+    | exception Failure _ -> ()
+    | exception e -> print_endline (m ^ "failed with " ^ Printexc.to_string e)
+  in
+  (check_fail non_infix_to_infix "Duplicating non-infix block with infix tag";
+   check_fail infix_to_non_infix "Duplicating infix block with non-infix tag";)
+
+(* Check duplication of closures and infix closures *)
+
+let () =
+  let [@opaque] rec f n = if n < 0 then 0 else g (n-1)
+  and [@opaque]     g n = if n < 0 then 0 else f (n-1)
+  in
+  (ignore (Obj.dup (Obj.repr f));
+   ignore (Obj.dup (Obj.repr g)))
+
+
 let () =
   print_endline "ok"


### PR DESCRIPTION
Fix caml_obj_with_tag to handle closures and infix tags. Upstreamed from oxcaml/oxcaml#3465