### PR TITLE
Replace No_scan_tag uses with Scannable_* macros

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,10 @@ Working version
 - #14494: Consistently use macro to test header promotion.
   (Nick Barnes, review by Gabriel Scherer)
 
+- #14493: Use Scannable_* macros instead of comparisons to No_scan_tag, for
+  legibility and correctness (fixes one bug, in weak.c).
+  (Nick Barnes, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 * #13919: optimize `lazy v` when `v` is a structured constant

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -42,13 +42,13 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
     }else{
       Caml_check_caml_state();
       Alloc_small (result, wosize, tag, Alloc_small_enter_GC);
-      if (tag < No_scan_tag){
+      if (Scannable_tag(tag)){
         for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;
       }
     }
   } else {
     result = caml_alloc_shr (wosize, tag);
-    if (tag < No_scan_tag) {
+    if (Scannable_tag(tag)) {
       for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;
     }
     result = caml_check_urgent_gc (result);
@@ -66,7 +66,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 #ifdef NATIVE_CODE
 CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 {
-  CAMLassert(tag < No_scan_tag);
+  CAMLassert(Scannable_tag(tag));
   caml_check_urgent_gc (Val_unit);
   value result = caml_alloc_shr (wosize, tag);
   for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -250,7 +250,9 @@ CAMLno_tsan_for_perf Caml_inline header_t Hd_val(value val)
 
 /* The lowest tag for blocks containing no value. */
 #define No_scan_tag 251
-
+#define Scannable_tag(t)   ((t) < No_scan_tag)
+#define Scannable_hd(hd)   Scannable_tag(Tag_hd(hd))
+#define Scannable_val(val) Scannable_tag(Tag_val(val))
 
 /* 1- If tag < No_scan_tag : a tuple of fields.  */
 

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -1305,7 +1305,7 @@ CAMLprim value caml_obj_reachable_words(value v)
       extern_record_location(s, v, h);
       /* The block contributes to the total size */
       size += 1 + sz;           /* header word included */
-      if (tag < No_scan_tag) {
+      if (Scannable_tag(tag)) {
         /* i is the position of the first field to traverse recursively */
         uintnat i =
           tag == Closure_tag ? Start_env_closinfo(Closinfo_val(v)) : 0;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1358,7 +1358,7 @@ static intnat mark_stack_push_block(struct mark_stack* stk, value block)
   CAMLassert(Is_block(block));
   CAMLassert(!Is_young(block));
   CAMLassert(Tag_val(block) != Infix_tag);
-  CAMLassert(Tag_val(block) < No_scan_tag);
+  CAMLassert(Scannable_val(block));
   CAMLassert(Tag_val(block) != Cont_tag);
 
   /* Optimisation to avoid pushing small, unmarkable objects such as
@@ -1447,7 +1447,7 @@ static void mark_slice_darken(struct mark_stack* stk, value child,
             Hp_atomic_val(child),
             With_status_hd(chd, caml_global_heap_state.MARKED));
         }
-        if(Tag_hd(chd) < No_scan_tag){
+        if(Scannable_hd(chd)) {
           *work -= mark_stack_push_block(stk, child);
         } else {
           *work -= Wosize_hd(chd);
@@ -1514,7 +1514,7 @@ again:
       }
 
       budget--; /* header word */
-      if (Tag_hd(hd) >= No_scan_tag) {
+      if (!Scannable_hd(hd)) {
         /* Nothing to scan here */
         budget -= Wosize_hd(hd);
         continue;
@@ -1675,7 +1675,7 @@ void caml_darken(void* state, value v, volatile value* ignored) {
       atomic_store_relaxed(
          Hp_atomic_val(v),
          With_status_hd(hd, caml_global_heap_state.MARKED));
-      if (Tag_hd(hd) < No_scan_tag) {
+      if (Scannable_hd(hd)) {
         mark_stack_push_block(domain_state->mark_stack, v);
         Caml_state->mark_work_done_between_slices += 1; /* just the header */
       } else {

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -438,7 +438,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   }
 
 #ifdef DEBUG
-  if (tag < No_scan_tag) {
+  if (Scannable_tag(tag)) {
     for (mlsize_t i = 0; i < wosize; i++)
       Op_hp(v)[i] = Debug_uninit_major;
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -343,7 +343,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
       #endif
     }
 
-  } else if (tag >= No_scan_tag) {
+  } else if (!Scannable_tag(tag)) {
     sz = Wosize_hd (hd);
     st->live_bytes += Bhsize_hd(hd);
     result = alloc_shared(st->domain, sz, tag, Reserved_hd(hd));

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -76,7 +76,7 @@ CAMLprim value caml_obj_block(value tag, value size)
   sz = Long_val(size);
   tg = Long_val(tag);
 
-  /* When [tg < No_scan_tag], [caml_alloc] returns an object whose fields are
+  /* When [Scannable_tag(tg)], [caml_alloc] returns an object whose fields are
    * initialised to [Val_unit]. Otherwise, the fields are uninitialised. We aim
    * to avoid inconsistent states in other cases, on a best-effort basis --
    * by default there is no initialization. */
@@ -140,7 +140,7 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
   sz = Wosize_val(arg);
   tg = (tag_t)Long_val(new_tag_v);
   if (sz == 0) CAMLreturn (Atom(tg));
-  if (tg >= No_scan_tag) {
+  if (!Scannable_tag(tg)) {
     res = caml_alloc(sz, tg);
     memcpy(Bp_val(res), Bp_val(arg), sz * sizeof(value));
   } else if (sz <= Max_young_wosize) {
@@ -353,7 +353,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
       Store_double_flat_field (dummy, i, Double_flat_field (newval, i));
     }
   } else {
-    CAMLassert (tag < No_scan_tag);
+    CAMLassert (Scannable_tag(tag));
     CAMLassert (Tag_val(dummy) != Infix_tag);
     Unsafe_store_tag_val(dummy, tag);
     size = Wosize_val(newval);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -981,7 +981,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
     struct stack_info* stk = Ptr_val(Field(v, 0));
     if (stk != NULL)
       caml_scan_stack(verify_push, verify_scanning_flags, st, stk, 0);
-  } else if (Tag_val(v) < No_scan_tag) {
+  } else if (Scannable_val(v)) {
     int i = 0;
     if (Tag_val(v) == Closure_tag) {
       i = Start_env_closinfo(Closinfo_val(v));
@@ -1090,7 +1090,7 @@ static void compact_update_block(header_t* p)
       offset = Start_env_closinfo(Closinfo_val(Val_hp(p)));
     }
 
-    if (tag < No_scan_tag) {
+    if (Scannable_tag(tag)) {
       mlsize_t wosz = Wosize_hd(hd);
       for (mlsize_t i = offset; i < wosz; i++) {
         compact_update_value_at(&Field(Val_hp(p), i));

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -336,7 +336,7 @@ static void ephe_copy_and_darken(value from, value to)
   CAMLassert(Tag_val(from) != Infix_tag);
   CAMLassert(Wosize_val(from) == Wosize_val(to));
 
-  if (Tag_val(from) > No_scan_tag) {
+  if (!Scannable_val(from)) {
     i = Wosize_val(to);
   }
   else if (Tag_val(from) == Closure_tag) {


### PR DESCRIPTION
In the runtime we compare header tags against `No_scan_tag`: Blocks with scannable fields have tags less than `No_scan_tag`; tags greater than or equal to `No_scan_tag` indicate non-scannable blocks. It is easy to get the direction and equality-inclusion of this test wrong, when either reading or writing code. This change replaces all comparisons against `No_scan_tag` with macros `Scannable_tag`, `Scannable_hd`, and `Scannable_val`, which are harder to get wrong and easier to check.

Incidentally this fixes one hard-to-trigger bug, in `weak.c`.

Upstreamed from oxcaml/oxcaml#3722. The first commit here is #14492; review should focus on the second commit.