### PR TITLE
mmap error check

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,6 +39,9 @@ Working version
 
 ### Bug fixes:
 
+- #14519: Fix segfault when using `Runtime_events` under certain
+  circumstances due to bad error checking when calling `mmap()`.
+  (Mark Elvers, review by Nicolás Ojeda Bär)
 
 OCaml 5.5.0
 -----------

--- a/Changes
+++ b/Changes
@@ -39,10 +39,6 @@ Working version
 
 ### Bug fixes:
 
-- #14519: Fix segfault when using `Runtime_events` under certain
-  circumstances due to bad error checking when calling `mmap()`.
-  (Mark Elvers, review by Nicolás Ojeda Bär)
-
 OCaml 5.5.0
 -----------
 
@@ -732,6 +728,10 @@ OCaml 5.5.0
 - #14495: Fix infix-tag bug in the minor collector which could cause SEGVs
   in multi-domain programs.
   (Nick Barnes, review by Gabriel Scherer)
+
+- #14519: Fix segfault when using `Runtime_events` under certain
+  circumstances due to bad error checking when calling `mmap()`.
+  (Mark Elvers, review by Nicolás Ojeda Bär)
 
 OCaml 5.4.0 (9 October 2025)
 ----------------------------

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -330,7 +330,7 @@ static void runtime_events_create_from_stw_single(void) {
                         mmap(NULL, current_ring_total_size,
                             PROT_READ | PROT_WRITE, MAP_SHARED, ring_fd, 0);
 
-    if (current_metadata == NULL) {
+    if (current_metadata == MAP_FAILED) {
       caml_fatal_error("Unable to mmap ring buffer");
     }
 


### PR DESCRIPTION
When running the test suite mounted on a Plan 9 file system, via QEMU, I noticed that some tests failed with a segmentation fault. Plan 9 doesn't support `mmap`, but the test for a failed `mmap` call compares it with `NULL`, but `mmap()` returns `MAP_FAILED` (which is `(void*)-1`) on failure.