### PR TITLE
VSCode file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  // This file tries to enforce some of the hygiene rules
+  // enforced in CI by tools/check-typo.
+  "files.insertFinalNewline": true, // (missing-lf)
+  "files.trimFinalNewlines": true, // (white-at-eof)
+  "files.trimTrailingWhitespace": true, // (white-at-eol)
+  "editor.detectIndentation": false,
+  "editor.insertSpaces": true, // (tab)
+  "editor.tabSize": 2,
+  "editor.renderWhitespace": "all", // Makes trailing spaces visible
+  "editor.rulers": [
+    80, // (long-line)
+    132 // (very-long-line)
+  ],
+  "files.eol": "\n"
+}


### PR DESCRIPTION
Couldn't find the policy on editor-specific config.

I only found #12504 which added `.vscode` to gitignore but it looks like it's not in there anymore, so not quite sure what happened.

Again, made this mostly for myself, because I keep getting hit by the hygiene CI, feel free to reject if not welcom.