### PR TITLE
refactorisation: a more structured type for the typechecker's error trace

### DIFF
--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -200,7 +200,7 @@ Error: Signature mismatch:
        Their parameters differ
        The type "< x : 'a. 'a -> 'a >" is not equal to the type
          "< x : 'a. 'a -> x >"
-       Type "'a" is not equal to type "x" = "M.x"
        The method "x" has type "'a. 'a -> 'a", but the expected method type was
        "'a. 'a -> x"
+       Type "'a" is not equal to type "x" = "M.x"
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -699,6 +699,7 @@ Line 2, characters 14-15:
                   ^
 Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -712,6 +713,7 @@ Line 2, characters 22-23:
                           ^
 Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -752,6 +754,7 @@ Line 4, characters 44-45:
                                                 ^
 Error: The value "o" has type "< m : a >" but an expression was expected of type
          "< m : b >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -768,6 +771,7 @@ Line 3, characters 44-45:
                                                 ^
 Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -781,7 +781,7 @@ Line 2, characters 14-15:
                   ^
 Error: The value "o" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -794,7 +794,7 @@ Line 2, characters 22-23:
                           ^
 Error: The value "v" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -852,7 +852,7 @@ Line 4, characters 49-50:
                                                      ^
 Error: The value "o" has type "[ `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -868,7 +868,7 @@ Line 3, characters 49-50:
                                                      ^
 Error: The value "o" has type "[> `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -247,7 +247,7 @@ Line 5, characters 25-26:
                              ^
 Error: The value "x" has type "[ `X of int ]"
        but an expression was expected of type "[ `X ]"
-       Types for tag "`X" are incompatible
+       Arities for tag "`X" are incompatible.
 |}]
 
 
@@ -258,7 +258,7 @@ Line 1, characters 25-26:
                              ^
 Error: The value "x" has type "[ `X of int ]"
        but an expression was expected of type "[< `X of & int ]"
-       Types for tag "`X" are incompatible
+       Arities for tag "`X" are incompatible.
 |}]
 
 (** Inconsistent type *)
@@ -270,7 +270,7 @@ Line 3, characters 36-37:
                                         ^
 Error: The value "x" has type "[< `X of & int & float ]"
        but an expression was expected of type "[ `X ]"
-       Types for tag "`X" are incompatible
+       Arities for tag "`X" are incompatible.
 |}]
 
 
@@ -302,7 +302,7 @@ Line 4, characters 10-50:
 4 | let f x = (x : [ `Foo of int ] :> [ `Foo | `Bar ])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "[ `Foo of int ]" is not a subtype of "[ `Bar | `Foo ]"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}]
 
 let f x = (x : [ `Foo of int ] list :> [ `Foo | `Bar ] list)
@@ -312,7 +312,7 @@ Line 1, characters 10-60:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "[ `Foo of int ] list" is not a subtype of "[ `Bar | `Foo ] list"
        Type "[ `Foo of int ]" is not a subtype of "[ `Bar | `Foo ]"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}]
 
 (** When typing pattern match containing possibly absent polymorphic variants,
@@ -328,4 +328,29 @@ Error: This pattern matches values of type "[< `A ] * unit * 'a option"
        but a pattern was expected which matches values of type
          "[< `A ] * unit * unit"
        Type "'a option" is not compatible with type "unit"
+|}]
+
+
+(** Present tag arities must be consistent *)
+let f x =
+  let u = match x with
+  | `A 0 -> [x]
+  in
+let v = match x with
+  | `A -> [x]
+  in
+  [ `A; x]
+[%%expect {|
+Lines 2-3, characters 10-15:
+2 | ..........match x with
+3 |   | `A 0 -> [x]
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "`A 1"
+
+Line 8, characters 8-9:
+8 |   [ `A; x]
+            ^
+Error: The value "x" has type "[< `A of & int ]"
+       but an expression was expected of type "[> `A ]"
+       Arities for tag "`A" are incompatible.
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -287,8 +287,8 @@ Line 4, characters 30-31:
                                   ^
 Error: The value "x" has type "[ `A | `R of rt ]"
        but an expression was expected of type "[< `A | `R of 'a ] as 'a"
-       Type "rt" = "[ `A | `B of string | `R of rt ]" is not compatible with type
-         "[< `A | `R of 'a ] as 'a"
+       In tag "`R", type "rt" = "[ `A | `B of string | `R of rt ]"
+       is not compatible with type "[< `A | `R of 'a ] as 'a"
        The second variant type does not allow tag(s) "`B"
 |}]
 

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -24,7 +24,7 @@ Error: Signature mismatch:
        is not included in
          type t = [ `T of t/3 ]
        The type "[ `T of t ]" is not equal to the type "[ `T of t/2 ]"
-       Type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
+       In tag "`T", type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
        Types for tag "`T" are incompatible
        Line 4, characters 2-20:
          Definition of type "t"

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -25,7 +25,6 @@ Error: Signature mismatch:
          type t = [ `T of t/3 ]
        The type "[ `T of t ]" is not equal to the type "[ `T of t/2 ]"
        In tag "`T", type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
-       Types for tag "`T" are incompatible
        Line 4, characters 2-20:
          Definition of type "t"
        Line 1, characters 0-12:

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -96,5 +96,6 @@ Error: Signature mismatch:
        Type "[> `B of [> `BA | `BB of int list ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]"
+       In tag "`BB", type "int" is not compatible with type "unit"
        Types for tag "`BB" are incompatible
 |}]

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -96,6 +96,5 @@ Error: Signature mismatch:
        Type "[> `B of [> `BA | `BB of int list ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]"
-       In tag "`BB", type "int" is not compatible with type "unit"
-       Types for tag "`BB" are incompatible
+       In tag "`BB", type "int list" is not compatible with type "unit list"
 |}]

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -94,9 +94,12 @@ type t2 = < m : 'a. 'a * ('a * 'b) > as 'b
 Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
-Error: The value "x" has type "t1" but an expression was expected of type "t2"
-       The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
-       but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
+Error: The value "x" has type
+         "t1" = "< m : 'a. 'a * ('a * < m : 'c. 'c * 'b > as 'b) >"
+       but an expression was expected of type
+         "t2" = "< m : 'a. 'a * ('a * 'd) > as 'd"
+       The method "m" has type "'c. 'c * ('a * < m : 'c. 'e >) as 'e",
+       but the expected method type was "'a. 'a * ('a * < m : 'a. 'f >) as 'f"
        The universal variable "'a" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -94,12 +94,9 @@ type t2 = < m : 'a. 'a * ('a * 'b) > as 'b
 Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
-Error: The value "x" has type
-         "t1" = "< m : 'a. 'a * ('a * < m : 'c. 'c * 'b > as 'b) >"
-       but an expression was expected of type
-         "t2" = "< m : 'a. 'a * ('a * 'd) > as 'd"
-       The method "m" has type "'c. 'c * ('a * < m : 'c. 'e >) as 'e",
-       but the expected method type was "'a. 'a * ('a * < m : 'a. 'f >) as 'f"
+Error: The value "x" has type "t1" but an expression was expected of type "t2"
+       The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
+       but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
        The universal variable "'a" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -327,7 +327,7 @@ Error: Signature mismatch:
        is not included in
          type t = private [ `C of int ]
        The type "[ `C ]" is not equal to the type "[ `C of int ]"
-       Types for tag "`C" are incompatible
+       Arities for tag "`C" are incompatible.
 |}];;
 
 module M : sig
@@ -350,7 +350,7 @@ Error: Signature mismatch:
        is not included in
          type t = private [ `C ]
        The type "[ `C of int ]" is not equal to the type "[ `C ]"
-       Types for tag "`C" are incompatible
+       Arities for tag "`C" are incompatible.
 |}];;
 
 module M : sig
@@ -946,7 +946,7 @@ Error: Signature mismatch:
          val f : [< `C ] -> unit
        The type "[< `C of & int & float ] -> unit"
        is not compatible with the type "[< `C ] -> unit"
-       Types for tag "`C" are incompatible
+       Arities for tag "`C" are incompatible.
 |}];;
 
 module M : sig
@@ -970,7 +970,7 @@ Error: Signature mismatch:
          val f : [ `Foo ] -> unit
        The type "[ `Foo of int ] -> unit" is not compatible with the type
          "[ `Foo ] -> unit"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}];;
 
 module M : sig
@@ -994,7 +994,7 @@ Error: Signature mismatch:
          val f : [ `Foo of int ] -> unit
        The type "[ `Foo ] -> unit" is not compatible with the type
          "[ `Foo of int ] -> unit"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}];;
 
 module M : sig

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -345,7 +345,7 @@ Error: In this "with" constraint, the new definition of "M.t"
          type t = s
        is not included in
          type t = private [ `Foo of M.r ]
-       The type "s" = "[ `Foo of s ]" is not equal to the type "[ `Foo of M.r ]"
+       The type "s" is not equal to the type "[ `Foo of M.r ]"
        In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
 |}]
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -346,7 +346,7 @@ Error: In this "with" constraint, the new definition of "M.t"
        is not included in
          type t = private [ `Foo of M.r ]
        The type "s" = "[ `Foo of s ]" is not equal to the type "[ `Foo of M.r ]"
-       Type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
+       In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
        Types for tag "`Foo" are incompatible
 |}]
 
@@ -385,7 +385,7 @@ Error: In this "with" constraint, the new definition of "M.N"
        is not included in
          type t = private [ `Foo of M.r ]
        The type "[ `Foo of t ]" is not equal to the type "[ `Foo of M.r ]"
-       Type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
+       In tag "`Foo", type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
        Types for tag "`Foo" are incompatible
 |}]
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -347,7 +347,6 @@ Error: In this "with" constraint, the new definition of "M.t"
          type t = private [ `Foo of M.r ]
        The type "s" = "[ `Foo of s ]" is not equal to the type "[ `Foo of M.r ]"
        In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
-       Types for tag "`Foo" are incompatible
 |}]
 
 (* Should succeed *)
@@ -386,7 +385,6 @@ Error: In this "with" constraint, the new definition of "M.N"
          type t = private [ `Foo of M.r ]
        The type "[ `Foo of t ]" is not equal to the type "[ `Foo of M.r ]"
        In tag "`Foo", type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
-       Types for tag "`Foo" are incompatible
 |}]
 
 (* Should succeed *)

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -127,6 +127,8 @@ Error: Signature mismatch:
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
        The type "[ `Bar of int | `Foo of t -> int ]" is not equal to the type
          "[ `Bar of int | `Foo of 'a -> int ] as 'a"
+       In tag "`Foo", type "t" is not equal to type
+         "[ `Bar of int | `Foo of 'a -> int ] as 'a"
        Types for tag "`Foo" are incompatible
 |}]
 

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -127,9 +127,8 @@ Error: Signature mismatch:
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
        The type "[ `Bar of int | `Foo of t -> int ]" is not equal to the type
          "[ `Bar of int | `Foo of 'a -> int ] as 'a"
-       In tag "`Foo", type "t" is not equal to type
-         "[ `Bar of int | `Foo of 'a -> int ] as 'a"
-       Types for tag "`Foo" are incompatible
+       In tag "`Foo", type "t -> int" is not equal to type
+         "[ `Bar of int | `Foo of 'b ] -> int as 'b"
 |}]
 
 (* nondep_type_decl + nondep_type_rec *)

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -38,7 +38,7 @@ Error: The class type
          as 'a
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
-       Type exp = < eval : (string, exp) Hashtbl.t -> expr >
+       In tag `App, type exp = < eval : (string, exp) Hashtbl.t -> expr >
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
        Types for tag `App are incompatible

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -38,7 +38,10 @@ Error: The class type
          as 'a
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
-       In tag `App, type exp = < eval : (string, exp) Hashtbl.t -> expr >
+       In tag `App, type
+         [ `Abs of string * [> `App of 'b ] | `App of expr * expr ] * exp
+         as 'b
+       is not compatible with type expr * expr
+       Type exp = < eval : (string, exp) Hashtbl.t -> expr >
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
-       Types for tag `App are incompatible

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -14,12 +14,12 @@ Error: This type entity = < destroy_subject : id subject; entity_id : id >
          < add_observer : < destroy_subject : 'c; .. > entity_container -> 'b;
            .. >
          as 'c
-       Type (id subject, id) observer = < notify : id subject -> id -> unit >
-       is not compatible with type
-         (< destroy_subject : < add_observer : 'd -> 'b; .. >; .. > as 'a)
-         entity_container as 'd =
-           < add_entity : 'a -> 'b; notify : 'a -> id -> unit >
        The method add_observer has type (id subject, id) observer -> unit,
        but the expected method type was
-       < destroy_subject : < add_observer : 'e; .. >; .. > entity_container ->
-       'b as 'e
+       < destroy_subject : < add_observer : 'd; .. >; .. > entity_container ->
+       'b as 'd
+       Type (id subject, id) observer = < notify : id subject -> id -> unit >
+       is not compatible with type
+         (< destroy_subject : < add_observer : 'e -> 'b; .. >; .. > as 'a)
+         entity_container as 'e =
+           < add_entity : 'a -> 'b; notify : 'a -> id -> unit >

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -593,6 +593,8 @@ Error: The value "c3" has type
            "< cmp : int_comparable -> int; setx : int -> unit; x : int >"
        but an expression was expected of type
          "#comparable as 'a" = "< cmp : 'a -> int; .. >"
+       The method "cmp" has type "int_comparable -> int",
+       but the expected method type was "#comparable -> int"
        Type "int_comparable" = "< cmp : int_comparable -> int; x : int >"
        is not compatible with type
          "#comparable as 'a" = "< cmp : 'a -> int; .. >"

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -197,6 +197,8 @@ Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+       The method "redrawWidget" has type "parameter_contains_self -> unit",
+       but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
        is not compatible with type "< invalidate : unit; .. >"
        Self type cannot be unified with a closed object type
@@ -213,6 +215,8 @@ Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+       The method "redrawWidget" has type "parameter_contains_self -> unit",
+       but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
        is not compatible with type "< invalidate : unit; .. >"
        Self type cannot be unified with a closed object type
@@ -260,6 +264,8 @@ Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+       The method "redrawWidget" has type "parameter_contains_self -> unit",
+       but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
        is not compatible with type "< invalidate : unit; .. >"
        Self type cannot be unified with a closed object type

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -58,11 +58,11 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type "< f : 'b -> int >"
-       but an expression was expected of type "t_a" = "< f : 'a. 'a -> int >"
-       The method "f" has type "'b -> int", but the expected method type was
-       "'a. 'a -> int"
-       The universal variable "'a" would escape its scope
+Error: This expression has type "< f : 'a -> int >"
+       but an expression was expected of type "t_a"
+       The method "f" has type "'a -> int", but the expected method type was
+       "'a0. 'a0 -> int"
+       The universal variable "'a0" would escape its scope
 |}
 ]
 
@@ -77,12 +77,11 @@ val f : uv -> int = <fun>
 Line 4, characters 11-49:
 4 | let () = f ( `A (object method f _ = 0 end): _ v);;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "'b v" = "[ `A of < f : 'b -> int > ]"
-       but an expression was expected of type
-         "uv" = "[ `A of < f : 'a. 'a -> int > ]"
-       The method "f" has type "'b -> int", but the expected method type was
-       "'a. 'a -> int"
-       The universal variable "'a" would escape its scope
+Error: This expression has type "'a v" but an expression was expected of type
+         "uv"
+       The method "f" has type "'a -> int", but the expected method type was
+       "'a0. 'a0 -> int"
+       The universal variable "'a0" would escape its scope
 |}]
 
 (* Issue #8702: row types unified with universally quantified types*)

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -58,11 +58,11 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type "< f : 'a -> int >"
-       but an expression was expected of type "t_a"
-       The method "f" has type "'a -> int", but the expected method type was
-       "'a0. 'a0 -> int"
-       The universal variable "'a0" would escape its scope
+Error: This expression has type "< f : 'b -> int >"
+       but an expression was expected of type "t_a" = "< f : 'a. 'a -> int >"
+       The method "f" has type "'b -> int", but the expected method type was
+       "'a. 'a -> int"
+       The universal variable "'a" would escape its scope
 |}
 ]
 
@@ -77,11 +77,12 @@ val f : uv -> int = <fun>
 Line 4, characters 11-49:
 4 | let () = f ( `A (object method f _ = 0 end): _ v);;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "'a v" but an expression was expected of type
-         "uv"
-       The method "f" has type "'a -> int", but the expected method type was
-       "'a0. 'a0 -> int"
-       The universal variable "'a0" would escape its scope
+Error: This expression has type "'b v" = "[ `A of < f : 'b -> int > ]"
+       but an expression was expected of type
+         "uv" = "[ `A of < f : 'a. 'a -> int > ]"
+       The method "f" has type "'b -> int", but the expected method type was
+       "'a. 'a -> int"
+       The universal variable "'a" would escape its scope
 |}]
 
 (* Issue #8702: row types unified with universally quantified types*)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1831,6 +1831,7 @@ Line 2, characters 2-72:
 Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
+       In tag "`Foo", type "'x" is not compatible with type "int"
        Types for tag "`Foo" are incompatible
 |}];;
 (* fail *)
@@ -1843,6 +1844,7 @@ Line 2, characters 2-72:
 Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
+       In tag "`Foo", type "'x" is not compatible with type "int"
        Types for tag "`Foo" are incompatible
 |}];;
 (* ok *)
@@ -1863,6 +1865,7 @@ Line 2, characters 3-4:
 Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >"
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
+       In tag "`Foo", type "'a" is not compatible with type "int"
        Types for tag "`Foo" are incompatible
 |}]
 (* ok (with implicit universal quantification) *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1832,7 +1832,6 @@ Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
        In tag "`Foo", type "'x" is not compatible with type "int"
-       Types for tag "`Foo" are incompatible
 |}];;
 (* fail *)
 let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
@@ -1845,7 +1844,6 @@ Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
        In tag "`Foo", type "'x" is not compatible with type "int"
-       Types for tag "`Foo" are incompatible
 |}];;
 (* ok *)
 let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
@@ -1866,7 +1864,6 @@ Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
        In tag "`Foo", type "'a" is not compatible with type "int"
-       Types for tag "`Foo" are incompatible
 |}]
 (* ok (with implicit universal quantification) *)
 let f (n : < m : 'a. [< `Foo of 'a & int | `Bar] >) =
@@ -2167,7 +2164,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = [S]
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c"
+       but an expression was expected of type "'a c" = "< x : 'a list >"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope
@@ -2184,9 +2181,12 @@ let f (x : u) = (x : v)
 Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
-Error: The value "x" has type "u" but an expression was expected of type "v"
-       The method "m" has type "'a s list * < m : 'b > as 'b",
-       but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
+Error: The value "x" has type
+         "u" = "< m : 'a. 'a s list * (< m : 'a s list * 'b > as 'b) >"
+       but an expression was expected of type
+         "v" = "< m : 'a. 'a s list * 'c > as 'c"
+       The method "m" has type "'a s list * < m : 'd > as 'd",
+       but the expected method type was "'a. 'a s list * < m : 'a. 'e > as 'e"
        The universal variable "'a" would escape its scope
 |}]
 
@@ -2203,7 +2203,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = []
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c"
+       but an expression was expected of type "'a c" = "< x : 'a list >"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -2164,7 +2164,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = [S]
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c" = "< x : 'a list >"
+       but an expression was expected of type "'a c"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope
@@ -2181,12 +2181,9 @@ let f (x : u) = (x : v)
 Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
-Error: The value "x" has type
-         "u" = "< m : 'a. 'a s list * (< m : 'a s list * 'b > as 'b) >"
-       but an expression was expected of type
-         "v" = "< m : 'a. 'a s list * 'c > as 'c"
-       The method "m" has type "'a s list * < m : 'd > as 'd",
-       but the expected method type was "'a. 'a s list * < m : 'a. 'e > as 'e"
+Error: The value "x" has type "u" but an expression was expected of type "v"
+       The method "m" has type "'a s list * < m : 'b > as 'b",
+       but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
        The universal variable "'a" would escape its scope
 |}]
 
@@ -2203,7 +2200,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = []
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c" = "< x : 'a list >"
+       but an expression was expected of type "'a c"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2659,13 +2659,15 @@ let expand_to_moregen_error env trace =
 
 (* Equivalent to [expand_trace env [Diff {got; expected}]] for a single
    element *)
+let mk_diff ~got ~expected = { d = {got; expected}; ctx = None }
+
 let expanded_diff env ~got ~expected =
-  Diff (map_diff (expand_type env) {got; expected})
+  Diff (map_ctx (expand_type env) (mk_diff ~got ~expected))
 
 (* Diff while transforming a [type_expr] into an [expanded_type] without
    expanding *)
 let unexpanded_diff ~got ~expected =
-  Diff (map_diff trivial_expansion {got; expected})
+  Diff (map_ctx trivial_expansion (mk_diff ~got ~expected))
 
 (**** Unification ****)
 
@@ -3243,7 +3245,7 @@ let rec unify uenv t1 t2 =
     reset_trace_gadt_instances reset_tracing;
   with Unify_trace trace ->
     reset_trace_gadt_instances reset_tracing;
-    raise_trace_for Unify (Diff {got = t1; expected = t2} :: trace)
+    raise_trace_for Unify (diff ~got:t1 ~expected:t2 trace)
 
 and unify2 uenv t1 t2 = unify2_expand uenv t1 t1 t2 t2
 
@@ -3341,8 +3343,10 @@ and unify3 uenv t1 t1' t2 t2' =
               unify_package uenv (get_level t1) pack1 (get_level t2) pack2
             with Unify_trace trace ->
               raise_trace_for Unify
-                (Diff {got = newty (Tpackage pack1);
-                       expected = newty (Tpackage pack2)} :: trace)
+                (diff
+                   ~got:(newty (Tpackage pack1))
+                   ~expected:(newty (Tpackage pack2))
+                  trace)
             end;
             let env = get_env uenv in
             let mty2 = modtype_of_package env Location.none pack2 in
@@ -3565,7 +3569,7 @@ and unify_fields uenv ty1 ty2 =          (* Optimization *)
           unify uenv t1 t2
         with Unify_trace trace ->
           raise_trace_for Unify
-            (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
+            (incompatible_fields ~name ~got:t1 ~expected:t2 trace)
       )
       pairs
   with exn ->
@@ -3675,7 +3679,7 @@ and unify_row uenv row1 row2 =
       (fun (l,f1,f2) ->
         try unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2
         with Unify_trace trace ->
-          raise_trace_for Unify (Variant (Incompatible_types_for l) :: trace)
+          raise_trace_for Unify (in_tag ~l trace)
       )
       pairs;
     if static_row row1 then begin
@@ -3718,7 +3722,7 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
          !rigid_variants && (List.length tl1 = 1 || List.length tl2 = 1)) &&
         begin match tl1 @ tl2 with [] -> false
         | t1 :: tl ->
-            if no_arg then raise_unexplained_for Unify;
+            if no_arg then raise_for Unify (variant_arity_mismatch ~l);
             Types.changed_row_field_exts [f1;f2] (fun () ->
                 List.iter (unify uenv t1) tl
               )
@@ -3788,11 +3792,11 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
   | (Rpresent None | Reither(true,_,_)),
     (Rpresent (Some _) | Reither(false,_,_)) ->
       (* constructor arity mismatch: 0 <> 1 *)
-      raise_unexplained_for Unify
+      raise_for Unify (variant_arity_mismatch ~l)
   | Reither(true, _ :: _, _ ), Rpresent _
   | Rpresent _ , Reither(true, _ :: _, _ ) ->
       (* inconsistent conjunction on a non-absent field *)
-      raise_unexplained_for Unify
+      raise_for Unify (inconsistent_conjunction ~l)
 
 let unify uenv ty1 ty2 =
   let snap = Btype.snapshot () in
@@ -3846,7 +3850,7 @@ let unify_var uenv t1 t2 =
         reset_trace_gadt_instances reset_tracing;
         raise (Unify (expand_to_unification_error
                         env
-                        (Diff { got = t1; expected = t2 } :: trace)))
+                        (diff ~got:t1 ~expected:t2 trace)))
       end
   | _ ->
       unify uenv t1 t2
@@ -3897,7 +3901,7 @@ let instance_funct_nondep env l (tfun : Types.tfunctor) mty =
     let expected =
       newty (Tarrow (l, newmono_package tfun.pack, newvar (), commu_ok))
     in
-    let trace = Diff {got; expected} :: trace in
+    let trace = diff ~got ~expected trace in
     raise (Unify (expand_to_unification_error env trace))
 
 (*
@@ -3971,14 +3975,13 @@ let filter_arrow env ~in_apply t l ~param_hole =
             let t' =
               newty (Tarrow (l, newmono_package pack, newvar (), commu_ok))
             in
-            let diff =
+            let trace =
               if in_apply then
-                Diff { got = t; expected = t' }
+                diff ~got:t ~expected:t' trace
               else
-                Diff { got = t'; expected = t }
+                diff ~got:t' ~expected:t trace
             in
-            Error (Unification_error
-                    (expand_to_unification_error env (diff :: trace)))
+            Error (Unification_error (expand_to_unification_error env trace))
           | () ->
             let ty_param = newmono_package ~level:(get_level t) pack in
             let t' = newty2 ~level:(get_level t)
@@ -3992,16 +3995,13 @@ let filter_arrow env ~in_apply t l ~param_hole =
     end
   | exception Unify_trace trace ->
       let t', _, _ = function_type l ~param_hole (get_level t) in
-      let diff =
+      let trace =
         if in_apply then
-          Diff { got = t; expected = t' }
+          diff ~got:t ~expected:t' trace
         else
-          Diff { got = t'; expected = t }
+          diff ~got:t' ~expected:t trace
       in
-      Error (Unification_error
-              (expand_to_unification_error
-                  env
-                  (diff :: trace)))
+      Error (Unification_error (expand_to_unification_error env trace))
 
 let filter_functor env t l =
   match expand_head_trace env t with
@@ -4021,7 +4021,7 @@ let filter_functor env t l =
       Error (Unification_error
               (expand_to_unification_error
                   env
-                  (Diff { got = t'; expected = t } :: trace)))
+                  (diff ~got:t' ~expected:t trace)))
 
 let is_really_poly env ty =
   let snap = Btype.snapshot () in
@@ -4057,7 +4057,7 @@ let rec filter_method_field env name ty =
                (Unification_error
                   (expand_to_unification_error
                      env
-                     (Diff { got = ty; expected = ty' } :: trace))))
+                     (diff ~got:ty ~expected:ty' trace))))
   in
   match get_desc ty with
   | Tvar _ ->
@@ -4092,7 +4092,7 @@ let filter_method env name ty =
                (Unification_error
                   (expand_to_unification_error
                      env
-                     (Diff { got = ty; expected = ty' } :: trace))))
+                     (diff ~got:ty ~expected:ty' trace))))
   in
   match get_desc ty with
   | Tvar _ ->
@@ -4276,7 +4276,8 @@ let unify_self_types env sign1 sign2 =
   | () -> ()
   | exception Unify err -> begin
       match err.trace with
-      | Errortrace.Diff _ :: Errortrace.Incompatible_fields {name; _} :: rem ->
+      | Errortrace.Diff { ctx=None; _ }
+        :: Errortrace.Diff { ctx = Some (In_method name); _ } :: rem ->
           let err = Errortrace.unification_error ~trace:rem in
           let failure = Method (name, Type_mismatch err) in
           raise (Inherit_class_signature_failed failure)
@@ -4560,7 +4561,7 @@ let rec moregen type_pairs env t1 t2 =
               raise_unexplained_for Moregen
         end
   with Moregen_trace trace ->
-    raise_trace_for Moregen (Diff {got = t1; expected = t2} :: trace)
+    raise_trace_for Moregen (diff ~got:t1 ~expected:t2 trace)
 
 
 and moregen_list type_pairs env tl1 tl2 =
@@ -4605,7 +4606,7 @@ and moregen_fields type_pairs env ty1 ty2 =
        moregen_kind k1 k2;
        try moregen type_pairs env t1 t2 with Moregen_trace trace ->
          raise_trace_for Moregen
-           (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
+           (incompatible_fields ~name ~got:t1 ~expected:t2 trace)
     )
     pairs
 
@@ -4670,15 +4671,15 @@ and moregen_row type_pairs env row1 row2 =
              try
                moregen type_pairs env t1 t2
              with Moregen_trace trace ->
-               raise_trace_for Moregen
-                 (Variant (Incompatible_types_for l) :: trace)
+               raise_trace_for Moregen (in_tag ~l trace)
            end
          | Rpresent None, Rpresent None -> ()
          (* Both [Reither] *)
          | Reither(c1, tl1, _), Reither(c2, tl2, m2) -> begin
              try
                if not (eq_row_field_ext f1 f2) then begin
-                 if c1 && not c2 then raise_unexplained_for Moregen;
+                 if c1 && not c2 then
+                   raise_for Moregen (variant_arity_mismatch ~l);
                  let f2' =
                    rf_either [] ~use_ext_of:f2 ~no_arg:c2 ~matched:m2 in
                  link_row_field_ext ~inside:f1 f2';
@@ -4689,11 +4690,12 @@ and moregen_row type_pairs env row1 row2 =
                      List.iter
                        (fun t1 -> moregen type_pairs env t1 t2)
                        tl1
-                   | [] -> if tl1 <> [] then raise_unexplained_for Moregen
+                   | [] ->
+                      if tl1 <> [] then
+                        raise_for Moregen (variant_arity_mismatch ~l)
                end
              with Moregen_trace trace ->
-               raise_trace_for Moregen
-                 (Variant (Incompatible_types_for l) :: trace)
+               raise_trace_for Moregen (in_tag ~l trace)
            end
          (* Generalizing [Reither] *)
          | Reither(false, tl1, _), Rpresent(Some t2) when may_inst -> begin
@@ -4704,7 +4706,7 @@ and moregen_row type_pairs env row1 row2 =
                  tl1
              with Moregen_trace trace ->
                raise_trace_for Moregen
-                 (Variant (Incompatible_types_for l) :: trace)
+                 (in_tag ~l trace)
            end
          | Reither(true, [], _), Rpresent None when may_inst ->
              link_row_field_ext ~inside:f1 f2
@@ -4715,7 +4717,7 @@ and moregen_row type_pairs env row1 row2 =
          (* Mismatched constructor arguments *)
          | Rpresent (Some _), Rpresent None
          | Rpresent None, Rpresent (Some _) ->
-             raise_for Moregen (Variant (Incompatible_types_for l))
+             raise_for Moregen (variant_arity_mismatch ~l)
          (* Mismatched presence *)
          | Reither _, Rpresent _ ->
              raise_for Moregen
@@ -4965,7 +4967,7 @@ let rec eqtype rename type_pairs subst env t1 t2 =
               raise_unexplained_for Equality
         end
   with Equality_trace trace ->
-    raise_trace_for Equality (Diff {got = t1; expected = t2} :: trace)
+    raise_trace_for Equality (diff ~got:t1 ~expected:t2 trace)
 
 and eqtype_list_same_length rename type_pairs subst env tl1 tl2 =
   List.iter2 (eqtype rename type_pairs subst env) tl1 tl2
@@ -5021,7 +5023,7 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
              eqtype rename type_pairs subst env t1 t2;
            with Equality_trace trace ->
              raise_trace_for Equality
-               (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace))
+               (incompatible_fields ~name ~got:t1 ~expected:t2 trace))
         pairs
 
 and eqtype_kind k1 k2 =
@@ -5071,8 +5073,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
            try
              eqtype rename type_pairs subst env t1 t2
            with Equality_trace trace ->
-             raise_trace_for Equality
-               (Variant (Incompatible_types_for l) :: trace)
+             raise_trace_for Equality (in_tag ~l trace)
          end
        | Rpresent None, Rpresent None -> ()
        (* Both matching [Reither]s *)
@@ -5091,8 +5092,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
                  (fun t1 -> eqtype rename type_pairs subst env t1 t2) tl1
              end
            with Equality_trace trace ->
-             raise_trace_for Equality
-               (Variant (Incompatible_types_for l) :: trace)
+             raise_trace_for Equality (in_tag ~l trace)
          end
        (* Both [Rabsent]s *)
        | Rabsent, Rabsent -> ()
@@ -5100,7 +5100,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
        | Rpresent (Some _), Rpresent None
        | Rpresent None, Rpresent (Some _)
        | Reither _, Reither _ ->
-           raise_for Equality (Variant (Incompatible_types_for l))
+           raise_for Equality (variant_arity_mismatch ~l)
        (* Mismatched presence *)
        | Reither _, Rpresent _ ->
            raise_for Equality
@@ -5955,7 +5955,7 @@ and subtype_row env trace row1 row2 constraints =
           | Rpresent None, Rpresent (Some _)
           | Rpresent (Some _), Rpresent None ->
               subtype_error ~env ~trace
-                ~unification_trace:[Variant (Incompatible_types_for l)]
+                ~unification_trace:[variant_arity_mismatch ~l]
           | _ ->
               raise Exit)
         constraints pairs

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -108,10 +108,10 @@ let raise_trace_for
    trace information; sometimes it makes sense, however, since we're maintaining
    the trace at an outer exception handler. *)
 let raise_unexplained_for tr_exn =
-  raise_trace_for tr_exn []
+  raise_trace_for tr_exn empty_root
 
 let raise_for tr_exn e =
-  raise_trace_for tr_exn [e]
+  raise_trace_for tr_exn (root e)
 
 (* Thrown from [moregen_kind] *)
 exception Public_method_to_private_method
@@ -2659,15 +2659,14 @@ let expand_to_moregen_error env trace =
 
 (* Equivalent to [expand_trace env [Diff {got; expected}]] for a single
    element *)
-let mk_diff ~got ~expected = { d = {got; expected}; ctx = None }
-
-let expanded_diff env ~got ~expected =
-  Diff (map_ctx (expand_type env) (mk_diff ~got ~expected))
+let with_diff f ~got ~expected t = diff ~got:(f got) ~expected:(f expected) t
+let expanded_diff env ~got ~expected t =
+  with_diff (expand_type env) ~got ~expected t
 
 (* Diff while transforming a [type_expr] into an [expanded_type] without
    expanding *)
-let unexpanded_diff ~got ~expected =
-  Diff (map_ctx trivial_expansion (mk_diff ~got ~expected))
+let unexpanded_diff ~got ~expected t =
+  with_diff trivial_expansion ~got ~expected t
 
 (**** Unification ****)
 
@@ -3697,8 +3696,8 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
     match fixed with
     | None -> f ()
     | Some fix ->
-        let tr = [Variant(Fixed_row(pos,Cannot_add_tags [l],fix))] in
-        raise_trace_for Unify tr in
+        let tr = Errortrace.Variant(Fixed_row(pos,Cannot_add_tags [l],fix)) in
+        raise_for Unify tr in
   let first = First, fixed1 and second = Second, fixed2 in
   let either_fixed = match fixed1, fixed2 with
     | None, None -> false
@@ -3784,9 +3783,9 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
   | Rpresent None, Reither(true, [], _) ->
       if_not_fixed second (fun () -> link_row_field_ext ~inside:f2 f1)
   | Rabsent, (Rpresent _ | Reither(_,_,true)) ->
-      raise_trace_for Unify [Variant(No_tags(First, [l,f1]))]
+      raise_for Unify (Variant(No_tags(First, [l,f1])))
   | (Rpresent _ | Reither (_,_,true)), Rabsent ->
-      raise_trace_for Unify [Variant(No_tags(Second, [l,f2]))]
+      raise_for Unify (Variant(No_tags(Second, [l,f2])))
   | (Rpresent (Some _) | Reither(false,_,_)),
     (Rpresent None | Reither(true,_,_))
   | (Rpresent None | Reither(true,_,_)),
@@ -4275,10 +4274,10 @@ let unify_self_types env sign1 sign2 =
   match unify env self_type1 self_type2 with
   | () -> ()
   | exception Unify err -> begin
-      match err.trace with
-      | Errortrace.Diff { ctx=None; _ }
-        :: Errortrace.Diff { ctx = Some (In_method name); _ } :: rem ->
-          let err = Errortrace.unification_error ~trace:rem in
+      match err.trace.path with
+      | { ctx=None; _ } :: { ctx = Some (In_method name); _ } :: rem ->
+          let trace = { err.trace with path = rem } in
+          let err = Errortrace.unification_error ~trace in
           let failure = Method (name, Type_mismatch err) in
           raise (Inherit_class_signature_failed failure)
       | _ ->
@@ -4834,12 +4833,12 @@ let matches ~expand_error_trace env ty ty' =
   | () ->
       if not (all_distinct_vars env vars) then begin
         backtrack snap;
-        let diff =
+        let trace =
           if expand_error_trace
-          then expanded_diff env ~got:ty ~expected:ty'
-          else unexpanded_diff ~got:ty ~expected:ty'
+          then expanded_diff env ~got:ty ~expected:ty' empty_root
+          else unexpanded_diff ~got:ty ~expected:ty' empty_root
         in
-        raise (Matches_failure (env, unification_error ~trace:[diff]))
+        raise (Matches_failure (env, unification_error ~trace))
       end;
       backtrack snap
   | exception Unify err ->
@@ -5704,7 +5703,7 @@ let rec subtype_rec env trace t1 t2 constraints =
         let constraints = subtype_rec env trace t2 t1 constraints in
         subtype_rec
           env
-          (Subtype.Diff {got = u1; expected = u2} :: trace)
+          (Subtype.diff ~got:u1 ~expected:u2 trace)
           u1 u2
           constraints
     | (Tfunctor (l1, id1, pack1, u1), Tfunctor (l2, id2, pack2, u2))
@@ -5713,7 +5712,7 @@ let rec subtype_rec env trace t1 t2 constraints =
         let fcm2 = newty (Tpackage pack2) in
         let constraints =
           subtype_package env
-            (Subtype.Diff {got = fcm2; expected = fcm1} :: trace)
+            (Subtype.diff ~got:fcm2 ~expected:fcm1 trace)
             (get_level t2) pack2 (get_level t1) pack1 constraints
         in
         begin
@@ -5773,7 +5772,7 @@ let rec subtype_rec env trace t1 t2 constraints =
                 else
                   subtype_rec
                     env
-                    (Subtype.Diff {got = t1; expected = t2} :: trace)
+                    (Subtype.diff ~got:t1 ~expected:t2 trace)
                     t1 t2
                     constraints
               else
@@ -5781,7 +5780,7 @@ let rec subtype_rec env trace t1 t2 constraints =
                 then
                   subtype_rec
                     env
-                    (Subtype.Diff {got = t2; expected = t1} :: trace)
+                    (Subtype.diff ~got:t2 ~expected:t1 trace)
                     t2 t1
                     constraints
                 else constraints)
@@ -5807,14 +5806,14 @@ let rec subtype_rec env trace t1 t2 constraints =
           (env, trace, t1, t2, !univar_pairs)::constraints
         end
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
-        let trace = Subtype.Diff {got = u1; expected = u2} :: trace in
+        let trace = Subtype.diff ~got:u1 ~expected:u2 trace in
         subtype_rec env trace u1 u2 constraints
     | (Tpoly (u1, tl1), Tpoly (u2, [])) ->
-        let trace = Subtype.Diff {got = t1; expected = u2} :: trace in
+        let trace = Subtype.diff ~got:t1 ~expected:u2 trace in
         let u1' = instance_poly tl1 u1 in
         subtype_rec env trace u1' u2 constraints
     | (Tpoly (u1, tl1), Tpoly (u2,tl2)) ->
-        let trace = Subtype.Diff {got = t1; expected = t2} :: trace in
+        let trace = Subtype.diff ~got:t1 ~expected:t2 trace in
         begin try
           enter_poly env u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 constraints)
@@ -5830,14 +5829,14 @@ let rec subtype_rec env trace t1 t2 constraints =
 
 and subtype_labeled_list env trace labeled_tl1 labeled_tl2 constraints =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
-    subtype_error ~env ~trace ~unification_trace:[];
+    subtype_error ~env ~trace ~unification_trace:empty_root;
   List.fold_left2
     (fun constraints (label1, ty1) (label2, ty2) ->
       if not (Option.equal String.equal label1 label2) then
-        subtype_error ~env ~trace ~unification_trace:[];
+        subtype_error ~env ~trace ~unification_trace:empty_root;
       subtype_rec
         env
-        (Subtype.Diff { got = ty1; expected = ty2 } :: trace)
+        (Subtype.diff ~got:ty1 ~expected:ty2 trace)
         ty1 ty2
         constraints)
     constraints labeled_tl1 labeled_tl2
@@ -5878,7 +5877,7 @@ and subtype_functor env trace ?id1 id pack u1 u2 constraints =
   let env = Env.add_module (Ident.of_unscoped id) Mp_present mty env in
   subtype_rec
     env
-    (Subtype.Diff {got = u1; expected = u2} :: trace)
+    (Subtype.diff ~got:u1 ~expected:u2 trace)
     u1 u2
     constraints
 
@@ -5892,7 +5891,7 @@ and subtype_fields env trace ty1 ty2 constraints =
     if miss1 = [] then
       subtype_rec
         env
-        (Subtype.Diff {got = rest1; expected = rest2} :: trace)
+        (Subtype.diff ~got:rest1 ~expected:rest2 trace)
         rest1 rest2
         constraints
     else
@@ -5911,7 +5910,7 @@ and subtype_fields env trace ty1 ty2 constraints =
        (* These fields are always present *)
        subtype_rec
          env
-         (Subtype.Diff {got = t1; expected = t2} :: trace)
+         (Subtype.diff ~got:t1 ~expected:t2 trace)
          t1 t2
          constraints)
     constraints pairs
@@ -5929,7 +5928,7 @@ and subtype_row env trace row1 row2 constraints =
     Tconstr(p1,_,_), Tconstr(p2,_,_) when Env_unscoped.path_equiv env p1 p2 ->
       subtype_rec
         env
-        (Subtype.Diff {got = more1; expected = more2} :: trace)
+        (Subtype.diff ~got:more1 ~expected:more2 trace)
         more1 more2
         constraints
   | (Tvar _|Tconstr _|Tnil), (Tvar _|Tconstr _|Tnil)
@@ -5942,20 +5941,20 @@ and subtype_row env trace row1 row2 constraints =
           | Rpresent(Some t1), Rpresent(Some t2) ->
               subtype_rec
                 env
-                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                (Subtype.diff ~got:t1 ~expected:t2 trace)
                 t1 t2
                 constraints
           | Reither(false, t1::_, _), Rpresent(Some t2) ->
               subtype_rec
                 env
-                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                (Subtype.diff ~got:t1 ~expected:t2 trace)
                 t1 t2
                 constraints
           | Rabsent, _ -> constraints
           | Rpresent None, Rpresent (Some _)
           | Rpresent (Some _), Rpresent None ->
               subtype_error ~env ~trace
-                ~unification_trace:[variant_arity_mismatch l]
+                ~unification_trace:(root (variant_arity_mismatch l))
           | _ ->
               raise Exit)
         constraints pairs
@@ -5964,7 +5963,7 @@ and subtype_row env trace row1 row2 constraints =
       let constraints =
         subtype_rec
           env
-          (Subtype.Diff {got = more1; expected = more2} :: trace)
+          (Subtype.diff ~got:more1 ~expected:more2 trace)
           more1 more2
           constraints
       in
@@ -5979,7 +5978,7 @@ and subtype_row env trace row1 row2 constraints =
           | Reither(false,[t1],_), Reither(false,[t2],_) ->
               subtype_rec
                 env
-                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                (Subtype.diff ~got:t1 ~expected:t2 trace)
                 t1 t2
                 constraints
           | _ -> raise Exit)
@@ -5992,7 +5991,7 @@ let subtype env ty1 ty2 =
   with_univar_pairs [] (fun () ->
     (* Build constraint set. *)
     let constraints =
-      subtype_rec env [Subtype.Diff {got = ty1; expected = ty2}] ty1 ty2 []
+      subtype_rec env (Subtype.diff ~got:ty1 ~expected:ty2 []) ty1 ty2 []
     in
     TypePairs.clear subtypes;
     (* Enforce constraints. *)
@@ -6003,7 +6002,7 @@ let subtype env ty1 ty2 =
            subtype_error
              ~env
              ~trace:trace0
-             ~unification_trace:(List.tl trace))
+             ~unification_trace:({ trace with path = List.tl trace.path}))
         (List.rev constraints))
 
                               (*******************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3722,7 +3722,7 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
          !rigid_variants && (List.length tl1 = 1 || List.length tl2 = 1)) &&
         begin match tl1 @ tl2 with [] -> false
         | t1 :: tl ->
-            if no_arg then raise_for Unify (variant_arity_mismatch ~l);
+            if no_arg then raise_for Unify (variant_arity_mismatch l);
             Types.changed_row_field_exts [f1;f2] (fun () ->
                 List.iter (unify uenv t1) tl
               )
@@ -3792,11 +3792,11 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
   | (Rpresent None | Reither(true,_,_)),
     (Rpresent (Some _) | Reither(false,_,_)) ->
       (* constructor arity mismatch: 0 <> 1 *)
-      raise_for Unify (variant_arity_mismatch ~l)
-  | Reither(true, _ :: _, _ ), Rpresent _
-  | Rpresent _ , Reither(true, _ :: _, _ ) ->
-      (* inconsistent conjunction on a non-absent field *)
-      raise_for Unify (inconsistent_conjunction ~l)
+      raise_for Unify (variant_arity_mismatch l)
+  | Reither(true, _ :: _, _ ), Rpresent None
+  | Rpresent None , Reither(true, _ :: _, _ ) ->
+      (* inconsistent arity on a non-absent field *)
+      raise_for Unify (variant_arity_mismatch l)
 
 let unify uenv ty1 ty2 =
   let snap = Btype.snapshot () in
@@ -4679,7 +4679,7 @@ and moregen_row type_pairs env row1 row2 =
              try
                if not (eq_row_field_ext f1 f2) then begin
                  if c1 && not c2 then
-                   raise_for Moregen (variant_arity_mismatch ~l);
+                   raise_for Moregen (variant_arity_mismatch l);
                  let f2' =
                    rf_either [] ~use_ext_of:f2 ~no_arg:c2 ~matched:m2 in
                  link_row_field_ext ~inside:f1 f2';
@@ -4692,7 +4692,7 @@ and moregen_row type_pairs env row1 row2 =
                        tl1
                    | [] ->
                       if tl1 <> [] then
-                        raise_for Moregen (variant_arity_mismatch ~l)
+                        raise_for Moregen (variant_arity_mismatch l)
                end
              with Moregen_trace trace ->
                raise_trace_for Moregen (in_tag ~l trace)
@@ -4717,7 +4717,7 @@ and moregen_row type_pairs env row1 row2 =
          (* Mismatched constructor arguments *)
          | Rpresent (Some _), Rpresent None
          | Rpresent None, Rpresent (Some _) ->
-             raise_for Moregen (variant_arity_mismatch ~l)
+             raise_for Moregen (variant_arity_mismatch l)
          (* Mismatched presence *)
          | Reither _, Rpresent _ ->
              raise_for Moregen
@@ -5100,7 +5100,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
        | Rpresent (Some _), Rpresent None
        | Rpresent None, Rpresent (Some _)
        | Reither _, Reither _ ->
-           raise_for Equality (variant_arity_mismatch ~l)
+           raise_for Equality (variant_arity_mismatch l)
        (* Mismatched presence *)
        | Reither _, Rpresent _ ->
            raise_for Equality
@@ -5955,7 +5955,7 @@ and subtype_row env trace row1 row2 constraints =
           | Rpresent None, Rpresent (Some _)
           | Rpresent (Some _), Rpresent None ->
               subtype_error ~env ~trace
-                ~unification_trace:[variant_arity_mismatch ~l]
+                ~unification_trace:[variant_arity_mismatch l]
           | _ ->
               raise Exit)
         constraints pairs

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -297,14 +297,16 @@ val expand_head_opt: Env.t -> type_expr -> type_expr
 val expanded_diff :
   Env.t ->
   got:type_expr -> expected:type_expr ->
-  (Errortrace.expanded_type, 'variant) Errortrace.elt
+  (Errortrace.expanded_type, 'v) Errortrace.t ->
+  (Errortrace.expanded_type, 'v) Errortrace.t
 
 (** Create an [Errortrace.Diff] by *duplicating* the two types, so that each
     one's expansion is identical to itself.  Despite the name, does create
     [Errortrace.expanded_type]s. *)
 val unexpanded_diff :
   got:type_expr -> expected:type_expr ->
-  (Errortrace.expanded_type, 'variant) Errortrace.elt
+  (Errortrace.expanded_type, 'v) Errortrace.t ->
+  (Errortrace.expanded_type, 'v) Errortrace.t
 
 val full_expand: may_forget_scope:bool -> Env.t -> type_expr -> type_expr
 

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -231,7 +231,11 @@ module Subtype = struct
 end
 
 module Structured = struct
+(** This module contains helper functions to parse the error trace into the more
+    structured type {!Stuctured.t} *)
 
+(** We extend the core explanation type with promoted explanation generated from
+    the main trace *)
 type 'a extended_explanation =
   | Promoted of Format_doc.t
   | Standard of 'a
@@ -241,28 +245,28 @@ type ('a,'b) s = {
   tr: 'a ctx_diff list;
   expl: ('a,'b) root extended_explanation option;
 }
-(**
-This module contains helper functions to split the error trace into three parts:
+(** The structured version of the trace is split in three parts:
 - {!top} the first element of the trace
 - {!tr} a list of meaningful context difference element
 - {!expl} a root explanation for a type error
 *)
 
-(** The first intermediary representation splits the trace into four parts:
+(**  The first intermediary representation splits the trace into four parts:
 - the {!head} element of the trace
-- the {!top_to_ctx} trace elements in reverse order situated before the last
-  method or tag difference
+- {!before}: trace elements appearing before the last method or tag
+  difference, in reverse order.
 - {!last_ctx}: the last method or tag context, and the list of elements after it
-- {!optional}: the last element that might be printed if we don't discover a
-  better element to print later on.
-*)
+  in reverse order.
+- {!optional}: the last element that might be useful to print, if we do not
+  discover a better element to print later on.
+Contrarily to the {!t} format this form can be built element by element. *)
 type ('a,'b) segments =
   {
     head: 'a;
     before:'a list;
     last_ctx:('a * 'a list) option;
     optional: 'a option;
-    expl:  'b option;
+    expl: 'b option;
   }
 
 let head_segment hd expl =

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -300,7 +300,7 @@ type printing_status =
       type error.
   *)
 
-(** Construct a segment from an unstructured trace *)
+(** Construct a segmented trace from an unstructured trace *)
 let segment status path expl = match path with
   | [] -> assert false
   | hd :: tr ->
@@ -314,29 +314,33 @@ let segment status path expl = match path with
 
 let promoted x = Option.map (fun p -> Promoted p) x
 let merge promote s =
-  (* First, we commit the last contextualized segment of the trace to the
-     trace *)
-  let rtr, opt, maybe_compact = match s.last_ctx with
-    | None -> s.before, s.optional, false
-    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
+  (* First, we commit the last contextualized segment of the trace to the trace
+     if there one. We also discard the optional last element in this
+     case. *)
+  let rtr, opt = match s.last_ctx with
+    | None -> s.before, s.optional
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None
   in
-  let head, rtr, expl = match s.expl, rtr with
-    | Some expl, _ -> Some s.head, rtr, Some (Standard expl)
-    | None, [] -> Some s.head, [], promoted (promote s.head.d)
-    | None, d :: _ ->
-        match promote d.d with
-        | Some p -> Some s.head, rtr, Some (Promoted p)
-        | None -> Some s.head, rtr, None
+  let rtr, expl =
+    (* If there are no root explanation, we try to promote one from the last
+       element*)
+    match s.expl, rtr, s.head with
+    | Some expl, _, _ -> rtr, Some (Standard expl)
+    | None, [], last | None, last :: _, _ -> rtr, promoted (promote last.d)
   in
+  (* Finally, we keep the last optional element only if there were no
+     explanation at all.*)
   let tr = match expl, opt with
     | None, Some opt -> List.rev (opt :: rtr)
-    | Some _, _ | None, _  -> List.rev rtr
+    | Some _, _ | None, None  -> List.rev rtr
   in
-  let compact head = match tr, maybe_compact with
-    | [], _ | [_], true -> head, true
-    | _ -> head, false
+  (* We use a compact presentation for the top element only if the trace is
+     empty, or is a singleton contextual element (?). *)
+  let compact_head = match tr with
+    | [] | [{ ctx = Some _; _}] -> s.head, true
+    | _ -> s.head, false
   in
-  { top=Option.map compact head; tr; expl }
+  { top = Some compact_head; tr; expl }
 
   let parse ~promote ~status s =
     match s.path with
@@ -345,6 +349,8 @@ let merge promote s =
         { top = None; tr = []; expl}
     | path -> merge promote (segment status path s.root)
 
+  (* In the simple case, we are handling a partial trace with no explanation at
+     all.*)
   let parse_simple status tr =
     match tr with
     | [] -> { top = None; tr = []; expl = None}

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -39,14 +39,24 @@ type expanded_type = { ty: type_expr; expanded: type_expr }
 let trivial_expansion ty = { ty; expanded = ty }
 
 type 'a diff = { got: 'a; expected: 'a }
+type ctx =
+  | In_method of string
+  | In_tag of string
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 
 let map_diff f r =
   (* ordering is often meaningful when dealing with type_expr *)
   let got = f r.got in
   let expected = f r.expected in
   { got; expected }
-
 let swap_diff x = { got = x.expected; expected = x.got }
+
+let map_cdiff f x = { x with d = map_diff f x.d }
+let swap_cdiff x = { x with d = swap_diff x.d }
+
+
+
+
 
 type 'a escape_kind =
   | Constructor of Path.t
@@ -115,13 +125,6 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
-type ctx =
-  | In_method of string
-  | In_tag of string
-type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
-let map_ctx f x = { x with d = map_diff f x.d }
-let swap_ctx x = { x with d = swap_diff x.d }
-
 type ('a, 'variety) root  =
   (* Common *)
   | Variant : 'variety variant -> ('a, 'variety) root
@@ -156,8 +159,10 @@ let map_root (type variety) f : ('a, variety) root -> ('b, variety) root =
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
 
-let map f t =
-  { path = List.map (map_ctx f) t.path; root = Option.map (map_root f) t.root }
+let map f t ={
+  path = List.map (map_cdiff f) t.path;
+  root = Option.map (map_root f) t.root
+}
 let diff ?ctx ~got ~expected trace =
   { trace with path = { ctx; d = {got;expected} } :: trace.path }
 
@@ -187,7 +192,7 @@ let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =
 
 let swap_trace t = {
   root = Option.map swap_root t.root;
-  path = List.map swap_ctx t.path
+  path = List.map swap_cdiff t.path
 }
 
 type unification_error = { trace : unification error } [@@unboxed]
@@ -236,7 +241,7 @@ module Subtype = struct
   assert (trace <> []);
   { trace; unification_trace }
 
-  let map f t = List.map (map_ctx f) t
+  let map f t = List.map (map_cdiff f) t
 end
 
 module Structured = struct

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -356,7 +356,7 @@ let merge promote s =
 
   let parse_simple status tr =
     match tr with
-    | [] -> None
+    | [] -> { top = None; tr = []; expl = None}
     | _ ->
         let s = segment status tr None in
         let rtr = match s.last_ctx with
@@ -367,6 +367,6 @@ let merge promote s =
           | Some x -> x :: rtr
           | None -> rtr
         in
-        Some (s.head, List.rev rtr)
+        { top = Some (s.head,false); tr = List.rev rtr; expl = None }
 
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -89,7 +89,8 @@ type fixed_row_case =
 
 type 'variety variant =
   (* Common *)
-  | Incompatible_types_for : string -> _ variant
+  | Arity_mismatch : string -> _ variant
+  | Inconsistent_conjunction: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -115,16 +116,21 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
+type ctx =
+  | In_method of string
+  | In_tag of string
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
+let map_ctx f x = { x with d = map_diff f x.d }
+let swap_ctx x = { x with d = swap_diff x.d }
+
 type ('a, 'variety) elt =
   (* Common *)
-  | Diff : 'a diff -> ('a, _) elt
+  | Diff : 'a ctx_diff -> ('a, _) elt
   | Variant : 'variety variant -> ('a, 'variety) elt
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
-      (* Could move [Incompatible_fields] into [obj] *)
   | First_class_module: first_class_module -> ('a,_) elt
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
@@ -136,26 +142,29 @@ type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
 let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
-  | Diff x -> Diff (map_diff f x)
+  | Diff x -> Diff (map_ctx f x)
   | Escape {kind = Equation x; context} ->
       Escape { kind = Equation (f x); context }
   | Escape {kind = (Univ _ | Self | Constructor _
       | Module_type _ | Module _ | Constraint);
             _}
   | Variant _ | Obj _ | Function_label_mismatch _ | Tuple_label_mismatch _
-  | Incompatible_fields _
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
 
 let map f t = List.map (map_elt f) t
+let diff ?ctx ~got ~expected trace = Diff { ctx; d = {got;expected} } :: trace
 
-let incompatible_fields ~name ~got ~expected =
-  Incompatible_fields { name; diff={got; expected} }
+let incompatible_fields ~name ~got ~expected  t =
+  Diff { ctx = Some (In_method name); d = { got; expected} } :: t
+let in_tag ~l = function
+  | Diff { ctx = None; d} :: rem -> Diff { ctx = Some(In_tag l); d} :: rem
+  | trace -> trace
+let variant_arity_mismatch ~l = Variant (Arity_mismatch l)
+let inconsistent_conjunction ~l = Variant (Inconsistent_conjunction l)
 
 let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
-  | Diff x -> Diff (swap_diff x)
-  | Incompatible_fields { name; diff } ->
-    Incompatible_fields { name; diff = swap_diff diff}
+  | Diff x -> Diff (swap_ctx x)
   | Obj (Missing_field(pos,s)) -> Obj (Missing_field(swap_position pos,s))
   | Obj (Abstract_row pos) -> Obj (Abstract_row (swap_position pos))
   | Variant (Fixed_row(pos,k,f)) ->

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -54,10 +54,6 @@ let swap_diff x = { got = x.expected; expected = x.got }
 let map_cdiff f x = { x with d = map_diff f x.d }
 let swap_cdiff x = { x with d = swap_diff x.d }
 
-
-
-
-
 type 'a escape_kind =
   | Constructor of Path.t
   | Univ of type_expr
@@ -78,16 +74,6 @@ let map_escape f esc =
      | Equation eq -> Equation (f eq)
      | (Constructor _ | Univ _ | Self | Module_type _
         | Module _ | Constraint) as c -> c}
-
-let explain trace f =
-  let rec explain = function
-    | [] -> None
-    | [h] -> f ~prev:None h
-    | h :: (prev :: _ as rem) ->
-      match f ~prev:(Some prev) h with
-      | Some _ as m -> m
-      | None -> explain rem in
-  explain (List.rev trace)
 
 (* Type indices *)
 type unification = private Unification

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -90,7 +90,6 @@ type fixed_row_case =
 type 'variety variant =
   (* Common *)
   | Arity_mismatch : string -> _ variant
-  | Inconsistent_conjunction: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -160,8 +159,7 @@ let incompatible_fields ~name ~got ~expected  t =
 let in_tag ~l = function
   | Diff { ctx = None; d} :: rem -> Diff { ctx = Some(In_tag l); d} :: rem
   | trace -> trace
-let variant_arity_mismatch ~l = Variant (Arity_mismatch l)
-let inconsistent_conjunction ~l = Variant (Inconsistent_conjunction l)
+let variant_arity_mismatch l = Variant (Arity_mismatch l)
 
 let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
   | Diff x -> Diff (swap_ctx x)

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -122,26 +122,31 @@ type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 let map_ctx f x = { x with d = map_diff f x.d }
 let swap_ctx x = { x with d = swap_diff x.d }
 
-type ('a, 'variety) elt =
+type ('a, 'variety) root  =
   (* Common *)
-  | Diff : 'a ctx_diff -> ('a, _) elt
-  | Variant : 'variety variant -> ('a, 'variety) elt
-  | Obj : 'variety obj -> ('a, 'variety) elt
-  | Escape : 'a escape -> ('a, _) elt
+  | Variant : 'variety variant -> ('a, 'variety) root
+  | Obj : 'variety obj -> ('a, 'variety) root
+  | Escape : 'a escape -> ('a, _) root
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | First_class_module: first_class_module -> ('a,_) elt
+  | First_class_module: first_class_module -> ('a,_) root
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
-  | Rec_occur : type_expr * type_expr -> ('a, _) elt
+  | Rec_occur : type_expr * type_expr -> ('a, _) root
 
-type ('a, 'variety) t = ('a, 'variety) elt list
+type ('a, 'variety) t = {
+  path: 'a ctx_diff list;
+  root: ('a, 'variety) root option
+}
+
+let root root = { root= Some root; path = [] }
+let empty_root = { root = None; path = [] }
 
 type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
-let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
-  | Diff x -> Diff (map_ctx f x)
+let map_root (type variety) f : ('a, variety) root -> ('b, variety) root =
+  function
   | Escape {kind = Equation x; context} ->
       Escape { kind = Equation (f x); context }
   | Escape {kind = (Univ _ | Self | Constructor _
@@ -151,18 +156,21 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
 
-let map f t = List.map (map_elt f) t
-let diff ?ctx ~got ~expected trace = Diff { ctx; d = {got;expected} } :: trace
+let map f t =
+  { path = List.map (map_ctx f) t.path; root = Option.map (map_root f) t.root }
+let diff ?ctx ~got ~expected trace =
+  { trace with path = { ctx; d = {got;expected} } :: trace.path }
 
 let incompatible_fields ~name ~got ~expected  t =
-  Diff { ctx = Some (In_method name); d = { got; expected} } :: t
-let in_tag ~l = function
-  | Diff { ctx = None; d} :: rem -> Diff { ctx = Some(In_tag l); d} :: rem
-  | trace -> trace
+  diff ~ctx:(In_method name) ~got ~expected t
+let in_tag ~l t = match t.path with
+  | { ctx = None; d} :: rem ->
+      { t with path = { ctx = Some(In_tag l); d } :: rem }
+  | _ -> t
 let variant_arity_mismatch l = Variant (Arity_mismatch l)
 
-let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
-  | Diff x -> Diff (swap_ctx x)
+let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =
+  function
   | Obj (Missing_field(pos,s)) -> Obj (Missing_field(swap_position pos,s))
   | Obj (Abstract_row pos) -> Obj (Abstract_row (swap_position pos))
   | Variant (Fixed_row(pos,k,f)) ->
@@ -177,7 +185,10 @@ let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
   | Univar (Quantification_mismatch _) as x -> x
   | x -> x
 
-let swap_trace e = List.map swap_elt e
+let swap_trace t = {
+  root = Option.map swap_root t.root;
+  path = List.map swap_ctx t.path
+}
 
 type unification_error = { trace : unification error } [@@unboxed]
 
@@ -187,16 +198,17 @@ type equality_error =
 
 type moregen_error = { trace : comparison error } [@@unboxed]
 
+let non_empty trace = trace.root <> None || trace.path <> []
 let unification_error ~trace : unification_error =
-  assert (trace <> []);
+  assert (non_empty trace);
   { trace }
 
 let equality_error ~trace ~subst : equality_error =
-    assert (trace <> []);
+    assert (non_empty trace);
     { trace; subst }
 
 let moregen_error ~trace : moregen_error =
-  assert (trace <> []);
+  assert (non_empty trace);
   { trace }
 
 type comparison_error =
@@ -207,10 +219,8 @@ let swap_unification_error ({trace} : unification_error) =
   ({trace = swap_trace trace} : unification_error)
 
 module Subtype = struct
-  type 'a elt =
-    | Diff of 'a diff
 
-  type 'a t = 'a elt list
+  type 'a t = 'a ctx_diff list
 
   type trace       = type_expr t
   type error_trace = expanded_type t
@@ -221,14 +231,12 @@ module Subtype = struct
     { trace             : error_trace
     ; unification_trace : unification error }
 
+  let diff ?ctx ~got ~expected t = { ctx; d = { got; expected }} :: t
   let error ~trace ~unification_trace =
   assert (trace <> []);
   { trace; unification_trace }
 
-  let map_elt f = function
-    | Diff x -> Diff (map_diff f x)
-
-  let map f t = List.map (map_elt f) t
+  let map f t = List.map (map_ctx f) t
 end
 
 module Structured = struct
@@ -237,10 +245,10 @@ type 'a extended_explanation =
   | Promoted of Format_doc.t
   | Standard of 'a
 
-type 'a t = {
-  top: ('a * bool) option;
-  tr: 'a list;
-  expl: 'a extended_explanation option;
+type ('a,'b) s = {
+  top: ('a ctx_diff * bool) option;
+  tr: 'a ctx_diff list;
+  expl: ('a,'b) root extended_explanation option;
 }
 (**
 This module contains helper functions to split the error trace into three parts:
@@ -257,16 +265,17 @@ This module contains helper functions to split the error trace into three parts:
 - {!optional}: the last element that might be printed if we don't discover a
   better element to print later on.
 *)
-type 'a segments =
+type ('a,'b) segments =
   {
     head: 'a;
     before:'a list;
     last_ctx:('a * 'a list) option;
-    optional: 'a option
+    optional: 'a option;
+    expl:  'b option;
   }
 
-let head_segment hd =
-  { head = hd; before=[]; last_ctx = None; optional = None }
+let head_segment hd expl =
+  { head = hd; before=[]; last_ctx = None; optional = None; expl }
 
 (** Add a non-contextual element to the active context *)
 let add x s = match s.last_ctx with
@@ -281,7 +290,8 @@ let add_ctx c s = match s.last_ctx with
       head = s.head;
       optional = None;
       before = rest @ s.before;
-      last_ctx = Some (c,[])
+      last_ctx = Some (c,[]);
+      expl = s.expl
     }
 
 type printing_status =
@@ -300,7 +310,7 @@ type printing_status =
   *)
 
 (** Construct a segment from an unstructured trace *)
-let segment status = function
+let segment status path expl = match path with
   | [] -> assert false
   | hd :: tr ->
       List.fold_left (fun s x ->
@@ -309,7 +319,7 @@ let segment status = function
       | Keep -> add x s
       | Optional_refinement -> { s with optional = Some x }
       | Context -> add_ctx x s
-    ) (head_segment hd) tr
+    ) (head_segment hd expl) tr
 
 let promoted x = Option.map (fun p -> Promoted p) x
 let merge promote s =
@@ -319,18 +329,13 @@ let merge promote s =
     | None -> s.before, s.optional, false
     | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
   in
-  let head, rtr, expl = match rtr with
-    | Diff d :: _ ->
-        begin match promote d.d with
+  let head, rtr, expl = match s.expl, rtr with
+    | Some expl, _ -> Some s.head, rtr, Some (Standard expl)
+    | None, [] -> Some s.head, [], promoted (promote s.head.d)
+    | None, d :: _ ->
+        match promote d.d with
         | Some p -> Some s.head, rtr, Some (Promoted p)
         | None -> Some s.head, rtr, None
-        end
-    | expl :: rest -> Some s.head, rest, Some (Standard expl)
-    | [] ->
-        begin match s.head with
-        | Diff d -> Some s.head, [], promoted (promote d.d)
-        | expl -> None, [], Some (Standard expl)
-        end
   in
   let tr = match expl, opt with
     | None, Some opt -> List.rev (opt :: rtr)
@@ -342,18 +347,26 @@ let merge promote s =
   in
   { top=Option.map compact head; tr; expl }
 
-  let parse ~promote ~status s = merge promote (segment status s)
+  let parse ~promote ~status s =
+    match s.path with
+    | [] ->
+        let expl = Option.map (fun s -> Standard s) s.root in
+        { top = None; tr = []; expl}
+    | path -> merge promote (segment status path s.root)
 
   let parse_simple status tr =
-    let s = segment status tr in
-    let rtr = match s.last_ctx with
-      | None -> s.before
-      | Some (ctx, rest) -> rest @ ctx :: s.before
-    in
-    let rtr = match s.optional with
-      | Some x -> x :: rtr
-      | None -> rtr
-    in
-    s.head, List.rev rtr
+    match tr with
+    | [] -> None
+    | _ ->
+        let s = segment status tr None in
+        let rtr = match s.last_ctx with
+          | None -> s.before
+          | Some (ctx, rest) -> rest @ ctx :: s.before
+        in
+        let rtr = match s.optional with
+          | Some x -> x :: rtr
+          | None -> rtr
+        in
+        Some (s.head, List.rev rtr)
 
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -349,21 +349,4 @@ let merge promote s =
         { top = None; tr = []; expl}
     | path -> merge promote (segment status path s.root)
 
-  (* In the simple case, we are handling a partial trace with no explanation at
-     all.*)
-  let parse_simple status tr =
-    match tr with
-    | [] -> { top = None; tr = []; expl = None}
-    | _ ->
-        let s = segment status tr None in
-        let rtr = match s.last_ctx with
-          | None -> s.before
-          | Some (ctx, rest) -> rest @ ctx :: s.before
-        in
-        let rtr = match s.optional with
-          | Some x -> x :: rtr
-          | None -> rtr
-        in
-        { top = Some (s.head,false); tr = List.rev rtr; expl = None }
-
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -230,3 +230,130 @@ module Subtype = struct
 
   let map f t = List.map (map_elt f) t
 end
+
+module Structured = struct
+
+type 'a extended_explanation =
+  | Promoted of Format_doc.t
+  | Standard of 'a
+
+type 'a t = {
+  top: ('a * bool) option;
+  tr: 'a list;
+  expl: 'a extended_explanation option;
+}
+(**
+This module contains helper functions to split the error trace into three parts:
+- {!top} the first element of the trace
+- {!tr} a list of meaningful context difference element
+- {!expl} a root explanation for a type error
+*)
+
+(** The first intermediary representation splits the trace into four parts:
+- the {!head} element of the trace
+- the {!top_to_ctx} trace elements in reverse order situated before the last
+  method or tag difference
+- {!last_ctx}: the last method or tag context, and the list of elements after it
+- {!optional}: the last element that might be printed if we don't discover a
+  better element to print later on.
+*)
+type 'a segments =
+  {
+    head: 'a;
+    before:'a list;
+    last_ctx:('a * 'a list) option;
+    optional: 'a option
+  }
+
+let head_segment hd =
+  { head = hd; before=[]; last_ctx = None; optional = None }
+
+(** Add a non-contextual element to the active context *)
+let add x s = match s.last_ctx with
+  | None ->  { s with optional = None; before = x :: s.before }
+  | Some (ctx, rest)->
+      { s with optional = None; last_ctx = Some (ctx, x :: rest)}
+
+(** Add a new context, add the last context contents to the {!before} trace *)
+let add_ctx c s = match s.last_ctx with
+  | None -> { s with optional = None; last_ctx = Some (c,[]) }
+  | Some (_ctx, rest) -> {
+      head = s.head;
+      optional = None;
+      before = rest @ s.before;
+      last_ctx = Some (c,[])
+    }
+
+type printing_status =
+  | Discard
+  | Keep
+  | Context
+    (** A {!Context} element marks the entry inside a method or a polymorphic
+        variant tag *)
+  | Optional_refinement
+  (** An [Optional_refinement] printing status is attributed to trace
+      elements that are focusing on a new subpart of a structural type.
+      Since the whole type should have been printed earlier in the trace,
+      we only print those elements if they are the last printed element
+      of a trace, and there is no explicit explanation for the
+      type error.
+  *)
+
+(** Construct a segment from an unstructured trace *)
+let segment status = function
+  | [] -> assert false
+  | hd :: tr ->
+      List.fold_left (fun s x ->
+      match status x with
+      | Discard -> s
+      | Keep -> add x s
+      | Optional_refinement -> { s with optional = Some x }
+      | Context -> add_ctx x s
+    ) (head_segment hd) tr
+
+let promoted x = Option.map (fun p -> Promoted p) x
+let merge promote s =
+  (* First, we commit the last contextualized segment of the trace to the
+     trace *)
+  let rtr, opt, maybe_compact = match s.last_ctx with
+    | None -> s.before, s.optional, false
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
+  in
+  let head, rtr, expl = match rtr with
+    | Diff d :: _ ->
+        begin match promote d.d with
+        | Some p -> Some s.head, rtr, Some (Promoted p)
+        | None -> Some s.head, rtr, None
+        end
+    | expl :: rest -> Some s.head, rest, Some (Standard expl)
+    | [] ->
+        begin match s.head with
+        | Diff d -> Some s.head, [], promoted (promote d.d)
+        | expl -> None, [], Some (Standard expl)
+        end
+  in
+  let tr = match expl, opt with
+    | None, Some opt -> List.rev (opt :: rtr)
+    | Some _, _ | None, _  -> List.rev rtr
+  in
+  let compact head = match tr, maybe_compact with
+    | [], _ | [_], true -> head, true
+    | _ -> head, false
+  in
+  { top=Option.map compact head; tr; expl }
+
+  let parse ~promote ~status s = merge promote (segment status s)
+
+  let parse_simple status tr =
+    let s = segment status tr in
+    let rtr = match s.last_ctx with
+      | None -> s.before
+      | Some (ctx, rest) -> rest @ ctx :: s.before
+    in
+    let rtr = match s.optional with
+      | Some x -> x :: rtr
+      | None -> rtr
+    in
+    s.head, List.rev rtr
+
+end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -104,27 +104,33 @@ type ctx =
 type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 val map_ctx: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
 
-type ('a, 'variety) elt =
+type ('a, 'variety) root =
   (* Common *)
-  | Diff : 'a ctx_diff -> ('a, _) elt
-  | Variant : 'variety variant -> ('a, 'variety) elt
-  | Obj : 'variety obj -> ('a, 'variety) elt
-  | Escape : 'a escape -> ('a, _) elt
+  | Variant : 'variety variant -> ('a, 'variety) root
+  | Obj : 'variety obj -> ('a, 'variety) root
+  | Escape : 'a escape -> ('a, _) root
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | First_class_module: first_class_module -> ('a,_) elt
+  | First_class_module: first_class_module -> ('a,_) root
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
-  | Rec_occur : type_expr * type_expr -> ('a, _) elt
+  | Rec_occur : type_expr * type_expr -> ('a, _) root
 
-type ('a, 'variety) t = ('a, 'variety) elt list
+type ('a, 'variety) t = {
+  path: 'a ctx_diff list;
+  root: ('a, 'variety) root option
+}
 
 type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
 val map : ('a -> 'b) -> ('a, 'variety) t -> ('b, 'variety) t
+
 val diff:
   ?ctx:ctx -> got:'a -> expected:'a -> ('a,'variety) t -> ('a,'variety) t
+val root: ('a,'variety) root -> ('a,'variety) t
+val empty_root: ('a,'variety) t
+
 
 val incompatible_fields:
   name:string -> got:type_expr -> expected:type_expr ->
@@ -133,7 +139,7 @@ val incompatible_fields:
 val in_tag:
   l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
 
-val variant_arity_mismatch: string -> ('any, 'f) elt
+val variant_arity_mismatch: string -> ('any, 'f) root
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 
@@ -171,10 +177,9 @@ type comparison_error =
 val swap_unification_error : unification_error -> unification_error
 
 module Subtype : sig
-  type 'a elt =
-    | Diff of 'a diff
 
-  type 'a t = 'a elt list
+  type 'a t = 'a ctx_diff list
+  val diff: ?ctx:ctx -> got:'a -> expected:'a -> 'a t -> 'a t
 
   (** Just as outside [Subtype], we split traces, completed traces, and complete
       errors.  However, in a minor asymmetry, the name [Subtype.error_trace]
@@ -204,10 +209,10 @@ module Structured: sig
     | Promoted of Format_doc.t
     | Standard of 'a
 
-  type 'a t = {
-    top: ('a * bool) option;
-    tr: 'a list;
-    expl: 'a extended_explanation option
+  type ('a,'b) s = {
+    top: ('a ctx_diff * bool) option;
+    tr: 'a ctx_diff list;
+    expl: ('a, 'b) root extended_explanation option
   }
   (**
      This module contains helper functions to split the error trace into three
@@ -235,10 +240,10 @@ module Structured: sig
 
 val parse:
     promote:('a diff -> Format_doc.t option) ->
-    status:(('a, 'b) elt -> printing_status) ->
-    ('a, 'b) elt list ->
-    ('a, 'b) elt t
+    status:('a ctx_diff -> printing_status) ->
+    ('a, 'b) t -> ('a, 'b) s
 
-  val parse_simple: ('a -> printing_status) -> 'a list -> 'a * 'a list
+  val parse_simple:
+    ('a  -> printing_status) -> 'a list -> ('a  * 'a  list) option
 
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -71,7 +71,8 @@ type fixed_row_case =
 
 type 'variety variant =
   (* Common *)
-  | Incompatible_types_for : string -> _ variant
+  | Arity_mismatch : string -> _ variant
+  | Inconsistent_conjunction: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -97,15 +98,21 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
+type ctx =
+  | In_method of string
+  | In_tag of string
+
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
+val map_ctx: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
+
 type ('a, 'variety) elt =
   (* Common *)
-  | Diff : 'a diff -> ('a, _) elt
+  | Diff : 'a ctx_diff -> ('a, _) elt
   | Variant : 'variety variant -> ('a, 'variety) elt
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   | First_class_module: first_class_module -> ('a,_) elt
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
@@ -117,9 +124,19 @@ type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
 val map : ('a -> 'b) -> ('a, 'variety) t -> ('b, 'variety) t
+val diff:
+  ?ctx:ctx -> got:'a -> expected:'a -> ('a,'variety) t -> ('a,'variety) t
 
-val incompatible_fields :
-  name:string -> got:type_expr -> expected:type_expr -> (type_expr, _) elt
+val incompatible_fields:
+  name:string -> got:type_expr -> expected:type_expr ->
+  (type_expr, 'v) t -> (type_expr, 'v) t
+
+val in_tag:
+  l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
+
+val variant_arity_mismatch: l:string -> ('any, 'f) elt
+val inconsistent_conjunction: l:string -> ('any, 'f) elt
+
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -204,7 +204,7 @@ module Structured: sig
     | Standard of 'a
 
   type ('a,'b) s = {
-    top: ('a ctx_diff * bool) option;
+    top: ('a ctx_diff * bool) option; (* top = None => tr = [] *)
     tr: 'a ctx_diff list;
     expl: ('a, 'b) root extended_explanation option
   }
@@ -235,8 +235,5 @@ val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->
     ('a, 'b) t -> ('a, 'b) s
-
-  val parse_simple:
-    ('a ctx_diff -> printing_status) -> 'a ctx_diff list -> ('a, 'b) s
 
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -35,9 +35,14 @@ type expanded_type = { ty: type_expr; expanded: type_expr }
 val trivial_expansion : type_expr -> expanded_type
 
 type 'a diff = { got: 'a; expected: 'a }
+type ctx =
+  | In_method of string
+  | In_tag of string
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 
 (** [map_diff f {expected;got}] is [{expected=f expected; got=f got}] *)
 val map_diff: ('a -> 'b) -> 'a diff -> 'b diff
+val map_cdiff: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
 
 (** Scope escape related errors *)
 type 'a escape_kind =
@@ -96,13 +101,6 @@ type first_class_module =
 type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
-
-type ctx =
-  | In_method of string
-  | In_tag of string
-
-type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
-val map_ctx: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
 
 type ('a, 'variety) root =
   (* Common *)

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -198,7 +198,11 @@ module Subtype : sig
 end
 
 module Structured: sig
+(** This module contains helper functions to parse the error trace into the more
+    structured type {!Stuctured.t} *)
 
+  (** We extend the core explanation type with promoted explanation generated
+      from the main trace *)
   type 'a extended_explanation =
     | Promoted of Format_doc.t
     | Standard of 'a
@@ -208,14 +212,11 @@ module Structured: sig
     tr: 'a ctx_diff list;
     expl: ('a, 'b) root extended_explanation option
   }
-  (**
-     This module contains helper functions to split the error trace into three
-     parts:
-     - {!top} the first element of the trace
-     - {!tr} a list of meaningful context difference element
-     - {!expl} a root explanation for a type error
-  *)
-
+  (** The structured version of the trace is split in three parts:
+      - {!top} the first element of the trace
+      - {!tr} a list of meaningful context difference element
+      - {!expl} a root explanation for a type error
+   *)
 
   type printing_status =
     | Discard
@@ -231,6 +232,12 @@ module Structured: sig
         of a trace, and there is no explicit explanation for the
         type error.
     *)
+
+  (** [parse ~promote ~status] builds a structured trace from an unstructured
+      one. The [status] function is used to classify elements of the trace,
+      whereas the [promote] function describe which kind of trace element might
+      be promoted to an extended explanation in the absence of a standard
+      explanation. *)
 val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -197,3 +197,48 @@ module Subtype : sig
 
   val map : ('a -> 'b) -> 'a t -> 'b t
 end
+
+module Structured: sig
+
+  type 'a extended_explanation =
+    | Promoted of Format_doc.t
+    | Standard of 'a
+
+  type 'a t = {
+    top: ('a * bool) option;
+    tr: 'a list;
+    expl: 'a extended_explanation option
+  }
+  (**
+     This module contains helper functions to split the error trace into three
+     parts:
+     - {!top} the first element of the trace
+     - {!tr} a list of meaningful context difference element
+     - {!expl} a root explanation for a type error
+  *)
+
+
+  type printing_status =
+    | Discard
+    | Keep
+    | Context
+    (** A {!Context} element marks the entry inside a method or a polymorphic
+        variant tag *)
+    | Optional_refinement
+    (** An [Optional_refinement] printing status is attributed to trace
+        elements that are focusing on a new subpart of a structural type.
+        Since the whole type should have been printed earlier in the trace,
+        we only print those elements if they are the last printed element
+        of a trace, and there is no explicit explanation for the
+        type error.
+    *)
+
+val parse:
+    promote:('a diff -> Format_doc.t option) ->
+    status:(('a, 'b) elt -> printing_status) ->
+    ('a, 'b) elt list ->
+    ('a, 'b) elt t
+
+  val parse_simple: ('a -> printing_status) -> 'a list -> 'a * 'a list
+
+end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -71,8 +71,7 @@ type fixed_row_case =
 
 type 'variety variant =
   (* Common *)
-  | Arity_mismatch : string -> _ variant
-  | Inconsistent_conjunction: string -> _ variant
+  | Arity_mismatch: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -134,9 +133,7 @@ val incompatible_fields:
 val in_tag:
   l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
 
-val variant_arity_mismatch: l:string -> ('any, 'f) elt
-val inconsistent_conjunction: l:string -> ('any, 'f) elt
-
+val variant_arity_mismatch: string -> ('any, 'f) elt
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -62,10 +62,6 @@ type 'a escape =
 
 val map_escape : ('a -> 'b) -> 'a escape -> 'b escape
 
-val explain: 'a list ->
-  (prev:'a option -> 'a -> 'b option) ->
-  'b option
-
 (** Type indices *)
 type unification = private Unification
 type comparison  = private Comparison

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -237,13 +237,12 @@ module Structured: sig
         of a trace, and there is no explicit explanation for the
         type error.
     *)
-
 val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->
     ('a, 'b) t -> ('a, 'b) s
 
   val parse_simple:
-    ('a  -> printing_status) -> 'a list -> ('a  * 'a  list) option
+    ('a ctx_diff -> printing_status) -> 'a ctx_diff list -> ('a, 'b) s
 
 end

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -177,9 +177,9 @@ let promote_diff env {Errortrace.got; expected} =
   res
 
 let merge env s =
-  let rtr, opt = match s.last_ctx with
-    | None -> s.before, s.optional
-    | Some (ctx, rest) -> rest @ ctx :: s.before, None
+  let rtr, opt, maybe_compact = match s.last_ctx with
+    | None -> s.before, s.optional, false
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
   in
   let head, rtr, expl = match rtr with
     | Errortrace.Diff d :: _ ->
@@ -199,7 +199,11 @@ let merge env s =
     | None, Some opt -> head @ List.rev (opt :: rtr)
     | Some _, _ | None, _  -> head @ List.rev rtr
   in
-  rtr, expl
+  let compact = match rtr, maybe_compact with
+    | [_], _ | [_;_], true -> true
+    | _ -> false
+  in
+  rtr, expl, compact
 
   let split env status s= merge env (segment status s)
 end
@@ -612,16 +616,16 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
   let tr = Errortrace.map hide_variant tr in
-  let tr, expl = Structured_trace.split env printing_status tr in
+  let tr, expl, compact = Structured_trace.split env printing_status tr in
   let elt, tr = match tr with
     | [] -> None, tr
     | hd :: tr -> Some hd, tr
   in
   with_labels (not !Clflags.classic) (fun () ->
       let tr = simplify_trace tr in
-      let head = Option.bind elt (prepare_expansion_head (List.is_empty tr)) in
-      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
+      let head = Option.bind elt (prepare_expansion_head compact) in
       let head_error = head_error_printer mode txt1 txt2 head in
+      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 expl in
       fprintf ppf
@@ -679,7 +683,9 @@ module Subtype = struct
     let tr = Errortrace.map f tr in
     match tr with
     | [] -> [], None
-    | _ -> Structured_trace.split env printing_status tr
+    | _ ->
+        let tr, expl, _ = Structured_trace.split env printing_status tr in
+        tr, expl
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -36,6 +36,7 @@ open Out_type
 open Format_doc
 module Fmt = Format_doc
 module Style = Misc.Style
+module Structured = Errortrace.Structured
 
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
@@ -71,13 +72,13 @@ let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
                                       expected = {ty = t2; expanded = t2'} } =
   if  Btype.is_constr_row ~allow_ident:true t1'
    || Btype.is_constr_row ~allow_ident:true t2'
-  then Errortrace.Structured.Discard
+  then Structured.Discard
   else if same_path t1 t1' && same_path t2 t2' then
-    Errortrace.Structured.Optional_refinement
-  else Errortrace.Structured.Keep
+    Structured.Optional_refinement
+  else Structured.Keep
 
 let printing_status = function
-  | { Errortrace.ctx = Some _; _} -> Errortrace.Structured.Context
+  | { Errortrace.ctx = Some _; _} -> Structured.Context
   | d -> diff_printing_status d.Errortrace.d
 
 let is_unit_param env ty =
@@ -387,8 +388,8 @@ let explanation (type variety) intro
 let mismatch intro expl =
   match expl with
   | None -> None
-  | Some (Errortrace.Structured.Promoted msg) -> Some msg
-  | Some (Errortrace.Structured.Standard e) -> explanation intro e
+  | Some (Structured.Promoted msg) -> Some msg
+  | Some (Structured.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
   match Types.get_desc t with
@@ -493,8 +494,7 @@ let hide_variant ty_exp =
   Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
 
 let structured_trace env tr =
- Errortrace.Structured.parse ~promote:(promote_diff env) ~status:printing_status
-   tr
+  Structured.parse ~promote:(promote_diff env) ~status:printing_status tr
 
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
@@ -551,73 +551,52 @@ let comparison ppf mode env = function
   | Errortrace.Moregen_error  error -> moregen  ppf mode env error
 
 module Subtype = struct
-  (* There's a frustrating amount of code duplication between this module and
-     the outside code, particularly in [prepare_trace] and [filter_trace].
-     Unfortunately, [Subtype] is *just* similar enough to have code duplication,
-     while being *just* different enough (it's only [Diff]) for the abstraction
-     to be nonobvious.  Someday, perhaps... *)
 
-  let prepare_unification_trace env f tr =
-    let tr = Errortrace.map f tr in
-    match tr.path with
-    | [] -> None, Option.map (fun x -> Errortrace.Structured.Standard x) tr.root
-    | _ ->
-        let str = structured_trace env tr in
-        match str.top with
-        | Some (h,_) -> Some (h,str.tr), str.expl
-        | None -> None, str.expl
+  let prepare_trace { Errortrace.Subtype.trace; unification_trace } =
+    let trace = Errortrace.Subtype.map prepare_expansion trace in
+    let unification_trace =
+      Errortrace.map prepare_expansion unification_trace in
+    Errortrace.Subtype.error ~trace ~unification_trace
 
-  let prepare_trace f tr =
-    let tr = Errortrace.Subtype.map f tr in
-    Errortrace.Structured.parse_simple printing_status tr
-
-  let trace filter_trace fst txt ppf htr =
+  let flatten_trace filter_trace fst (str: _ Structured.s) =
     with_labels (not !Clflags.classic) (fun () ->
-      match htr with
-      | Some (elt,tr) ->
+      match str.top, str.tr with
+      | Some (elt,_), tr ->
         let diffed_elt =
           Errortrace.map_ctx (trees_of_type_expansion Type) elt
         in
-        let tr = filter_trace tr in
-        let tr =
-          trees_of_trace Type
-          @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
-        let tr = if fst then diffed_elt :: tr else tr in
-        trace fst txt ppf tr
-      | None -> ()
+        let tr = trees_of_trace Type (filter_trace tr) in
+        if fst then diffed_elt :: tr else tr
+      | None, _ -> []
     )
 
-  let rec filter_subtype_trace keep_last = function
+  let rec filter_trace keep_last = function
     | [] -> []
-    | [elt]
-      when printing_status elt = Errortrace.Structured.Optional_refinement ->
+    | [elt] when printing_status elt = Structured.Optional_refinement ->
         if keep_last then [elt] else []
-    | d :: rem -> d :: filter_subtype_trace keep_last rem
+    | d :: rem -> d :: filter_trace keep_last rem
 
+  let obj_only_trace (trace: _ Structured.s) =
+    match trace.top, trace.tr, trace.expl with
+    | None, [], Some (Standard (Obj _ | Variant _ | Escape _ ))
+    | None, [], None -> true
+    | _ -> false
 
-  let error
-        ppf
-        env
-        (Errortrace.Subtype.{trace = tr_sub; unification_trace = tr_unif})
-        txt1 =
+  let error ppf env tr txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub = prepare_trace prepare_expansion tr_sub in
-      let tr_unif, expl =
-        prepare_unification_trace env prepare_expansion tr_unif
-      in
-      let keep_first = match tr_unif, expl with
-        | None, Some (Standard (Obj _ | Variant _ | Escape _ ))
-        | None, None -> true
-        | _ -> false in
-      fprintf ppf "@[<v>%a"
-        (trace (filter_subtype_trace keep_first) true txt1) tr_sub;
-      if tr_unif = None && expl = None then fprintf ppf "@]" else
-        let mis = mismatch (doc_printf "Within this type") expl in
-        fprintf ppf "%a%a%t@]"
-          (trace Fun.id false "is not compatible with type") tr_unif
-          (pp_print_option pp_doc) mis
-          Ident_conflicts.err_print
+      let tr = prepare_trace tr in
+      let tr_sub = Structured.parse_simple printing_status tr.trace in
+      let str_unif = structured_trace env tr.unification_trace in
+      let keep_last = obj_only_trace str_unif in
+      let tr_sub = flatten_trace (filter_trace keep_last) true tr_sub in
+      let tr_unif = flatten_trace Fun.id false str_unif in
+      let mis = mismatch (doc_printf "Within this type") str_unif.expl in
+      fprintf ppf "@[<v>%a%a%a%t@]"
+        (trace true txt1) tr_sub
+        (trace false "is not compatible with type") tr_unif
+        (pp_print_option pp_doc) mis
+        Ident_conflicts.err_print
     )
 end
 

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -43,8 +43,6 @@ let trees_of_trace mode =
   List.map (Errortrace.map_ctx (trees_of_type_expansion mode))
 
 let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
-let incompatible_tag_types s =
-  doc_printf "@,Types for tag %a are incompatible" print_tag s
 
 let rec trace fst txt ppf = function
   | elt :: rem ->
@@ -62,14 +60,62 @@ and trace_elt txt ppf = function
        print_tag l
        pp_type_expansion got txt pp_type_expansion expected
   | { ctx = Some (In_method m); Errortrace.d = {got; expected} } ->
-      fprintf ppf "In method %a, type@;<1 2>%a@ %s@;<1 2>%a"
-       Style.inline_code m
-       pp_type_expansion got txt pp_type_expansion expected
+      fprintf ppf "@,@[The method %a has type@ %a,@ \
+                   but the expected method type was@ %a@]"
+        Style.inline_code m
+        pp_type_expansion got
+        pp_type_expansion expected
+
+(**
+This module contains helper functions to split the error trace into two parts:
+- a list of meaningful context difference element
+- a root explanation
+*)
+module Structured_trace = struct
+
+(** Flatten the trace and remove elements that are always discarded
+    during printing *)
+
+(** The first intermediary representation splits the trace into four parts:
+- the head element of the trace
+- the trace elements in reverse order situated before the last method or tag
+  difference
+- the last method or tag context, and the list of elements after it
+- the last element that could be optioannly printed
+*)
+type 'a segments =
+  {
+    head: 'a;
+    before:'a list;
+    last_ctx:('a * 'a list) option;
+    optional: 'a option
+  }
+
+let head_segment hd =
+  { head = hd; before=[]; last_ctx = None; optional = None }
+
+(** Add a non-contextual element to the active context *)
+let add x s = match s.last_ctx with
+  | None ->  { s with optional = None; before = x :: s.before }
+  | Some (ctx, rest)->
+      { s with optional = None; last_ctx = Some (ctx, x :: rest)}
+
+(** Add a new context, add the last context contents to the {!before} trace *)
+let add_ctx c s = match s.last_ctx with
+  | None ->  { s with optional = None; last_ctx = Some (c,[]) }
+  | Some (_ctx, rest) -> {
+      head = s.head;
+      optional = None;
+      before = rest @ s.before;
+      last_ctx = Some (c,[])
+    }
 
 type printing_status =
   | Discard
   | Keep
-  | Contextual_refinement of Errortrace.ctx
+  | Context
+    (** A {!Context} element marks the entry inside a method or a polymorphic
+        variant tag *)
   | Optional_refinement
   (** An [Optional_refinement] printing status is attributed to trace
       elements that are focusing on a new subpart of a structural type.
@@ -79,57 +125,116 @@ type printing_status =
       type error.
   *)
 
+(** Construct a segment from an unstructured trace *)
+let segment status = function
+  | [] -> assert false
+  | hd :: tr ->
+      List.fold_left (fun s x ->
+      match status x with
+      | Discard -> s
+      | Keep -> add x s
+      | Optional_refinement -> { s with optional = Some x }
+      | Context -> add_ctx x s
+    ) (head_segment hd) tr
+
+type 'a extended_explanation =
+  | Promoted of Format_doc.t
+  | Standard of 'a
+
+let is_unit_param env ty =
+  let ty, vars = Btype.tpoly_get_poly ty in
+  if vars <> [] then false
+  else begin
+    match Types.get_desc (Ctype.expand_head env ty) with
+    | Tconstr (p, _, _) -> Path.same p Predef.path_unit
+    | _ -> false
+  end
+
+let unifiable env ty1 ty2 =
+    try Ctype.unify env ty1 ty2; true
+    with Ctype.Unify _ -> false
+
+let promote_diff env {Errortrace.got; expected} =
+  let snap = Btype.snapshot () in
+  let t3, t4 = Errortrace.(got.expanded, expected.expanded) in
+  let res = match Types.get_desc t3, Types.get_desc t4 with
+  | Tarrow (_, ty1, ty2, _), _
+    when is_unit_param env ty1 && unifiable env ty2 t4 ->
+      Some (Promoted (doc_printf
+          "@,@[@{<hint>Hint@}: Did you forget to provide %a as argument?@]"
+          Style.inline_code "()"
+        ))
+  | _, Tarrow (_, ty1, ty2, _)
+    when is_unit_param env ty1 && unifiable env t3 ty2 ->
+      Some (Promoted (doc_printf
+          "@,@[@{<hint>Hint@}: Did you forget to wrap the expression using \
+           %a?@]"
+          Style.inline_code "fun () ->"
+        ))
+  | _ -> None
+  in
+  Btype.backtrack snap;
+  res
+
+let merge env s =
+  let rtr, opt = match s.last_ctx with
+    | None -> s.before, s.optional
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None
+  in
+  let head, rtr, expl = match rtr with
+    | Errortrace.Diff d :: _ ->
+        begin match promote_diff env d.d with
+        | Some p -> [s.head], rtr, Some p
+        | None -> [s.head], rtr, None
+        end
+    | expl :: rest -> [s.head], rest, Some (Standard expl)
+    | [] ->
+        begin match s.head with
+        | Errortrace.Diff d -> [s.head], [], promote_diff env d.d
+        | expl -> [], [], Some (Standard expl)
+        end
+  in
+  let rtr =
+    match expl, opt with
+    | None, Some opt -> head @ List.rev (opt :: rtr)
+    | Some _, _ | None, _  -> head @ List.rev rtr
+  in
+  rtr, expl
+
+  let split env status s= merge env (segment status s)
+end
+
 let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
                                       expected = {ty = t2; expanded = t2'} } =
   if  Btype.is_constr_row ~allow_ident:true t1'
    || Btype.is_constr_row ~allow_ident:true t2'
-  then Discard
-  else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
-  else Keep
+  then Structured_trace.Discard
+  else if same_path t1 t1' && same_path t2 t2' then
+    Structured_trace.Optional_refinement
+  else Structured_trace.Keep
 
 let printing_status = function
-  | Errortrace.Diff { ctx = Some (In_method _); _} -> Keep
-  | Errortrace.Diff d ->
-      begin match diff_printing_status d.d, d.ctx with
-      | Optional_refinement, Some c -> Contextual_refinement c
-      | x, _ -> x
-      end
-  | Errortrace.Escape {kind = Constraint} -> Keep
-  | _ -> Keep
+  | Errortrace.Diff { ctx = Some _; _} -> Structured_trace.Context
+  | Errortrace.Diff d -> diff_printing_status d.d
+  | _ -> Structured_trace.Keep
 
-(** Flatten the trace and remove elements that are always discarded
-    during printing *)
-
-(* Takes [printing_status] to change behavior for [Subtype] *)
-let prepare_any_trace merge printing_status tr =
-  let clean_trace x l = match printing_status x, l with
-    | Keep , _ -> x :: l
-    | (Contextual_refinement _ | Optional_refinement), [] -> [x]
-    | Contextual_refinement ctx, [x] -> [merge ctx x]
-    | (Contextual_refinement _ | Optional_refinement | Discard), _ -> l
-  in
-  match tr with
-  | [] -> []
-  | elt :: rem -> elt :: List.fold_right clean_trace rem []
-
-let merge_ctx ctx = function
-  | Errortrace.Diff ({ ctx = None; _ } as d) ->
-      Errortrace.Diff { d with ctx = Some ctx }
-  | d -> d
-
-let prepare_trace f tr =
-  prepare_any_trace merge_ctx printing_status (Errortrace.map f tr)
 
 (** Keep elements that are [Diff _ ] and split the the last element if it is
     optionally elidable, require a prepared trace *)
-let rec filter_trace = function
-  | [] -> [], None
+let rec filter_trace keep_last = function
+  | [] -> []
   | [Errortrace.Diff d as elt]
-    when printing_status elt = Optional_refinement -> [], Some d
+    when printing_status elt = Structured_trace.Optional_refinement ->
+      if keep_last then [d] else []
   | Errortrace.Diff ({ctx=(None|Some (In_tag _)); _ } as d) :: rem ->
-      let filtered, last = filter_trace rem in
-      d :: filtered, last
-  | _ :: rem -> filter_trace rem
+      d :: filter_trace keep_last rem
+  | _ :: rem -> filter_trace keep_last rem
+
+let simplify_trace tr =
+  List.filter_map (function
+      | Errortrace.Diff d -> Some d
+      | _ -> None)
+    tr
 
 let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
   match Types.get_desc expanded with
@@ -142,42 +247,6 @@ let print_path p =
 
 let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
-
-let is_unit_param env ty =
-  let ty, vars = Btype.tpoly_get_poly ty in
-  if vars <> [] then false
-  else begin
-    match Types.get_desc (Ctype.expand_head env ty) with
-    | Tconstr (p, _, _) -> Path.same p Predef.path_unit
-    | _ -> false
-  end
-
-let unifiable env ty1 ty2 =
-  let snap = Btype.snapshot () in
-  let res =
-    try Ctype.unify env ty1 ty2; true
-    with Ctype.Unify _ -> false
-  in
-  Btype.backtrack snap;
-  res
-
-let explanation_diff env t3 t4 =
-  match Types.get_desc t3, Types.get_desc t4 with
-  | Tarrow (_, ty1, ty2, _), _
-    when is_unit_param env ty1 && unifiable env ty2 t4 ->
-      Some (doc_printf
-          "@,@[@{<hint>Hint@}: Did you forget to provide %a as argument?@]"
-          Style.inline_code "()"
-        )
-  | _, Tarrow (_, ty1, ty2, _)
-    when is_unit_param env ty1 && unifiable env t3 ty2 ->
-      Some (doc_printf
-          "@,@[@{<hint>Hint@}: Did you forget to wrap the expression using \
-           %a?@]"
-          Style.inline_code "fun () ->"
-        )
-  | _ ->
-      None
 
 let explain_fixed_row_case = function
   | Errortrace.Cannot_be_closed -> doc_printf "it cannot be closed"
@@ -296,16 +365,6 @@ let explain_object (type variety) : variety Errortrace.obj -> _ = function
               "@,Self type cannot be unified with a closed object type"
            )
 
-let explain_incompatible_fields name (diff: Types.type_expr Errortrace.diff) =
-  Variable_names.reserve diff.got;
-  Variable_names.reserve diff.expected;
-  doc_printf "@,@[The method %a has type@ %a,@ \
-  but the expected method type was@ %a@]"
-    Style.inline_code name
-    (Style.as_inline_code type_expr_with_reserved_names) diff.got
-    (Style.as_inline_code type_expr_with_reserved_names) diff.expected
-
-
 let explain_label_mismatch ~missing_label_msg  {Errortrace.got;expected} =
   let quoted_label ppf l = Style.inline_code ppf (Asttypes.string_of_label l) in
   match got, expected with
@@ -342,14 +401,8 @@ let explain_first_class_module = function
   | Errortrace.Package_coercion pr ->
       Some(doc_printf "@,@[%a@]" Fmt.pp_doc pr)
 
-let explain_univar prev = function
+let explain_univar = function
   | Errortrace.Var_mismatch { diff; order} ->
-      let prev = match prev with
-        | Some (Errortrace.Diff { ctx=Some (In_method name); d }) ->
-            let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
-            explain_incompatible_fields name d
-        | _ -> Fmt.Doc.empty
-      in
       add_type_to_preparation diff.got;
       add_type_to_preparation diff.expected;
       let more = match order with
@@ -366,8 +419,7 @@ let explain_univar prev = function
               (Style.as_inline_code prepared_type_expr) diff.expected
       in
       doc_printf
-        "%a@,@[The universal variables@ %a and@ %a@ are distinct.%a@]"
-        Fmt.pp_doc prev
+        "@,@[The universal variables@ %a and@ %a@ are distinct.%a@]"
         (Style.as_inline_code prepared_type_expr) diff.got
         (Style.as_inline_code prepared_type_expr) diff.expected
         pp_doc more
@@ -395,25 +447,15 @@ let explain_univar prev = function
       let pp_sep _ () = () in
       doc_printf "%a" (pp_print_list ~pp_sep pp) delta
 
-let explanation (type variety) intro prev env
+let explanation (type variety) intro
   : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
-  | Errortrace.Diff { ctx = None; d = {got; expected} } ->
-    explanation_diff env got.expanded expected.expanded
-  | Errortrace.Diff { ctx = Some (In_method name); d } ->
-    let diff = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
-    Some(explain_incompatible_fields name diff)
-  | Errortrace.Diff { ctx = Some (In_tag name); _ } ->
-    Some(incompatible_tag_types name)
   | Errortrace.Escape {kind; context} ->
     let pre =
-      match context, kind, prev with
-      | Some ctx, _, _ ->
+      match context, kind with
+      | Some ctx, _ ->
         Variable_names.reserve ctx;
         doc_printf "@[%a@;<1 2>%a@]" pp_doc intro
           (Style.as_inline_code type_expr_with_reserved_names) ctx
-      | None, Univ _, Some(Errortrace.Diff { ctx=Some (In_method name); d} ) ->
-          let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
-          explain_incompatible_fields name d
       | _ -> Format_doc.Doc.empty
     in
     explain_escape pre kind
@@ -461,10 +503,14 @@ let explanation (type variety) intro prev env
              {[ The type int occurs inside int list -> 'a |}
         *)
     end
-  | Univar um -> Some (explain_univar prev um)
+  | Univar um -> Some (explain_univar um)
+  | Diff _ -> None
 
-let mismatch intro env trace =
-  Errortrace.explain trace (fun ~prev h -> explanation intro prev env h)
+let mismatch intro expl =
+  match expl with
+  | None -> None
+  | Some (Structured_trace.Promoted msg) -> Some msg
+  | Some (Structured_trace.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
   match Types.get_desc t with
@@ -567,34 +613,27 @@ let explain_names env ppf =
              Style.inline_code constructor
     ) explanations
 
+let hide_variant ty_exp =
+  Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
+
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
-  let tr =
-    prepare_trace
-      (fun ty_exp ->
-         Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded})
-      tr
+  let tr = Errortrace.map hide_variant tr in
+  let tr, expl = Structured_trace.split env printing_status tr in
+  let elt, tr = match tr with
+    | [] -> None, tr
+    | hd :: tr -> Some hd, tr
   in
-  match tr with
-  | [] -> assert false
-  | (elt :: tr) as full_trace ->
-      with_labels (not !Clflags.classic) (fun () ->
-      let tr, last = filter_trace tr in
-      let head = prepare_expansion_head (tr=[] && last=None) elt in
+  with_labels (not !Clflags.classic) (fun () ->
+      let tr = simplify_trace tr in
+      let head = Option.bind elt (prepare_expansion_head (List.is_empty tr)) in
       let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
-      let last = Option.map (Errortrace.map_ctx prepare_expansion) last in
       let head_error = head_error_printer mode txt1 txt2 head in
       let tr = trees_of_trace mode tr in
-      let last =
-        Option.map (Errortrace.map_ctx (trees_of_type_expansion mode)) last in
-      let mis = mismatch txt1 env full_trace in
-      let tr = match mis, last with
-        | None, Some elt -> tr @ [elt]
-        | Some _, _ | _, None -> tr
-      in
+      let mis = mismatch txt1 expl in
       fprintf ppf
         "@[<v>\
          @[%a%a@]%a%a\
@@ -643,25 +682,34 @@ module Subtype = struct
      while being *just* different enough (it's only [Diff]) for the abstraction
      to be nonobvious.  Someday, perhaps... *)
 
-  let printing_status = function
+  let sub_printing_status = function
     | Errortrace.Subtype.Diff d -> diff_printing_status d
 
-  let prepare_unification_trace = prepare_trace
+  let prepare_unification_trace env f tr =
+    let tr = Errortrace.map f tr in
+    match tr with
+    | [] -> [], None
+    | _ -> Structured_trace.split env printing_status tr
 
   let prepare_trace f tr =
-    prepare_any_trace (fun _ d -> d) printing_status
-      (Errortrace.Subtype.map f tr)
+    let tr = Errortrace.Subtype.map f tr in
+    let s = Structured_trace.segment sub_printing_status tr in
+    let rtr = match s.last_ctx with
+    | None -> s.before
+    | Some (ctx, rest) -> rest @ ctx :: s.before
+    in
+    let rtr = match s.optional with
+      | Some x -> x :: rtr
+      | None -> rtr
+    in
+    s.head :: List.rev rtr, None
 
   let trace filter_trace get_diff fst keep_last txt ppf tr =
     with_labels (not !Clflags.classic) (fun () ->
       match tr with
       | elt :: tr' ->
         let diffed_elt = get_diff elt in
-        let tr, last = filter_trace tr' in
-        let tr = match keep_last, last with
-          | true, Some last -> tr @ [last]
-          | _ -> tr
-        in
+        let tr = filter_trace keep_last tr' in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
@@ -675,14 +723,13 @@ module Subtype = struct
     )
 
   let no_ctx d = { Errortrace.d; ctx = None}
-  let rec filter_subtype_trace = function
-    | [] -> [], None
+  let rec filter_subtype_trace keep_last = function
+    | [] -> []
     | [Errortrace.Subtype.Diff d as elt]
-      when printing_status elt = Optional_refinement ->
-        [], Some (no_ctx d)
+      when sub_printing_status elt = Structured_trace.Optional_refinement ->
+        if keep_last then [no_ctx d] else []
     | Errortrace.Subtype.Diff d :: rem ->
-        let ftr, last = filter_subtype_trace rem in
-        no_ctx d :: ftr, last
+        no_ctx d :: filter_subtype_trace keep_last rem
 
   let unification_get_diff = function
     | Errortrace.Diff diff ->
@@ -701,16 +748,18 @@ module Subtype = struct
         txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub = prepare_trace prepare_expansion tr_sub in
-      let tr_unif = prepare_unification_trace prepare_expansion tr_unif in
-      let keep_first = match tr_unif with
-        | [Obj _ | Variant _ | Escape _ ] | [] -> true
+      let tr_sub, _ = prepare_trace prepare_expansion tr_sub in
+      let tr_unif, expl_unif =
+        prepare_unification_trace env prepare_expansion tr_unif
+      in
+      let keep_first = match tr_unif, expl_unif with
+        | [], Some (Standard (Obj _ | Variant _ | Escape _ )) | [], None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
         (trace filter_subtype_trace subtype_get_diff true keep_first txt1)
         tr_sub;
-      if tr_unif = [] then fprintf ppf "@]" else
-        let mis = mismatch (doc_printf "Within this type") env tr_unif in
+      if tr_unif = [] && expl_unif = None then fprintf ppf "@]" else
+        let mis = mismatch (doc_printf "Within this type") expl_unif in
         fprintf ppf "%a%a%t@]"
           (trace filter_trace unification_get_diff false
              (mis = None) "is not compatible with type") tr_unif

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -219,17 +219,7 @@ let printing_status = function
   | _ -> Structured_trace.Keep
 
 
-(** Keep elements that are [Diff _ ] and split the the last element if it is
-    optionally elidable, require a prepared trace *)
-let rec filter_trace keep_last = function
-  | [] -> []
-  | [Errortrace.Diff d as elt]
-    when printing_status elt = Structured_trace.Optional_refinement ->
-      if keep_last then [d] else []
-  | Errortrace.Diff ({ctx=(None|Some (In_tag _)); _ } as d) :: rem ->
-      d :: filter_trace keep_last rem
-  | _ :: rem -> filter_trace keep_last rem
-
+(** Keep elements that are [Diff _ ]  *)
 let simplify_trace tr =
   List.filter_map (function
       | Errortrace.Diff d -> Some d
@@ -704,12 +694,12 @@ module Subtype = struct
     in
     s.head :: List.rev rtr, None
 
-  let trace filter_trace get_diff fst keep_last txt ppf tr =
+  let trace filter_trace get_diff fst txt ppf tr =
     with_labels (not !Clflags.classic) (fun () ->
       match tr with
       | elt :: tr' ->
         let diffed_elt = get_diff elt in
-        let tr = filter_trace keep_last tr' in
+        let tr = filter_trace tr' in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
@@ -756,13 +746,13 @@ module Subtype = struct
         | [], Some (Standard (Obj _ | Variant _ | Escape _ )) | [], None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
-        (trace filter_subtype_trace subtype_get_diff true keep_first txt1)
+        (trace (filter_subtype_trace keep_first) subtype_get_diff true txt1)
         tr_sub;
       if tr_unif = [] && expl_unif = None then fprintf ppf "@]" else
         let mis = mismatch (doc_printf "Within this type") expl_unif in
         fprintf ppf "%a%a%t@]"
-          (trace filter_trace unification_get_diff false
-             (mis = None) "is not compatible with type") tr_unif
+          (trace simplify_trace unification_get_diff false
+             "is not compatible with type") tr_unif
           (pp_print_option pp_doc) mis
           Ident_conflicts.err_print
     )

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -558,6 +558,11 @@ module Subtype = struct
       Errortrace.map prepare_expansion unification_trace in
     Errortrace.Subtype.error ~trace ~unification_trace
 
+  let parse_sub tr =
+    (* The subtype part of the trace does not contain any explanation *)
+    let trace = { Errortrace.root = None; path = tr } in
+    Structured.parse ~promote:(Fun.const None) ~status:printing_status trace
+
   let flatten_trace filter_trace fst (str: _ Structured.s) =
     with_labels (not !Clflags.classic) (fun () ->
       match str.top, str.tr with
@@ -586,7 +591,7 @@ module Subtype = struct
     wrap_printing_env ~error:true env (fun () ->
       reset ();
       let tr = prepare_trace tr in
-      let tr_sub = Structured.parse_simple printing_status tr.trace in
+      let tr_sub = parse_sub tr.trace in
       let str_unif = structured_trace env tr.unification_trace in
       let keep_last = obj_only_trace str_unif in
       let tr_sub = flatten_trace (filter_trace keep_last) true tr_sub in

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -40,19 +40,36 @@ module Style = Misc.Style
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
 let trees_of_trace mode =
-  List.map (Errortrace.map_diff (trees_of_type_expansion mode))
+  List.map (Errortrace.map_ctx (trees_of_type_expansion mode))
+
+let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
+let incompatible_tag_types s =
+  doc_printf "@,Types for tag %a are incompatible" print_tag s
 
 let rec trace fst txt ppf = function
-  | {Errortrace.got; expected} :: rem ->
+  | elt :: rem ->
       if not fst then fprintf ppf "@,";
-      fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@]%a"
+      fprintf ppf "@[%a@]%a"
+      (trace_elt txt) elt
+      (trace false txt) rem
+  | [] -> ()
+and trace_elt txt ppf = function
+  | { ctx = None; Errortrace.d = {got; expected} } ->
+      fprintf ppf "Type@;<1 2>%a@ %s@;<1 2>%a"
        pp_type_expansion got txt pp_type_expansion expected
-       (trace false txt) rem
-  | _ -> ()
+  | { ctx = Some (In_tag l); Errortrace.d = {got; expected} } ->
+      fprintf ppf "In tag %a, type@;<1 2>%a@ %s@;<1 2>%a"
+       print_tag l
+       pp_type_expansion got txt pp_type_expansion expected
+  | { ctx = Some (In_method m); Errortrace.d = {got; expected} } ->
+      fprintf ppf "In method %a, type@;<1 2>%a@ %s@;<1 2>%a"
+       Style.inline_code m
+       pp_type_expansion got txt pp_type_expansion expected
 
 type printing_status =
   | Discard
   | Keep
+  | Contextual_refinement of Errortrace.ctx
   | Optional_refinement
   (** An [Optional_refinement] printing status is attributed to trace
       elements that are focusing on a new subpart of a structural type.
@@ -71,7 +88,12 @@ let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
   else Keep
 
 let printing_status = function
-  | Errortrace.Diff d -> diff_printing_status d
+  | Errortrace.Diff { ctx = Some (In_method _); _} -> Keep
+  | Errortrace.Diff d ->
+      begin match diff_printing_status d.d, d.ctx with
+      | Optional_refinement, Some c -> Contextual_refinement c
+      | x, _ -> x
+      end
   | Errortrace.Escape {kind = Constraint} -> Keep
   | _ -> Keep
 
@@ -79,18 +101,24 @@ let printing_status = function
     during printing *)
 
 (* Takes [printing_status] to change behavior for [Subtype] *)
-let prepare_any_trace printing_status tr =
-  let clean_trace x l = match printing_status x with
-    | Keep -> x :: l
-    | Optional_refinement when l = [] -> [x]
-    | Optional_refinement | Discard -> l
+let prepare_any_trace merge printing_status tr =
+  let clean_trace x l = match printing_status x, l with
+    | Keep , _ -> x :: l
+    | (Contextual_refinement _ | Optional_refinement), [] -> [x]
+    | Contextual_refinement ctx, [x] -> [merge ctx x]
+    | (Contextual_refinement _ | Optional_refinement | Discard), _ -> l
   in
   match tr with
   | [] -> []
   | elt :: rem -> elt :: List.fold_right clean_trace rem []
 
+let merge_ctx ctx = function
+  | Errortrace.Diff ({ ctx = None; _ } as d) ->
+      Errortrace.Diff { d with ctx = Some ctx }
+  | d -> d
+
 let prepare_trace f tr =
-  prepare_any_trace printing_status (Errortrace.map f tr)
+  prepare_any_trace merge_ctx printing_status (Errortrace.map f tr)
 
 (** Keep elements that are [Diff _ ] and split the the last element if it is
     optionally elidable, require a prepared trace *)
@@ -98,7 +126,7 @@ let rec filter_trace = function
   | [] -> [], None
   | [Errortrace.Diff d as elt]
     when printing_status elt = Optional_refinement -> [], Some d
-  | Errortrace.Diff d :: rem ->
+  | Errortrace.Diff ({ctx=(None|Some (In_tag _)); _ } as d) :: rem ->
       let filtered, last = filter_trace rem in
       d :: filtered, last
   | _ :: rem -> filter_trace rem
@@ -111,8 +139,6 @@ let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
 
 let print_path p =
   Fmt.dprintf "%a" !Oprint.out_ident (namespaced_tree_of_path Type p)
-
-let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
 
 let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
@@ -180,12 +206,11 @@ let explain_fixed_row pos expl = match expl with
       p
   | Types.Rigid -> Format_doc.Doc.empty
 
+
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
   (* Common *)
-  | Errortrace.Incompatible_types_for s ->
-      Some(doc_printf "@,Types for tag %a are incompatible"
-             print_tag s
-          )
+  | Errortrace.Arity_mismatch s -> Some(incompatible_tag_types s)
+  | Errortrace.Inconsistent_conjunction s -> Some (incompatible_tag_types s)
   (* Unification *)
   | Errortrace.No_intersection ->
       Some(doc_printf "@,These two variant types have no intersection")
@@ -319,8 +344,9 @@ let explain_first_class_module = function
 let explain_univar prev = function
   | Errortrace.Var_mismatch { diff; order} ->
       let prev = match prev with
-        | Some (Errortrace.Incompatible_fields f) ->
-            explain_incompatible_fields f.name f.diff
+        | Some (Errortrace.Diff { ctx=Some (In_method name); d }) ->
+            let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
+            explain_incompatible_fields name d
         | _ -> Fmt.Doc.empty
       in
       add_type_to_preparation diff.got;
@@ -370,8 +396,13 @@ let explain_univar prev = function
 
 let explanation (type variety) intro prev env
   : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
-  | Errortrace.Diff {got; expected} ->
+  | Errortrace.Diff { ctx = None; d = {got; expected} } ->
     explanation_diff env got.expanded expected.expanded
+  | Errortrace.Diff { ctx = Some (In_method name); d } ->
+    let diff = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
+    Some(explain_incompatible_fields name diff)
+  | Errortrace.Diff { ctx = Some (In_tag name); _ } ->
+    Some(incompatible_tag_types name)
   | Errortrace.Escape {kind; context} ->
     let pre =
       match context, kind, prev with
@@ -379,13 +410,12 @@ let explanation (type variety) intro prev env
         Variable_names.reserve ctx;
         doc_printf "@[%a@;<1 2>%a@]" pp_doc intro
           (Style.as_inline_code type_expr_with_reserved_names) ctx
-      | None, Univ _, Some(Errortrace.Incompatible_fields {name; diff}) ->
-        explain_incompatible_fields name diff
+      | None, Univ _, Some(Errortrace.Diff { ctx=Some (In_method name); d} ) ->
+          let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
+          explain_incompatible_fields name d
       | _ -> Format_doc.Doc.empty
     in
     explain_escape pre kind
-  | Errortrace.Incompatible_fields { name; diff} ->
-    Some(explain_incompatible_fields name diff)
   | Errortrace.Function_label_mismatch diff ->
     let missing_label_msg =
       format_of_string
@@ -462,21 +492,21 @@ let warn_on_missing_def env ppf t =
 
 let prepare_expansion_head empty_tr = function
   | Errortrace.Diff d ->
-      Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
+      Some (Errortrace.map_ctx (may_prepare_expansion empty_tr) d)
   | _ -> None
 
 let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
   | Some d ->
-      let d = Errortrace.map_diff (trees_of_type_expansion mode) d in
+      let d = Errortrace.(map_diff (trees_of_type_expansion mode) d.d) in
       doc_printf "%a@;<1 2>%a@ %a@;<1 2>%a"
-        pp_doc txt_got pp_type_expansion d.Errortrace.got
-        pp_doc txt_but pp_type_expansion d.Errortrace.expected
+        pp_doc txt_got pp_type_expansion d.got
+        pp_doc txt_but pp_type_expansion d.expected
 
 let warn_on_missing_defs env ppf = function
   | None -> ()
-  | Some Errortrace.{got      = {ty=te1; expanded=_};
-                     expected = {ty=te2; expanded=_} } ->
+  | Some Errortrace.{ d = { got      = {ty=te1; expanded=_};
+                            expected = {ty=te2; expanded=_} }; _ } ->
       warn_on_missing_def env ppf te1;
       warn_on_missing_def env ppf te2
 
@@ -553,12 +583,12 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
       with_labels (not !Clflags.classic) (fun () ->
       let tr, last = filter_trace tr in
       let head = prepare_expansion_head (tr=[] && last=None) elt in
-      let tr = List.map (Errortrace.map_diff prepare_expansion) tr in
-      let last = Option.map (Errortrace.map_diff prepare_expansion) last in
+      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
+      let last = Option.map (Errortrace.map_ctx prepare_expansion) last in
       let head_error = head_error_printer mode txt1 txt2 head in
       let tr = trees_of_trace mode tr in
       let last =
-        Option.map (Errortrace.map_diff (trees_of_type_expansion mode)) last in
+        Option.map (Errortrace.map_ctx (trees_of_type_expansion mode)) last in
       let mis = mismatch txt1 env full_trace in
       let tr = match mis, last with
         | None, Some elt -> tr @ [elt]
@@ -618,7 +648,8 @@ module Subtype = struct
   let prepare_unification_trace = prepare_trace
 
   let prepare_trace f tr =
-    prepare_any_trace printing_status (Errortrace.Subtype.map f tr)
+    prepare_any_trace (fun _ d -> d) printing_status
+      (Errortrace.Subtype.map f tr)
 
   let trace filter_trace get_diff fst keep_last txt ppf tr =
     with_labels (not !Clflags.classic) (fun () ->
@@ -632,7 +663,7 @@ module Subtype = struct
         in
         let tr =
           trees_of_trace Type
-          @@ List.map (Errortrace.map_diff prepare_expansion) tr in
+          @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
         let tr =
           match fst, diffed_elt with
           | true, Some elt -> elt :: tr
@@ -642,23 +673,25 @@ module Subtype = struct
       | _ -> ()
     )
 
+  let no_ctx d = { Errortrace.d; ctx = None}
   let rec filter_subtype_trace = function
     | [] -> [], None
     | [Errortrace.Subtype.Diff d as elt]
       when printing_status elt = Optional_refinement ->
-        [], Some d
+        [], Some (no_ctx d)
     | Errortrace.Subtype.Diff d :: rem ->
         let ftr, last = filter_subtype_trace rem in
-        d :: ftr, last
+        no_ctx d :: ftr, last
 
   let unification_get_diff = function
     | Errortrace.Diff diff ->
-        Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
+        Some (Errortrace.map_ctx (trees_of_type_expansion Type) diff)
     | _ -> None
 
   let subtype_get_diff = function
     | Errortrace.Subtype.Diff diff ->
-        Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
+        let d = Errortrace.map_diff (trees_of_type_expansion Type) diff in
+        Some { Errortrace.d; ctx = None }
 
   let error
         ppf

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -41,7 +41,7 @@ module Structured = Errortrace.Structured
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
 let trees_of_trace mode =
-  List.map (Errortrace.map_ctx (trees_of_type_expansion mode))
+  List.map (Errortrace.map_cdiff (trees_of_type_expansion mode))
 
 let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
 
@@ -417,7 +417,7 @@ let warn_on_missing_def env ppf t =
   | _ -> ()
 
 let prepare_expansion_head (h,empty_tr)=
-  Errortrace.map_ctx (may_prepare_expansion empty_tr) h
+  Errortrace.map_cdiff (may_prepare_expansion empty_tr) h
 
 let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
@@ -506,7 +506,7 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   with_labels (not !Clflags.classic) (fun () ->
       let head = Option.map prepare_expansion_head str.top in
       let head_error = head_error_printer mode txt1 txt2 head in
-      let tr = List.map (Errortrace.map_ctx prepare_expansion) str.tr in
+      let tr = List.map (Errortrace.map_cdiff prepare_expansion) str.tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 str.expl in
       fprintf ppf
@@ -563,7 +563,7 @@ module Subtype = struct
       match str.top, str.tr with
       | Some (elt,_), tr ->
         let diffed_elt =
-          Errortrace.map_ctx (trees_of_type_expansion Type) elt
+          Errortrace.map_cdiff (trees_of_type_expansion Type) elt
         in
         let tr = trees_of_trace Type (filter_trace tr) in
         if fst then diffed_elt :: tr else tr

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -66,87 +66,28 @@ and trace_elt txt ppf = function
         pp_type_expansion got
         pp_type_expansion expected
 
-module Structured_trace = struct
+
+let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
+                                      expected = {ty = t2; expanded = t2'} } =
+  if  Btype.is_constr_row ~allow_ident:true t1'
+   || Btype.is_constr_row ~allow_ident:true t2'
+  then Errortrace.Structured.Discard
+  else if same_path t1 t1' && same_path t2 t2' then
+    Errortrace.Structured.Optional_refinement
+  else Errortrace.Structured.Keep
+
+let printing_status = function
+  | Errortrace.Diff { ctx = Some _; _} -> Errortrace.Structured.Context
+  | Errortrace.Diff d -> diff_printing_status d.d
+  | _ -> Errortrace.Structured.Keep
 
 
-  type ('a,'b) t = {
-  top: ('a * bool) option;
-  tr: 'a list;
-  expl: 'b
-}
-(**
-This module contains helper functions to split the error trace into three parts:
-- {!top} the first element of the trace
-- {!tr} a list of meaningful context difference element
-- {!expl} a root explanation for a type error
-*)
-
-(** The first intermediary representation splits the trace into four parts:
-- the {!head} element of the trace
-- the {!top_to_ctx} trace elements in reverse order situated before the last
-  method or tag difference
-- {!last_ctx}: the last method or tag context, and the list of elements after it
-- {!optional}: the last element that might be printed if we don't discover a
-  better element to print later on.
-*)
-type 'a segments =
-  {
-    head: 'a;
-    before:'a list;
-    last_ctx:('a * 'a list) option;
-    optional: 'a option
-  }
-
-
-let head_segment hd =
-  { head = hd; before=[]; last_ctx = None; optional = None }
-
-(** Add a non-contextual element to the active context *)
-let add x s = match s.last_ctx with
-  | None ->  { s with optional = None; before = x :: s.before }
-  | Some (ctx, rest)->
-      { s with optional = None; last_ctx = Some (ctx, x :: rest)}
-
-(** Add a new context, add the last context contents to the {!before} trace *)
-let add_ctx c s = match s.last_ctx with
-  | None -> { s with optional = None; last_ctx = Some (c,[]) }
-  | Some (_ctx, rest) -> {
-      head = s.head;
-      optional = None;
-      before = rest @ s.before;
-      last_ctx = Some (c,[])
-    }
-
-type printing_status =
-  | Discard
-  | Keep
-  | Context
-    (** A {!Context} element marks the entry inside a method or a polymorphic
-        variant tag *)
-  | Optional_refinement
-  (** An [Optional_refinement] printing status is attributed to trace
-      elements that are focusing on a new subpart of a structural type.
-      Since the whole type should have been printed earlier in the trace,
-      we only print those elements if they are the last printed element
-      of a trace, and there is no explicit explanation for the
-      type error.
-  *)
-
-(** Construct a segment from an unstructured trace *)
-let segment status = function
-  | [] -> assert false
-  | hd :: tr ->
-      List.fold_left (fun s x ->
-      match status x with
-      | Discard -> s
-      | Keep -> add x s
-      | Optional_refinement -> { s with optional = Some x }
-      | Context -> add_ctx x s
-    ) (head_segment hd) tr
-
-type 'a extended_explanation =
-  | Promoted of Format_doc.t
-  | Standard of 'a
+(** Keep elements that are [Diff _ ]  *)
+let simplify_trace tr =
+  List.filter_map (function
+      | Errortrace.Diff d -> Some d
+      | _ -> None)
+    tr
 
 let is_unit_param env ty =
   let ty, vars = Btype.tpoly_get_poly ty in
@@ -167,76 +108,21 @@ let promote_diff env {Errortrace.got; expected} =
   let res = match Types.get_desc t3, Types.get_desc t4 with
   | Tarrow (_, ty1, ty2, _), _
     when is_unit_param env ty1 && unifiable env ty2 t4 ->
-      Some (Promoted (doc_printf
+      Some (doc_printf
           "@,@[@{<hint>Hint@}: Did you forget to provide %a as argument?@]"
           Style.inline_code "()"
-        ))
+        )
   | _, Tarrow (_, ty1, ty2, _)
     when is_unit_param env ty1 && unifiable env t3 ty2 ->
-      Some (Promoted (doc_printf
+      Some (doc_printf
           "@,@[@{<hint>Hint@}: Did you forget to wrap the expression using \
            %a?@]"
           Style.inline_code "fun () ->"
-        ))
+        )
   | _ -> None
   in
   Btype.backtrack snap;
   res
-
-let merge env s =
-  (* First, we commit the last contextualized segment of the trace to the
-     trace *)
-  let rtr, opt, maybe_compact = match s.last_ctx with
-    | None -> s.before, s.optional, false
-    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
-  in
-  let head, rtr, expl = match rtr with
-    | Errortrace.Diff d :: _ ->
-        begin match promote_diff env d.d with
-        | Some p -> Some s.head, rtr, Some p
-        | None -> Some s.head, rtr, None
-        end
-    | expl :: rest -> Some s.head, rest, Some (Standard expl)
-    | [] ->
-        begin match s.head with
-        | Errortrace.Diff d -> Some s.head, [], promote_diff env d.d
-        | expl -> None, [], Some (Standard expl)
-        end
-  in
-  let tr = match expl, opt with
-    | None, Some opt -> List.rev (opt :: rtr)
-    | Some _, _ | None, _  -> List.rev rtr
-  in
-  let compact head = match tr, maybe_compact with
-    | [], _ | [_], true -> head, true
-    | _ -> head, false
-  in
-  { top=Option.map compact head; tr; expl }
-
-  let split env status s = merge env (segment status s)
-end
-
-let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
-                                      expected = {ty = t2; expanded = t2'} } =
-  if  Btype.is_constr_row ~allow_ident:true t1'
-   || Btype.is_constr_row ~allow_ident:true t2'
-  then Structured_trace.Discard
-  else if same_path t1 t1' && same_path t2 t2' then
-    Structured_trace.Optional_refinement
-  else Structured_trace.Keep
-
-let printing_status = function
-  | Errortrace.Diff { ctx = Some _; _} -> Structured_trace.Context
-  | Errortrace.Diff d -> diff_printing_status d.d
-  | _ -> Structured_trace.Keep
-
-
-(** Keep elements that are [Diff _ ]  *)
-let simplify_trace tr =
-  List.filter_map (function
-      | Errortrace.Diff d -> Some d
-      | _ -> None)
-    tr
 
 let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
   match Types.get_desc expanded with
@@ -511,8 +397,8 @@ let explanation (type variety) intro
 let mismatch intro expl =
   match expl with
   | None -> None
-  | Some (Structured_trace.Promoted msg) -> Some msg
-  | Some (Structured_trace.Standard e) -> explanation intro e
+  | Some (Errortrace.Structured.Promoted msg) -> Some msg
+  | Some (Errortrace.Structured.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
   match Types.get_desc t with
@@ -618,13 +504,17 @@ let explain_names env ppf =
 let hide_variant ty_exp =
   Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
 
+let structured_trace env tr =
+ Errortrace.Structured.parse ~promote:(promote_diff env) ~status:printing_status
+   tr
+
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
   let tr = Errortrace.map hide_variant tr in
-  let str = Structured_trace.split env printing_status tr in
+  let str = structured_trace env tr in
   with_labels (not !Clflags.classic) (fun () ->
       let tr = simplify_trace str.tr in
       let head = Option.bind str.top prepare_expansion_head in
@@ -680,7 +570,7 @@ module Subtype = struct
      while being *just* different enough (it's only [Diff]) for the abstraction
      to be nonobvious.  Someday, perhaps... *)
 
-  let sub_printing_status = function
+  let printing_status = function
     | Errortrace.Subtype.Diff d -> diff_printing_status d
 
   let prepare_unification_trace env f tr =
@@ -688,23 +578,15 @@ module Subtype = struct
     match tr with
     | [] -> None, None
     | _ ->
-        let str = Structured_trace.split env printing_status tr in
+        let str = structured_trace env tr in
         match str.top with
         | Some (h,_) -> Some (h,str.tr), str.expl
         | None -> None, str.expl
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in
-    let s = Structured_trace.segment sub_printing_status tr in
-    let rtr = match s.last_ctx with
-    | None -> s.before
-    | Some (ctx, rest) -> rest @ ctx :: s.before
-    in
-    let rtr = match s.optional with
-      | Some x -> x :: rtr
-      | None -> rtr
-    in
-    Some (s.head, List.rev rtr), None
+    let htr = Errortrace.Structured.parse_simple printing_status tr in
+    Some htr, None
 
   let trace filter_trace get_diff fst txt ppf htr =
     with_labels (not !Clflags.classic) (fun () ->
@@ -728,7 +610,7 @@ module Subtype = struct
   let rec filter_subtype_trace keep_last = function
     | [] -> []
     | [Errortrace.Subtype.Diff d as elt]
-      when sub_printing_status elt = Structured_trace.Optional_refinement ->
+      when printing_status elt = Errortrace.Structured.Optional_refinement ->
         if keep_last then [no_ctx d] else []
     | Errortrace.Subtype.Diff d :: rem ->
         no_ctx d :: filter_subtype_trace keep_last rem

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -209,8 +209,9 @@ let explain_fixed_row pos expl = match expl with
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
   (* Common *)
-  | Errortrace.Arity_mismatch s -> Some(incompatible_tag_types s)
-  | Errortrace.Inconsistent_conjunction s -> Some (incompatible_tag_types s)
+  | Errortrace.Arity_mismatch s ->
+      Some(doc_printf "@,@[Arities for tag %a are incompatible.@]"
+             print_tag s)
   (* Unification *)
   | Errortrace.No_intersection ->
       Some(doc_printf "@,These two variant types have no intersection")

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -77,17 +77,8 @@ let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
   else Errortrace.Structured.Keep
 
 let printing_status = function
-  | Errortrace.Diff { ctx = Some _; _} -> Errortrace.Structured.Context
-  | Errortrace.Diff d -> diff_printing_status d.d
-  | _ -> Errortrace.Structured.Keep
-
-
-(** Keep elements that are [Diff _ ]  *)
-let simplify_trace tr =
-  List.filter_map (function
-      | Errortrace.Diff d -> Some d
-      | _ -> None)
-    tr
+  | { Errortrace.ctx = Some _; _} -> Errortrace.Structured.Context
+  | d -> diff_printing_status d.Errortrace.d
 
 let is_unit_param env ty =
   let ty, vars = Btype.tpoly_get_poly ty in
@@ -336,7 +327,7 @@ let explain_univar = function
       doc_printf "%a" (pp_print_list ~pp_sep pp) delta
 
 let explanation (type variety) intro
-  : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
+  : (Errortrace.expanded_type, variety) Errortrace.root -> _ = function
   | Errortrace.Escape {kind; context} ->
     let pre =
       match context, kind with
@@ -392,7 +383,6 @@ let explanation (type variety) intro
         *)
     end
   | Univar um -> Some (explain_univar um)
-  | Diff _ -> None
 
 let mismatch intro expl =
   match expl with
@@ -425,10 +415,8 @@ let warn_on_missing_def env ppf t =
       end
   | _ -> ()
 
-let prepare_expansion_head (h,empty_tr)= match h with
-  | Errortrace.Diff d ->
-      Some (Errortrace.map_ctx (may_prepare_expansion empty_tr) d)
-  | _ -> None
+let prepare_expansion_head (h,empty_tr)=
+  Errortrace.map_ctx (may_prepare_expansion empty_tr) h
 
 let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
@@ -516,10 +504,9 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   let tr = Errortrace.map hide_variant tr in
   let str = structured_trace env tr in
   with_labels (not !Clflags.classic) (fun () ->
-      let tr = simplify_trace str.tr in
-      let head = Option.bind str.top prepare_expansion_head in
+      let head = Option.map prepare_expansion_head str.top in
       let head_error = head_error_printer mode txt1 txt2 head in
-      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
+      let tr = List.map (Errortrace.map_ctx prepare_expansion) str.tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 str.expl in
       fprintf ppf
@@ -570,13 +557,10 @@ module Subtype = struct
      while being *just* different enough (it's only [Diff]) for the abstraction
      to be nonobvious.  Someday, perhaps... *)
 
-  let printing_status = function
-    | Errortrace.Subtype.Diff d -> diff_printing_status d
-
   let prepare_unification_trace env f tr =
     let tr = Errortrace.map f tr in
-    match tr with
-    | [] -> None, None
+    match tr.path with
+    | [] -> None, Option.map (fun x -> Errortrace.Structured.Standard x) tr.root
     | _ ->
         let str = structured_trace env tr in
         match str.top with
@@ -585,45 +569,31 @@ module Subtype = struct
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in
-    let htr = Errortrace.Structured.parse_simple printing_status tr in
-    Some htr, None
+    Errortrace.Structured.parse_simple printing_status tr
 
-  let trace filter_trace get_diff fst txt ppf htr =
+  let trace filter_trace fst txt ppf htr =
     with_labels (not !Clflags.classic) (fun () ->
       match htr with
       | Some (elt,tr) ->
-        let diffed_elt = get_diff elt in
+        let diffed_elt =
+          Errortrace.map_ctx (trees_of_type_expansion Type) elt
+        in
         let tr = filter_trace tr in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
-        let tr =
-          match fst, diffed_elt with
-          | true, Some elt -> elt :: tr
-          | _, _ -> tr
-        in
+        let tr = if fst then diffed_elt :: tr else tr in
         trace fst txt ppf tr
       | None -> ()
     )
 
-  let no_ctx d = { Errortrace.d; ctx = None}
   let rec filter_subtype_trace keep_last = function
     | [] -> []
-    | [Errortrace.Subtype.Diff d as elt]
+    | [elt]
       when printing_status elt = Errortrace.Structured.Optional_refinement ->
-        if keep_last then [no_ctx d] else []
-    | Errortrace.Subtype.Diff d :: rem ->
-        no_ctx d :: filter_subtype_trace keep_last rem
+        if keep_last then [elt] else []
+    | d :: rem -> d :: filter_subtype_trace keep_last rem
 
-  let unification_get_diff = function
-    | Errortrace.Diff diff ->
-        Some (Errortrace.map_ctx (trees_of_type_expansion Type) diff)
-    | _ -> None
-
-  let subtype_get_diff = function
-    | Errortrace.Subtype.Diff diff ->
-        let d = Errortrace.map_diff (trees_of_type_expansion Type) diff in
-        Some { Errortrace.d; ctx = None }
 
   let error
         ppf
@@ -632,22 +602,20 @@ module Subtype = struct
         txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub, _ = prepare_trace prepare_expansion tr_sub in
-      let tr_unif, expl_unif =
+      let tr_sub = prepare_trace prepare_expansion tr_sub in
+      let tr_unif, expl =
         prepare_unification_trace env prepare_expansion tr_unif
       in
-      let keep_first = match tr_unif, expl_unif with
+      let keep_first = match tr_unif, expl with
         | None, Some (Standard (Obj _ | Variant _ | Escape _ ))
         | None, None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
-        (trace (filter_subtype_trace keep_first) subtype_get_diff true txt1)
-        tr_sub;
-      if tr_unif = None && expl_unif = None then fprintf ppf "@]" else
-        let mis = mismatch (doc_printf "Within this type") expl_unif in
+        (trace (filter_subtype_trace keep_first) true txt1) tr_sub;
+      if tr_unif = None && expl = None then fprintf ppf "@]" else
+        let mis = mismatch (doc_printf "Within this type") expl in
         fprintf ppf "%a%a%t@]"
-          (trace simplify_trace unification_get_diff false
-             "is not compatible with type") tr_unif
+          (trace Fun.id false "is not compatible with type") tr_unif
           (pp_print_option pp_doc) mis
           Ident_conflicts.err_print
     )

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -66,22 +66,28 @@ and trace_elt txt ppf = function
         pp_type_expansion got
         pp_type_expansion expected
 
-(**
-This module contains helper functions to split the error trace into two parts:
-- a list of meaningful context difference element
-- a root explanation
-*)
 module Structured_trace = struct
 
-(** Flatten the trace and remove elements that are always discarded
-    during printing *)
+
+  type ('a,'b) t = {
+  top: ('a * bool) option;
+  tr: 'a list;
+  expl: 'b
+}
+(**
+This module contains helper functions to split the error trace into three parts:
+- {!top} the first element of the trace
+- {!tr} a list of meaningful context difference element
+- {!expl} a root explanation for a type error
+*)
 
 (** The first intermediary representation splits the trace into four parts:
-- the head element of the trace
-- the trace elements in reverse order situated before the last method or tag
-  difference
-- the last method or tag context, and the list of elements after it
-- the last element that could be optioannly printed
+- the {!head} element of the trace
+- the {!top_to_ctx} trace elements in reverse order situated before the last
+  method or tag difference
+- {!last_ctx}: the last method or tag context, and the list of elements after it
+- {!optional}: the last element that might be printed if we don't discover a
+  better element to print later on.
 *)
 type 'a segments =
   {
@@ -90,6 +96,7 @@ type 'a segments =
     last_ctx:('a * 'a list) option;
     optional: 'a option
   }
+
 
 let head_segment hd =
   { head = hd; before=[]; last_ctx = None; optional = None }
@@ -102,7 +109,7 @@ let add x s = match s.last_ctx with
 
 (** Add a new context, add the last context contents to the {!before} trace *)
 let add_ctx c s = match s.last_ctx with
-  | None ->  { s with optional = None; last_ctx = Some (c,[]) }
+  | None -> { s with optional = None; last_ctx = Some (c,[]) }
   | Some (_ctx, rest) -> {
       head = s.head;
       optional = None;
@@ -177,6 +184,8 @@ let promote_diff env {Errortrace.got; expected} =
   res
 
 let merge env s =
+  (* First, we commit the last contextualized segment of the trace to the
+     trace *)
   let rtr, opt, maybe_compact = match s.last_ctx with
     | None -> s.before, s.optional, false
     | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
@@ -184,28 +193,27 @@ let merge env s =
   let head, rtr, expl = match rtr with
     | Errortrace.Diff d :: _ ->
         begin match promote_diff env d.d with
-        | Some p -> [s.head], rtr, Some p
-        | None -> [s.head], rtr, None
+        | Some p -> Some s.head, rtr, Some p
+        | None -> Some s.head, rtr, None
         end
-    | expl :: rest -> [s.head], rest, Some (Standard expl)
+    | expl :: rest -> Some s.head, rest, Some (Standard expl)
     | [] ->
         begin match s.head with
-        | Errortrace.Diff d -> [s.head], [], promote_diff env d.d
-        | expl -> [], [], Some (Standard expl)
+        | Errortrace.Diff d -> Some s.head, [], promote_diff env d.d
+        | expl -> None, [], Some (Standard expl)
         end
   in
-  let rtr =
-    match expl, opt with
-    | None, Some opt -> head @ List.rev (opt :: rtr)
-    | Some _, _ | None, _  -> head @ List.rev rtr
+  let tr = match expl, opt with
+    | None, Some opt -> List.rev (opt :: rtr)
+    | Some _, _ | None, _  -> List.rev rtr
   in
-  let compact = match rtr, maybe_compact with
-    | [_], _ | [_;_], true -> true
-    | _ -> false
+  let compact head = match tr, maybe_compact with
+    | [], _ | [_], true -> head, true
+    | _ -> head, false
   in
-  rtr, expl, compact
+  { top=Option.map compact head; tr; expl }
 
-  let split env status s= merge env (segment status s)
+  let split env status s = merge env (segment status s)
 end
 
 let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
@@ -531,7 +539,7 @@ let warn_on_missing_def env ppf t =
       end
   | _ -> ()
 
-let prepare_expansion_head empty_tr = function
+let prepare_expansion_head (h,empty_tr)= match h with
   | Errortrace.Diff d ->
       Some (Errortrace.map_ctx (may_prepare_expansion empty_tr) d)
   | _ -> None
@@ -616,18 +624,14 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
   let tr = Errortrace.map hide_variant tr in
-  let tr, expl, compact = Structured_trace.split env printing_status tr in
-  let elt, tr = match tr with
-    | [] -> None, tr
-    | hd :: tr -> Some hd, tr
-  in
+  let str = Structured_trace.split env printing_status tr in
   with_labels (not !Clflags.classic) (fun () ->
-      let tr = simplify_trace tr in
-      let head = Option.bind elt (prepare_expansion_head compact) in
+      let tr = simplify_trace str.tr in
+      let head = Option.bind str.top prepare_expansion_head in
       let head_error = head_error_printer mode txt1 txt2 head in
       let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
       let tr = trees_of_trace mode tr in
-      let mis = mismatch txt1 expl in
+      let mis = mismatch txt1 str.expl in
       fprintf ppf
         "@[<v>\
          @[%a%a@]%a%a\
@@ -682,10 +686,12 @@ module Subtype = struct
   let prepare_unification_trace env f tr =
     let tr = Errortrace.map f tr in
     match tr with
-    | [] -> [], None
+    | [] -> None, None
     | _ ->
-        let tr, expl, _ = Structured_trace.split env printing_status tr in
-        tr, expl
+        let str = Structured_trace.split env printing_status tr in
+        match str.top with
+        | Some (h,_) -> Some (h,str.tr), str.expl
+        | None -> None, str.expl
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in
@@ -698,14 +704,14 @@ module Subtype = struct
       | Some x -> x :: rtr
       | None -> rtr
     in
-    s.head :: List.rev rtr, None
+    Some (s.head, List.rev rtr), None
 
-  let trace filter_trace get_diff fst txt ppf tr =
+  let trace filter_trace get_diff fst txt ppf htr =
     with_labels (not !Clflags.classic) (fun () ->
-      match tr with
-      | elt :: tr' ->
+      match htr with
+      | Some (elt,tr) ->
         let diffed_elt = get_diff elt in
-        let tr = filter_trace tr' in
+        let tr = filter_trace tr in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
@@ -715,7 +721,7 @@ module Subtype = struct
           | _, _ -> tr
         in
         trace fst txt ppf tr
-      | _ -> ()
+      | None -> ()
     )
 
   let no_ctx d = { Errortrace.d; ctx = None}
@@ -749,12 +755,13 @@ module Subtype = struct
         prepare_unification_trace env prepare_expansion tr_unif
       in
       let keep_first = match tr_unif, expl_unif with
-        | [], Some (Standard (Obj _ | Variant _ | Escape _ )) | [], None -> true
+        | None, Some (Standard (Obj _ | Variant _ | Escape _ ))
+        | None, None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
         (trace (filter_subtype_trace keep_first) subtype_get_diff true txt1)
         tr_sub;
-      if tr_unif = [] && expl_unif = None then fprintf ppf "@]" else
+      if tr_unif = None && expl_unif = None then fprintf ppf "@]" else
         let mis = mismatch (doc_printf "Within this type") expl_unif in
         fprintf ppf "%a%a%t@]"
           (trace simplify_trace unification_get_diff false

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1798,7 +1798,7 @@ let check_scope_escape loc env level ty =
   with Escape esc ->
     (* We don't expand the type here because if we do, we might expand to the
        type that escaped, leading to confusing error messages. *)
-    let trace = Errortrace.[Escape (map_escape trivial_expansion esc)] in
+    let trace = Errortrace.(root (Escape (map_escape trivial_expansion esc))) in
     raise (Error(loc,
                  env,
                  Pattern_type_clash(Errortrace.unification_error ~trace, None)))
@@ -3658,9 +3658,9 @@ let check_univars env kind exp ty_expected vars =
   let ty, errs = polyfy env exp_ty vars in
   if errs <> [] then
     let ty_expected = instance ty_expected in
-    let diff = Ctype.expanded_diff env ~got:ty ~expected:ty_expected in
-    let explanation = Errortrace.Univar (Quantification_mismatch errs) in
-    let err = Errortrace.unification_error ~trace:[diff;explanation] in
+    let root = Errortrace.(root (Univar (Quantification_mismatch errs))) in
+    let trace = Ctype.expanded_diff env ~got:ty ~expected:ty_expected root in
+    let err = Errortrace.unification_error ~trace in
     raise (Error(exp.exp_loc, env, Less_general(kind,err)))
 
 (* [check_statement] implements the [non-unit-statement] check.
@@ -7416,11 +7416,9 @@ let tuple_component ~print_article ppf lbl =
   | None -> fprintf ppf "%sunlabeled component" article
 
 (* Returns the first diff of the trace *)
-let type_clash_of_trace trace =
-  Errortrace.(explain trace (fun ~prev:_ -> function
-    | Diff diff -> Some diff
-    | _ -> None
-  ))
+let type_clash_of_trace trace = match trace.Errortrace.path with
+  | d :: _ -> Some d
+  | _ -> None
 
 (** More precise denomination for type errors. Used by messages:
 
@@ -7668,15 +7666,9 @@ let report_error ~loc env = function
     (* The last diff's expected type will be the locally-abstract type
        that the GADT pattern introduced an equation on.
     *)
-    let type_with_local_equation =
-      let last_diff =
-        List.find_map
-          (function Errortrace.Diff diff -> Some diff | _ -> None)
-          (List.rev trace)
-      in
-      match last_diff with
-      | None -> None
-      | Some diff -> Some diff.d.expected.ty
+    let type_with_local_equation = match List.rev trace.path with
+        | x :: _ -> Some x.d.expected.ty
+        | [] -> None
     in
     (* [syntactic_arity>1] for this error, so "arguments" is always plural. *)
     Location.errorf ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7490,7 +7490,7 @@ let report_literal_type_constraint expected_type const =
 
 let report_literal_type_constraint const = function
   | Some tr ->
-      begin match get_desc Errortrace.(tr.expected.ty) with
+      begin match get_desc Errortrace.(tr.d.expected.ty) with
         Tconstr (typ, [], _) ->
           report_literal_type_constraint typ const
       | _ -> []
@@ -7499,7 +7499,7 @@ let report_literal_type_constraint const = function
 
 let report_partial_application = function
   | Some tr -> begin
-      match get_desc tr.Errortrace.got.Errortrace.expanded with
+      match get_desc Errortrace.(tr.d.got.expanded) with
       | Tarrow _ ->
           [ Location.msg
               "@[@{<hint>Hint@}:@ This function application is partial,@ \
@@ -7676,7 +7676,7 @@ let report_error ~loc env = function
       in
       match last_diff with
       | None -> None
-      | Some diff -> Some diff.expected.ty
+      | Some diff -> Some diff.d.expected.ty
     in
     (* [syntactic_arity>1] for this error, so "arguments" is always plural. *)
     Location.errorf ~loc

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -308,9 +308,10 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
                 (* Expansion is not helpful here -- the restriction on GADT
                    return types is purely syntactic.  (In the worst case,
                    expansion produces gibberish.) *)
-                [Ctype.unexpanded_diff
+                Ctype.unexpanded_diff
                    ~got:ret_type
-                   ~expected:(Ctype.newconstr type_path type_params)]
+                   ~expected:(Ctype.newconstr type_path type_params)
+                   Errortrace.empty_root
               in
               raise (Error(sret_type.ptyp_loc,
                            Constraint_failed(


### PR DESCRIPTION
This PR proposes to decouple the postprocessing of the typechecker error trace
from the generation of the corresponding error report. The objectives is to pave the way 
for further improvements to those error reports by reducing the amount of guesswork
about the actual structure of the error trace.

More precisely, currently, in the error path the typechecker constructs
an unstructured trace of error as an homogeneous list of elements that can be either

- A  `Diff` difference between an expected and actual type: 
`This expression has type float but an expression was expected of type int`
- A `Method` difference between an expected and actual method type
`  The method m has type a, but the expected method type was b`
- A `Tag` incompatibility for the types of a polymorphic variant tag
`` Types for tag `A are incompatible ``
- An explanation for a deeper conflict: a recursive occurrence of a type
  variable, a missing field in an object type, an escaping existential types, ...
  

```
┌───────────────┐
│ Diff          │
│ Diff          │
│ Method        │
┊               ┊
┊               ┊
┊               ┊
| Tag           │
│ Diff          │
│ Diff          │
│ Method        │
│ explanation?  │
└───────────────┘
```

Once this trace has been produced, the `Errortrace_report` module
post-processes this trace in order to:

- remove non-informative `Diff` elements
- try to locate an explanation starting with the bottom of the trace
- for some root explanations, promote a `Method` element to an informative elements
- if there are no root explanation try to promote either a `Method`/`Tag`/`Diff`
  elements to a root explanation
- in the absence of a root explanation, consider a potential last
  semi-informative element as informative.
- then remove all non-`Diff` elements to obtain a difference trace and a
  potential explanation

At the end of the process the trace is implicitly split in three:
a head, a list of differences, and a root explanation:
```
┌───────────────┐
│ Diff          │
└───────────────┘

┌───────────────┐
│ Diff          │
┊               ┊
┊               ┊
│ Diff ?        │
└───────────────┘

┌───────────────┐
| Method?       |
├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤ 
│ Root          │
│ explanation?  │
└───────────────┘
```

This reshaping relies on invariants in the current structure of the error trace
which are not reflected in the trace type, and sometimes wrong:

- First, there is at most one root explanation (this is true)
- Second, that a root explanation if it exists is the last element (same as above).
- Third, that there is no informative `Diff` elements between the bottom of the trace and the
  first `Tag` or `Method` elements (this is false, and this is the reason some of the 
   "method" submessages move around in the testsuite).
  
Moreover, the `Tag` and `Method` elements are sometimes considered part of the
contextual part of the trace, but some other times they are handled as a root
explanation.

The aim to this PR is to make this handling more regular and explicit in the
codebase.

First, we add a root explanation for mismatch in polymorphic variant arity. With
this new explanations, we can avoid using the `Tag` element as a root
explanation. With this change, we can then merge the `Diff`, `Method` and `Tag `trace
elements into a single kind of `Diff` element with contextual information.

Second, we add two intermediary representation for the error trace: a temporary segmented type,
and a structured trace type that reflect the processing done in `Errortrace_report` before.
Along the way, we make the handling of context more regular: rather than sometimes displaying
the last `Method` element, we now always display the last contextual element.
Consequently, once processed a structured trace is split in three parts:

```
┌───────────────────┐
│ Diff              │
└───────────────────┘

┌───────────────────┐
│ Diff              │
┊                   ┊
│ Diff(Method|Tag)  │
│ Diff              │
┊                   ┊
│ Diff ?            │
└───────────────────┘

┌───────────────────┐
│ Root              │
│ explanation?      │
└───────────────────┘
```

This more regular processing has been moved to the `Errortrace` module,
isolating the trace processing code from the printing code in
`Errortrace_report`. This also fixes a bug where a method appearing in the
middle of a chain of informative differences ended up being chosen as the root
explanation for the whole trace.

Third, with this processing refactored while preserving the current behavior, 
we can move the trace to a more structured type which ensures that there is only
one root explanation, and that all other elements are differences:

```
┌───────────────┐
│ Diff          │
┊               ┊
│ Diff(method)  │
│ Diff          │
┊               ┊
| Diff (tag)    │
│ Diff          │
┊               ┊
└───────────────┘

┌───────────────┐
│  Root         │
│  explanation? │
└───────────────┘
```

Finally, this last change decreases the difference between the subtyping trace and the unification trace, and thus 
this PR uses this opportunity to simplify the code for reporting subtyping errors.