### PR TITLE
Always use a macro when checking for a promoted header

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,9 @@ Working version
   occur when concurrent threads or processes were trying to create socketpairs.
   (Jessie Grosen, review by Antonin Décimo and Nicolás Ojeda Bär)
 
+- #14494: Consistently use macro to test header promotion.
+  (Nick Barnes, review by ???)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -72,6 +72,13 @@ struct caml_minor_tables {
   struct caml_custom_table custom;
 };
 
+/* Setting this to a different value can be useful for debugging
+ * although may cause some slowdown. It must be a header value not
+ * otherwise found on the minor heap, not using Infix_tag, and not
+ * equal to In_progress_hd.  I suggest Make_header(0 ,0, 0x200). */
+#define Promoted_hd (Make_header(0, 0, 0))
+#define Is_promoted_hd(hd) ((hd) == Promoted_hd)
+
 CAMLextern void caml_minor_collection (void);
 
 #ifdef __cplusplus

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -241,7 +241,7 @@ static void generic_final_minor_update
   for (uintnat i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val) &&
-        caml_get_header_val(final->table[i].val) != 0){
+        !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
       ++ todo_count;
     }
   }
@@ -264,7 +264,7 @@ static void generic_final_minor_update
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
       if (Is_young(final->table[i].val) &&
-          caml_get_header_val(final->table[i].val) != 0) {
+          !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */
@@ -286,7 +286,7 @@ static void generic_final_minor_update
   for (uintnat i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val)) {
-      CAMLassert (caml_get_header_val(final->table[i].val) == 0);
+      CAMLassert (Is_promoted_hd(caml_get_header_val(final->table[i].val)));
       final->table[i].val = Field(final->table[i].val, 0);
     }
   }

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1503,7 +1503,7 @@ static bool entry_update_after_minor_gc(entry_t e, void *data)
   CAMLassert(Is_block(e->block)
              || e->deleted || e->deallocated || e->offset);
   if (!e->offset && Is_block(e->block) && Is_young(e->block)) {
-    if (Hd_val(e->block) == 0) {
+    if (Is_promoted_hd(Hd_val(e->block))) {
       /* Block has been promoted */
       e->block = Field(e->block, 0);
       e->promoted = true;


### PR DESCRIPTION
A distinguished value is used to mark block headers as "promoted" (i.e. copied by the minor collector). This value happens to be zero, which is efficient, but the code is clearer if we test it with a macro (`Is_promoted_hd`).

This also makes it easy to change the distinguished value to something else (such as `Make_header(0, 0, 0x200)`, which can be useful when testing.

Upstreamed from oxcaml/oxcaml#3493.