### PR TITLE
ocamltest: conditionals in test statements

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,11 @@ Working version
   predicate-like action.
   (Gabriel Scherer, review by Olivier Nicole)
 
+- #14532: in ocamltest, support `<action> && <action>`,
+  `<action> || <action>`
+  and `if <action> then <action> [else <action>]`.
+  (Gabriel Scherer, review by Olivier Nicole)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -117,7 +117,7 @@ let test_file test_filename =
       let default_tests = Tests.default_tests() in
       let make_tree test =
         let id = make_identifier test.Tests.test_name in
-        Ast ([Test (Pos, id, [])], [])
+        Ast ([Action { name = id; modifiers = [] }], [])
       in
       Ast ([], List.map make_tree default_tests)
     | _ -> tsl_ast

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -37,6 +37,7 @@ type statement =
   | Not of statement
   | And of statement * statement
   | Or of statement * statement
+  | If of statement * statement * statement option
 
 type t = Ast of statement list * t list
 

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -35,6 +35,8 @@ type statement =
   | Environment_statement of environment_statement located
   | Action of action
   | Not of statement
+  | And of statement * statement
+  | Or of statement * statement
 
 type t = Ast of statement list * t list
 

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -20,8 +20,6 @@ type 'a located = {
   loc : Location.t
 }
 
-type sign = Pos | Neg
-
 type environment_statement =
   | Assignment of bool * string located * string located (* variable = value *)
   | Append of string located * string located
@@ -35,9 +33,8 @@ type action = {
 
 type statement =
   | Environment_statement of environment_statement located
-  | Test of
-    sign (* when Neg, negate the test *) *
-    action
+  | Action of action
+  | Not of statement
 
 type t = Ast of statement list * t list
 

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -28,14 +28,18 @@ type environment_statement =
   | Include of string located (* include named environment *)
   | Unset of string located (* clear environment variable *)
 
-type tsl_item =
+type action = {
+  name: string located;
+  modifiers: string located list;
+}
+
+type statement =
   | Environment_statement of environment_statement located
   | Test of
     sign (* when Neg, negate the test *) *
-    string located (* test name *) *
-    string located list (* environment modifiers *)
+    action
 
-type t = Ast of tsl_item list * t list
+type t = Ast of statement list * t list
 
 let rec split_env l =
   match l with

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -35,6 +35,8 @@ type statement =
   | Environment_statement of environment_statement located
   | Action of action
   | Not of statement
+  | And of statement * statement
+  | Or of statement * statement
 
 type t = Ast of statement list * t list
 (* <item>; <item>; ...; { <block> } { <block> } ... *)

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -20,8 +20,6 @@ type 'a located = {
   loc : Location.t
 }
 
-type sign = Pos | Neg
-
 type environment_statement =
   | Assignment of bool * string located * string located (* variable = value *)
   | Append of string located * string located (* variable += value *)
@@ -35,9 +33,8 @@ type action = {
 
 type statement =
   | Environment_statement of environment_statement located
-  | Test of
-    sign (* when Neg, negate the test *) *
-    action
+  | Action of action
+  | Not of statement
 
 type t = Ast of statement list * t list
 (* <item>; <item>; ...; { <block> } { <block> } ... *)

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -28,18 +28,22 @@ type environment_statement =
   | Include of string located (* include named environment *)
   | Unset of string located (* clear environment variable *)
 
-type tsl_item =
+type action = {
+  name: string located;
+  modifiers: string located list;
+}
+
+type statement =
   | Environment_statement of environment_statement located
   | Test of
     sign (* when Neg, negate the test *) *
-    string located (* test name *) *
-    string located list (* environment modifiers *)
+    action
 
-type t = Ast of tsl_item list * t list
+type t = Ast of statement list * t list
 (* <item>; <item>; ...; { <block> } { <block> } ... *)
 
 val split_env :
-  tsl_item list -> environment_statement located list * tsl_item list
+  statement list -> environment_statement located list * statement list
 
 val make_identifier : ?loc:Location.t -> string -> string located
 val make_string : ?loc:Location.t -> string -> string located

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -37,6 +37,7 @@ type statement =
   | Not of statement
   | And of statement * statement
   | Or of statement * statement
+  | If of statement * statement * statement option
 
 type t = Ast of statement list * t list
 (* <item>; <item>; ...; { <block> } { <block> } ... *)

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -20,27 +20,33 @@ type 'a located = {
   loc : Location.t
 }
 
-type environment_statement =
-  | Assignment of bool * string located * string located (* variable = value *)
-  | Append of string located * string located (* variable += value *)
-  | Include of string located (* include named environment *)
-  | Unset of string located (* clear environment variable *)
+type environment_statement = (* <env update> ::= *)
+  | Assignment of bool * string located * string located
+    (* <variable> = <value> *)
+  | Append of string located * string located
+    (* <variable> += <value> *)
+  | Include of string located
+    (* include <named environment> *)
+  | Unset of string located
+    (* clear <variable> *)
 
 type action = {
   name: string located;
   modifiers: string located list;
-}
+} (* <action> ::= <name> [with <named environment>, <named environment>....] *)
 
 type statement =
-  | Environment_statement of environment_statement located
-  | Action of action
-  | Not of statement
-  | And of statement * statement
-  | Or of statement * statement
+  | Environment_statement of environment_statement located (* <env update> *)
+  | Action of action (* <action> *)
+  | Not of statement (* not <statement> *)
+  | And of statement * statement (* <statement> && <statement> *)
+  | Or of statement * statement (* <statement> || <statement> *)
   | If of statement * statement * statement option
+    (* if <statement> then <statement> [else <statement>] *)
 
 type t = Ast of statement list * t list
-(* <item>; <item>; ...; { <block> } { <block> } ... *)
+(* <block> ::=
+     <statement>; <statement>; ...; { <block> } { <block> } ... *)
 
 val split_env :
   statement list -> environment_statement located list * statement list

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -66,9 +66,12 @@ and token = parse
   | identchar *
     { let s = Lexing.lexeme lexbuf in
       match s with
+        | "else" -> ELSE
+        | "if" -> IF
         | "include" -> INCLUDE
         | "not" -> NOT
         | "set" -> SET
+        | "then" -> THEN
         | "unset" -> UNSET
         | "with" -> WITH
         | _ -> IDENTIFIER s

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -61,6 +61,8 @@ and token = parse
   | "," { COMMA }
   | "+=" { PLUSEQUAL }
   | "=" { EQUAL }
+  | "||" { OR }
+  | "&&" { AND }
   | identchar *
     { let s = Lexing.lexeme lexbuf in
       match s with
@@ -73,6 +75,8 @@ and token = parse
     }
   | "{" { LEFT_BRACE }
   | "}" { RIGHT_BRACE }
+  | "(" { LEFT_PAREN }
+  | ")" { RIGHT_PAREN }
   | ";" { SEMI }
   | "(*"
     {

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -65,10 +65,13 @@ statement_list:
 action:
 | identifier with_environment_modifiers { { name = $1; modifiers = $2 } }
 
+test:
+| env_item { mkenvstmt $1 }
+| action   { Action $1 }
+| NOT test { Not $2 }
+
 statement:
-| env_item   SEMI { $1 }
-|     action SEMI { Test (Pos, $1) }
-| NOT action SEMI { Test (Neg, $2) }
+| test SEMI { $1 }
 
 tsl_script:
 | TSL_BEGIN_C_STYLE node TSL_END_C_STYLE { $2 }
@@ -84,16 +87,16 @@ opt_environment_modifiers:
 
 env_item:
 | identifier EQUAL string
-    { mkenvstmt (Assignment (false, $1, $3)) }
+    { Assignment (false, $1, $3) }
 | identifier PLUSEQUAL string
-    { mkenvstmt (Append ($1, $3)) }
+    { Append ($1, $3) }
 | SET identifier EQUAL string
-    { mkenvstmt (Assignment (true, $2, $4)) }
+    { Assignment (true, $2, $4) }
 | UNSET identifier
-    { mkenvstmt (Unset $2) }
+    { Unset $2 }
 
 | INCLUDE identifier
-  { mkenvstmt (Include $2) }
+  { Include $2 }
 
 identifier: IDENTIFIER { mkidentifier $1 }
 

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -38,6 +38,7 @@ let mkenvstmt envstmt =
 %token COMMA LEFT_BRACE RIGHT_BRACE SEMI
 %token LEFT_PAREN RIGHT_PAREN
 %token AND OR NOT
+%token IF THEN ELSE
 %token EQUAL PLUSEQUAL
 /* %token COLON */
 %token INCLUDE SET UNSET WITH
@@ -67,6 +68,11 @@ action:
 | identifier with_environment_modifiers { { name = $1; modifiers = $2 } }
 
 test:
+| test_if { $1 }
+
+test_if:
+| IF test_or THEN test_or { If ($2, $4, None) }
+| IF test_or THEN test_or ELSE test_if { If ($2, $4, Some $6) }
 | test_or { $1 }
 
 test_or:

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -62,10 +62,13 @@ statement_list:
 | { [] }
 | statement statement_list { $1 :: $2 }
 
+action:
+| identifier with_environment_modifiers { { name = $1; modifiers = $2 } }
+
 statement:
-| env_item SEMI { $1 }
-|     identifier with_environment_modifiers SEMI { Test (Pos, $1, $2) }
-| NOT identifier with_environment_modifiers SEMI { Test (Neg, $2, $3) }
+| env_item   SEMI { $1 }
+|     action SEMI { Test (Pos, $1) }
+| NOT action SEMI { Test (Neg, $2) }
 
 tsl_script:
 | TSL_BEGIN_C_STYLE node TSL_END_C_STYLE { $2 }

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -36,7 +36,8 @@ let mkenvstmt envstmt =
 %token <[`Above | `Below]> TSL_BEGIN_OCAML_STYLE
 %token TSL_END_OCAML_STYLE
 %token COMMA LEFT_BRACE RIGHT_BRACE SEMI
-%token NOT
+%token LEFT_PAREN RIGHT_PAREN
+%token AND OR NOT
 %token EQUAL PLUSEQUAL
 /* %token COLON */
 %token INCLUDE SET UNSET WITH
@@ -66,9 +67,24 @@ action:
 | identifier with_environment_modifiers { { name = $1; modifiers = $2 } }
 
 test:
+| test_or { $1 }
+
+test_or:
+| test_and OR test_or { Or ($1, $3) }
+| test_and { $1 }
+
+test_and:
+| test_not AND test_and { And ($1, $3) }
+| test_not { $1 }
+
+test_not:
+| NOT test_atom { Not $2 }
+| test_atom { $1 }
+
+test_atom:
 | env_item { mkenvstmt $1 }
 | action   { Action $1 }
-| NOT test { Not $2 }
+| LEFT_PAREN test RIGHT_PAREN { $2 }
 
 statement:
 | test SEMI { $1 }

--- a/ocamltest/tsl_printer.ml
+++ b/ocamltest/tsl_printer.ml
@@ -28,13 +28,13 @@ let print_tsl_ast ~compact oc ast =
     print_ast (indent ^ "  ") ast;
     pr "%s}" indent;
 
-  and print_statement indent stmt =
+  and print_statement stmt =
     match stmt with
     | Not test ->
-      pr "%snot" indent;
-      print_statement "" test
+      pr "not";
+      print_statement test
     | Action { name; modifiers } ->
-      pr "%s%s" indent name.node;
+      pr "%s" name.node;
       begin match modifiers with
       | m :: tl ->
         pr " with %s" m.node;
@@ -42,12 +42,13 @@ let print_tsl_ast ~compact oc ast =
       | [] -> ()
       end;
     | Environment_statement env ->
-      print_env indent env
+      print_env env
 
   and print_statements indent stmts =
     match stmts with
     | stmt :: tl ->
-      print_statement indent stmt;
+      pr "%s" indent;
+      print_statement stmt;
       pr ";\n";
       if tl <> [] && not compact then pr "\n";
       print_statements indent tl;
@@ -60,17 +61,16 @@ let print_tsl_ast ~compact oc ast =
       pr "\n";
     end
 
-  and print_env indent e =
+  and print_env e =
     match e.node with
     | Assignment (set, variable, value) ->
-      pr "%s" indent;
       if set then pr "set ";
       pr "%s = \"%s\"" variable.node value.node;
     | Append (variable, value) ->
-      pr "%s%s += \"%s\"" indent variable.node value.node;
+      pr "%s += \"%s\"" variable.node value.node;
     | Include ls ->
-      pr "%sinclude %s" indent ls.node;
+      pr "include %s" ls.node;
     | Unset ls ->
-      pr "%sunset %s" indent ls.node;
+      pr "unset %s" ls.node;
   in
   print_ast " " ast;

--- a/ocamltest/tsl_printer.ml
+++ b/ocamltest/tsl_printer.ml
@@ -30,12 +30,12 @@ let print_tsl_ast ~compact oc ast =
 
   and print_statements indent stmts =
     match stmts with
-    | Test (sign, name, mods) :: tl ->
+    | Test (sign, { name; modifiers }) :: tl ->
       pr (match sign with
           | Pos -> ""
           | Neg -> "not ");
       pr "%s%s" indent name.node;
-      begin match mods with
+      begin match modifiers with
       | m :: tl ->
         pr " with %s" m.node;
         List.iter (fun m -> pr ", %s" m.node) tl;

--- a/ocamltest/tsl_printer.ml
+++ b/ocamltest/tsl_printer.ml
@@ -30,7 +30,20 @@ let print_tsl_ast ~compact oc ast =
 
   and print_statement stmt =
     let rec print_test test =
-      print_test_or test
+      print_test_if test
+    and print_test_if test =
+      let print_self = print_test_if in
+      let print_next = print_test_or in
+      match test with
+      | If (t1, t2, t3) ->
+        pr "if "; print_next t1;
+        pr " then "; print_next t2;
+        begin match t3 with
+        | None -> ()
+        | Some t3 ->
+            pr " else "; print_self t3
+        end;
+      | other -> print_next other
     and print_test_or test =
       let print_self = print_test_or in
       let print_next = print_test_and in
@@ -55,7 +68,7 @@ let print_tsl_ast ~compact oc ast =
       | Action act -> print_action act
       | Environment_statement env -> print_env env
       | (
-        Not _ | And _ | Or _
+        Not _ | And _ | Or _ | If _
         ) as other -> pr "("; print_test other; pr ")"
     and print_action { name; modifiers } =
       pr "%s" name.node;

--- a/ocamltest/tsl_query.ml
+++ b/ocamltest/tsl_query.ml
@@ -19,8 +19,10 @@ let rec tests_in_stmt set stmt =
   match stmt with
   | Environment_statement _ -> set
   | Not test -> tests_in_stmt set test
-  | And (t1, t2) | Or (t1, t2) ->
+  | And (t1, t2) | Or (t1, t2) | If (t1, t2, None) ->
     tests_in_stmt (tests_in_stmt set t1) t2
+  | If (t1, t2, Some t3) ->
+    tests_in_stmt (tests_in_stmt (tests_in_stmt set t1) t2) t3
   | Action { name; _ } ->
     begin match Tsl_semantics.lookup_test name with
     | t -> Tests.TestSet.add t set

--- a/ocamltest/tsl_query.ml
+++ b/ocamltest/tsl_query.ml
@@ -19,6 +19,8 @@ let rec tests_in_stmt set stmt =
   match stmt with
   | Environment_statement _ -> set
   | Not test -> tests_in_stmt set test
+  | And (t1, t2) | Or (t1, t2) ->
+    tests_in_stmt (tests_in_stmt set t1) t2
   | Action { name; _ } ->
     begin match Tsl_semantics.lookup_test name with
     | t -> Tests.TestSet.add t set

--- a/ocamltest/tsl_query.ml
+++ b/ocamltest/tsl_query.ml
@@ -18,7 +18,7 @@ open Tsl_ast
 let tests_in_stmt set stmt =
   match stmt with
   | Environment_statement _ -> set
-  | Test (_sign, name, _) ->
+  | Test (_sign, { name; _ }) ->
     begin match Tsl_semantics.lookup_test name with
     | t -> Tests.TestSet.add t set
     | exception Tsl_semantics.No_such_test_or_action _ -> set

--- a/ocamltest/tsl_query.ml
+++ b/ocamltest/tsl_query.ml
@@ -15,10 +15,11 @@
 
 open Tsl_ast
 
-let tests_in_stmt set stmt =
+let rec tests_in_stmt set stmt =
   match stmt with
   | Environment_statement _ -> set
-  | Test (_sign, { name; _ }) ->
+  | Not test -> tests_in_stmt set test
+  | Action { name; _ } ->
     begin match Tsl_semantics.lookup_test name with
     | t -> Tests.TestSet.add t set
     | exception Tsl_semantics.No_such_test_or_action _ -> set

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -137,6 +137,14 @@ let run ~log ~add_msg ~report_error behavior env summ ast =
       | Fail | Pass -> Ok (env', status1)
       | Skip -> run_test behavior env' t2
       end
+    | If (t1, t2, t3) ->
+      let* (env', status1) = run_test behavior env t1 in
+      begin match status1, t3 with
+      | Fail, _ -> Ok (env', status1)
+      | Pass, _ -> run_test behavior env' t2
+      | Skip, Some t3 -> run_test behavior env' t3
+      | Skip, None -> Ok (env', status1)
+      end
     | Action { name; modifiers } ->
       let (msg, env', result) =
         match behavior with

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -120,7 +120,7 @@ let run ~log ~add_msg ~report_error behavior env summ ast =
       | Ok env' -> Ok (behavior, env', summ)
       | Error () -> Error Fail
       end
-    | Test (sign, name, mods) ->
+    | Test (sign, { name; modifiers }) ->
       let locstr =
         if name.loc = Location.none then
           "default"
@@ -132,7 +132,7 @@ let run ~log ~add_msg ~report_error behavior env summ ast =
         | Skip_all -> ("=> n/a", Skip_all, env, Test_result.skip)
         | Run ->
           begin try
-            let testenv = List.fold_left apply_modifiers env mods in
+            let testenv = List.fold_left apply_modifiers env modifiers in
             let test = lookup_test name in
             let (result, newenv) = Tests.run log testenv test in
             let result =

--- a/testsuite/tests/runtime-errors/syserror.ml
+++ b/testsuite/tests/runtime-errors/syserror.ml
@@ -1,35 +1,22 @@
 (* TEST
  flags = "-w -a";
+ if target-windows
+ then reference = "${test_source_directory}/syserror.win32.reference"
+ else reference = "${test_source_directory}/syserror.unix.reference";
  {
    setup-ocamlc.byte-build-env;
    ocamlc.byte;
    exit_status = "2";
    run;
    hasunix;
-   {
-     not target-windows;
-     reference = "${test_source_directory}/syserror.unix.reference";
-     check-program-output;
-   }{
-     target-windows;
-     reference = "${test_source_directory}/syserror.win32.reference";
-     check-program-output;
-   }
+   check-program-output;
  }{
    setup-ocamlopt.byte-build-env;
    ocamlopt.byte;
    exit_status = "2";
    run;
    hasunix;
-   {
-     not target-windows;
-     reference = "${test_source_directory}/syserror.unix.reference";
-     check-program-output;
-   }{
-     target-windows;
-     reference = "${test_source_directory}/syserror.win32.reference";
-     check-program-output;
-   }
+   check-program-output;
  }
 *)
 

--- a/testsuite/tests/tool-ocamltest/and.reference
+++ b/testsuite/tests/tool-ocamltest/and.reference
@@ -1,0 +1,31 @@
+Specified modules: and.test
+Source modules: and.test
+ ... testing 'and.test'Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+ => passed

--- a/testsuite/tests/tool-ocamltest/and.test
+++ b/testsuite/tests/tool-ocamltest/and.test
@@ -1,0 +1,18 @@
+(* TEST
+{
+pass && pass;
+pass;
+}
+{
+pass && skip;
+fail;
+}
+{
+skip && pass;
+fail;
+}
+{
+skip && skip;
+fail;
+}
+*)

--- a/testsuite/tests/tool-ocamltest/or.reference
+++ b/testsuite/tests/tool-ocamltest/or.reference
@@ -1,0 +1,39 @@
+Specified modules: or.test
+Source modules: or.test
+ ... testing 'or.test'Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test pass with 1 actions
+
+Running action 1/1 (pass)
+Action 1/1 (pass) => passed (the pass action always succeeds)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+Running test skip with 1 actions
+
+Running action 1/1 (skip)
+Action 1/1 (skip) => skipped (the skip action always skips)
+ => passed

--- a/testsuite/tests/tool-ocamltest/or.test
+++ b/testsuite/tests/tool-ocamltest/or.test
@@ -1,0 +1,18 @@
+(* TEST
+{
+pass || pass;
+pass;
+}
+{
+pass || skip;
+pass;
+}
+{
+skip || pass;
+pass;
+}
+{
+skip || skip;
+fail;
+}
+*)

--- a/testsuite/tests/tool-ocamltest/semantics.ml
+++ b/testsuite/tests/tool-ocamltest/semantics.ml
@@ -8,4 +8,22 @@
   reference="negation.reference";
   check-program-output;
 }
+{
+  readonly_files="and.test and.reference";
+  program="and.test";
+  output="and.result";
+  flags="-e";
+  ocamltest;
+  reference="and.reference";
+  check-program-output;
+}
+{
+  readonly_files="or.test or.reference";
+  program="or.test";
+  output="or.result";
+  flags="-e";
+  ocamltest;
+  reference="or.reference";
+  check-program-output;
+}
 *)


### PR DESCRIPTION
This PR introduces `test1 && test2`, `test1 || test2` and `if test1 then test2 [else test3]` at the level of ocamltest statements.

Before:

```
 flags = "-w -a";
 {
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
   exit_status = "2";
   run;
   hasunix;
   {
     not target-windows;
     reference = "${test_source_directory}/syserror.unix.reference";
     check-program-output;
   }{
     target-windows;
     reference = "${test_source_directory}/syserror.win32.reference";
     check-program-output;
   }
 }{
   setup-ocamlopt.byte-build-env;
   ocamlopt.byte;
   exit_status = "2";
   run;
   hasunix;
   {
     not target-windows;
     reference = "${test_source_directory}/syserror.unix.reference";
     check-program-output;
   }{
     target-windows;
     reference = "${test_source_directory}/syserror.win32.reference";
     check-program-output;
   }
 }
```

After:

```
 flags = "-w -a";
 if target-windows
 then reference = "${test_source_directory}/syserror.win32.reference"
 else reference = "${test_source_directory}/syserror.unix.reference";
 {
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
   exit_status = "2";
   run;
   hasunix;
   check-program-output;
 }{
   setup-ocamlopt.byte-build-env;
   ocamlopt.byte;
   exit_status = "2";
   run;
   hasunix;
   check-program-output;
 }
```

This PR is best reviewed commit-by-commit, as it is built as a series of small changes.

I checked that the test output is exactly preserved by those changes.

It would be nice to also support `if test then { ... } else { ... }` at the level of blocks, but this is left as future work.