### PR TITLE
Fix multidomain minor-GC infix tag bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -649,6 +649,10 @@ Working version
   DragonFly.
   (Michael Neumann, review by Gabriel Scherer and Kate Deplaix)
 
+- #14495: Fix infix-tag bug in the minor collector which could cause SEGVs
+  in multi-domain programs.
+  (Nick Barnes, review by Gabriel Scherer)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 


### PR DESCRIPTION
When promoting an infix pointer, it's essential that the infix headers, at least, should be copied into the promoted block before the header word is marked as promoted. Otherwise any other domain oldifying an infix pointer to the same block will get a pointer to an uninitialized area of the major heap.
Upstreamed from oxcaml/oxcaml#4046, where this bug was causing SEGVs.