### PR TITLE
intf-c: replace redefine with redeclare

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -3026,14 +3026,14 @@ Since OCaml 4.04, it is possible to get access to every part of the internal
 runtime API by defining the "CAML_INTERNALS" macro before loading caml header files.
 If this macro is not defined, parts of the internal runtime API are hidden.
 
-If you are using internal C variables, do not redefine them by hand. You should
+If you are using internal C variables, do not redeclare them by hand. You should
 import those variables by including the corresponding header files. The
 representation of those variables has already changed once in OCaml 4.10, and is
 still under evolution.
 If your code relies on such internal and brittle properties, it will be broken
 at some point in time.
 
-For instance, rather than redefining "caml_young_limit":
+For instance, rather than redeclaring "caml_young_limit":
 \begin{verbatim}
 extern int caml_young_limit;
 \end{verbatim}


### PR DESCRIPTION
Trying to be super pedantic here, but most of the time the headers have _declarations_ of entities, not _definitions_. The example using `caml_young_limit` is a declaration.  
https://en.wikipedia.org/wiki/Declaration_(computer_programming)#Declarations_and_definitions

(no change entry needed)