### PR TITLE
Suppress warning in bigarray.h in strict C++ mode with less eye-strain

### DIFF
--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -16,6 +16,41 @@
 #ifndef CAML_BIGARRAY_H
 #define CAML_BIGARRAY_H
 
+/* ISO C++ doesn't permit flexible array members, but GCC, Clang and MSVC all
+   support them as compiler extensions. The pragmas below temporarily disable
+   the warnings which these compilers emit for this, which allows this public
+   header to be used in C++ in pedantic/non-permissive mode.
+
+   These macros are here, rather than misc.h, to discourage the potential future
+   use of flexible array members! */
+#ifdef __cplusplus
+  #if defined(__clang__)
+    #define CAML_flexible_array_member_start \
+      _Pragma("clang diagnostic push") \
+      _Pragma("GCC diagnostic ignored \"-Wc99-extensions\"")
+    #define CAML_flexible_array_member_end \
+      _Pragma("clang diagnostic pop")
+  #elif defined(__GNUC__)
+    #define CAML_flexible_array_member_start \
+      _Pragma("GCC diagnostic push") \
+      _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+    #define CAML_flexible_array_member_end \
+      _Pragma("GCC diagnostic pop")
+  #elif defined(_MSC_VER)
+    #define CAML_flexible_array_member_start \
+      _Pragma("warning(push)") \
+      _Pragma("warning(disable: 4200)")
+    #define CAML_flexible_array_member_end \
+      _Pragma("warning(pop)")
+  #else
+    #define CAML_flexible_array_member_start
+    #define CAML_flexible_array_member_end
+  #endif
+#else
+  #define CAML_flexible_array_member_start
+  #define CAML_flexible_array_member_end
+#endif
+
 #include "config.h"
 #include "mlvalues.h"
 #include "camlatomic.h"
@@ -83,35 +118,9 @@ struct caml_ba_array {
   intnat num_dims;            /* Number of dimensions */
   intnat flags;  /* Kind of element array + memory layout + allocation status */
   struct caml_ba_proxy * proxy; /* The proxy for sub-arrays, or NULL */
-
-  /* ISO C++ doesn't permit flexible array members, but GCC, Clang and MSVC all
-     support them as compiler extensions. The pragmas below temporarily disable
-     the warnings which these compilers emit for this, which allows this public
-     header to be used in C++ in pedantic/non-permissive mode. */
-#ifdef __cplusplus
-  #if defined(__clang__)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wc99-extensions"
-  #elif defined(__GNUC__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wpedantic"
-  #elif defined(_MSC_VER)
-    #pragma warning(push)
-    #pragma warning(disable: 4200)
-  #endif
-#endif
-
+CAML_flexible_array_member_start
   intnat dim[/* num_dims */]; /* Size in each dimension */
-
-#ifdef __cplusplus
-  #if defined(__clang__)
-    #pragma clang diagnostic pop
-  #elif defined(__GNUC__)
-    #pragma GCC diagnostic pop
-  #elif defined(_MSC_VER)
-    #pragma warning(pop)
-  #endif
-#endif
+CAML_flexible_array_member_end
 };
 
 /* Size of struct caml_ba_array, in bytes, without [dim] array */


### PR DESCRIPTION
Following on from the comments at https://github.com/ocaml/ocaml/pull/14490#issuecomment-3798809143.

This version instead introduces a `CAML_flexible_array_member_start`/`CAML_flexible_array_member_end` pair to be used either side of the field declaration. It's still kept in bigarray.h because it's currently the only place it's used, and it seems sensible to keep the explanation as close to the use, given that it's an obscure feature.

It would be nice to be able to have `CAML_flexible_array_member(intnat dim[/* num_dims */]);` but this is difficult/impossible because we're in a `struct` declaration, not a function body.

The diff is largely horrific, however viewed. The diff prior to #14490 is:
```diff
diff --git a/runtime/caml/bigarray.h b/runtime/caml/bigarray.h
index ae88477e1f..65f7a74d51 100644
--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -78,12 +78,46 @@ struct caml_ba_proxy {
   uintnat size;                 /* Size of data in bytes (if mapped file) */
 };

+/* ISO C++ doesn't permit flexible array members, but GCC, Clang and MSVC all
+   support them as compiler extensions. The pragmas below temporarily disable
+   the warnings which these compilers emit for this, which allows this public
+   header to be used in C++ in pedantic/non-permissive mode. */
+#ifdef __cplusplus
+  #if defined(__clang__)
+    #define CAML_flexible_array_member_start \
+      _Pragma("clang diagnostic push") \
+      _Pragma("GCC diagnostic ignored \"-Wc99-extensions\"")
+    #define CAML_flexible_array_member_end \
+      _Pragma("clang diagnostic pop")
+  #elif defined(__GNUC__)
+    #define CAML_flexible_array_member_start \
+      _Pragma("GCC diagnostic push") \
+      _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+    #define CAML_flexible_array_member_end \
+      _Pragma("GCC diagnostic pop")
+  #elif defined(_MSC_VER)
+    #define CAML_flexible_array_member_start \
+      _Pragma("warning(push)") \
+      _Pragma("warning(disable: 4200)")
+    #define CAML_flexible_array_member_end \
+      _Pragma("warning(pop)")
+  #else
+    #define CAML_flexible_array_member_start
+    #define CAML_flexible_array_member_end
+  #endif
+#else
+  #define CAML_flexible_array_member_start
+  #define CAML_flexible_array_member_end
+#endif
+
 struct caml_ba_array {
   void * data;                /* Pointer to raw data */
   intnat num_dims;            /* Number of dimensions */
   intnat flags;  /* Kind of element array + memory layout + allocation status */
   struct caml_ba_proxy * proxy; /* The proxy for sub-arrays, or NULL */
+CAML_flexible_array_member_start
   intnat dim[/* num_dims */]; /* Size in each dimension */
+CAML_flexible_array_member_end
 };

 /* Size of struct caml_ba_array, in bytes, without [dim] array */
```