### PR TITLE
Restore the Dune build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,10 +493,10 @@ reconfigure:
 	                                    $(ADDITIONAL_CONFIGURE_ARGS)
 
 utils/domainstate.ml: utils/domainstate.ml.c runtime/caml/domain_state.tbl
-	$(V_GEN)$(CPP) -I runtime/caml $< > $@
+	$(V_GEN)$(CPP) -I runtime $< > $@
 
 utils/domainstate.mli: utils/domainstate.mli.c runtime/caml/domain_state.tbl
-	$(V_GEN)$(CPP) -I runtime/caml $< > $@
+	$(V_GEN)$(CPP) -I runtime $< > $@
 
 configure: tools/autogen configure.ac aclocal.m4 build-aux/ocaml_version.m4
 	$<

--- a/asmcomp/dune
+++ b/asmcomp/dune
@@ -24,7 +24,7 @@
           (glob_files power/*.ml)
           (glob_files riscv/*.ml)
           (glob_files s390x/*.ml))
- (action  (bash "cp `grep '^ARCH=' %{conf} | cut -d'=' -f2`/*.ml .")))
+ (action  (bash "cp %{read-lines:../build-aux/arch}/*.ml .")))
 
 (rule
  (targets emit.ml)
@@ -39,7 +39,7 @@
    (no-infer
     (progn
       (with-stdout-to contains-input-name
-        (bash "echo `grep '^ARCH=' %{conf} | cut -d'=' -f2`/emit.mlp"))
+        (bash "echo %{read-lines:../build-aux/arch}/emit.mlp"))
       (with-stdout-to %{targets}
         (progn
           (bash "echo \\# 1 \\\"`cat contains-input-name`\\\"")

--- a/build-aux/Makefile
+++ b/build-aux/Makefile
@@ -1,0 +1,23 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                   David Allsopp, Jane Street Europe                    *
+#*                                                                        *
+#*   Copyright 2026 Jane Street Group LLC                                 *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+ROOTDIR = ..
+
+include $(ROOTDIR)/Makefile.common
+
+cpp:
+	@echo $(call QUOTE_SINGLE,$(CPP)) > $@
+
+arch:
+	@echo '$(ARCH)' > $@

--- a/build-aux/dune
+++ b/build-aux/dune
@@ -2,9 +2,9 @@
 ;*                                                                        *
 ;*                                 OCaml                                  *
 ;*                                                                        *
-;*                     Thomas Refis, Jane Street Europe                   *
+;*                   David Allsopp, Jane Street Europe                    *
 ;*                                                                        *
-;*   Copyright 2018 Jane Street Group LLC                                 *
+;*   Copyright 2026 Jane Street Group LLC                                 *
 ;*                                                                        *
 ;*   All rights reserved.  This file is distributed under the terms of    *
 ;*   the GNU Lesser General Public License version 2.1, with the          *
@@ -13,11 +13,11 @@
 ;**************************************************************************
 
 (rule
- (target opcodes.ml)
- (mode   fallback)
- (deps   ../runtime/caml/opcodes.h)
- (action
-   (with-stdout-to %{target}
-     (system
-       "%{read-lines:../build-aux/cpp} -I ../runtime %{dep:opcodes.ml.c}"
-       ))))
+  (targets cpp arch)
+  (deps Makefile
+        ../Makefile.build_config
+        ../Makefile.common
+        ../Makefile.config_if_required
+        ../Makefile.config)
+  (action
+    (run make %{targets})))

--- a/bytecomp/dune
+++ b/bytecomp/dune
@@ -13,8 +13,13 @@
 ;**************************************************************************
 
 (rule
- (targets opcodes.ml)
- (mode    fallback)
- (deps    (:instr (file ../runtime/caml/instruct.h)))
+ (target opcodes.ml)
+ (mode   fallback)
+ (deps    (:conf ../Makefile.config)
+          (:c opcodes.ml.c)
+          (:tbl ../runtime/caml/opcodes.h))
  (action
-  (bash "%{dep:../tools/make_opcodes.exe} -opcodes < %{instr} > %{targets}")))
+   (with-stdout-to %{target}
+     (bash
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime %{c}"
+       ))))

--- a/tools/dune
+++ b/tools/dune
@@ -12,13 +12,9 @@
 ;*                                                                        *
 ;**************************************************************************
 
-(executables
- (names   make_opcodes cvt_emit)
- (modules make_opcodes cvt_emit))
-
-(ocamllex
- (modules make_opcodes)
- (mode    fallback))
+(executable
+ (name    cvt_emit)
+ (modules cvt_emit))
 
 (ocamllex
  (modules cvt_emit)

--- a/utils/domainstate.ml.c
+++ b/utils/domainstate.ml.c
@@ -15,12 +15,12 @@
 /**************************************************************************/
 
 #define CAML_CONFIG_H_NO_TYPEDEFS
-#include "config.h"
+#include "caml/config.h"
 let stack_ctx_words = Stack_ctx_words
 
 type t =
 #define DOMAIN_STATE(type, name) | Domain_##name
-#include "domain_state.tbl"
+#include "caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
 let idx_of_field =
@@ -28,11 +28,11 @@ let idx_of_field =
 #define DOMAIN_STATE(type, name) \
   let idx__##name = curr in \
   let curr = curr + 1 in
-#include "domain_state.tbl"
+#include "caml/domain_state.tbl"
 #undef DOMAIN_STATE
   let _ = curr in
   function
 #define DOMAIN_STATE(type, name) \
   | Domain_##name -> idx__##name
-#include "domain_state.tbl"
+#include "caml/domain_state.tbl"
 #undef DOMAIN_STATE

--- a/utils/domainstate.mli.c
+++ b/utils/domainstate.mli.c
@@ -18,7 +18,7 @@ val stack_ctx_words : int
 
 type t =
 #define DOMAIN_STATE(type, name) | Domain_##name
-#include "domain_state.tbl"
+#include "caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
 val idx_of_field : t -> int

--- a/utils/dune
+++ b/utils/dune
@@ -23,23 +23,19 @@
 (rule
  (targets domainstate.ml)
  (mode    fallback)
- (deps    (:conf ../Makefile.config)
-          (:c domainstate.ml.c)
-          (:tbl ../runtime/caml/domain_state.tbl))
+ (deps    ../runtime/caml/domain_state.tbl)
  (action
    (with-stdout-to %{targets}
-     (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime %{c}"
+     (system
+       "%{read-lines:../build-aux/cpp} -I ../runtime %{dep:domainstate.ml.c}"
        ))))
 
 (rule
  (targets domainstate.mli)
  (mode    fallback)
- (deps    (:conf ../Makefile.config)
-          (:c domainstate.mli.c)
-          (:tbl ../runtime/caml/domain_state.tbl))
+ (deps    ../runtime/caml/domain_state.tbl)
  (action
    (with-stdout-to %{targets}
-     (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime %{c}"
+     (system
+       "%{read-lines:../build-aux/cpp} -I ../runtime %{dep:domainstate.mli.c}"
        ))))

--- a/utils/dune
+++ b/utils/dune
@@ -29,7 +29,7 @@
  (action
    (with-stdout-to %{targets}
      (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime %{c}"
        ))))
 
 (rule
@@ -41,5 +41,5 @@
  (action
    (with-stdout-to %{targets}
      (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime %{c}"
        ))))


### PR DESCRIPTION
Alternate approach to #14509.

The first commit simply restores the build by duplicating the logic for bytecomp/opnames.ml already present for utils/domainstate.ml. There's no need to generate the .mli file (it wasn't ever being generated before #14488, either).

The third commit then replaces the slightly unfortunate hacks to get CPP with a less unfortunate Dune hack. The Dune version has the benefit that it is both shared and cached.

The middle commit makes a tiny uniformity tweak to the build of utils/domainstate.ml and utils/domainstate.mli the sole purpose of which is to keep the resulting line in the `dune` file below 80 characters...