### PR TITLE
Fix Ptype_external printing

### DIFF
--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1771,7 +1771,7 @@ and type_declaration ctxt f x =
     | Ptype_open ->
         pp f "%t%t@;.." intro priv
     | Ptype_external name ->
-        pp f " =@ external %a" constant_string name
+        pp f "@;external %a" constant_string name
   in
   let constraints f =
     List.iter

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7551,3 +7551,6 @@ let () =
   let module%foo M = P(A) [@@foo] in
   let%e[@foo] x = 12 in
   ()
+
+(* 5.5 Features *)
+type t = external "foo"


### PR DESCRIPTION
There appears to be a stray `=` in the printing of the new `Ptype_external` type kind. I have targeted the 5.5 branch here, hopefully that is the right thing to do.

```ocaml
let () =
  let td =
    Ast_helper.Type.mk ~kind:(Ptype_external "bar") { txt = "foo"; loc = Location.none }
  in
  let sign = Ast_helper.Sig.mk (Psig_type (Nonrecursive, [ td ])) in
  Pprintast.signature_item Format.std_formatter sign
```

This would print 

```
type nonrec foo = = external "bar"
```

(discovered during ppxlib testing for the upcoming 5.5 release)