### PR TITLE
Support frame pointers on RiscV architecture

### DIFF
--- a/.depend
+++ b/.depend
@@ -4278,10 +4278,12 @@ asmcomp/selection.cmx : \
 asmcomp/stackframe.cmo : \
     asmcomp/stackframegen.cmi \
     asmcomp/mach.cmi \
+    utils/config.cmi \
     asmcomp/stackframe.cmi
 asmcomp/stackframe.cmx : \
     asmcomp/stackframegen.cmx \
     asmcomp/mach.cmx \
+    utils/config.cmx \
     asmcomp/stackframe.cmi
 endif # ifeq "$(ARCH)" "riscv"
 middle_end/backend_intf.cmi : \

--- a/Changes
+++ b/Changes
@@ -111,6 +111,9 @@ Working version
   GetFileInformationByName call underpinning the CRT's stat implementation.
   (David Allsopp, review by Nicolás Ojeda Bär and Antonin Décimo)
 
+- #14506: Add frame pointers support for RISC-V Linux.
+  (Miod Vallat and Tim McGilchrist, review by Zane Hambly)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -27,11 +27,16 @@ open Emitenv
 (* Layout of the stack.  The C stack must be 16-aligned, but 8-alignment
    is enough for the OCaml stack. *)
 
+let fp = Config.with_frame_pointers
+
 let frame_size env =
   env.stack_offset +                     (* Trap frame, outgoing parameters *)
   size_int * env.f.fun_num_stack_slots.(0) +    (* Local int variables *)
   size_float * env.f.fun_num_stack_slots.(1) +  (* Local float variables *)
-  (if env.f.fun_frame_required then size_addr else 0) (* Return address *)
+  (if env.f.fun_frame_required then
+     (* Return address + optional frame pointer *)
+     size_addr + (if fp then size_addr else 0)
+   else 0)
 
 let slot_offset env loc cls =
   match loc with
@@ -107,15 +112,19 @@ let emit_stack_adjustment n =
     cfi_adjust_cfa_offset (-n)
   end
 
-(* Output add-immediate instruction, clobbers reg_tmp2 *)
+(* Output add-immediate instruction, clobbers reg_tmp2.
+   The _gen form names its registers as strings, so that it can be used
+   with sp, which is not one of the allocatable registers. *)
 
-let emit_addimm rd rs n =
+let emit_addimm_gen rd rs n =
   if is_immediate n then
-    `	addi	{emit_reg rd}, {emit_reg rs}, {emit_int n}\n`
+    `	addi	{emit_string rd}, {emit_string rs}, {emit_int n}\n`
   else begin
     `	li	{emit_reg reg_tmp2}, {emit_int n}\n`;
-    `	add	{emit_reg rd}, {emit_reg rs}, {emit_reg reg_tmp2}\n`
+    `	add	{emit_string rd}, {emit_string rs}, {emit_reg reg_tmp2}\n`
   end
+
+let emit_addimm rd rs n = emit_addimm_gen (reg_name rd) (reg_name rs) n
 
 (* Output memory operation with a possibly non-immediate offset,
    clobbers reg_tmp *)
@@ -134,6 +143,20 @@ let reload_ra n =
 
 let store_ra n =
   emit_mem_op "sd" "ra" (n - 8) "sp"
+
+let reload_fp n =
+  emit_mem_op "ld" "s0" (n - 16) "sp"
+
+let store_fp n =
+  emit_mem_op "sd" "s0" (n - 16) "sp"
+
+let output_epilogue env =
+  let n = frame_size env in
+  if env.f.fun_frame_required then begin
+    reload_ra n;
+    if fp then reload_fp n
+  end;
+  emit_stack_adjustment n
 
 let emit_store rs ofs rd =
   emit_mem_op "sd" (reg_name rs) ofs rd
@@ -267,7 +290,12 @@ let emit_instr env i =
       emit_stack_adjustment (-n);
       if env.f.fun_frame_required then begin
         store_ra n;
-        cfi_offset ~reg:1 (* ra *) ~offset:(-8)
+        cfi_offset ~reg:1 (* ra *) ~offset:(-8);
+        if fp then begin
+          store_fp n;
+          cfi_offset ~reg:8 (* s0 = x8 *) ~offset:(-16);
+          emit_addimm_gen "s0" "sp" n
+        end;
       end;
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
@@ -310,17 +338,13 @@ let emit_instr env i =
       `	{emit_call func}\n`;
       record_frame env i.live (Dbg_other i.dbg)
   | Lop(Itailcall_ind) ->
-      let n = frame_size env in
-      if env.f.fun_frame_required then reload_ra n;
-      emit_stack_adjustment n;
+      output_epilogue env;
       `	jr	{emit_reg i.arg.(0)}\n`
   | Lop(Itailcall_imm {func}) ->
       if func = env.f.fun_name then begin
         `	j	{emit_label env.f.fun_tailrec_entry_point_label}\n`
       end else begin
-        let n = frame_size env in
-        if env.f.fun_frame_required then reload_ra n;
-        emit_stack_adjustment n;
+        output_epilogue env;
         `	{emit_tail func}\n`
       end
   | Lop(Iextcall{func; alloc; stack_ofs}) ->
@@ -335,16 +359,32 @@ let emit_instr env i =
         `	{emit_call "caml_c_call"}\n`;
         record_frame env i.live (Dbg_other i.dbg)
       end else begin
-        (* store ocaml stack in s0, which is marked as being destroyed
-           at noalloc calls *)
-        `	mv	s0, sp\n`;
-        cfi_remember_state ();
-        cfi_def_cfa_register ~reg:8;
-        let ofs = Domainstate.(idx_of_field Domain_c_stack) * 8 in
-        `	ld	sp, {emit_int ofs}({emit_reg reg_domain_state_ptr})\n`;
-        `	{emit_call func}\n`;
-        `	mv	sp, s0\n`;
-        cfi_restore_state ()
+        if fp then begin
+          (* save ocaml stack to C stack around the call *)
+          `	mv	{emit_reg reg_tmp}, sp\n`;
+          cfi_remember_state ();
+          (* sp leaves the OCaml stack, so anchor the CFA on s0 *)
+          cfi_def_cfa_register ~reg:8;
+          cfi_def_cfa_offset 0;
+          let ofs = Domainstate.(idx_of_field Domain_c_stack) * 8 in
+          `	ld	sp, {emit_int ofs}({emit_reg reg_domain_state_ptr})\n`;
+          `	addi	sp, sp, -16\n`;
+          `	sd	{emit_reg reg_tmp}, 0(sp)\n`;
+          `	{emit_call func}\n`;
+          `	ld	sp, 0(sp)\n`;
+          cfi_restore_state ();
+        end else begin
+          (* store ocaml stack in s0, which is marked as being destroyed
+             at noalloc calls *)
+          `	mv	s0, sp\n`;
+          cfi_remember_state ();
+          cfi_def_cfa_register ~reg:8;
+          let ofs = Domainstate.(idx_of_field Domain_c_stack) * 8 in
+          `	ld	sp, {emit_int ofs}({emit_reg reg_domain_state_ptr})\n`;
+          `	{emit_call func}\n`;
+          `	mv	sp, s0\n`;
+          cfi_restore_state ();
+        end
       end
   | Lop(Istackoffset n) ->
       assert (n mod 16 = 0);
@@ -515,6 +555,7 @@ let emit_instr env i =
       reload_ra n
   | Lreturn ->
       let n = frame_size env in
+      if fp && env.f.fun_frame_required then reload_fp n;
       emit_stack_adjustment n;
       `	ret\n`
   | Llabel lbl ->
@@ -584,9 +625,15 @@ let emit_instr env i =
       done;
       `.option pop\n`
   | Lentertrap ->
-      ()
+      if fp then begin
+        (* Recompute the frame pointer after entering an exception handler.
+           On RISC-V, s0 points to CFA (sp at function entry), so we need
+           s0 = sp + frame_size. *)
+        let delta = frame_size env in
+        emit_addimm_gen "s0" "sp" delta
+      end
   | Ladjust_trap_depth { delta_traps } ->
-      (* each trap occupes 16 bytes on the stack *)
+      (* Each trap occupies 16 bytes on the stack *)
       let delta = 16 * delta_traps in
       cfi_adjust_cfa_offset delta;
       env.stack_offset <- env.stack_offset + delta

--- a/asmcomp/riscv/proc.ml
+++ b/asmcomp/riscv/proc.ml
@@ -33,7 +33,7 @@ open Mach
     a0-a7        0-7       arguments/results
     s2-s9        8-15      arguments/results (preserved by C)
     t2-t6        16-20     temporary
-    s0           21        general purpose (preserved by C)
+    s0           21        general purpose or frame pointer (preserved by C)
     t0, t1       22-23     temporaries (used by call veneers)
     s10          24        trap pointer (preserved by C)
     s1           25        allocation pointer (preserved by C)
@@ -59,6 +59,8 @@ open Mach
       arguments and may be clobbered by [Ialloc] in the presence of dynamic
       linking.
 *)
+
+let fp = Config.with_frame_pointers
 
 let int_reg_name =
   [| "a0"; "a1"; "a2"; "a3"; "a4"; "a5"; "a6"; "a7";  (* 0 - 7 *)
@@ -233,8 +235,10 @@ let loc_exn_bucket = phys_reg 0
 (* Registers destroyed by operations *)
 
 let destroyed_at_c_noalloc_call =
-  (* s0-s11 and fs0-fs11 are callee-save, but s0 is
-     used to preserve OCaml sp. *)
+  (* s0-s11 and fs0-fs11 are callee-save, but s0 is used to preserve the
+     OCaml sp across the call when frame pointers are disabled.  With frame
+     pointers, s0 is the frame pointer and the OCaml sp is saved on the
+     C stack instead. *)
   Array.of_list(List.map phys_reg
     [0; 1; 2; 3; 4; 5; 6; 7; 16; 17; 18; 19; 20; 21 (* s0 *);
      100; 101; 102; 103; 104; 105; 106; 107; 110; 111; 112; 113; 114; 115; 116;
@@ -263,11 +267,11 @@ let destroyed_at_reloadretaddr = [| |]
 
 let safe_register_pressure = function
   | Iextcall _ -> 9
-  | _ -> 23
+  | _ -> if fp then 22 else 23
 
 let max_register_pressure = function
   | Iextcall _ -> [| 9; 12 |]
-  | _ -> [| 23; 30 |]
+  | _ -> if fp then [| 22; 30 |] else [| 23; 30 |]
 
 (* See
    https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc
@@ -305,4 +309,8 @@ let assemble_file infile outfile =
   Ccomp.command
     (Config.asm ^ " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 
-let init () = ()
+let init () =
+  if fp then
+    num_available_registers.(0) <- 21
+  else
+    num_available_registers.(0) <- 22

--- a/asmcomp/riscv/stackframe.ml
+++ b/asmcomp/riscv/stackframe.ml
@@ -22,9 +22,14 @@ let trap_handler_size = 16
 
 class stackframe = object
 
-inherit Stackframegen.stackframe_generic
+inherit Stackframegen.stackframe_generic as super
 
 method trap_handler_size = trap_handler_size
+
+(* When frame pointers are enabled, we must always allocate a frame
+   so that the frame pointer chain is properly maintained. *)
+method! frame_required f contains_calls =
+  Config.with_frame_pointers || super#frame_required f contains_calls
 
 end
 

--- a/configure
+++ b/configure
@@ -23794,7 +23794,7 @@ if test x"$enable_frame_pointers" = "xyes"
 then :
   case $target in #(
   x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|x86_64-*-dragonfly*| \
-     aarch64-*-linux*|aarch64-*-darwin*|aarch64-*-freebsd*) :
+     aarch64-*-linux*|aarch64-*-darwin*|aarch64-*-freebsd*|riscv64-*-linux*) :
     case $ocaml_cc_vendor in #(
   clang-*|gcc-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/configure.ac
+++ b/configure.ac
@@ -2815,7 +2815,7 @@ AS_IF([$native_compiler],
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
   [AS_CASE([$target],
     [x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|x86_64-*-dragonfly*| \
-     aarch64-*-linux*|aarch64-*-darwin*|aarch64-*-freebsd*],
+     aarch64-*-linux*|aarch64-*-darwin*|aarch64-*-freebsd*|riscv64-*-linux*],
      [AS_CASE([$ocaml_cc_vendor],
         [clang-*|gcc-*],
          [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -474,6 +474,7 @@ void caml_rewrite_exception_stack(struct stack_info *old_stack,
     fiber_debug_log ("exn_ptr is null");
   }
 }
+
 #endif
 
 int caml_try_realloc_stack(asize_t required_space)
@@ -538,7 +539,27 @@ int caml_try_realloc_stack(asize_t required_space)
            This is somewhat tricky to guarantee when there are stack
            arguments to C calls: see caml_c_call_copy_stack_args */
         struct stack_frame* fp = ((struct stack_frame*)link) - 1;
-        CAMLassert(fp->prev == link->sp);
+
+#if defined(TARGET_riscv)
+        /* On RISC-V, the frame pointer s0 = CFA = sp + frame_size,
+           pointing to the address just AFTER the {saved_s0, saved_ra}
+           frame record.  So fp->prev gives a CFA value, and the
+           actual frame record is at (CFA - sizeof(struct stack_frame)).
+           ENTER_FUNCTION sets s0 = sp + 16, so the saved s0 in the
+           C function's frame equals link->sp + 16. */
+        CAMLassert(fp->prev ==
+                   (struct stack_frame*)((char*)link->sp + 16));
+
+        /* Rewrite OCaml frame pointers above this C frame.
+           fp->prev is a CFA; the frame record is at CFA - 1 (in
+           struct stack_frame units, i.e. CFA - 16 bytes). */
+        while ((value*)fp->prev > Stack_base(old_stack) &&
+               (value*)fp->prev <= Stack_high(old_stack)) {
+          fp->prev = (struct stack_frame*)((char*)fp->prev + delta);
+          fp = fp->prev - 1; /* CFA - 16 = frame record */
+        }
+#else
+        CAMLassert(fp->prev == (struct stack_frame*)link->sp);
 
         /* Rewrite OCaml frame pointers above this C frame */
         while (Stack_base(old_stack) <= (value*)fp->prev &&
@@ -546,6 +567,7 @@ int caml_try_realloc_stack(asize_t required_space)
           fp->prev = (struct stack_frame*)((char*)fp->prev + delta);
           fp = fp->prev;
         }
+#endif
 #endif
         link->stack = new_stack;
         link->sp = (char*)link->sp + delta;

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -43,8 +43,8 @@
    https://github.com/riscv-non-isa/riscv-elf-psabi-doc/releases/tag/v1.0
 
 */
-#define DW_REG_s4                 20
-#define DW_REG_sp                 2
+#define DW_REG_s4                 20 /* x20 */
+#define DW_REG_sp                 2  /* x2  */
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -113,14 +113,22 @@ name:
 /* Function prologue and epilogue */
 
 .macro ENTER_FUNCTION
-        CFI_OFFSET(ra, -8)
         addi    sp, sp, -16
-        sd      ra, 8(sp)
         CFI_ADJUST(16)
+        sd      ra, 8(sp)
+        CFI_OFFSET(ra, -8)
+#ifdef WITH_FRAME_POINTERS
+        sd      s0, 0(sp)
+        CFI_OFFSET(s0, -16)
+        add     s0, sp, 16
+#endif
 .endm
 
 .macro LEAVE_FUNCTION
         ld      ra, 8(sp)
+#ifdef WITH_FRAME_POINTERS
+        ld      s0, 0(sp)
+#endif
         addi    sp, sp, 16
         CFI_ADJUST(-16)
 .endm
@@ -147,7 +155,12 @@ name:
 #define Handler_parent(reg)     24(reg)
 #define Handler_parent_offset   24
 
-/* Switch from OCaml to C stack. */
+/* Switch from OCaml to C stack.
+
+   If a C function is called which might call back into OCaml,
+   then nothing may be pushed to the C stack between SWITCH_OCAML_TO_C
+   and the next C call. (This is to ensure frame pointers are correctly
+   maintained if the stack is reallocated) */
 .macro SWITCH_OCAML_TO_C
     /* Fill in Caml_state->current_stack->sp */
         ld      TMP, Caml_state(current_stack)
@@ -291,6 +304,34 @@ name:
         ld      ALLOC_PTR, Caml_state(young_ptr)
         ld      TRAP_PTR, Caml_state(exn_handler)
 .endm
+
+/* Updates the oldest saved frame pointer in the target fiber.
+
+   A fiber stack may need to grow, causing the reallocation of the entire fiber,
+   including stack_info and stack_handler structures.
+   caml_try_realloc_stack will not be able to update the linked list of
+   frame-pointers if it has been split (i.e., in a continuation).
+   caml_resume and caml_reperform use this macro to update the oldest saved s0
+   (highest one in the stack) in case the fiber was reallocated to reattach the
+   frame-pointer linked list.
+
+   REG: Stack_handler(target_fiber)
+
+   The frame record is pushed immediately after these instructions, by the
+   ENTER_FUNCTION in SWITCH_OCAML_STACKS.  It spans [sp-16, sp), so the value
+   s0 will take -- its CFA -- is the current sp.
+
+   The offset of the oldest saved s0 in a fiber from the stack handler is
+   48 = 4 words (caml_runstack) + 2 words (ra and s0).
+   */
+#ifdef WITH_FRAME_POINTERS
+.macro UPDATE_BASE_POINTER reg
+        sd     sp, -48(\reg)
+.endm
+#else
+.macro UPDATE_BASE_POINTER reg
+.endm
+#endif
 
 #if defined(WITH_THREAD_SANITIZER) /* { */
 
@@ -583,6 +624,14 @@ FUNCTION(caml_c_call_stack_args)
     /* Make the exception handler alloc ptr available to the C code */
         sd      ALLOC_PTR, Caml_state(young_ptr)
         sd      TRAP_PTR, Caml_state(exn_handler)
+#ifdef WITH_FRAME_POINTERS
+    /* Copy the arguments and call.
+       This is done in a separate function so that nothing is pushed
+       between the c_stack_link and the first frame pointer on the C stack
+       (required for correct frame pointer rewriting during stack
+       reallocation; see caml_try_realloc_stack in fiber.c). */
+        call    PLT(caml_c_call_copy_stack_args)
+#else
     /* Store sp to restore after call */
         mv      s2, sp
     /* Copy arguments from OCaml to C stack
@@ -600,6 +649,7 @@ FUNCTION(caml_c_call_stack_args)
         jalr    ADDITIONAL_ARG
     /* Restore stack */
         mv      sp, s2
+#endif
     /* Reload new allocation pointer & exn handler */
         ld      ALLOC_PTR, Caml_state(young_ptr)
         ld      TRAP_PTR, Caml_state(exn_handler)
@@ -612,6 +662,50 @@ FUNCTION(caml_c_call_stack_args)
         LEAVE_FUNCTION
         RET_FROM_C_CALL
 END_FUNCTION(caml_c_call_stack_args)
+
+#ifdef WITH_FRAME_POINTERS
+/* To correctly maintain frame pointers during stack reallocation,
+   the runtime assumes that the caml_c_call stub does not push
+   anything to the stack before the first frame pointer on the C stack.
+   To guarantee this when stack arguments are used, the actual pushing
+   of arguments is done by this separate function. */
+FUNCTION(caml_c_call_copy_stack_args)
+        ENTER_FUNCTION
+#if defined(WITH_THREAD_SANITIZER)
+        TSAN_SAVE_CALLER_REGS
+        /* TSAN_ENTER_FUNCTION, but without switching stacks
+           (we are already on the C stack) */
+        mv      a0, ra
+        call    PLT(caml_tsan_func_entry_asm)
+        TSAN_RESTORE_CALLER_REGS
+#endif
+    /* Copy arguments from OCaml to C stack
+       NB: STACK_ARG_END - STACK_ARG_BEGIN is a multiple of 16 */
+1:      addi    STACK_ARG_END, STACK_ARG_END, -16
+        bltu    STACK_ARG_END, STACK_ARG_BEGIN, 2f
+        ld      TMP, 0(STACK_ARG_END)
+        ld      TMP2, 8(STACK_ARG_END)
+        addi    sp, sp, -16
+        sd      TMP, 0(sp)
+        sd      TMP2, 8(sp)
+        CFI_ADJUST(16)
+        j       1b
+2:  /* Call the function */
+        jalr    ADDITIONAL_ARG
+#if defined(WITH_THREAD_SANITIZER)
+        TSAN_PUSH_RETURN_REGS /* Save return value. */
+        /* TSAN_EXIT_FUNCTION, but without switching stacks */
+        call    PLT(caml_tsan_func_exit_asm)
+        TSAN_POP_RETURN_REGS
+#endif
+    /* Restore stack: s0 = CFA = sp before args were pushed + 16.
+       The loop pushed a dynamic number of words, so resync the CFA. */
+        addi    sp, s0, -16
+        CFI_DEF_CFA_OFFSET(16)
+        LEAVE_FUNCTION
+        ret
+END_FUNCTION(caml_c_call_copy_stack_args)
+#endif
 
 /* Start the OCaml program */
 
@@ -641,14 +735,32 @@ FUNCTION(caml_start_program)
 /* Arguments to the OCaml code are in a0...a7 */
 
 L(jump_to_caml):
-    /* Set up stack frame and save callee-save registers */
+    /* Set up stack frame and save callee-save registers.
+       Without frame pointers the frame is 208 bytes: {s0, ra} at sp+0/sp+8,
+       then the 24 callee-save registers at sp+16..sp+200.
+       With frame pointers the frame is 224 bytes: the {s0, ra} record moves
+       to CFA-16/CFA-8 (sp+208/sp+216) so that a frame-pointer walker can
+       find it, the callee-saves stay put, and sp+0..sp+15 becomes padding. */
+#ifdef WITH_FRAME_POINTERS
+#define JUMP_TO_CAML_FRAME_SZ 224
+        CFI_OFFSET(s0, -16)
+        CFI_OFFSET(ra, -8)
+        addi    sp, sp, -JUMP_TO_CAML_FRAME_SZ
+        sd      s0, (26*8)(sp)
+        sd      ra, (27*8)(sp)
+        CFI_ADJUST(JUMP_TO_CAML_FRAME_SZ)
+        sd      s0, (2*8)(sp)
+        add     s0, sp, JUMP_TO_CAML_FRAME_SZ
+#else
+#define JUMP_TO_CAML_FRAME_SZ 208
         CFI_OFFSET(s0, -208)
         CFI_OFFSET(ra, -200)
-        addi    sp, sp, -208
+        addi    sp, sp, -JUMP_TO_CAML_FRAME_SZ
         sd      s0, 0(sp)
         sd      ra, 8(sp)
-        CFI_ADJUST(208)
+        CFI_ADJUST(JUMP_TO_CAML_FRAME_SZ)
         sd      s0, (2*8)(sp)
+#endif
         sd      s1, (3*8)(sp)
         sd      s2, (4*8)(sp)
         sd      s3, (5*8)(sp)
@@ -705,15 +817,23 @@ L(jump_to_caml):
         mv      sp, t2
 #ifdef ASM_CFI_SUPPORTED
         CFI_REMEMBER_STATE
-        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2 + 2,             \
-            /* sp points to the exn handler on the OCaml stack */     \
-            /* sp + 16 contains the C_STACK_SP */                     \
-          DW_OP_breg + DW_REG_sp, 16 /* exn handler */, DW_OP_deref,  \
-            /* 32   struct c_stack_link + pad */                      \
-            /* 24*8 callee save regs */                               \
-            /* 16   fp + ret addr */                                  \
-            /* need to split to get under 127 limit */                \
+    /* sp points to the exn handler on the OCaml stack, and sp + 16 contains
+       the C_STACK_SP.  The CFA is C_STACK_SP + 32 (struct c_stack_link + pad)
+       + JUMP_TO_CAML_FRAME_SZ, and the addend has to be split into terms
+       below the 127 limit of a single-byte ULEB128 operand. */
+#ifdef WITH_FRAME_POINTERS
+    /* 32 + 224 = 256 = 85 + 85 + 86; the frame carries the {s0, ra} record */
+        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2 + 2 + 2,          \
+          DW_OP_breg + DW_REG_sp, 16 /* exn handler */, DW_OP_deref,   \
+          DW_OP_plus_uconst, 85, DW_OP_plus_uconst, 85,                \
+          DW_OP_plus_uconst, 86
+#else
+    /* 32 + 208 = 240 = 120 + 120
+       208 = 24*8 callee save regs + 16 fp + ret addr */
+        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2 + 2,              \
+          DW_OP_breg + DW_REG_sp, 16 /* exn handler */, DW_OP_deref,   \
           DW_OP_plus_uconst, 120, DW_OP_plus_uconst, 120
+#endif
 #endif
     /* Call the OCaml code */
         jalr    TMP2
@@ -781,9 +901,13 @@ L(return_result):
         fld     fs9, (23*8)(sp)
         fld     fs10, (24*8)(sp)
         fld     fs11, (25*8)(sp)
+#ifdef WITH_FRAME_POINTERS
+        ld      ra, (27*8)(sp)
+#else
         ld      ra, 8(sp)
-        addi    sp, sp, 208
-        CFI_ADJUST(-208)
+#endif
+        addi    sp, sp, JUMP_TO_CAML_FRAME_SZ
+        CFI_ADJUST(-JUMP_TO_CAML_FRAME_SZ)
     /* Return to C caller */
         ret
 END_FUNCTION(caml_start_program)
@@ -1097,6 +1221,9 @@ FUNCTION(caml_reperform)
         ld      a4, Handler_parent(TMP) /* a4 := cont_head */
         sd      a2, Handler_parent(TMP) /* parent(cont_tail) := current_stack */
         addi    a3, a2, 1 /* a3 := Val_ptr(current_stack) */
+     /* Need to update the oldest saved frame pointer here as the execution of
+        the handler may have caused the current fiber stack to reallocate. */
+        UPDATE_BASE_POINTER TMP
         j       L(do_perform)
 END_FUNCTION(caml_reperform)
 
@@ -1145,6 +1272,9 @@ FUNCTION(caml_resume)
         ld      t2, Stack_handler(a3)
         ld      t3, Caml_state(current_stack)
         sd      t3, Handler_parent(t2)
+    /* Need to update the oldest saved frame pointer here as the execution of
+       the handler may have caused the current fiber stack to reallocate. */
+        UPDATE_BASE_POINTER t2
         SWITCH_OCAML_STACKS t3, a0
         mv      a0, a2
         jr      a4
@@ -1208,7 +1338,10 @@ FUNCTION(caml_runstack)
           DW_OP_plus_uconst, Stack_sp_offset, DW_OP_deref,  \
           DW_OP_plus_uconst, 16 /* fp + ret addr */
 #endif
-    /* Call the function on the new stack */
+    /* Call the function on the new stack.
+       With frame pointers, s0 points to the parent stack's CFA (from
+       ENTER_FUNCTION above).  The OCaml function will save it, creating
+       a cross-fiber chain that fp_backtrace can follow. */
         mv      a0, a2
         jalr    a3
 L(frame_runstack):

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -124,18 +124,29 @@ void fp_backtrace(CAMLunused value argv0)
 {
   const char* symbol = NULL;
 
-  for (struct frame_info *fi = __builtin_frame_address(0), *next = NULL;
-       fi;
-       fi = next) {
-    next = fi->prev;
+  for (struct frame_info *frame = __builtin_frame_address(0), *next = NULL;
+       frame;
+       frame = next) {
+#if defined(__riscv)
+    /* On RISC-V, __builtin_frame_address returns s0 = CFA, which points
+       past the frame record.  Subtract one record to reach {prev, retaddr}. */
+    frame--;
+#endif
+    next = frame->prev;
 
     /* Detect the simplest kind of infinite loop */
-    if (fi == next) {
+#if defined(__riscv)
+    /* On RISC-V, frame is CFA-16 (record) but next is a CFA value,
+       so a self-loop means next == frame + 1 (in struct units). */
+    if (next == frame + 1) {
+#else
+    if (frame == next) {
+#endif
       fprintf(stderr, "fp_backtrace: loop detected\n");
       break;
     }
 
-    symbol = backtrace_symbol(fi);
+    symbol = backtrace_symbol(frame);
     if (!symbol)
       continue;
 

--- a/testsuite/tests/frame-pointers/stack_realloc.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc.ml
@@ -5,7 +5,7 @@
  (* NOTE clang on macOS and gcc on Linux are less eager to inline
    certain C functions in the runtime. *)
  if bsd then flags = "-cclib -lexecinfo";
- arch_arm64 || arch_amd64;
+ arch_arm64 || arch_amd64 || arch_riscv;
  reference = "${test_source_directory}/stack_realloc.${arch}.reference";
  native;
  *)

--- a/testsuite/tests/frame-pointers/stack_realloc.riscv.reference
+++ b/testsuite/tests/frame-pointers/stack_realloc.riscv.reference
@@ -1,0 +1,10 @@
+camlStack_realloc.callback
+caml_start_program
+caml_callback_exn
+caml_callback
+c_fun
+caml_c_call
+camlStack_realloc.f_comp
+caml_runstack
+camlStack_realloc.entry
+caml_program

--- a/testsuite/tests/frame-pointers/stack_realloc2.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc2.ml
@@ -5,7 +5,7 @@
  (* NOTE clang on macOS and gcc on Linux are less eager to inline
     certain C functions in the runtime. *)
  if bsd then flags = "-cclib -lexecinfo";
- arch_arm64 || arch_amd64;
+ arch_arm64 || arch_amd64 || arch_riscv;
  reference = "${test_source_directory}/stack_realloc2.${arch}.reference";
  native;
  *)

--- a/testsuite/tests/frame-pointers/stack_realloc2.riscv.reference
+++ b/testsuite/tests/frame-pointers/stack_realloc2.riscv.reference
@@ -1,0 +1,10 @@
+camlStack_realloc2.callback
+caml_start_program
+caml_callback_exn
+caml_callback
+c_fun
+caml_c_call
+camlStack_realloc2.f_comp
+caml_runstack
+camlStack_realloc2.entry
+caml_program


### PR DESCRIPTION
### Support frame pointers on RiscV architecture

RISC-V uses s0 (x8) as the frame pointer register, this PR adds support for maintaining frame pointers in OCaml generated code. It works with C code that has and omits frame pointers.

For a function `f` in `foo.ml`:
```
camlFoo.f:
  # prologue function with frame_size = 32 (32 bytes for ra + s0 + 2 spilled regs)
          addi    sp, sp, -32             # Allocate frame (must be 16-byte aligned)
          sd      ra, 24(sp)              # Save return address
          sd      s0, 16(sp)              # Save old frame pointer
          add     s0, sp, 32              # Set frame pointer to top of frame

  # Function body with register spills

  # epilogue
          ld      ra, 24(sp)              # Load return address
          ld      s0, 16(sp)              # Restore old frame pointer
          addi    sp, sp, 32              # Restore sp
          ret
```

This gives us an OCaml stack frame
```
                          ┌─────────────────────────┐
             CFA (s0) ──▶ │                         │  ◄── sp at function entry
                          ├─────────────────────────┤
                CFA-8     │  saved ra               │  ◄── return address
                          ├─────────────────────────┤
                CFA-16    │  saved s0 (caller's CFA)│  ◄── frame pointer link
                          ├─────────────────────────┤
                CFA-24    │  spilled regs / locals  │
                          │  ...                    │
                          ├─────────────────────────┤
                   sp ──▶ │  (trap frames if any)   │
                          └─────────────────────────┘

    frame_size = align16(num_saved_regs * 8 + 8(ra) + 8(s0))
    s0 = sp + frame_size = CFA
```

RISC-V uses s0 (x8) as the frame pointer with the convention s0 = CFA (Canonical Frame Address = sp at function entry). This differs from ARM64 where the frame pointer register x29 = CFA - 16. I found this diagram helpful to understand the difference (AMD64 should be similar layout to ARM64).


```
    RISC-V                              ARM64
    ──────                              ─────
         ┌───────────┐                       ┌───────────┐
    s0 ──▶  CFA      │                       │  CFA      │
         ├───────────┤                       ├───────────┤
    -8   │  ra       │                  -8   │  x30 (lr) │
         ├───────────┤                       ├───────────┤
    -16  │  old s0   │            x29 ──▶-16 │  old x29  │
         ├───────────┤                       ├───────────┤
         │  locals   │                       │  locals   │
         └───────────┘                       └───────────┘

    s0 = CFA                           x29 = CFA - 16
    s0 = sp + frame_size               x29 = sp + frame_size - 16
```

The stack walking code needs to account for this *different* layout and I've tried to minimise the diff for those parts of the runtime that need to do this. In particular runtime/fiber.c and testsuite/tests/frame-pointers/fp_backtrace.c need to do things differently to the existing ARM64 and AMD64 code. I've included the fix from #13635 to avoid issues with C code not compiled with frame pointers enabled (RISC-V support in Linux seems to be mixed whether a distro supports frame pointers or not).

In general:
* [4ed35be](https://github.com/ocaml/ocaml/pull/14506/commits/4ed35be5711cdd699ecac32239db995870ac38c8) is just configure changes
* [e56df84](https://github.com/ocaml/ocaml/pull/14506/commits/e56df840fa3babc777e5981c817115d795125165) is the main implementation (including Miod's original work from 2024)

The changes @Zaneham submitted in https://github.com/ocaml/ocaml/pull/14504 should be covered in this PR. This code has been tested on Ubuntu 24.04 TLS RISC-V. I still need to validate this doesn't break Thread Sanitizer with frame pointers.
