### PR TITLE
testsuite: partial type instantiation in patterns

### DIFF
--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -314,3 +314,18 @@ Error: Type "[ `Foo of int ] list" is not a subtype of "[ `Bar | `Foo ] list"
        Type "[ `Foo of int ]" is not a subtype of "[ `Bar | `Foo ]"
        Types for tag "`Foo" are incompatible
 |}]
+
+(** When typing pattern match containing possibly absent polymorphic variants,
+    we temporarily forget non-generic type information *)
+let f (x: [< `A] * 'a * ' a ) = match x with
+  | `A , _, _ -> ()
+  | `B, (), (None|Some _) -> ()
+[%%expect {|
+Line 2, characters 4-13:
+2 |   | `A , _, _ -> ()
+        ^^^^^^^^^
+Error: This pattern matches values of type "[< `A ] * unit * 'a option"
+       but a pattern was expected which matches values of type
+         "[< `A ] * unit * unit"
+       Type "'a option" is not compatible with type "unit"
+|}]


### PR DESCRIPTION
This micro-PR adds a test for the partial type instantiation in pattern match: for patterns containing possibly absent polymorphic variants, the typechecker temporarily forgets which polymorphic variants are possibly absents (in order to
only emits a warning in
```ocaml
let f (x:[< `X ]) = x
let test x = match f x with
| `X -> 0
| `Y -> 1
```
)
and type information not principally known. However, this second behaviour is not currently tested in the testsuite.
This PR fixes this point by adding a test constructed to fail only after we re-add the temporarily forgotten type constraints:
```ocaml
let f (x: [< `A] * 'a * 'a ) = match x with
  | `A , _, _ -> ()
  | `B, (), (None|Some _) -> ()
```
>```
>       | `A , _, _ -> ()
>         ^^^^^^^^^
>Error: This pattern matches values of type "[< `A ] * unit * 'a option"
>       but a pattern was expected which matches values of type
>         "[< `A ] * unit * unit"
>       Type "'a option" is not compatible with type "unit"
>```
By contrast, in the absence of possibly absent polymorphic variant we get the better localized error message
```ocaml
let f (x: [> `A | `B] * 'a * 'a ) = match x with
  | `A , _, _ -> ()
  | `B, (), (None|Some _) -> ()
  | _ -> ()
```
>```
>       | `B, (), (None|Some _) -> ()
>                  ^^^^
> Error: This variant pattern is expected to have type unit
>       There is no constructor None within type unit
>```