### PR TITLE
Continue to clean `opnames.h` and `jumptbl.h`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1699,8 +1699,11 @@ clean::
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
 	rm -f $(addprefix runtime/, \
 	  ocamlrun.exe ocamlrund.exe ocamlruni.exe ocamlruns.exe sak.exe)
+# jumptbl.h and opnames.h stopped being generated in #14488, but the two headers
+# continue to be removed as otherwise when switching between branches based
+# before this change the (stale) headers trip the C/C++ compatibility tests.
 	rm -f runtime/primitives runtime/primitives*.new runtime/prims.c \
-	  $(runtime_BUILT_HEADERS)
+	  $(runtime_BUILT_HEADERS) runtime/caml/jumptbl.h runtime/caml/opnames.h
 	rm -f runtime/domain_state.inc
 	rm -rf $(DEPDIR)
 	rm -f stdlib/libcamlrun.a stdlib/libcamlrun.lib


### PR DESCRIPTION
Post #14488, as noted in https://github.com/ocaml/ocaml/pull/14488#issuecomment-3861269001, when switching branches you can end up with a stale and untracked jumptbl.h and opnames.h which then trip the test in #14498, which is a nuisance.

In a similar way to that done in #10301 when the casing of stdlib artefacts changed, I propose just to keep partialclean removing those two headers and at some suitable point in the future, the recipe can be updated, as was then done in https://github.com/ocaml/ocaml/pull/11590/changes/f459b70d4be312971b0838999c488dc85c6574e7.