### PR TITLE
The Hunt for C++ Compiler

### DIFF
--- a/Changes
+++ b/Changes
@@ -692,8 +692,8 @@ OCaml 5.5.0
   in an unbounded number of labeled or optional arguments.
   (Stefan Muenzel, report by Samuel Vivien, review by Florian Angeletti)
 
-- #13777, #14347, #14348, #14421: Test that C++ compilers can link with
-  the OCaml runtime and include its headers.
+- #13777, #14347, #14348, #14421, #14498, #14526: Test that C++
+  compilers can link with the OCaml runtime and include its headers.
   (Antonin Décimo, review by David Allsopp and Gabriel Scherer)
 
 - #14255: Fix TSan bug with C calls that take many arguments

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -666,6 +666,7 @@ AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #error "No C++11 support"
 #endif
+#include <iostream>
           ]])],
           [ocaml_cv_prog_cxx="$CC"],
           [ocaml_cv_prog_cxx=""])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -661,7 +661,9 @@ AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
     AS_CASE(["$ccomp_type"],
       [cc], [
         saved_CC="$CC"
-        CC="$CC -xc++"
+        saved_CFLAGS="$CFLAGS"
+        AS_IF([test x"$CXX" = x],
+          [CC="$CC -xc++"; CFLAGS="$CXXFLAGS"], [CC="$CXX"; CFLAGS="$CXXFLAGS"])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #error "No C++11 support"
@@ -670,7 +672,8 @@ AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
           ]])],
           [ocaml_cv_prog_cxx="$CC"],
           [ocaml_cv_prog_cxx=""])
-        CC="$saved_CC"],
+        CC="$saved_CC"
+        CFLAGS="$saved_CFLAGS"],
       [msvc], [
         # cl.exe selects between C and C++ based on the file extension
         ocaml_cv_prog_cxx="$CC"],

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -656,8 +656,8 @@ AC_DEFUN([OCAML_CHECK_WINDOWS_TRIPLET], [
 # This macro is only used for ocamltest to call the C++11 compiler if the
 # default C compiler also can build C++.
 AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
-  AC_CACHE_CHECK([for a C++11 compiler],
-    [ocaml_cv_prog_cxx], [
+  AC_MSG_CHECKING([for a C++11 compiler])
+  AC_CACHE_VAL([ocaml_cv_prog_cxx], [
     AS_CASE(["$ccomp_type"],
       [cc], [
         saved_CC="$CC"
@@ -675,4 +675,5 @@ AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
         # cl.exe selects between C and C++ based on the file extension
         ocaml_cv_prog_cxx="$CC"],
       [ocaml_cv_prog_cxx=""])])
+  AC_MSG_RESULT([${ocaml_cv_prog_cxx:-none found}])
   ocamltest_CXX="$ocaml_cv_prog_cxx"])

--- a/configure
+++ b/configure
@@ -23908,7 +23908,7 @@ fi
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a C++11 compiler" >&5
 printf %s "checking for a C++11 compiler... " >&6; }
-if test ${ocaml_cv_prog_cxx+y}
+  if test ${ocaml_cv_prog_cxx+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
@@ -23950,8 +23950,9 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     ocaml_cv_prog_cxx="" ;;
 esac
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_cxx" >&5
-printf "%s\n" "$ocaml_cv_prog_cxx" >&6; }
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${ocaml_cv_prog_cxx:-none found}" >&5
+printf "%s\n" "${ocaml_cv_prog_cxx:-none found}" >&6; }
   ocamltest_CXX="$ocaml_cv_prog_cxx" ;; #(
   *) :
     build_ocamltest=false

--- a/configure
+++ b/configure
@@ -23917,7 +23917,13 @@ else $as_nop
   cc) :
 
         saved_CC="$CC"
-        CC="$CC -xc++"
+        saved_CFLAGS="$CFLAGS"
+        if test x"$CXX" = x
+then :
+  CC="$CC -xc++"; CFLAGS="$CXXFLAGS"
+else $as_nop
+  CC="$CXX"; CFLAGS="$CXXFLAGS"
+fi
         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -23941,7 +23947,8 @@ else $as_nop
   ocaml_cv_prog_cxx=""
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-        CC="$saved_CC" ;; #(
+        CC="$saved_CC"
+        CFLAGS="$saved_CFLAGS" ;; #(
   msvc) :
 
         # cl.exe selects between C and C++ based on the file extension

--- a/configure
+++ b/configure
@@ -23924,6 +23924,7 @@ else $as_nop
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #error "No C++11 support"
 #endif
+#include <iostream>
 
 int
 main (void)


### PR DESCRIPTION
The Hunt for C&zwj;+&zwj;+ Compiler fails when a covert C compiler (`zig cc` of class `0.16.0-dev.2471+e9eadee00`) that is categorized with `ccomp_type="cc"` delegates its powers to its second in command Clang, that accepts the `-xc++` flag to turn over the compiler driver to C&zwj;+&zwj;+, but fails at executing the orders: it fishes the macro `__cplusplus` but cannot reach the atomic library ; for `zig cc` and `zig c++` look through the periscope to see in `conftest.c` the extension, go rogue and disobey commands by ignoring the `-xc++` flag (unless told twice!).

```console
$ ./configure CC="zig cc" && make V=1
...
  GEN runtime/api-testing/runtime_events_consumer.cpp
  CXX runtime/api-testing/runtime_events_consumer.cpp.o
In file included from runtime/api-testing/runtime_events_consumer.cpp:1:
In file included from otherlibs/runtime_events/caml/runtime_events_consumer.h:22:
In file included from runtime/caml/runtime_events.h:31:
In file included from runtime/caml/mlvalues.h:20:
runtime/caml/misc.h:82:10: fatal error: 'atomic' file not found
   82 | #include <atomic>
      |          ^~~~~~~~
1 error generated.
make[2]: *** [Makefile:1427: runtime/api-testing/runtime_events_consumer.cpp.o] Error 1
```

Test the C++ compiler with a complete C&zwj;+&zwj;+ program including one stdc++ header. Improve reporting whether a C&zwj;+&zwj;+11 compiler was found.

```console
$ ./configure CC="zig cc"
checking for a C++11 compiler... none found
$ ./configure CC="zig cc" CXX="zig c++ -xc++"
checking for a C++11 compiler... zig c++ -xc++
```

Follow-up to #14498. Cf #14478.
cc @dra27 @gasche @gridbugs 