### PR TITLE
fix Complex.sqrt(_, -0.0)

### DIFF
--- a/stdlib/complex.ml
+++ b/stdlib/complex.ml
@@ -68,7 +68,7 @@ let sqrt x =
       end in
     if x.re >= 0.0
     then { re = w;  im = 0.5 *. x.im /. w }
-    else { re = 0.5 *. i /. w;  im = if x.im >= 0.0 then w else -. w }
+    else { re = 0.5 *. i /. w;  im = Float.copy_sign w x.im }
   end
 
 let exp x =

--- a/testsuite/tests/lib-complex/test.ml
+++ b/testsuite/tests/lib-complex/test.ml
@@ -1,0 +1,39 @@
+(* TEST *)
+
+let approx_equal ~eps a b =
+  abs_float (a -. b) < eps
+
+let check_sqrt n z expected_re expected_im =
+  let r = Complex.sqrt z in
+  let ok =
+    approx_equal ~eps:1e-10 r.re expected_re
+    && approx_equal ~eps:1e-10 r.im expected_im
+    (* Also check sign of zero *)
+    && Float.sign_bit r.re = Float.sign_bit expected_re
+    && Float.sign_bit r.im = Float.sign_bit expected_im
+  in
+  Printf.printf "%03d: %s\n" n (if ok then "OK" else
+    Printf.sprintf "FAIL: sqrt(%g + %gi) = %g + %gi, expected %g + %gi"
+      z.re z.im r.re r.im expected_re expected_im)
+
+let () =
+  (* Basic cases *)
+  check_sqrt 1 {re = 4.0; im = 0.0} 2.0 0.0;
+  check_sqrt 2 {re = 0.0; im = 0.0} 0.0 0.0;
+  check_sqrt 3 {re = 1.0; im = 0.0} 1.0 0.0;
+  check_sqrt 4 {re = -1.0; im = 0.0} 0.0 1.0;
+  (* Negative reals: branch cut with signed zero *)
+  check_sqrt 5 {re = -4.0; im = 0.0} 0.0 2.0;
+  check_sqrt 6 {re = -4.0; im = -0.0} 0.0 (-2.0);
+  check_sqrt 7 {re = -1.0; im = -0.0} 0.0 (-1.0);
+  check_sqrt 8 {re = -9.0; im = 0.0} 0.0 3.0;
+  check_sqrt 9 {re = -9.0; im = -0.0} 0.0 (-3.0);
+  (* Complex values *)
+  check_sqrt 10 {re = 0.0; im = 4.0}
+    (sqrt 2.0) (sqrt 2.0);
+  check_sqrt 11 {re = 0.0; im = -4.0}
+    (sqrt 2.0) (-. (sqrt 2.0));
+  check_sqrt 12 {re = 3.0; im = 4.0}
+    2.0 1.0;
+  check_sqrt 13 {re = 3.0; im = -4.0}
+    2.0 (-1.0)

--- a/testsuite/tests/lib-complex/test.reference
+++ b/testsuite/tests/lib-complex/test.reference
@@ -1,0 +1,13 @@
+001: OK
+002: OK
+003: OK
+004: OK
+005: OK
+006: FAIL: sqrt(-4 + -0i) = 0 + 2i, expected 0 + -2i
+007: FAIL: sqrt(-1 + -0i) = 0 + 1i, expected 0 + -1i
+008: OK
+009: FAIL: sqrt(-9 + -0i) = 0 + 3i, expected 0 + -3i
+010: OK
+011: OK
+012: OK
+013: OK

--- a/testsuite/tests/lib-complex/test.reference
+++ b/testsuite/tests/lib-complex/test.reference
@@ -3,10 +3,10 @@
 003: OK
 004: OK
 005: OK
-006: FAIL: sqrt(-4 + -0i) = 0 + 2i, expected 0 + -2i
-007: FAIL: sqrt(-1 + -0i) = 0 + 1i, expected 0 + -1i
+006: OK
+007: OK
 008: OK
-009: FAIL: sqrt(-9 + -0i) = 0 + 3i, expected 0 + -3i
+009: OK
 010: OK
 011: OK
 012: OK


### PR DESCRIPTION
Fix Complex.sqrt branch cut for negative reals with -0.0 imaginary
    
Complex.sqrt used x.im >= 0.0 to choose the sign of the imaginary
part of the result. Since IEEE 754 defines -0.0 >= 0.0 as true,
sqrt(-4 - 0i) incorrectly returned 0 + 2i instead of 0 - 2i.
    
Use Float.copy_sign to propagate the sign of x.im onto w, which
correctly distinguishes -0.0 from +0.0 and matches the C99 csqrt
branch cut convention.

Bug found and fixed by Claude AI assistant 