### PR TITLE
ocamltest negation: `not <action>;`

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,10 @@ Working version
   to convert from this syntax.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- #14502: in ocamltest, `not <action>` negates a
+  predicate-like action.
+  (Gabriel Scherer, review by Olivier Nicole)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -127,6 +127,13 @@ let not_windows = make
     "not running on Windows"
     "running on Windows")
 
+let msvc = make
+  ~name:"msvc"
+  ~description:"Pass if using MSVC / clang-cl"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.ccomp_type = "msvc")
+    "using MSVC / clang-cl"
+    "not using MSVC / clang-cl")
+
 let not_msvc = make
   ~name:"not-msvc"
   ~description:"Pass if not using MSVC / clang-cl"
@@ -136,6 +143,13 @@ let not_msvc = make
 
 let is_clang =
   List.mem "clang" (String.split_on_char '-' Ocamltest_config.c_compiler_vendor)
+
+let clang = make
+  ~name:"clang"
+  ~description:"Pass if using clang"
+  (Actions_helpers.pass_or_skip is_clang
+    "using clang"
+    "not using clang")
 
 let not_clang = make
   ~name:"not-clang"
@@ -421,7 +435,9 @@ let _ =
     libwin32unix;
     windows;
     not_windows;
+    msvc;
     not_msvc;
+    clang;
     not_clang;
     target_windows;
     not_target_windows;

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -120,26 +120,12 @@ let windows = make
     "running on Windows"
     "not running on Windows")
 
-let not_windows = make
-  ~name:"not-windows"
-  ~description:"Pass if not running on Windows"
-  (Actions_helpers.pass_or_skip (get_OS () <> windows_OS)
-    "not running on Windows"
-    "running on Windows")
-
 let msvc = make
   ~name:"msvc"
   ~description:"Pass if using MSVC / clang-cl"
   (Actions_helpers.pass_or_skip (Ocamltest_config.ccomp_type = "msvc")
     "using MSVC / clang-cl"
     "not using MSVC / clang-cl")
-
-let not_msvc = make
-  ~name:"not-msvc"
-  ~description:"Pass if not using MSVC / clang-cl"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.ccomp_type <> "msvc")
-    "not using MSVC / clang-cl"
-    "using MSVC / clang-cl")
 
 let is_clang =
   List.mem "clang" (String.split_on_char '-' Ocamltest_config.c_compiler_vendor)
@@ -151,13 +137,6 @@ let clang = make
     "using clang"
     "not using clang")
 
-let not_clang = make
-  ~name:"not-clang"
-  ~description:"Pass if not using clang"
-  (Actions_helpers.pass_or_skip (not is_clang)
-    "not using clang"
-    "using clang")
-
 (* windows _passes_ on Cygwin; target_windows _skips_ for Cygwin *)
 
 let target_windows = make
@@ -166,13 +145,6 @@ let target_windows = make
   (Actions_helpers.pass_or_skip (Ocamltest_config.target_os_type = "Win32")
     "targeting native Windows"
     "not targeting native Windows")
-
-let not_target_windows = make
-  ~name:"not-target-windows"
-  ~description:"Pass if the compiler does not target native Windows"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.target_os_type <> "Win32")
-    "not targeting native Windows"
-    "targeting native Windows")
 
 let is_bsd_system s =
   match s with
@@ -185,13 +157,6 @@ let bsd = make
   (Actions_helpers.pass_or_skip (is_bsd_system Ocamltest_config.system)
     "on a BSD system"
     "not on a BSD system")
-
-let not_bsd = make
-  ~name:"not-bsd"
-  ~description:"Pass if not running on a BSD system"
-  (Actions_helpers.pass_or_skip (not (is_bsd_system Ocamltest_config.system))
-    "not on a BSD system"
-    "on a BSD system")
 
 let linux_system = "linux"
 
@@ -304,13 +269,6 @@ let tsan = make
   (Actions_helpers.pass_or_skip (Ocamltest_config.tsan)
      "tsan available"
      "tsan not available")
-
-let no_tsan = make
-  ~name:"no-tsan"
-  ~description:"Pass if thread sanitizer is not supported"
-  (Actions_helpers.pass_or_skip (not Ocamltest_config.tsan)
-     "tsan not available"
-     "tsan available")
 
 let has_symlink = make
   ~name:"has_symlink"
@@ -434,15 +392,10 @@ let _ =
     libunix;
     libwin32unix;
     windows;
-    not_windows;
     msvc;
-    not_msvc;
     clang;
-    not_clang;
     target_windows;
-    not_target_windows;
     bsd;
-    not_bsd;
     linux;
     macos;
     not_macos_amd64_tsan;
@@ -467,5 +420,4 @@ let _ =
     file_exists;
     copy;
     tsan;
-    no_tsan;
   ]

--- a/ocamltest/builtin_actions.mli
+++ b/ocamltest/builtin_actions.mli
@@ -26,10 +26,7 @@ val libunix : Actions.t
 val libwin32unix : Actions.t
 
 val windows : Actions.t
-val not_windows : Actions.t
-
 val bsd : Actions.t
-val not_bsd : Actions.t
 
 val arch32 : Actions.t
 val arch64 : Actions.t

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -117,7 +117,7 @@ let test_file test_filename =
       let default_tests = Tests.default_tests() in
       let make_tree test =
         let id = make_identifier test.Tests.test_name in
-        Ast ([Test (id, [])], [])
+        Ast ([Test (Pos, id, [])], [])
       in
       Ast ([], List.map make_tree default_tests)
     | _ -> tsl_ast

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -20,6 +20,8 @@ type 'a located = {
   loc : Location.t
 }
 
+type sign = Pos | Neg
+
 type environment_statement =
   | Assignment of bool * string located * string located (* variable = value *)
   | Append of string located * string located
@@ -29,6 +31,7 @@ type environment_statement =
 type tsl_item =
   | Environment_statement of environment_statement located
   | Test of
+    sign (* when Neg, negate the test *) *
     string located (* test name *) *
     string located list (* environment modifiers *)
 

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -20,6 +20,8 @@ type 'a located = {
   loc : Location.t
 }
 
+type sign = Pos | Neg
+
 type environment_statement =
   | Assignment of bool * string located * string located (* variable = value *)
   | Append of string located * string located (* variable += value *)
@@ -29,6 +31,7 @@ type environment_statement =
 type tsl_item =
   | Environment_statement of environment_statement located
   | Test of
+    sign (* when Neg, negate the test *) *
     string located (* test name *) *
     string located list (* environment modifiers *)
 

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -65,6 +65,7 @@ and token = parse
     { let s = Lexing.lexeme lexbuf in
       match s with
         | "include" -> INCLUDE
+        | "not" -> NOT
         | "set" -> SET
         | "unset" -> UNSET
         | "with" -> WITH

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -36,6 +36,7 @@ let mkenvstmt envstmt =
 %token <[`Above | `Below]> TSL_BEGIN_OCAML_STYLE
 %token TSL_END_OCAML_STYLE
 %token COMMA LEFT_BRACE RIGHT_BRACE SEMI
+%token NOT
 %token EQUAL PLUSEQUAL
 /* %token COLON */
 %token INCLUDE SET UNSET WITH
@@ -63,7 +64,8 @@ statement_list:
 
 statement:
 | env_item SEMI { $1 }
-| identifier with_environment_modifiers SEMI { Test ($1, $2) }
+|     identifier with_environment_modifiers SEMI { Test (Pos, $1, $2) }
+| NOT identifier with_environment_modifiers SEMI { Test (Neg, $2, $3) }
 
 tsl_script:
 | TSL_BEGIN_C_STYLE node TSL_END_C_STYLE { $2 }

--- a/ocamltest/tsl_printer.ml
+++ b/ocamltest/tsl_printer.ml
@@ -30,7 +30,10 @@ let print_tsl_ast ~compact oc ast =
 
   and print_statements indent stmts =
     match stmts with
-    | Test (name, mods) :: tl ->
+    | Test (sign, name, mods) :: tl ->
+      pr (match sign with
+          | Pos -> ""
+          | Neg -> "not ");
       pr "%s%s" indent name.node;
       begin match mods with
       | m :: tl ->

--- a/ocamltest/tsl_query.ml
+++ b/ocamltest/tsl_query.ml
@@ -18,7 +18,7 @@ open Tsl_ast
 let tests_in_stmt set stmt =
   match stmt with
   | Environment_statement _ -> set
-  | Test (name, _) ->
+  | Test (_sign, name, _) ->
     begin match Tsl_semantics.lookup_test name with
     | t -> Tests.TestSet.add t set
     | exception Tsl_semantics.No_such_test_or_action _ -> set

--- a/testsuite/tests/asmgen/soli.cmm
+++ b/testsuite/tests/asmgen/soli.cmm
@@ -1,7 +1,7 @@
 (* TEST
  readonly_files = "main.c";
  arguments = "-DUNIT_INT -DFUN=solitaire main.c";
- no-tsan; (* The asmgen action does not support TSan *)
+ not tsan; (* The asmgen action does not support TSan *)
  asmgen;
 *)
 

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -25,7 +25,7 @@ let cas (r : 'a atomic) oldv newv =
 (* TEST
 
   (* we restrict this test to a single configuration,
-       amd64+linux no-tsan no-flambda
+       amd64+linux not tsan no-flambda
      to avoid dealing with differences in cmm output across systems
      (the check is known to fail under MSCV, which uses a different
      symbol generator.)
@@ -33,7 +33,7 @@ let cas (r : 'a atomic) oldv newv =
    arch_amd64;
    linux;
    no-flambda; (* the output will be slightly different under Flambda *)
-   no-tsan; (* TSan modifies the generated code *)
+   not tsan; (* TSan modifies the generated code *)
 
    setup-ocamlopt.byte-build-env;
    flags = "-c -dcmm -dno-locations -dno-unique-ids";

--- a/testsuite/tests/backtrace/pr2195.ml
+++ b/testsuite/tests/backtrace/pr2195.ml
@@ -31,7 +31,7 @@ let () =
 (* TEST
  flags += "-g";
  exit_status = "2";
- no-tsan; (* Exhausting file descriptors kills TSan support (libunwind fails) *)
+ not tsan; (* Exhausting file descriptors kills TSan support (libunwind fails) *)
  {
    ocamlrunparam += ",b=0";
    reference = "${test_source_directory}/pr2195-nolocs.byte.reference";

--- a/testsuite/tests/callback/signals_alloc.ml
+++ b/testsuite/tests/callback/signals_alloc.ml
@@ -2,7 +2,7 @@
  include unix;
  modules = "callbackprim.c";
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/callback/test3.ml
+++ b/testsuite/tests/callback/test3.ml
@@ -1,6 +1,6 @@
 (* TEST
  modules = "test3_.c";
- no-tsan; (* TSan does not support call stacks bigger than 64k frames *)
+ not tsan; (* TSan does not support call stacks bigger than 64k frames *)
  {
    bytecode;
  }{

--- a/testsuite/tests/callback/test_signalhandler.ml
+++ b/testsuite/tests/callback/test_signalhandler.ml
@@ -2,7 +2,7 @@
  include unix;
  modules = "test_signalhandler_.c";
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/cxx-api/all_includes.ml
+++ b/testsuite/tests/cxx-api/all_includes.ml
@@ -1,7 +1,7 @@
 (* TEST
  modules = "stubs.c";
  readonly_files = "all-includes.h";
- not-msvc;
+ not msvc;
  flags = "-ccopt -x -ccopt c++ -ccopt -std=c++11";
 *)
 

--- a/testsuite/tests/hidden_includes/test.ml
+++ b/testsuite/tests/hidden_includes/test.ml
@@ -93,7 +93,7 @@ ocamlc.byte;
   ocamlc.byte;
 }
 {
-  not-target-windows;
+  not target-windows;
   flags = "-H liba -I liba_alt -I libb -nocwd";
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
@@ -104,7 +104,7 @@ ocamlc.byte;
   check-ocamlc.byte-output;
 }
 {
-  not-target-windows;
+  not target-windows;
   flags = "-I liba_alt -H liba -I libb -nocwd";
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
@@ -117,7 +117,7 @@ ocamlc.byte;
 
 (* The next two tests show that earlier -Hs take priority over later -Hs *)
 {
-  not-target-windows;
+  not target-windows;
   flags = "-H liba_alt -H liba -I libb -nocwd";
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;

--- a/testsuite/tests/lf_skiplist/test_parallel.ml
+++ b/testsuite/tests/lf_skiplist/test_parallel.ml
@@ -1,6 +1,6 @@
 (* TEST
  modules = "stubs.c";
- no-tsan; (* Takes too much time and memory with tsan *)
+ not tsan; (* Takes too much time and memory with tsan *)
  {
    bytecode;
  }

--- a/testsuite/tests/lib-channels/close_during_flush.ml
+++ b/testsuite/tests/lib-channels/close_during_flush.ml
@@ -1,5 +1,5 @@
 (* TEST
- not-windows;
+ not windows;
  include unix;
  hasunix;
  native;

--- a/testsuite/tests/lib-dynlink-domains/test_generator.ml
+++ b/testsuite/tests/lib-dynlink-domains/test_generator.ml
@@ -515,7 +515,7 @@ include dynlink
 libraries = ""
 readonly_files = "@[<h>store.ml main.ml%a@]"
 
-*01 not-windows
+*01 not windows
 *02 shared-libraries
 *03 setup-ocamlc.byte-build-env
 *04 ocamlc.byte

--- a/testsuite/tests/lib-marshal/intext_par.ml
+++ b/testsuite/tests/lib-marshal/intext_par.ml
@@ -1,6 +1,6 @@
 (* TEST
  modules = "intextaux_par.c";
- no-tsan; (* Takes too much time and memory with tsan *)
+ not tsan; (* Takes too much time and memory with tsan *)
  {
    bytecode;
  }

--- a/testsuite/tests/lib-runtime-events/test_corrupted.ml
+++ b/testsuite/tests/lib-runtime-events/test_corrupted.ml
@@ -3,7 +3,7 @@
  include unix;
  set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_external.ml
+++ b/testsuite/tests/lib-runtime-events/test_external.ml
@@ -2,7 +2,7 @@
  include runtime_events;
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_external_preserve.ml
+++ b/testsuite/tests/lib-runtime-events/test_external_preserve.ml
@@ -3,7 +3,7 @@
  include unix;
  set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_fork.ml
+++ b/testsuite/tests/lib-runtime-events/test_fork.ml
@@ -2,7 +2,7 @@
  include runtime_events;
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-runtime-events/test_user_event_signal.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_signal.ml
@@ -2,7 +2,7 @@
  include runtime_events;
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }

--- a/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
@@ -3,7 +3,7 @@
  include unix;
  set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-sys/signal.ml
+++ b/testsuite/tests/lib-sys/signal.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-windows;
+ not windows;
  native;
 *)
 open Sys

--- a/testsuite/tests/lib-systhreads/boundscheck.ml
+++ b/testsuite/tests/lib-systhreads/boundscheck.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- no-tsan; (* See https://github.com/ocaml-multicore/ocaml-tsan/issues/31 *)
+ not tsan; (* See https://github.com/ocaml-multicore/ocaml-tsan/issues/31 *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/eintr.ml
+++ b/testsuite/tests/lib-systhreads/eintr.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/test_c_thread_register.ml
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register.ml
@@ -1,9 +1,9 @@
 (* TEST
  modules = "test_c_thread_register_cstubs.c";
  include systhreads;
- no-tsan; (* Flaky under TSan, disable until fixed (see issue #13472) *)
+ not tsan; (* Flaky under TSan, disable until fixed (see issue #13472) *)
  hassysthreads;
- not-bsd;
+ not bsd;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testfork.ml
+++ b/testsuite/tests/lib-systhreads/testfork.ml
@@ -1,10 +1,10 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-bsd;
+ not bsd;
  hasunix;
- not-target-windows;
- no-tsan; (* tsan limitation: starting new threads after fork is not supported *)
+ not target-windows;
+ not tsan; (* tsan limitation: starting new threads after fork is not supported *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testfork2.ml
+++ b/testsuite/tests/lib-systhreads/testfork2.ml
@@ -1,9 +1,9 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-bsd;
+ not bsd;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testpreempt.ml
+++ b/testsuite/tests/lib-systhreads/testpreempt.ml
@@ -6,7 +6,7 @@
      However, this does not seem very reliable, so that this test fails
      on some Windows configurations. See GPR #1533.
    *)
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/testyield.ml
+++ b/testsuite/tests/lib-systhreads/testyield.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-systhreads/threadsigmask.ml
+++ b/testsuite/tests/lib-systhreads/threadsigmask.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-threads/delayintr.ml
+++ b/testsuite/tests/lib-threads/delayintr.ml
@@ -2,7 +2,7 @@
  include systhreads;
  readonly_files = "sigint.c";
  hassysthreads;
- not-target-windows; (* excludes mingw32/64 and msvc32/64 *)
+ not target-windows; (* excludes mingw32/64 and msvc32/64 *)
  {
    program = "${test_build_directory}/delayintr.byte";
    setup-ocamlc.byte-build-env;

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- no-tsan; (* tsan detects the mutex errors and fails *)
+ not tsan; (* tsan detects the mutex errors and fails *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-threads/signal.ml
+++ b/testsuite/tests/lib-threads/signal.ml
@@ -2,7 +2,7 @@
  include systhreads;
  readonly_files = "sigint.c";
  hassysthreads;
- not-target-windows; (* excludes mingw32/64 and msvc32/64 *)
+ not target-windows; (* excludes mingw32/64 and msvc32/64 *)
  {
    program = "${test_build_directory}/signal.byte";
    setup-ocamlc.byte-build-env;

--- a/testsuite/tests/lib-threads/sockets.ml
+++ b/testsuite/tests/lib-threads/sockets.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-target-windows; (* Broken on Windows (missing join?), needs to be fixed *)
+ not target-windows; (* Broken on Windows (missing join?), needs to be fixed *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -18,7 +18,7 @@
      run;
      check-program-output;
    }{
-     not-target-windows; (* Unix.create_process doesn't pass fds on Windows *)
+     not target-windows; (* Unix.create_process doesn't pass fds on Windows *)
      arguments = "create_process";
      run;
      check-program-output;
@@ -38,7 +38,7 @@
      run;
      check-program-output;
    }{
-     not-target-windows; (* Unix.create_process doesn't pass fds on Windows *)
+     not target-windows; (* Unix.create_process doesn't pass fds on Windows *)
      arguments = "create_process";
      run;
      check-program-output;

--- a/testsuite/tests/lib-unix/common/fork_cleanup.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
@@ -1,7 +1,7 @@
 (* TEST
  include systhreads;
  hassysthreads;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/sigwait.ml
+++ b/testsuite/tests/lib-unix/common/sigwait.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/kill/unix_kill.ml
+++ b/testsuite/tests/lib-unix/kill/unix_kill.ml
@@ -1,7 +1,7 @@
 (* TEST
  include unix;
  hasunix;
- not-target-windows;
+ not target-windows;
  (*
    Disabled on MacOS amd64 with TSan due to a
    possible infinite signal loop with TSan under MacOS

--- a/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx.ml
+++ b/testsuite/tests/lib-unix/unix-sockaddr/sockaddr_cxx.ml
@@ -1,5 +1,5 @@
 (* TEST
- not-msvc;
+ not msvc;
  readonly_files = "sockaddr_cxx_aux.cpp";
  hasunix;
  include unix;

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
@@ -2,7 +2,7 @@
  include unix;
  modules = "recvfrom.ml";
  hasunix;
- not-windows;
+ not windows;
  {
    bytecode;
  }{

--- a/testsuite/tests/memory-model/forbidden.ml
+++ b/testsuite/tests/memory-model/forbidden.ml
@@ -1,8 +1,8 @@
 (* TEST
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
  multicore;
- not-bsd;
- no-tsan; (* tsan detects the intentional data races and fails *)
+ not bsd;
+ not tsan; (* tsan detects the intentional data races and fails *)
  {
    bytecode;
  }{

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -1,10 +1,10 @@
 (* TEST
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
  multicore;
- no-tsan; (* tsan detects data races and fails *)
- not-bsd;
+ not tsan; (* tsan detects data races and fails *)
+ not bsd;
  {
-   not-windows;
+   not windows;
    bytecode;
  }{
    native;

--- a/testsuite/tests/misc/pr7168.ml
+++ b/testsuite/tests/misc/pr7168.ml
@@ -1,6 +1,6 @@
 (* TEST
  ocamlrunparam += "l=100000";
- no-tsan; (* TSan does not support call stacks bigger than 64k frames *)
+ not tsan; (* TSan does not support call stacks bigger than 64k frames *)
  {
    bytecode;
  }

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -1,6 +1,6 @@
 (* TEST
    native-compiler;
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    not-clang; (* Skip, clang is tested on macOS *)
    arch_amd64;

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -2,7 +2,7 @@
    native-compiler;
    not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
-   not-clang; (* Skip, clang is tested on macOS *)
+   not clang; (* Skip, clang is tested on macOS *)
    arch_amd64;
    script = "sh ${test_source_directory}/has_gdb.sh";
    script;

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.ml
@@ -1,6 +1,6 @@
 (* TEST
    native-compiler;
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    not-clang; (* Skip, clang is tested on macOS *)
    arch_arm64;

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.ml
@@ -2,7 +2,7 @@
    native-compiler;
    not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
-   not-clang; (* Skip, clang is tested on macOS *)
+   not clang; (* Skip, clang is tested on macOS *)
    arch_arm64;
    script = "sh ${test_source_directory}/has_gdb.sh";
    script;

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.ml
@@ -2,7 +2,7 @@
    native-compiler;
    linux;
    not-clang; (* Skip, clang is tested on macOS *)
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    arch_riscv;
    script = "sh ${test_source_directory}/has_gdb.sh";
    script;

--- a/testsuite/tests/native-debugger/linux-gdb-riscv.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv.ml
@@ -1,7 +1,7 @@
 (* TEST
    native-compiler;
    linux;
-   not-clang; (* Skip, clang is tested on macOS *)
+   not clang; (* Skip, clang is tested on macOS *)
    not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    arch_riscv;
    script = "sh ${test_source_directory}/has_gdb.sh";

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.ml
@@ -1,7 +1,7 @@
 (* TEST
    unset BUILD_PATH_PREFIX_MAP;
    native-compiler;
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    not-clang; (* Skip, clang is tested on macOS *)
    arch_amd64;

--- a/testsuite/tests/native-debugger/linux-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64.ml
@@ -3,7 +3,7 @@
    native-compiler;
    not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
-   not-clang; (* Skip, clang is tested on macOS *)
+   not clang; (* Skip, clang is tested on macOS *)
    arch_amd64;
    script = "sh ${test_source_directory}/has_lldb.sh linux";
    script;

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.ml
@@ -1,7 +1,7 @@
 (* TEST
    unset BUILD_PATH_PREFIX_MAP;
    native-compiler;
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
    not-clang; (* Skip, clang is tested on macOS *)
    arch_arm64;

--- a/testsuite/tests/native-debugger/linux-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64.ml
@@ -3,7 +3,7 @@
    native-compiler;
    not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    linux;
-   not-clang; (* Skip, clang is tested on macOS *)
+   not clang; (* Skip, clang is tested on macOS *)
    arch_arm64;
    script = "sh ${test_source_directory}/has_lldb.sh linux";
    script;

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.ml
@@ -1,6 +1,6 @@
 (* TEST
    native-compiler;
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    macos;
    arch_amd64;
    script = "sh ${test_source_directory}/has_lldb.sh macos";

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.ml
@@ -1,6 +1,6 @@
 (* TEST
    native-compiler;
-   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   not tsan; (* Skip, TSan inserts extra frames into backtraces *)
    macos;
    arch_arm64;
    script = "sh ${test_source_directory}/has_lldb.sh macos";

--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -1,5 +1,5 @@
 (* TEST
- no-tsan; (* option -output-complete-obj is not supported with tsan *)
+ not tsan; (* option -output-complete-obj is not supported with tsan *)
  readonly_files = "test.ml_stub.c";
  {
    setup-ocamlc.byte-build-env;

--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -1,8 +1,8 @@
 (* TEST
 hassysthreads;
 include systhreads;
-not-target-windows;
-no-tsan;
+not target-windows;
+not tsan;
 {
   bytecode;
 }{

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -1,6 +1,6 @@
 (* TEST
  multicore;
- no-tsan; (* TSan detects the intentional data race *)
+ not tsan; (* TSan detects the intentional data race *)
  {
    bytecode;
  }

--- a/testsuite/tests/regression/pr9853/compaction_corner_case.ml
+++ b/testsuite/tests/regression/pr9853/compaction_corner_case.ml
@@ -1,5 +1,5 @@
 (* TEST
- no-tsan; (* Takes too much time with tsan *)
+ not tsan; (* Takes too much time with tsan *)
  {
  bytecode;
  }

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -1,7 +1,7 @@
 (* TEST
  flags = "-w -a";
  ocamlrunparam += "l=100000";
- no-tsan; (* TSan does not support call stacks bigger than 64k frames *)
+ not tsan; (* TSan does not support call stacks bigger than 64k frames *)
  {
    bytecode;
  }

--- a/testsuite/tests/runtime-errors/syserror.ml
+++ b/testsuite/tests/runtime-errors/syserror.ml
@@ -7,7 +7,7 @@
    run;
    hasunix;
    {
-     not-target-windows;
+     not target-windows;
      reference = "${test_source_directory}/syserror.unix.reference";
      check-program-output;
    }{
@@ -22,7 +22,7 @@
    run;
    hasunix;
    {
-     not-target-windows;
+     not target-windows;
      reference = "${test_source_directory}/syserror.unix.reference";
      check-program-output;
    }{

--- a/testsuite/tests/tool-ocamltest/negation.reference
+++ b/testsuite/tests/tool-ocamltest/negation.reference
@@ -1,0 +1,15 @@
+Specified modules: negation.test
+Source modules: negation.test
+ ... testing 'negation.test'Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+ => passed

--- a/testsuite/tests/tool-ocamltest/negation.test
+++ b/testsuite/tests/tool-ocamltest/negation.test
@@ -1,0 +1,10 @@
+(* TEST
+{
+not pass;
+fail;
+}
+{
+not skip;
+pass;
+}
+*)

--- a/testsuite/tests/tool-ocamltest/semantics.ml
+++ b/testsuite/tests/tool-ocamltest/semantics.ml
@@ -1,0 +1,11 @@
+(* TEST
+{
+  readonly_files="negation.test negation.reference";
+  program="negation.test";
+  output="negation.result";
+  flags="-e";
+  ocamltest;
+  reference="negation.reference";
+  check-program-output;
+}
+*)

--- a/testsuite/tests/weak-ephe-final/weak_array_par.ml
+++ b/testsuite/tests/weak-ephe-final/weak_array_par.ml
@@ -1,5 +1,5 @@
 (* TEST
-  no-tsan; (* TSan detects the intentional data race *)
+  not tsan; (* TSan detects the intentional data race *)
   { bytecode; }
   { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,5 +1,5 @@
 (* TEST
- no-tsan;
+ not tsan;
  {
    bytecode;
  }{


### PR DESCRIPTION
`not <action>;` performs `<action>`, passes if it skips and skips if it passes. This is intended to be used for predicate-like action which have no other observable behavior than passing or skipping. For example, `not msvc;` is equivalent to `not-msvc;`, and in fact that PR removes the latter action.

(This PR updates existing tests to use `not`, it removes all actions that are obviously the negative of something that is more natural to define, except for `not_macos_amd64_tsan` which would require conjunction and `not-root` which I felt like leaving alone.)