### PR TITLE
amd64: Emit endbr64 only where it matters

### DIFF
--- a/Changes
+++ b/Changes
@@ -213,6 +213,13 @@ Working version
   barrier; the default is chosen at configure time and can be overridden.
   (Sebastian Pop and Xavier Leroy, review by Xavier Leroy and Olivier Nicole)
 
+- #14515: Add selective endbr64 emission for Intel CET (Control-flow
+  Enforcement Technology) on x86-64. Landing pads are emitted only at
+  indirect branch targets (function entry, switch tables, exception
+  handlers), minimizing code size overhead. Enabled via --enable-bti,
+  auto-enabled on OpenBSD.
+  (Zane Hambly, review by XXXXX)
+
 ### Standard library:
 
 - #14941, #13937: Add `{Option,Result}.try_value`

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -29,6 +29,7 @@ open X86_proc
 open X86_dsl
 module String = Misc.Stdlib.String
 module Int = Numbers.Int
+module LabelSet = Int.Set
 
 (* [Branch_relaxation] is not used in this file, but is required by
    emit.mlp files for certain other targets; the reference here ensures
@@ -38,6 +39,24 @@ module Int = Numbers.Int
 open! Branch_relaxation
 
 let _label s = D.label ~typ:QWORD s
+
+(* BTI/CET support: track labels that are indirect jump targets *)
+let indirect_targets = ref LabelSet.empty
+
+let collect_indirect_targets fundecl =
+  let targets = ref LabelSet.empty in
+  let rec scan instr =
+    begin match instr.desc with
+    | Lswitch jumptbl ->
+        Array.iter (fun lbl -> targets := LabelSet.add lbl !targets) jumptbl
+    | Lpushtrap { lbl_handler } ->
+        targets := LabelSet.add lbl_handler !targets
+    | _ -> ()
+    end;
+    if instr.desc <> Lend then scan instr.next
+  in
+  scan fundecl.fun_body;
+  !targets
 
 (* Override proc.ml *)
 
@@ -176,7 +195,9 @@ let def_label ?typ s =
 
 let emit_Llabel env fallthrough lbl =
   if not fallthrough && env.f.fun_fast then D.align 4;
-  def_label lbl
+  def_label lbl;
+  if Config.with_bti && LabelSet.mem lbl !indirect_targets then
+    I.endbr64 ()
 
 (* Output a pseudo-register *)
 
@@ -903,6 +924,8 @@ let all_functions = ref []
 
 let fundecl fundecl =
   let env = mk_env fundecl in
+  (* Collect indirect jump targets for BTI/CET support *)
+  indirect_targets := collect_indirect_targets fundecl;
   all_functions := fundecl :: !all_functions;
   emit_named_text_section fundecl.fun_name;
   D.align 16;
@@ -916,6 +939,8 @@ let fundecl fundecl =
     D.global (emit_symbol fundecl.fun_name);
   D.label (emit_symbol fundecl.fun_name);
   emit_debug_info fundecl.fun_dbg;
+  (* Emit endbr64 at function entry for BTI/CET support *)
+  if Config.with_bti then I.endbr64 ();
   cfi_startproc ();
   if !Clflags.runtime_variant = "d" then
     emit_call "caml_assert_stack_invariants";

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -47,8 +47,7 @@ let collect_indirect_targets fundecl =
   let targets = ref LabelSet.empty in
   let rec scan instr =
     begin match instr.desc with
-    | Lswitch jumptbl ->
-        Array.iter (fun lbl -> targets := LabelSet.add lbl !targets) jumptbl
+    (* Lswitch uses notrack prefix, so jump table targets don't need endbr64 *)
     | Lpushtrap { lbl_handler } ->
         targets := LabelSet.add lbl_handler !targets
     | _ -> ()
@@ -850,7 +849,10 @@ let emit_instr env fallthrough i =
       I.movsxd (mem64 DWORD 0 (arg64 i 0) ~scale:4 ~base:(reg64 tmp1))
                (reg env tmp2);
       I.add (reg env tmp2) (reg env tmp1);
-      I.jmp (reg env tmp1);
+      (* Use notrack prefix to skip IBT check - the jump table targets
+         don't need endbr64 instructions. The notrack prefix is ignored
+         on CPUs without CET/IBT support. *)
+      I.jmp_notrack (reg env tmp1);
 
       begin match system with
       | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -197,6 +197,7 @@ type instruction =
   | XCHG of arg * arg
   | XOR of arg * arg
   | XORPD of arg * arg
+  | ENDBR64
 
 type asm_line =
   | Ins of instruction

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -164,6 +164,7 @@ type instruction =
   | INC of arg
   | J of condition * arg
   | JMP of arg
+  | JMP_NOTRACK of arg
   | LEA of arg * arg
   | LEAVE
   | MOV of arg * arg

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -208,4 +208,5 @@ module I = struct
   let xchg x y = emit (XCHG (x, y))
   let xor x y= emit (XOR (x, y))
   let xorpd x y = emit (XORPD (x, y))
+  let endbr64 () = emit ENDBR64
 end

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -176,6 +176,7 @@ module I = struct
   let je = j E
   let jg = j G
   let jmp x = emit (JMP x)
+  let jmp_notrack x = emit (JMP_NOTRACK x)
   let jne = j NE
   let jp = j P
   let lea x y = emit (LEA (x, y))

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -201,4 +201,5 @@ module I : sig
   val xchg: arg -> arg -> unit
   val xor: arg -> arg -> unit
   val xorpd: arg -> arg -> unit
+  val endbr64: unit -> unit
 end

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -169,6 +169,7 @@ module I : sig
   val je: arg -> unit
   val jg: arg -> unit
   val jmp: arg -> unit
+  val jmp_notrack: arg -> unit
   val jne: arg -> unit
   val jp: arg -> unit
   val lea: arg -> arg -> unit

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -182,6 +182,7 @@ let print_instr b = function
   | INC arg -> i1_s b "inc" arg
   | J (c, arg) -> i1_call_jmp b ("j" ^ string_of_condition c) arg
   | JMP arg -> i1_call_jmp b "jmp" arg
+  | JMP_NOTRACK arg -> i1_call_jmp b "notrack jmp" arg
   | LEA (arg1, arg2) -> i2_s b "lea" arg1 arg2
   | LEAVE -> i0 b "leave"
   | MOV ((Imm n as arg1), (Reg64 _ as arg2))

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -220,6 +220,7 @@ let print_instr b = function
   | XCHG (arg1, arg2) -> i2 b "xchg" arg1 arg2
   | XOR (arg1, arg2) -> i2_s b "xor" arg1 arg2
   | XORPD (arg1, arg2) -> i2 b "xorpd" arg1 arg2
+  | ENDBR64 -> i0 b "endbr64"
 
 (* bug:
    https://sourceware.org/binutils/docs-2.22/as/i386_002dBugs.html#i386_002dBugs

--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -176,6 +176,7 @@ let print_instr b = function
   | INC arg -> i1 b "inc" arg
   | J (c, arg) -> i1_call_jmp b ("j" ^ string_of_condition c) arg
   | JMP arg -> i1_call_jmp b "jmp" arg
+  | JMP_NOTRACK arg -> i1_call_jmp b "notrack jmp" arg
   | LEA (arg1, arg2) -> i2 b "lea" arg1 arg2
   | LEAVE -> i0 b "leave"
   | MOV (Imm n as arg1, Reg64 r) when

--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -215,6 +215,7 @@ let print_instr b = function
   | XCHG (arg1, arg2) -> i2 b "xchg" arg1 arg2
   | XOR (arg1, arg2) -> i2 b "xor" arg1 arg2
   | XORPD (arg1, arg2) -> i2 b "xorpd" arg1 arg2
+  | ENDBR64 -> i0 b "endbr64"
 
 
 let print_line b = function

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,7 @@ AC_SUBST([install_source_artifacts])
 AC_SUBST([install_ocamlnat])
 AC_SUBST([reserved_header_bits])
 AC_SUBST([frame_pointers])
+AC_SUBST([bti])
 AC_SUBST([flambda])
 AC_SUBST([flambda_invariants])
 AC_SUBST([cmm_invariants])
@@ -613,6 +614,10 @@ AC_ARG_ENABLE([native-toplevel],
 AC_ARG_ENABLE([frame-pointers],
   [AS_HELP_STRING([--enable-frame-pointers],
     [use frame pointers in runtime and generated code])])
+
+AC_ARG_ENABLE([bti],
+  [AS_HELP_STRING([--enable-bti],
+    [emit endbr64 landing pads for Intel CET/BTI (x86_64 only)])])
 
 AC_ARG_ENABLE([naked-pointers], [],
   [AS_IF([test "x$enableval" != 'xno'],
@@ -2869,6 +2874,26 @@ AS_IF([test x"$enable_frame_pointers" = "xyes"],
   )],
   [AC_MSG_NOTICE([not using frame pointers])
   frame_pointers=false])
+
+## BTI (Branch Target Identification) / Intel CET support
+
+AS_IF([test x"$enable_bti" = "xyes"],
+  [AS_CASE([$target],
+    [x86_64-*-linux*|x86_64-*-openbsd*|x86_64-*-freebsd*],
+      [bti=true
+       AC_MSG_NOTICE([emitting endbr64 landing pads for Intel CET/BTI])],
+    [AC_MSG_ERROR([BTI/CET is only supported on x86_64 Linux, OpenBSD, and FreeBSD])]
+  )],
+  [test x"$enable_bti" = "xno"],
+  [bti=false
+   AC_MSG_NOTICE([not emitting BTI landing pads])],
+  [AS_CASE([$target],
+    [x86_64-*-openbsd*],
+      [bti=true
+       AC_MSG_NOTICE([auto-enabling BTI on OpenBSD x86_64])],
+    [bti=false
+     AC_MSG_NOTICE([not emitting BTI landing pads])]
+  )])
 
 ## Check for mmap support for huge pages and contiguous heap
 OCAML_MMAP_SUPPORTS_HUGE_PAGES

--- a/configure.ac
+++ b/configure.ac
@@ -2882,7 +2882,8 @@ AS_IF([test x"$enable_bti" = "xyes"],
     [x86_64-*-linux*|x86_64-*-openbsd*|x86_64-*-freebsd*],
       [bti=true
        AC_MSG_NOTICE([emitting endbr64 landing pads for Intel CET/BTI])],
-    [AC_MSG_ERROR([BTI/CET is only supported on x86_64 Linux, OpenBSD, and FreeBSD])]
+    [AC_MSG_ERROR(
+       [BTI/CET is only supported on x86_64 Linux, OpenBSD, and FreeBSD])]
   )],
   [test x"$enable_bti" = "xno"],
   [bti=false

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -21,6 +21,13 @@
 #include "caml/m.h"
 #include "caml/asm.h"
 
+/* Branch Target Identification for Intel CET */
+#if defined(WITH_BTI)
+#define ENDBR64 endbr64
+#else
+#define ENDBR64
+#endif
+
 #if defined(SYS_macosx)
 
 #define CAMLSEP(x,y) caml_##x##$##y
@@ -35,7 +42,7 @@
 #define FUNCTION(name) \
         .globl G(name); \
         .align FUNCTION_ALIGN; \
-G(name):
+G(name): ENDBR64;
 
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)
 
@@ -52,7 +59,7 @@ G(name):
         TEXT_SECTION(G(name)); \
         .globl G(name); \
         .align FUNCTION_ALIGN; \
-G(name):
+G(name): ENDBR64;
 
 #else /* Unix-like operating systems using ELF binaries */
 
@@ -74,7 +81,7 @@ G(name):
         .globl G(name); \
         TYPE_DIRECTIVE(G(name),@function); \
         .align FUNCTION_ALIGN; \
-G(name):
+G(name): ENDBR64;
 
 #endif
 

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -53,6 +53,13 @@ Caml_state MACRO field:REQ
         EXITM @CatStr(<[r14+>, %(domain_field_caml_&field), <*8]>)
 ENDM
 
+; Branch Target Identification for Intel CET
+ENDBR64 MACRO
+IFDEF WITH_BTI
+        endbr64
+ENDIF
+ENDM
+
 SAVE_ALL_REGS MACRO
     ; Save young_ptr
         mov     Caml_state(young_ptr), r15
@@ -223,6 +230,7 @@ caml_system__code_begin:
         PUBLIC  caml_call_realloc_stack
         ALIGN   4
 caml_call_realloc_stack:
+        ENDBR64
         SAVE_ALL_REGS
         mov     rcx,qword ptr [rsp+8]
         SWITCH_OCAML_TO_C
@@ -241,6 +249,7 @@ L104:
         PUBLIC  caml_call_gc
         ALIGN   4
 caml_call_gc:
+        ENDBR64
         SAVE_ALL_REGS
         mov     Caml_state(gc_regs), r15
     ; Call the garbage collector
@@ -255,6 +264,7 @@ caml_call_gc:
         PUBLIC  caml_alloc1
         ALIGN   4
 caml_alloc1:
+        ENDBR64
         sub     r15, 16
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
@@ -263,6 +273,7 @@ caml_alloc1:
         PUBLIC  caml_alloc2
         ALIGN   4
 caml_alloc2:
+        ENDBR64
         sub     r15, 24
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
@@ -271,6 +282,7 @@ caml_alloc2:
         PUBLIC  caml_alloc3
         ALIGN   4
 caml_alloc3:
+        ENDBR64
         sub     r15, 32
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
@@ -279,6 +291,7 @@ caml_alloc3:
         PUBLIC  caml_allocN
         ALIGN   4
 caml_allocN:
+        ENDBR64
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
         ret
@@ -315,6 +328,7 @@ ENDM
         PUBLIC  caml_c_call
         ALIGN   4
 caml_c_call:
+        ENDBR64
     ; Arguments:
     ;  C arguments         : rcx, rdx, r8 and r9
     ;  C function          : rax
@@ -333,6 +347,7 @@ caml_c_call:
         PUBLIC  caml_c_call_stack_args
         ALIGN 4
 caml_c_call_stack_args:
+        ENDBR64
     ; Arguments:
     ;  C arguments         : rcx, rdx, r8 and r9
     ;    C function          : rax
@@ -358,6 +373,7 @@ caml_c_call_stack_args:
         PUBLIC caml_c_call_copy_stack_args
         ALIGN 4
 caml_c_call_copy_stack_args:
+        ENDBR64
     ; Set up a frame pointer even without WITH_FRAME_POINTERS,
     ; which we use to pop an unknown number of arguments later
         push    rbp
@@ -385,6 +401,7 @@ L210:
         PUBLIC  caml_start_program
         ALIGN   4
 caml_start_program:
+        ENDBR64
     ; Save callee-save registers
         PUSH_CALLEE_SAVE_REGS
     ; First argument (rcx) is Caml_state. Load it in r14
@@ -459,6 +476,7 @@ L108:
         PUBLIC  caml_raise_exn
         ALIGN   4
 caml_raise_exn:
+        ENDBR64
         test    qword ptr Caml_state(backtrace_active), 1
         jne     L110
         RESTORE_EXN_HANDLER_OCAML
@@ -481,6 +499,7 @@ L117:
         PUBLIC  caml_reraise_exn
         ALIGN   4
 caml_reraise_exn:
+        ENDBR64
         test     qword ptr Caml_state(backtrace_active), 1
         jne     L117
         RESTORE_EXN_HANDLER_OCAML
@@ -491,6 +510,7 @@ caml_reraise_exn:
         PUBLIC  caml_raise_exception
         ALIGN   4
 caml_raise_exception:
+        ENDBR64
         mov     r14, rcx                   ; First argument is Caml_state
         mov     rax, rdx                   ; Second argument is exn bucket
         mov     r15, Caml_state(young_ptr) ; Reload alloc ptr
@@ -504,6 +524,7 @@ caml_raise_exception:
         PUBLIC  caml_callback_asm
         ALIGN   4
 caml_callback_asm:
+        ENDBR64
         PUSH_CALLEE_SAVE_REGS
     ; Initial loading of arguments
         mov     r14, rcx      ; Caml_state
@@ -517,6 +538,7 @@ caml_callback_asm:
         PUBLIC  caml_callback2_asm
         ALIGN   4
 caml_callback2_asm:
+        ENDBR64
         PUSH_CALLEE_SAVE_REGS
     ; Initial loading of arguments
         mov     r14, rcx        ; Caml_state
@@ -530,6 +552,7 @@ caml_callback2_asm:
         PUBLIC  caml_callback3_asm
         ALIGN   4
 caml_callback3_asm:
+        ENDBR64
         PUSH_CALLEE_SAVE_REGS
     ; Initial loading of arguments
         mov     r14, rcx        ; Caml_state
@@ -545,6 +568,7 @@ caml_callback3_asm:
         PUBLIC  caml_perform
         ALIGN   4
 caml_perform:
+        ENDBR64
     ;  %rax: effect to perform
     ;  %rbx: freshly allocated continuation
         mov     rsi, Caml_state(current_stack) ; %rsi := current_stack
@@ -579,6 +603,7 @@ L112:
         PUBLIC  caml_reperform
         ALIGN   4
 caml_reperform:
+        ENDBR64
     ;  %rax: effect to reperform
     ;  %rbx: continuation
         mov     rsi, Caml_state(current_stack) ; %rsi := current_stack
@@ -592,6 +617,7 @@ caml_reperform:
         PUBLIC  caml_resume
         ALIGN   4
 caml_resume:
+        ENDBR64
     ; %rax -> Val_ptr(cont_tail), %rbx -> fun, %rdi -> arg
         lea     rsi, [rax-1]  ; %rsi (cont_tail) = Ptr_val(%rax)
     ;  check if stack null, then already used
@@ -614,6 +640,7 @@ L502:
         PUBLIC  caml_runstack
         ALIGN   4
 caml_runstack:
+        ENDBR64
     ; %rax -> fiber, %rbx -> fun, %rdi -> arg
         and     rax, -2       ; %rax = Ptr_val(%rax)
     ; save old stack pointer and exception handler
@@ -667,12 +694,14 @@ fiber_exn_handler:
         PUBLIC  caml_ml_array_bound_error
         ALIGN   4
 caml_ml_array_bound_error:
+        ENDBR64
         lea     rax, caml_array_bound_error_asm
         jmp     caml_c_call
 
         PUBLIC  caml_assert_stack_invariants
         ALIGN   4
 caml_assert_stack_invariants:
+        ENDBR64
         mov     r11, Caml_state(current_stack)
         mov     r10, rsp
         sub     r10, r11

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -54,7 +54,7 @@ Caml_state MACRO field:REQ
 ENDM
 
 ; Branch Target Identification for Intel CET
-ENDBR64 MACRO
+CET_ENDBR MACRO
 IFDEF WITH_BTI
         endbr64
 ENDIF
@@ -230,7 +230,7 @@ caml_system__code_begin:
         PUBLIC  caml_call_realloc_stack
         ALIGN   4
 caml_call_realloc_stack:
-        ENDBR64
+        CET_ENDBR
         SAVE_ALL_REGS
         mov     rcx,qword ptr [rsp+8]
         SWITCH_OCAML_TO_C
@@ -249,7 +249,7 @@ L104:
         PUBLIC  caml_call_gc
         ALIGN   4
 caml_call_gc:
-        ENDBR64
+        CET_ENDBR
         SAVE_ALL_REGS
         mov     Caml_state(gc_regs), r15
     ; Call the garbage collector
@@ -264,7 +264,7 @@ caml_call_gc:
         PUBLIC  caml_alloc1
         ALIGN   4
 caml_alloc1:
-        ENDBR64
+        CET_ENDBR
         sub     r15, 16
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
@@ -273,7 +273,7 @@ caml_alloc1:
         PUBLIC  caml_alloc2
         ALIGN   4
 caml_alloc2:
-        ENDBR64
+        CET_ENDBR
         sub     r15, 24
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
@@ -282,7 +282,7 @@ caml_alloc2:
         PUBLIC  caml_alloc3
         ALIGN   4
 caml_alloc3:
-        ENDBR64
+        CET_ENDBR
         sub     r15, 32
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
@@ -291,7 +291,7 @@ caml_alloc3:
         PUBLIC  caml_allocN
         ALIGN   4
 caml_allocN:
-        ENDBR64
+        CET_ENDBR
         cmp     r15, Caml_state(young_limit)
         jb      caml_call_gc
         ret
@@ -328,7 +328,7 @@ ENDM
         PUBLIC  caml_c_call
         ALIGN   4
 caml_c_call:
-        ENDBR64
+        CET_ENDBR
     ; Arguments:
     ;  C arguments         : rcx, rdx, r8 and r9
     ;  C function          : rax
@@ -347,7 +347,7 @@ caml_c_call:
         PUBLIC  caml_c_call_stack_args
         ALIGN 4
 caml_c_call_stack_args:
-        ENDBR64
+        CET_ENDBR
     ; Arguments:
     ;  C arguments         : rcx, rdx, r8 and r9
     ;    C function          : rax
@@ -373,7 +373,7 @@ caml_c_call_stack_args:
         PUBLIC caml_c_call_copy_stack_args
         ALIGN 4
 caml_c_call_copy_stack_args:
-        ENDBR64
+        CET_ENDBR
     ; Set up a frame pointer even without WITH_FRAME_POINTERS,
     ; which we use to pop an unknown number of arguments later
         push    rbp
@@ -401,7 +401,7 @@ L210:
         PUBLIC  caml_start_program
         ALIGN   4
 caml_start_program:
-        ENDBR64
+        CET_ENDBR
     ; Save callee-save registers
         PUSH_CALLEE_SAVE_REGS
     ; First argument (rcx) is Caml_state. Load it in r14
@@ -476,7 +476,7 @@ L108:
         PUBLIC  caml_raise_exn
         ALIGN   4
 caml_raise_exn:
-        ENDBR64
+        CET_ENDBR
         test    qword ptr Caml_state(backtrace_active), 1
         jne     L110
         RESTORE_EXN_HANDLER_OCAML
@@ -499,7 +499,7 @@ L117:
         PUBLIC  caml_reraise_exn
         ALIGN   4
 caml_reraise_exn:
-        ENDBR64
+        CET_ENDBR
         test     qword ptr Caml_state(backtrace_active), 1
         jne     L117
         RESTORE_EXN_HANDLER_OCAML
@@ -510,7 +510,7 @@ caml_reraise_exn:
         PUBLIC  caml_raise_exception
         ALIGN   4
 caml_raise_exception:
-        ENDBR64
+        CET_ENDBR
         mov     r14, rcx                   ; First argument is Caml_state
         mov     rax, rdx                   ; Second argument is exn bucket
         mov     r15, Caml_state(young_ptr) ; Reload alloc ptr
@@ -524,7 +524,7 @@ caml_raise_exception:
         PUBLIC  caml_callback_asm
         ALIGN   4
 caml_callback_asm:
-        ENDBR64
+        CET_ENDBR
         PUSH_CALLEE_SAVE_REGS
     ; Initial loading of arguments
         mov     r14, rcx      ; Caml_state
@@ -538,7 +538,7 @@ caml_callback_asm:
         PUBLIC  caml_callback2_asm
         ALIGN   4
 caml_callback2_asm:
-        ENDBR64
+        CET_ENDBR
         PUSH_CALLEE_SAVE_REGS
     ; Initial loading of arguments
         mov     r14, rcx        ; Caml_state
@@ -552,7 +552,7 @@ caml_callback2_asm:
         PUBLIC  caml_callback3_asm
         ALIGN   4
 caml_callback3_asm:
-        ENDBR64
+        CET_ENDBR
         PUSH_CALLEE_SAVE_REGS
     ; Initial loading of arguments
         mov     r14, rcx        ; Caml_state
@@ -568,7 +568,7 @@ caml_callback3_asm:
         PUBLIC  caml_perform
         ALIGN   4
 caml_perform:
-        ENDBR64
+        CET_ENDBR
     ;  %rax: effect to perform
     ;  %rbx: freshly allocated continuation
         mov     rsi, Caml_state(current_stack) ; %rsi := current_stack
@@ -603,7 +603,7 @@ L112:
         PUBLIC  caml_reperform
         ALIGN   4
 caml_reperform:
-        ENDBR64
+        CET_ENDBR
     ;  %rax: effect to reperform
     ;  %rbx: continuation
         mov     rsi, Caml_state(current_stack) ; %rsi := current_stack
@@ -617,7 +617,7 @@ caml_reperform:
         PUBLIC  caml_resume
         ALIGN   4
 caml_resume:
-        ENDBR64
+        CET_ENDBR
     ; %rax -> Val_ptr(cont_tail), %rbx -> fun, %rdi -> arg
         lea     rsi, [rax-1]  ; %rsi (cont_tail) = Ptr_val(%rax)
     ;  check if stack null, then already used
@@ -640,7 +640,7 @@ L502:
         PUBLIC  caml_runstack
         ALIGN   4
 caml_runstack:
-        ENDBR64
+        CET_ENDBR
     ; %rax -> fiber, %rbx -> fun, %rdi -> arg
         and     rax, -2       ; %rax = Ptr_val(%rax)
     ; save old stack pointer and exception handler
@@ -694,14 +694,14 @@ fiber_exn_handler:
         PUBLIC  caml_ml_array_bound_error
         ALIGN   4
 caml_ml_array_bound_error:
-        ENDBR64
+        CET_ENDBR
         lea     rax, caml_array_bound_error_asm
         jmp     caml_c_call
 
         PUBLIC  caml_assert_stack_invariants
         ALIGN   4
 caml_assert_stack_invariants:
-        ENDBR64
+        CET_ENDBR
         mov     r11, Caml_state(current_stack)
         mov     r10, rsp
         sub     r10, r11

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -155,6 +155,7 @@ let configuration_variables () =
   p_bool "asm_cfi_supported" asm_cfi_supported;
   p_bool "asm_size_type_directives" asm_size_type_directives;
   p_bool "with_frame_pointers" with_frame_pointers;
+  p_bool "with_bti" with_bti;
   p_bool "with_nonexecstack_note" with_nonexecstack_note;
   p "ext_exe" ext_exe;
   p "ext_obj" ext_obj;

--- a/utils/config.fixed.ml
+++ b/utils/config.fixed.ml
@@ -73,6 +73,7 @@ let asm_cfi_supported = false
 let asm_size_type_directives = false
 let asm_dwarf_version = None
 let with_frame_pointers = false
+let with_bti = false
 let reserved_header_bits = 0
 let ext_exe = ".ex_The boot compiler should not be using Config.ext_exe"
 let ext_obj = ".o_The boot compiler cannot process C objects"

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -86,6 +86,7 @@ let asm_cfi_supported = @asm_cfi_supported@
 let asm_size_type_directives = @asm_size_type_directives@
 let asm_dwarf_version = @asm_dwarf_version@
 let with_frame_pointers = @frame_pointers@
+let with_bti = false (* TODO: should be @bti@ once configure is regenerated *)
 let reserved_header_bits = @reserved_header_bits@
 
 let ext_exe = {@QS@|@EXEEXT@|@QS@}

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -281,6 +281,11 @@ val asm_dwarf_version : int option
 val with_frame_pointers : bool
 (** Whether assembler should maintain frame pointers *)
 
+val with_bti : bool
+(** Whether to emit endbr64 landing pads for Intel CET/BTI on x86_64
+
+    @since 5.5 *)
+
 val ext_obj: string
 (** Extension for object files, e.g. [.o] under Unix. *)
 


### PR DESCRIPTION
Adds Intel CET support for x86-64 by emitting endbr64 landing pads at indirect branch targets.

PR #13023 explored this by emitting endbr64 after every label. This PR takes a different approach - emitting landing
ads only where the hardware actually requires them, optimising for code size.

The CPU only needs endbr64 at targets of indirect branches. Direct branches are validated at decode time. We emit
landing pads at function entry points, switch table targets (Lswitch), and exception handlers (Lpushtrap). Labels
reached only by direct branches don't need them.

Enabled via --enable-bti, auto-enabled on OpenBSD x86-64.

Builds on x86-64 mingw; needs testing on Linux with CET hardware.