### PR TITLE
refactor(typing): refactor `type_approx` 2: electric boogaloo

### DIFF
--- a/.depend
+++ b/.depend
@@ -1661,6 +1661,28 @@ typing/tast_mapper.cmi : \
     parsing/location.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
+typing/type_approx.cmo : \
+    typing/typetexp.cmi \
+    typing/types.cmi \
+    typing/predef.cmi \
+    parsing/parsetree.cmi \
+    typing/ctype.cmi \
+    parsing/asttypes.cmi \
+    parsing/ast_helper.cmi \
+    typing/type_approx.cmi
+typing/type_approx.cmx : \
+    typing/typetexp.cmx \
+    typing/types.cmx \
+    typing/predef.cmx \
+    parsing/parsetree.cmi \
+    typing/ctype.cmx \
+    parsing/asttypes.cmx \
+    parsing/ast_helper.cmx \
+    typing/type_approx.cmi
+typing/type_approx.cmi : \
+    typing/types.cmi \
+    parsing/parsetree.cmi \
+    typing/env.cmi
 typing/type_immediacy.cmo : \
     parsing/builtin_attributes.cmi \
     typing/type_immediacy.cmi
@@ -1678,6 +1700,7 @@ typing/typeclass.cmo : \
     typing/typedecl_variance.cmi \
     typing/typedecl.cmi \
     typing/typecore.cmi \
+    typing/type_approx.cmi \
     typing/subst.cmi \
     typing/printtyp.cmi \
     typing/predef.cmi \
@@ -1711,6 +1734,7 @@ typing/typeclass.cmx : \
     typing/typedecl_variance.cmx \
     typing/typedecl.cmx \
     typing/typecore.cmx \
+    typing/type_approx.cmx \
     typing/subst.cmx \
     typing/printtyp.cmx \
     typing/predef.cmx \
@@ -1756,6 +1780,7 @@ typing/typecore.cmo : \
     typing/typetexp.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/type_approx.cmi \
     typing/subst.cmi \
     typing/shape.cmi \
     typing/printtyp.cmi \
@@ -1794,6 +1819,7 @@ typing/typecore.cmx : \
     typing/typetexp.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
+    typing/type_approx.cmx \
     typing/subst.cmx \
     typing/shape.cmx \
     typing/printtyp.cmx \

--- a/.depend
+++ b/.depend
@@ -1662,6 +1662,7 @@ typing/type_approx.cmo : \
     typing/types.cmi \
     typing/predef.cmi \
     parsing/parsetree.cmi \
+    typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
@@ -1671,6 +1672,7 @@ typing/type_approx.cmx : \
     typing/types.cmx \
     typing/predef.cmx \
     parsing/parsetree.cmi \
+    typing/env.cmx \
     typing/ctype.cmx \
     parsing/asttypes.cmx \
     parsing/ast_helper.cmx \

--- a/.depend
+++ b/.depend
@@ -1657,6 +1657,28 @@ typing/tast_mapper.cmi : \
     parsing/location.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
+typing/type_approx.cmo : \
+    typing/typetexp.cmi \
+    typing/types.cmi \
+    typing/predef.cmi \
+    parsing/parsetree.cmi \
+    typing/ctype.cmi \
+    parsing/asttypes.cmi \
+    parsing/ast_helper.cmi \
+    typing/type_approx.cmi
+typing/type_approx.cmx : \
+    typing/typetexp.cmx \
+    typing/types.cmx \
+    typing/predef.cmx \
+    parsing/parsetree.cmi \
+    typing/ctype.cmx \
+    parsing/asttypes.cmx \
+    parsing/ast_helper.cmx \
+    typing/type_approx.cmi
+typing/type_approx.cmi : \
+    typing/types.cmi \
+    parsing/parsetree.cmi \
+    typing/env.cmi
 typing/type_immediacy.cmo : \
     parsing/builtin_attributes.cmi \
     typing/type_immediacy.cmi
@@ -1673,6 +1695,7 @@ typing/typeclass.cmo : \
     typing/typedecl_variance.cmi \
     typing/typedecl.cmi \
     typing/typecore.cmi \
+    typing/type_approx.cmi \
     typing/subst.cmi \
     typing/printtyp.cmi \
     typing/predef.cmi \
@@ -1705,6 +1728,7 @@ typing/typeclass.cmx : \
     typing/typedecl_variance.cmx \
     typing/typedecl.cmx \
     typing/typecore.cmx \
+    typing/type_approx.cmx \
     typing/subst.cmx \
     typing/printtyp.cmx \
     typing/predef.cmx \
@@ -1748,6 +1772,7 @@ typing/typecore.cmo : \
     typing/typetexp.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/type_approx.cmi \
     typing/subst.cmi \
     typing/shape.cmi \
     typing/printtyp.cmi \
@@ -1784,6 +1809,7 @@ typing/typecore.cmx : \
     typing/typetexp.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
+    typing/type_approx.cmx \
     typing/subst.cmx \
     typing/shape.cmx \
     typing/printtyp.cmx \

--- a/.depend
+++ b/.depend
@@ -1666,6 +1666,7 @@ typing/type_approx.cmo : \
     typing/types.cmi \
     typing/predef.cmi \
     parsing/parsetree.cmi \
+    typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
@@ -1675,6 +1676,7 @@ typing/type_approx.cmx : \
     typing/types.cmx \
     typing/predef.cmx \
     parsing/parsetree.cmi \
+    typing/env.cmx \
     typing/ctype.cmx \
     parsing/asttypes.cmx \
     parsing/ast_helper.cmx \

--- a/Changes
+++ b/Changes
@@ -411,6 +411,10 @@ Working version
 - #14946: Keep the continuation inside the typedtree using a dedicated type.
   (Xavier Van de Woestyne, review by Florian Angeletti)
 
+* #14538 Refactor `type_approx` (again) and `type_let_rec` for polymorphic
+  recursion.
+  (Alistair O'Brien, review by ??)
+
 ### Build system:
 
 - #14552: Export `AR` and `ARFLAGS` in Makefile.config.

--- a/Changes
+++ b/Changes
@@ -120,6 +120,10 @@ Working version
   constructor declarations.
   (Florian Angeletti, review by Gabriel Scherer)
 
+* #14538 Refactor `type_approx` (again) and `type_let_rec` for polymorphic
+  recursion.
+  (Alistair O'Brien, review by ??)
+
 ### Build system:
 
 ### Bug fixes:

--- a/Changes
+++ b/Changes
@@ -728,6 +728,9 @@ OCaml 5.5.0
   definition
   (Ulysse Gérard, review by Florian Angeletti and Gabriel Scherer)
 
+- #14394: Refactor `type_let` into `type_let_nonrec` and `type_let_rec`.
+  (Alistair O'Brien, review by ??)
+
 ### Build system:
 
 - #13705, #14444: Cache test results of custom Autoconf tests from aclocal.m4.

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ typing_SOURCES = \
   typing/typeopt.mli typing/typeopt.ml \
   typing/typedecl.mli typing/typedecl.ml \
   typing/value_rec_check.mli typing/value_rec_check.ml \
+  typing/type_approx.ml typing/type_approx.mli \
   typing/typecore.mli typing/typecore.ml \
   typing/typeclass.mli typing/typeclass.ml \
   typing/typemod.mli typing/typemod.ml \

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ typing_SOURCES = \
   typing/typeopt.mli typing/typeopt.ml \
   typing/typedecl.mli typing/typedecl.ml \
   typing/value_rec_check.mli typing/value_rec_check.ml \
+  typing/type_approx.ml typing/type_approx.mli \
   typing/typecore.mli typing/typecore.ml \
   typing/typeclass.mli typing/typeclass.ml \
   typing/typemod.mli typing/typemod.ml \

--- a/testsuite/tests/shape-index/index.reference
+++ b/testsuite/tests/shape-index/index.reference
@@ -44,6 +44,7 @@ Resolved: Index.5: A (File "index.ml", line 31, characters 7-8)
 Resolved: Index.5: A (File "index.ml", line 34, characters 10-11)
 Resolved: Index.5: A (File "index.ml", line 28, characters 11-12)
 Resolved: Index.3: t (File "index.ml", line 25, characters 11-12)
+Resolved: Index.3: t (File "index.ml", line 25, characters 11-12)
 Resolved: Index.0: t (File "index.ml", line 20, characters 10-11)
 
 Uid of decls:

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -24,16 +24,6 @@ Lines 7-10, characters 2-22:
 10 |     with type t = M.t)
 Error: This expression has type "(module S with type t = M.t)"
        but an expression was expected of type "(module S)"
-       The type constructor "M.t" would escape its scope
-|}, Principal{|
-module type S = sig type t end
-Lines 7-10, characters 2-22:
- 7 | ..(module struct
- 8 |     type t = M.t
- 9 |   end : S
-10 |     with type t = M.t)
-Error: This expression has type "(module S with type t = M.t)"
-       but an expression was expected of type "(module S)"
        The constraint on "t" in the first module type is not compatible
        with the declaration of type t in the second module type.
 |}];;

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -24,16 +24,6 @@ Lines 7-10, characters 2-22:
 10 |     with type t = M.t)
 Error: This expression has type "(module S with type t = M.t)"
        but an expression was expected of type "(module S)"
-       The type constructor "M.t" would escape its scope
-|}, Principal{|
-module type S = sig type t end
-Lines 7-10, characters 2-22:
- 7 | ..(module struct
- 8 |     type t = M.t
- 9 |   end : S
-10 |     with type t = M.t)
-Error: This expression has type "(module S with type t = M.t)"
-       but an expression was expected of type "(module S)"
 |}];;
 
 let rec k =

--- a/testsuite/tests/typing-gadts/pr10907.ml
+++ b/testsuite/tests/typing-gadts/pr10907.ml
@@ -48,7 +48,7 @@ let unsound_cast : 'a 'b. 'a -> 'b = fun x ->
 Lines 1-2, characters 37-36:
 1 | .....................................fun x ->
 2 |   match t with Iso (g, h) -> h (g x)
-Error: This definition has type "'b. 'b -> 'b" which is less general than
+Error: This expression has type "'b. 'b -> 'b" which is less general than
          "'a 'b. 'a -> 'b"
        The universal type variable "'b" in the first type matches multiple
        distinct variables in the second type.

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -805,7 +805,7 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
-Error: This definition has type
+Error: This expression has type
          "'c 'b. ('b, 'b) eq -> ([< `A of 'b | `B ] as 'c) -> 'c"
        which is less general than
          "'d 'e 'a 'b.

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -773,6 +773,18 @@ Error: The value "o" has type "< m : a >" but an expression was expected of type
        it would escape the scope of its equation
        Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
+|}, Rectypes{|
+Lines 1-5, characters 4-5:
+1 | ....f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
+2 |   fun eq o ->
+3 |     ignore (o : < m : a >);
+4 |     let r : < m : b > = match eq with Eq -> o in (* fail with principal *)
+5 |     r..
+Error: This expression has type "'b. ('a, 'b) eq -> < m : 'a > -> < m : 'b >"
+       which is less general than
+         "'a0 'b. ('a0, 'b) eq -> < m : 'a0 > -> < m : 'b >"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 
 let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
@@ -829,7 +841,7 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
-Error: This definition has type
+Error: This expression has type
          "'c 'b. ('b, 'b) eq -> ([< `A of 'b | `B ] as 'c) -> 'c"
        which is less general than
          "'d 'e 'a 'b.

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
@@ -178,8 +178,10 @@ Error: The value "a" has type "int * lbl:(int * lbl:'a)"
        but an expression was expected of type "'a"
        The type variable "'a" occurs inside "int * lbl:(int * lbl:'a)"
 |}, Rectypes{|
-val a : int * lbl:(int * lbl:'a) as 'a = (1, ~lbl:(2, ~lbl:<cycle>))
-val b : int * lbl:(int * lbl:'a) as 'a = (2, ~lbl:(1, ~lbl:<cycle>))
+val a : int * lbl:(int * lbl:(int * lbl:'a) as 'a) =
+  (1, ~lbl:(2, ~lbl:<cycle>))
+val b : int * lbl:(int * lbl:(int * lbl:'a) as 'a) =
+  (2, ~lbl:(1, ~lbl:<cycle>))
 |}]
 
 let rec l = ~lbl: 5, ~lbl2: 10 :: l

--- a/testsuite/tests/typing-labels/pr13658.ml
+++ b/testsuite/tests/typing-labels/pr13658.ml
@@ -41,11 +41,8 @@ let u () =
   Format.printf "!@.";
   ignore f
 
-[%%expect{||}, Principal.Rectypes{|
+[%%expect{||}, (Principal.Rectypes, Rectypes){|
 val f : x:string -> y:string -> (x:string -> y:string -> 'a as 'a) = <fun>
-val u : unit -> unit = <fun>
-|}, Rectypes{|
-val f : x:string -> y:string -> 'a as 'a = <fun>
 val u : unit -> unit = <fun>
 |}]
 
@@ -67,35 +64,21 @@ val f : (?x:'a -> 'a as 'a) -> 'a = <fun>
 
 let rec f ?x = f
 let () = Clflags.classic := true;;
-[%%expect {||}, Principal.Rectypes.Nolabel{|
+[%%expect {||}, (Principal.Rectypes.Nolabel, Rectypes.Nolabel){|
 Line 1, characters 11-12:
 1 | let rec f ?x = f
                ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
 
 val f : ?x:'a -> (?x:'a -> 'b as 'b) = <fun>
-|}, Rectypes.Nolabel{|
-Line 1, characters 11-12:
-1 | let rec f ?x = f
-               ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
-
-val f : ?x:'b -> 'a as 'a = <fun>
 |}]
 
 let () = f 3
-[%%expect{||}, Principal.Rectypes.Nolabel{|
+[%%expect{||}, (Principal.Rectypes.Nolabel, Rectypes.Nolabel){|
 Line 1, characters 11-12:
 1 | let () = f 3
                ^
 Error: The function applied to this argument has type
          ?x:'a -> ?x:'a -> ?x:'a -> (?x:'a -> 'b as 'b)
-This argument cannot be applied without label
-|}, Rectypes.Nolabel{|
-Line 1, characters 11-12:
-1 | let () = f 3
-               ^
-Error: The function applied to this argument has type
-         ?x:'a -> ?x:'a -> (?x:'a -> 'b as 'b)
 This argument cannot be applied without label
 |}]

--- a/testsuite/tests/typing-labels/pr13658.ml
+++ b/testsuite/tests/typing-labels/pr13658.ml
@@ -42,9 +42,6 @@ let u () =
   ignore f
 
 [%%expect{|
-val f : x:string -> y:string -> 'a as 'a = <fun>
-val u : unit -> unit = <fun>
-|}, Principal{|
 val f : x:string -> y:string -> (x:string -> y:string -> 'a as 'a) = <fun>
 val u : unit -> unit = <fun>
 |}]
@@ -73,25 +70,11 @@ Line 1, characters 11-12:
                ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
 
-val f : ?x:'b -> 'a as 'a = <fun>
-|}, Principal{|
-Line 1, characters 11-12:
-1 | let rec f ?x = f
-               ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
-
 val f : ?x:'a -> (?x:'a -> 'b as 'b) = <fun>
 |}]
 
 let () = f 3
 [%%expect{|
-Line 1, characters 11-12:
-1 | let () = f 3
-               ^
-Error: The function applied to this argument has type
-         ?x:'a -> ?x:'a -> (?x:'a -> 'b as 'b)
-This argument cannot be applied without label
-|}, Principal{|
 Line 1, characters 11-12:
 1 | let () = f 3
                ^

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -152,8 +152,8 @@ class ['a, 'b] c :
   unit ->
   object
     constraint 'a = int -> 'c
-    constraint 'b = 'a * < x : 'b > * 'c * 'd
-    method f : 'a -> 'b -> unit
+    constraint 'b = 'a * (< x : 'b > as 'e) * 'c * 'd
+    method f : (int -> 'c) -> (int -> 'c) * 'e * 'c * 'd -> unit
   end
 |}];;
 class ['a, 'b] d () = object
@@ -293,7 +293,7 @@ module M :
         constraint 'a = int -> bool
         val x : float list
         val y : 'b
-        method f : 'a -> unit
+        method f : (int -> bool) -> unit
         method g : 'b
       end
   end
@@ -853,7 +853,10 @@ end;;
 [%%expect{|
 class ['a] c :
   unit ->
-  object constraint 'a = unit -> (< .. > as 'b) method m : 'a -> 'b end
+  object
+    constraint 'a = unit -> (< .. > as 'b)
+    method m : (unit -> 'b) -> 'b
+  end
 |}];;
 
 class c () = object (self)

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -18,7 +18,7 @@ end and ['a] d () = object
   inherit ['a] c ()
 end;;
 [%%expect{|
-class ['a] c : unit -> object constraint 'a = int method f : int c end
+class ['a] c : unit -> object constraint 'a = int method f : 'a c end
 and ['a] d : unit -> object constraint 'a = int method f : 'a c end
 |}];;
 (* class ['a] c : unit -> object constraint 'a = int method f : 'a c end *)
@@ -152,8 +152,8 @@ class ['a, 'b] c :
   unit ->
   object
     constraint 'a = int -> 'c
-    constraint 'b = 'a * < x : 'b > * 'c * 'd
-    method f : 'a -> 'b -> unit
+    constraint 'b = 'a * (< x : 'b > as 'e) * 'c * 'd
+    method f : (int -> 'c) -> (int -> 'c) * 'e * 'c * 'd -> unit
   end
 |}];;
 class ['a, 'b] d () = object
@@ -294,7 +294,7 @@ module M :
         constraint 'a = int -> bool
         val x : float list
         val y : 'b
-        method f : 'a -> unit
+        method f : (int -> bool) -> unit
         method g : 'b
       end
   end
@@ -854,7 +854,10 @@ end;;
 [%%expect{|
 class ['a] c :
   unit ->
-  object constraint 'a = unit -> (< .. > as 'b) method m : 'a -> 'b end
+  object
+    constraint 'a = unit -> (< .. > as 'b)
+    method m : (unit -> 'b) -> 'b
+  end
 |}];;
 
 class c () = object (self)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1627,8 +1627,13 @@ val f : 'a -> int = <fun>
 val g : 'a -> int = <fun>
 type 'a t = Leaf of 'a | Node of ('a * 'a) t
 val depth : 'a t -> int = <fun>
-val depth : 'a t -> int = <fun>
-val d : ('a * 'a) t -> int = <fun>
+Line 6, characters 2-42:
+6 |   function Leaf _ -> 1 | Node x -> 1 + d x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "'a t -> int" which is less general than
+         "'a0. 'a0 t -> int"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 let rec depth : 'a. 'a t -> _ =
   function Leaf x -> x | Node x -> 1 + depth x;; (* fails *)
@@ -1636,7 +1641,7 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-46:
 2 |   function Leaf x -> x | Node x -> 1 + depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "int t -> int" which is less general than
+Error: This expression has type "int t -> int" which is less general than
          "'a. 'a t -> int"
        The type "int" is not a type variable.
 |}];;
@@ -1646,8 +1651,8 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a t -> 'a" which is less general than
-         "'a0. 'a0 t -> 'b"
+Error: This expression has type "'a t -> 'a" which is less general than
+         "'a0. 'a0 t -> 'a"
        The type variable "'a" is not generalizable to an universal
        type variable.
 |}];;
@@ -1657,7 +1662,7 @@ let rec depth : 'a 'b. 'a t -> 'b =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'b. 'b t -> 'b" which is less general than
+Error: This expression has type "'b. 'b t -> 'b" which is less general than
          "'a 'b. 'a t -> 'b"
        The universal type variable "'b" in the first type matches multiple
        distinct variables in the second type.
@@ -2153,8 +2158,8 @@ let rec foo : 'a . 'a -> 'd = fun x -> x
 Line 1, characters 30-40:
 1 | let rec foo : 'a . 'a -> 'd = fun x -> x
                                   ^^^^^^^^^^
-Error: This definition has type "'a -> 'a" which is less general than
-         "'a0. 'a0 -> 'b"
+Error: This expression has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a"
        The type variable "'a" is not generalizable to an universal
        type variable.
 |}]
@@ -2234,7 +2239,7 @@ let f x =
 Line 2, characters 6-44:
 2 |   let ref : type a . a option ref = ref None in
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a option ref" which is less general than
+Error: This expression has type "'a option ref" which is less general than
          "'a0. 'a0 option ref"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -2326,7 +2331,7 @@ let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y ()
 Line 1, characters 65-85:
 1 | let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y (); o#x
                                                                      ^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a. < x : 'a; y : unit -> 'b; .. > -> 'a"
+Error: This expression has type "'a. < x : 'a; y : unit -> 'b; .. > -> 'a"
        which is less general than "'a 'c. (< x : 'a; .. > as 'c) -> 'a"
        The type "< y : unit -> 'd; .. >" is not a type variable.
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1612,8 +1612,13 @@ val f : 'a -> int = <fun>
 val g : 'a -> int = <fun>
 type 'a t = Leaf of 'a | Node of ('a * 'a) t
 val depth : 'a t -> int = <fun>
-val depth : 'a t -> int = <fun>
-val d : ('a * 'a) t -> int = <fun>
+Line 6, characters 2-42:
+6 |   function Leaf _ -> 1 | Node x -> 1 + d x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "'a t -> int" which is less general than
+         "'a0. 'a0 t -> int"
+       The type variable "'a" is not generalizable to an universal
+       type variable.
 |}];;
 let rec depth : 'a. 'a t -> _ =
   function Leaf x -> x | Node x -> 1 + depth x;; (* fails *)
@@ -1621,7 +1626,7 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-46:
 2 |   function Leaf x -> x | Node x -> 1 + depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "int t -> int" which is less general than
+Error: This expression has type "int t -> int" which is less general than
          "'a. 'a t -> int"
        The type "int" is not a type variable.
 |}];;
@@ -1631,8 +1636,8 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a t -> 'a" which is less general than
-         "'a0. 'a0 t -> 'b"
+Error: This expression has type "'a t -> 'a" which is less general than
+         "'a0. 'a0 t -> 'a"
        The type variable "'a" is not generalizable to an universal
        type variable.
 |}];;
@@ -1642,7 +1647,7 @@ let rec depth : 'a 'b. 'a t -> 'b =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'b. 'b t -> 'b" which is less general than
+Error: This expression has type "'b. 'b t -> 'b" which is less general than
          "'a 'b. 'a t -> 'b"
        The universal type variable "'b" in the first type matches multiple
        distinct variables in the second type.
@@ -2138,8 +2143,8 @@ let rec foo : 'a . 'a -> 'd = fun x -> x
 Line 1, characters 30-40:
 1 | let rec foo : 'a . 'a -> 'd = fun x -> x
                                   ^^^^^^^^^^
-Error: This definition has type "'a -> 'a" which is less general than
-         "'a0. 'a0 -> 'b"
+Error: This expression has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a"
        The type variable "'a" is not generalizable to an universal
        type variable.
 |}]
@@ -2215,7 +2220,7 @@ let f x =
 Line 2, characters 6-44:
 2 |   let ref : type a . a option ref = ref None in
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a option ref" which is less general than
+Error: This expression has type "'a option ref" which is less general than
          "'a0. 'a0 option ref"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -2307,7 +2312,7 @@ let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y ()
 Line 1, characters 65-85:
 1 | let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y (); o#x
                                                                      ^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a. < x : 'a; y : unit -> 'b; .. > -> 'a"
+Error: This expression has type "'a. < x : 'a; y : unit -> 'b; .. > -> 'a"
        which is less general than "'a 'c. (< x : 'a; .. > as 'c) -> 'a"
        The type "< y : unit -> 'd; .. >" is not a type variable.
 |}]

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -427,10 +427,7 @@ let rec f (x : (module T)) =
 
 [%%expect{|
 module type T = sig type 'a t = 'a list end
-Line 4, characters 58-69:
-4 |   let (module LocalModule) = x in (assert false : ('a. 'a LocalModule.t) -> unit)
-                                                              ^^^^^^^^^^^
-Error: Unbound module "LocalModule"
+val f : (module T) -> ('a. 'a list) -> unit = <fun>
 |}]
 
 (* The following test requires full translation in the [approx_type] function if
@@ -482,10 +479,8 @@ val f : unit -> ('a. 'a list) -> unit = <fun>
 let rec f () = g (module Map.Make(Int)) and g (m : (module Map.S)) = ();;
 
 [%%expect{|
-Line 1, characters 17-39:
-1 | let rec f () = g (module Map.Make(Int)) and g (m : (module Map.S)) = ();;
-                     ^^^^^^^^^^^^^^^^^^^^^^
-Error: The signature for this packaged module couldn't be inferred.
+val f : unit -> unit = <fun>
+val g : (module Map.S) -> unit = <fun>
 |}]
 
 let rec f () = g (module Map.Make(Int)) and g (m : 'a. (module Map.S)) = ();;

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -152,32 +152,22 @@ let rec poly6 : 'b. bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option =
   fun p id x ->
     if p then poly6 false id x else id x, id (Some x)
 [%%expect {|
-Line 1, characters 8-13:
-1 | let rec poly6 : 'b. bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option =
-            ^^^^^
-Error: This pattern matches values of type
-         "bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option"
-       but a pattern was expected which matches values of type
-         "bool -> 'c -> 'd -> 'e"
-       The universal variable "'a" would escape its scope
+val poly6 : bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option = <fun>
 |}];;
 
 let _ = poly6 true (fun x -> x) 8
 [%%expect {|
-Line 1, characters 8-13:
-1 | let _ = poly6 true (fun x -> x) 8
-            ^^^^^
-Error: Unbound value "poly6"
-Hint:   Did you mean "poly1", "poly2", "poly3", "poly4" or "poly5"?
+- : int * int option = (8, Some 8)
 |}];;
 
 let _ = poly6 true (fun x -> x + 1) 8
 [%%expect {|
-Line 1, characters 8-13:
+Line 1, characters 19-35:
 1 | let _ = poly6 true (fun x -> x + 1) 8
-            ^^^^^
-Error: Unbound value "poly6"
-Hint:   Did you mean "poly1", "poly2", "poly3", "poly4" or "poly5"?
+                       ^^^^^^^^^^^^^^^^
+Error: This argument has type "int -> int" which is less general than
+         "'a. 'a -> 'a"
+       The type "int" is not a type variable.
 |}];;
 
 let needs_magic (magic : 'a 'b. 'a -> 'b) = (magic 5 : string)

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -152,22 +152,32 @@ let rec poly6 : 'b. bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option =
   fun p id x ->
     if p then poly6 false id x else id x, id (Some x)
 [%%expect {|
-val poly6 : bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option = <fun>
+Line 1, characters 8-13:
+1 | let rec poly6 : 'b. bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option =
+            ^^^^^
+Error: This pattern matches values of type
+         "bool -> ('a. 'a -> 'a) -> 'b -> 'b * 'b option"
+       but a pattern was expected which matches values of type
+         "bool -> 'c -> 'd -> 'e"
+       The universal variable "'a" would escape its scope
 |}];;
 
 let _ = poly6 true (fun x -> x) 8
 [%%expect {|
-- : int * int option = (8, Some 8)
+Line 1, characters 8-13:
+1 | let _ = poly6 true (fun x -> x) 8
+            ^^^^^
+Error: Unbound value "poly6"
+Hint:   Did you mean "poly1", "poly2", "poly3", "poly4" or "poly5"?
 |}];;
 
 let _ = poly6 true (fun x -> x + 1) 8
 [%%expect {|
-Line 1, characters 19-35:
+Line 1, characters 8-13:
 1 | let _ = poly6 true (fun x -> x + 1) 8
-                       ^^^^^^^^^^^^^^^^
-Error: This argument has type "int -> int" which is less general than
-         "'a. 'a -> 'a"
-       The type "int" is not a type variable.
+            ^^^^^
+Error: Unbound value "poly6"
+Hint:   Did you mean "poly1", "poly2", "poly3", "poly4" or "poly5"?
 |}];;
 
 let needs_magic (magic : 'a 'b. 'a -> 'b) = (magic 5 : string)
@@ -427,10 +437,7 @@ let rec f (x : (module T)) =
 
 [%%expect{|
 module type T = sig type 'a t = 'a list end
-Line 4, characters 58-69:
-4 |   let (module LocalModule) = x in (assert false : ('a. 'a LocalModule.t) -> unit)
-                                                              ^^^^^^^^^^^
-Error: Unbound module "LocalModule"
+val f : (module T) -> ('a. 'a list) -> unit = <fun>
 |}]
 
 (* The following test requires full translation in the [approx_type] function if
@@ -482,10 +489,8 @@ val f : unit -> ('a. 'a list) -> unit = <fun>
 let rec f () = g (module Map.Make(Int)) and g (m : (module Map.S)) = ();;
 
 [%%expect{|
-Line 1, characters 17-39:
-1 | let rec f () = g (module Map.Make(Int)) and g (m : (module Map.S)) = ();;
-                     ^^^^^^^^^^^^^^^^^^^^^^
-Error: The signature for this packaged module couldn't be inferred.
+val f : unit -> unit = <fun>
+val g : (module Map.S) -> unit = <fun>
 |}]
 
 let rec f () = g (module Map.Make(Int)) and g (m : 'a. (module Map.S)) = ();;

--- a/testsuite/tests/typing-recovery/illegal_letrec.compilers.reference
+++ b/testsuite/tests/typing-recovery/illegal_letrec.compilers.reference
@@ -8,6 +8,16 @@ File "illegal_letrec.ml", line 17, characters 10-18:
 17 |   let rec (_ as f) = fun () -> f () in
                ^^^^^^^^
   Only variables are allowed as left-hand side of let rec
+File "illegal_letrec.ml", line 17, characters 33-35:
+17 |   let rec (_ as f) = fun () -> f () in
+                                      ^^
+  The function applied to this argument has type x:'a -> y:'b -> z:'c -> unit
+This argument cannot be applied without label
+File "illegal_letrec.ml", line 18, characters 4-6:
+18 |   f ()
+         ^^
+  The function applied to this argument has type x:'a -> y:'b -> z:'c -> unit
+This argument cannot be applied without label
 File "illegal_letrec.ml", line 20, characters 12-16:
 20 | let rec x = f ~x
                  ^^^^

--- a/testsuite/tests/typing-recovery/mutual_recursion.compilers.reference
+++ b/testsuite/tests/typing-recovery/mutual_recursion.compilers.reference
@@ -4,6 +4,14 @@ File "mutual_recursion.ml", line 11, characters 4-9:
 11 | and (a,b) = (1,2)
          ^^^^^
   Only variables are allowed as left-hand side of let rec
+File "mutual_recursion.ml", line 10, characters 20-21:
+10 | let rec foo x = x + a + b
+                         ^
+  Unbound value a
+File "mutual_recursion.ml", line 10, characters 24-25:
+10 | let rec foo x = x + a + b
+                             ^
+  Unbound value b
 File "mutual_recursion.ml", line 15, characters 13-18:
 15 | let d = 10 + "foo"
                   ^^^^^

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -83,13 +83,6 @@ Line 1, characters 13-14:
                  ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
 
-val baz : ?x:'b -> 'a as 'a = <fun>
-|}, Principal{|
-Line 1, characters 13-14:
-1 | let rec baz ?x = baz
-                 ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
-
 val baz : ?x:'a -> (?x:'a -> 'b as 'b) = <fun>
 |}]
 

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -77,20 +77,13 @@ val baz : unit -> ?x:'a -> unit = <fun>
 #rectypes
 
 let rec baz ?x = baz
-[%%expect{||}, Principal.Rectypes{|
+[%%expect{||}, (Principal.Rectypes, Rectypes){|
 Line 1, characters 13-14:
 1 | let rec baz ?x = baz
                  ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
 
 val baz : ?x:'a -> (?x:'a -> 'b as 'b) = <fun>
-|}, Rectypes{|
-Line 1, characters 13-14:
-1 | let rec baz ?x = baz
-                 ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
-
-val baz : ?x:'b -> 'a as 'a = <fun>
 |}]
 
 let rec baz (type a) ?x = baz

--- a/typing/type_approx.ml
+++ b/typing/type_approx.ml
@@ -19,37 +19,51 @@ open Types
 open Ctype
 open Predef
 
-let unknown () = newvar ()
 
-let approx_transl f =
-  try f () with
-  | Typetexp.Error.In_context _ | Env.Error.In_context _ -> unknown ()
+module Approx_env = struct
+  type t =
+    { env : Env.t
+    ; mono_lvl : int
+    }
 
+  let create ~env ?(mono_lvl = get_current_level ()) () = { env; mono_lvl }
 
-let match_or_keep_matchee env ty ~matchee =
+  (* [unknown t] returns a fresh 'unknown' type which indicates that
+     we cannot accurately approximate the type. *)
+  let unknown t = newvar2 t.mono_lvl
+
+  let approx_transl t f =
+    try
+      Typetexp.TyVarEnv.with_any_var_level ~level:t.mono_lvl (fun () ->
+          f t.env)
+    with
+    | Typetexp.Error.In_context _ | Env.Error.In_context _ -> unknown t
+end
+
+let match_or_keep_matchee (aenv : Approx_env.t) ty ~matchee =
   try
-    unify env ty matchee;
+    unify aenv.env ty matchee;
     matchee
   with
   | Ctype.Unify _ -> matchee
 
 
-let type_pattern env spat =
+let type_pattern aenv spat =
   match spat.ppat_desc with
   | Ppat_constraint (_, sty) ->
-    approx_transl (fun () ->
+    Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false sty).ctyp_type)
   | _ ->
     (* We do not approximate deep within the pattern. *)
-    unknown ()
+    Approx_env.unknown aenv
 
 
-let type_function_param env spat ~ret_ty =
+let type_function_param aenv spat ~ret_ty =
   let label, param_ty =
     match spat with
-    | `Cases -> Nolabel, newmono (unknown ())
+    | `Cases -> Nolabel, newmono (Approx_env.unknown aenv)
     | `Pat (label, default, spat) ->
-      let pat_ty = type_pattern env spat in
+      let pat_ty = type_pattern aenv spat in
       let param_ty =
         match label, default with
         | (Nolabel | Labelled _), _ ->
@@ -65,7 +79,7 @@ let type_function_param env spat ~ret_ty =
           (* The pattern must match on an option type (since no default is
              provided). *)
           let pat_ty =
-            match_or_keep_matchee env pat_ty ~matchee:(type_option (newvar ()))
+            match_or_keep_matchee aenv pat_ty ~matchee:(type_option (newvar ()))
           in
           newmono pat_ty
         | Optional _, Some _ ->
@@ -78,48 +92,48 @@ let type_function_param env spat ~ret_ty =
   newty (Tarrow (label, param_ty, ret_ty, commu_ok))
 
 
-let type_constraint env sconstraint =
+let type_constraint aenv sconstraint =
   match sconstraint with
   | Pconstraint pty ->
-    approx_transl (fun () ->
+    Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false pty).ctyp_type)
   | Pcoerce (_constrain, coerce) ->
-    approx_transl (fun () ->
+    Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false coerce).ctyp_type)
 
 
-let rec type_expression env sexp =
+let rec type_expression aenv sexp =
   match sexp.pexp_desc with
   (* Questionable legacy approximations *)
   | Pexp_let (_, _, sexp)
   | Pexp_match (_, { pc_rhs = sexp } :: _)
   | Pexp_ifthenelse (_, sexp, _)
   | Pexp_sequence (_, sexp)
-  | Pexp_try (sexp, _) -> type_expression env sexp
+  | Pexp_try (sexp, _) -> type_expression aenv sexp
   (* 'Telescope' approximations *)
   | Pexp_function (params, ret_constraint, body) ->
-    type_function env params ret_constraint body
-  | Pexp_tuple components -> type_tuple env components
+    type_function aenv params ret_constraint body
+  | Pexp_tuple components -> type_tuple aenv components
   | Pexp_constraint (_, sconstraint) ->
-    type_constraint env (Pconstraint sconstraint)
-  | Pexp_coerce (_, sty1, sty2) -> type_constraint env (Pcoerce (sty1, sty2))
+    type_constraint aenv (Pconstraint sconstraint)
+  | Pexp_coerce (_, sty1, sty2) -> type_constraint aenv (Pcoerce (sty1, sty2))
   | Pexp_pack (_, Some ptyp) ->
     let loc = sexp.pexp_loc in
     let sty = Ast_helper.Typ.package ~loc ptyp in
-    type_constraint env (Pconstraint sty)
-  | _ -> unknown ()
+    type_constraint aenv (Pconstraint sty)
+  | _ -> Approx_env.unknown aenv
 
 
-and type_tuple env components =
+and type_tuple aenv components =
   let labeled_tys =
     List.map
-      (fun (label, component) -> label, type_expression env component)
+      (fun (label, component) -> label, type_expression aenv component)
       components
   in
   newty (Ttuple labeled_tys)
 
 
-and type_function env params ret_constraint body =
+and type_function aenv params ret_constraint body =
   (* We can approximate types up to the first newtype parameter or potential
      dependent module argument, whereupon we give up. *)
   match params with
@@ -128,20 +142,24 @@ and type_function env params ret_constraint body =
           (Nolabel, _, { ppat_desc = Ppat_unpack ({ txt = Some _ }, _); _ })
     }
     :: _params
-  | { pparam_desc = Pparam_newtype _ } :: _params -> unknown ()
+  | { pparam_desc = Pparam_newtype _ } :: _params -> Approx_env.unknown aenv
   | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
     type_function_param
-      env
+      aenv
       (`Pat (label, default, pat))
-      ~ret_ty:(type_function env params ret_constraint body)
+      ~ret_ty:(type_function aenv params ret_constraint body)
   | [] ->
     (match ret_constraint with
-    | Some sconstraint -> type_constraint env sconstraint
+    | Some sconstraint -> type_constraint aenv sconstraint
     | None ->
       (match body with
-      | Pfunction_body sbody -> type_expression env sbody
+      | Pfunction_body sbody -> type_expression aenv sbody
       | Pfunction_cases ({ pc_rhs = sbody } :: _, _, _) ->
-        type_function_param env `Cases ~ret_ty:(type_expression env sbody)
+        type_function_param aenv `Cases ~ret_ty:(type_expression aenv sbody)
       | Pfunction_cases ([], _, _) ->
         (* This case is in fact not reachable. *)
         assert false))
+
+let type_expression ~env ?mono_lvl sexp =
+  let aenv = Approx_env.create ~env ?mono_lvl () in
+  type_expression aenv sexp

--- a/typing/type_approx.ml
+++ b/typing/type_approx.ml
@@ -95,8 +95,11 @@ let type_function_param aenv spat ~ret_ty =
 let type_constraint aenv sconstraint =
   match sconstraint with
   | Pconstraint pty ->
-    Approx_env.approx_transl aenv (fun env ->
+    let pty =
+      Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false pty).ctyp_type)
+    in
+    maybe_instance_poly pty
   | Pcoerce (_constrain, coerce) ->
     Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false coerce).ctyp_type)

--- a/typing/type_approx.ml
+++ b/typing/type_approx.ml
@@ -1,0 +1,147 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Alistair O'Brien, University of Cambridge             *)
+(*                                                                        *)
+(*   Copyright 2026, Alistair O'Brien                                     *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+
+open Asttypes
+open Parsetree
+open Types
+open Ctype
+open Predef
+
+let unknown () = newvar ()
+
+let approx_transl f =
+  try f () with
+  | _ -> unknown ()
+
+
+let match_or_keep_matchee env ty ~matchee =
+  try
+    unify env ty matchee;
+    matchee
+  with
+  | _ -> matchee
+
+
+let type_pattern env spat =
+  match spat.ppat_desc with
+  | Ppat_constraint (_, sty) ->
+    approx_transl (fun () ->
+        (Typetexp.transl_simple_type env ~closed:false sty).ctyp_type)
+  | _ ->
+    (* We do not approximate deep within the pattern. *)
+    unknown ()
+
+
+let type_function_param env spat ~ret_ty =
+  let label, param_ty =
+    match spat with
+    | `Cases -> Nolabel, newmono (unknown ())
+    | `Pat (label, default, spat) ->
+      let pat_ty = type_pattern env spat in
+      let param_ty =
+        match label, default with
+        | (Nolabel | Labelled _), _ ->
+          (match spat.ppat_desc with
+          | Ppat_constraint (_, { ptyp_desc = Ptyp_poly _; _ }) ->
+            (* If the function has a polymorphic parameter annotation,
+               then return the [Tpoly] produced by [type_pattern] *)
+            pat_ty
+          | _ ->
+            (* Otherwise, assume it is monomorphic *)
+            newmono pat_ty)
+        | Optional _, None ->
+          (* The pattern must match on an option type (since no default is
+             provided). *)
+          let pat_ty =
+            match_or_keep_matchee env pat_ty ~matchee:(type_option (newvar ()))
+          in
+          newmono pat_ty
+        | Optional _, Some _ ->
+          (* Since a default is provided, the pattern only needs to match on
+             the type of parameter (and not the optional parameter type). *)
+          newmono (type_option pat_ty)
+      in
+      label, param_ty
+  in
+  newty (Tarrow (label, param_ty, ret_ty, commu_ok))
+
+
+let type_constraint env sconstraint =
+  match sconstraint with
+  | Pconstraint pty ->
+    approx_transl (fun () ->
+        (Typetexp.transl_simple_type env ~closed:false pty).ctyp_type)
+  | Pcoerce (_constrain, coerce) ->
+    approx_transl (fun () ->
+        (Typetexp.transl_simple_type env ~closed:false coerce).ctyp_type)
+
+
+let rec type_expression env sexp =
+  match sexp.pexp_desc with
+  (* Questionable legacy approximations *)
+  | Pexp_let (_, _, sexp)
+  | Pexp_match (_, { pc_rhs = sexp } :: _)
+  | Pexp_ifthenelse (_, sexp, _)
+  | Pexp_sequence (_, sexp)
+  | Pexp_try (sexp, _) -> type_expression env sexp
+  (* 'Telescope' approximations *)
+  | Pexp_function (params, ret_constraint, body) ->
+    type_function env params ret_constraint body
+  | Pexp_tuple components -> type_tuple env components
+  | Pexp_constraint (_, sconstraint) ->
+    type_constraint env (Pconstraint sconstraint)
+  | Pexp_coerce (_, sty1, sty2) -> type_constraint env (Pcoerce (sty1, sty2))
+  | Pexp_pack (_, Some ptyp) ->
+    let loc = sexp.pexp_loc in
+    let sty = Ast_helper.Typ.package ~loc ptyp in
+    type_constraint env (Pconstraint sty)
+  | _ -> unknown ()
+
+
+and type_tuple env components =
+  let labeled_tys =
+    List.map
+      (fun (label, component) -> label, type_expression env component)
+      components
+  in
+  newty (Ttuple labeled_tys)
+
+
+and type_function env params ret_constraint body =
+  (* We can approximate types up to the first newtype parameter or potential
+     dependent module argument, whereupon we give up. *)
+  match params with
+  | { pparam_desc =
+        Pparam_val
+          (Nolabel, _, { ppat_desc = Ppat_unpack ({ txt = Some _ }, _); _ })
+    }
+    :: _params
+  | { pparam_desc = Pparam_newtype _ } :: _params -> unknown ()
+  | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
+    type_function_param
+      env
+      (`Pat (label, default, pat))
+      ~ret_ty:(type_function env params ret_constraint body)
+  | [] ->
+    (match ret_constraint with
+    | Some sconstraint -> type_constraint env sconstraint
+    | None ->
+      (match body with
+      | Pfunction_body sbody -> type_expression env sbody
+      | Pfunction_cases ({ pc_rhs = sbody } :: _, _, _) ->
+        type_function_param env `Cases ~ret_ty:(type_expression env sbody)
+      | Pfunction_cases ([], _, _) ->
+        (* This case is in fact not reachable. *)
+        assert false))

--- a/typing/type_approx.ml
+++ b/typing/type_approx.ml
@@ -1,0 +1,147 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Alistair O'Brien, University of Cambridge             *)
+(*                                                                        *)
+(*   Copyright 2026, Alistair O'Brien                                     *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+
+open Asttypes
+open Parsetree
+open Types
+open Ctype
+open Predef
+
+let unknown () = newvar ()
+
+let approx_transl f =
+  try f () with
+  | Typetexp.Error.In_context _ | Env.Error.In_context _ -> unknown ()
+
+
+let match_or_keep_matchee env ty ~matchee =
+  try
+    unify env ty matchee;
+    matchee
+  with
+  | Ctype.Unify _ -> matchee
+
+
+let type_pattern env spat =
+  match spat.ppat_desc with
+  | Ppat_constraint (_, sty) ->
+    approx_transl (fun () ->
+        (Typetexp.transl_simple_type env ~closed:false sty).ctyp_type)
+  | _ ->
+    (* We do not approximate deep within the pattern. *)
+    unknown ()
+
+
+let type_function_param env spat ~ret_ty =
+  let label, param_ty =
+    match spat with
+    | `Cases -> Nolabel, newmono (unknown ())
+    | `Pat (label, default, spat) ->
+      let pat_ty = type_pattern env spat in
+      let param_ty =
+        match label, default with
+        | (Nolabel | Labelled _), _ ->
+          (match spat.ppat_desc with
+          | Ppat_constraint (_, { ptyp_desc = Ptyp_poly _; _ }) ->
+            (* If the function has a polymorphic parameter annotation,
+               then return the [Tpoly] produced by [type_pattern] *)
+            pat_ty
+          | _ ->
+            (* Otherwise, assume it is monomorphic *)
+            newmono pat_ty)
+        | Optional _, None ->
+          (* The pattern must match on an option type (since no default is
+             provided). *)
+          let pat_ty =
+            match_or_keep_matchee env pat_ty ~matchee:(type_option (newvar ()))
+          in
+          newmono pat_ty
+        | Optional _, Some _ ->
+          (* Since a default is provided, the pattern only needs to match on
+             the type of parameter (and not the optional parameter type). *)
+          newmono (type_option pat_ty)
+      in
+      label, param_ty
+  in
+  newty (Tarrow (label, param_ty, ret_ty, commu_ok))
+
+
+let type_constraint env sconstraint =
+  match sconstraint with
+  | Pconstraint pty ->
+    approx_transl (fun () ->
+        (Typetexp.transl_simple_type env ~closed:false pty).ctyp_type)
+  | Pcoerce (_constrain, coerce) ->
+    approx_transl (fun () ->
+        (Typetexp.transl_simple_type env ~closed:false coerce).ctyp_type)
+
+
+let rec type_expression env sexp =
+  match sexp.pexp_desc with
+  (* Questionable legacy approximations *)
+  | Pexp_let (_, _, sexp)
+  | Pexp_match (_, { pc_rhs = sexp } :: _)
+  | Pexp_ifthenelse (_, sexp, _)
+  | Pexp_sequence (_, sexp)
+  | Pexp_try (sexp, _) -> type_expression env sexp
+  (* 'Telescope' approximations *)
+  | Pexp_function (params, ret_constraint, body) ->
+    type_function env params ret_constraint body
+  | Pexp_tuple components -> type_tuple env components
+  | Pexp_constraint (_, sconstraint) ->
+    type_constraint env (Pconstraint sconstraint)
+  | Pexp_coerce (_, sty1, sty2) -> type_constraint env (Pcoerce (sty1, sty2))
+  | Pexp_pack (_, Some ptyp) ->
+    let loc = sexp.pexp_loc in
+    let sty = Ast_helper.Typ.package ~loc ptyp in
+    type_constraint env (Pconstraint sty)
+  | _ -> unknown ()
+
+
+and type_tuple env components =
+  let labeled_tys =
+    List.map
+      (fun (label, component) -> label, type_expression env component)
+      components
+  in
+  newty (Ttuple labeled_tys)
+
+
+and type_function env params ret_constraint body =
+  (* We can approximate types up to the first newtype parameter or potential
+     dependent module argument, whereupon we give up. *)
+  match params with
+  | { pparam_desc =
+        Pparam_val
+          (Nolabel, _, { ppat_desc = Ppat_unpack ({ txt = Some _ }, _); _ })
+    }
+    :: _params
+  | { pparam_desc = Pparam_newtype _ } :: _params -> unknown ()
+  | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
+    type_function_param
+      env
+      (`Pat (label, default, pat))
+      ~ret_ty:(type_function env params ret_constraint body)
+  | [] ->
+    (match ret_constraint with
+    | Some sconstraint -> type_constraint env sconstraint
+    | None ->
+      (match body with
+      | Pfunction_body sbody -> type_expression env sbody
+      | Pfunction_cases ({ pc_rhs = sbody } :: _, _, _) ->
+        type_function_param env `Cases ~ret_ty:(type_expression env sbody)
+      | Pfunction_cases ([], _, _) ->
+        (* This case is in fact not reachable. *)
+        assert false))

--- a/typing/type_approx.ml
+++ b/typing/type_approx.ml
@@ -19,37 +19,51 @@ open Types
 open Ctype
 open Predef
 
-let unknown () = newvar ()
 
-let approx_transl f =
-  try f () with
-  | _ -> unknown ()
+module Approx_env = struct
+  type t =
+    { env : Env.t
+    ; mono_lvl : int
+    }
 
+  let create ~env ?(mono_lvl = get_current_level ()) () = { env; mono_lvl }
 
-let match_or_keep_matchee env ty ~matchee =
+  (* [unknown t] returns a fresh 'unknown' type which indicates that
+     we cannot accurately approximate the type. *)
+  let unknown t = newvar2 t.mono_lvl
+
+  let approx_transl t f =
+    try
+      Typetexp.TyVarEnv.with_any_var_level ~level:t.mono_lvl (fun () ->
+          f t.env)
+    with
+    | _ -> unknown t
+end
+
+let match_or_keep_matchee (aenv : Approx_env.t) ty ~matchee =
   try
-    unify env ty matchee;
+    unify aenv.env ty matchee;
     matchee
   with
   | _ -> matchee
 
 
-let type_pattern env spat =
+let type_pattern aenv spat =
   match spat.ppat_desc with
   | Ppat_constraint (_, sty) ->
-    approx_transl (fun () ->
+    Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false sty).ctyp_type)
   | _ ->
     (* We do not approximate deep within the pattern. *)
-    unknown ()
+    Approx_env.unknown aenv
 
 
-let type_function_param env spat ~ret_ty =
+let type_function_param aenv spat ~ret_ty =
   let label, param_ty =
     match spat with
-    | `Cases -> Nolabel, newmono (unknown ())
+    | `Cases -> Nolabel, newmono (Approx_env.unknown aenv)
     | `Pat (label, default, spat) ->
-      let pat_ty = type_pattern env spat in
+      let pat_ty = type_pattern aenv spat in
       let param_ty =
         match label, default with
         | (Nolabel | Labelled _), _ ->
@@ -65,7 +79,7 @@ let type_function_param env spat ~ret_ty =
           (* The pattern must match on an option type (since no default is
              provided). *)
           let pat_ty =
-            match_or_keep_matchee env pat_ty ~matchee:(type_option (newvar ()))
+            match_or_keep_matchee aenv pat_ty ~matchee:(type_option (newvar ()))
           in
           newmono pat_ty
         | Optional _, Some _ ->
@@ -78,48 +92,48 @@ let type_function_param env spat ~ret_ty =
   newty (Tarrow (label, param_ty, ret_ty, commu_ok))
 
 
-let type_constraint env sconstraint =
+let type_constraint aenv sconstraint =
   match sconstraint with
   | Pconstraint pty ->
-    approx_transl (fun () ->
+    Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false pty).ctyp_type)
   | Pcoerce (_constrain, coerce) ->
-    approx_transl (fun () ->
+    Approx_env.approx_transl aenv (fun env ->
         (Typetexp.transl_simple_type env ~closed:false coerce).ctyp_type)
 
 
-let rec type_expression env sexp =
+let rec type_expression aenv sexp =
   match sexp.pexp_desc with
   (* Questionable legacy approximations *)
   | Pexp_let (_, _, sexp)
   | Pexp_match (_, { pc_rhs = sexp } :: _)
   | Pexp_ifthenelse (_, sexp, _)
   | Pexp_sequence (_, sexp)
-  | Pexp_try (sexp, _) -> type_expression env sexp
+  | Pexp_try (sexp, _) -> type_expression aenv sexp
   (* 'Telescope' approximations *)
   | Pexp_function (params, ret_constraint, body) ->
-    type_function env params ret_constraint body
-  | Pexp_tuple components -> type_tuple env components
+    type_function aenv params ret_constraint body
+  | Pexp_tuple components -> type_tuple aenv components
   | Pexp_constraint (_, sconstraint) ->
-    type_constraint env (Pconstraint sconstraint)
-  | Pexp_coerce (_, sty1, sty2) -> type_constraint env (Pcoerce (sty1, sty2))
+    type_constraint aenv (Pconstraint sconstraint)
+  | Pexp_coerce (_, sty1, sty2) -> type_constraint aenv (Pcoerce (sty1, sty2))
   | Pexp_pack (_, Some ptyp) ->
     let loc = sexp.pexp_loc in
     let sty = Ast_helper.Typ.package ~loc ptyp in
-    type_constraint env (Pconstraint sty)
-  | _ -> unknown ()
+    type_constraint aenv (Pconstraint sty)
+  | _ -> Approx_env.unknown aenv
 
 
-and type_tuple env components =
+and type_tuple aenv components =
   let labeled_tys =
     List.map
-      (fun (label, component) -> label, type_expression env component)
+      (fun (label, component) -> label, type_expression aenv component)
       components
   in
   newty (Ttuple labeled_tys)
 
 
-and type_function env params ret_constraint body =
+and type_function aenv params ret_constraint body =
   (* We can approximate types up to the first newtype parameter or potential
      dependent module argument, whereupon we give up. *)
   match params with
@@ -128,20 +142,20 @@ and type_function env params ret_constraint body =
           (Nolabel, _, { ppat_desc = Ppat_unpack ({ txt = Some _ }, _); _ })
     }
     :: _params
-  | { pparam_desc = Pparam_newtype _ } :: _params -> unknown ()
+  | { pparam_desc = Pparam_newtype _ } :: _params -> Approx_env.unknown aenv
   | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
     type_function_param
-      env
+      aenv
       (`Pat (label, default, pat))
-      ~ret_ty:(type_function env params ret_constraint body)
+      ~ret_ty:(type_function aenv params ret_constraint body)
   | [] ->
     (match ret_constraint with
-    | Some sconstraint -> type_constraint env sconstraint
+    | Some sconstraint -> type_constraint aenv sconstraint
     | None ->
       (match body with
-      | Pfunction_body sbody -> type_expression env sbody
+      | Pfunction_body sbody -> type_expression aenv sbody
       | Pfunction_cases ({ pc_rhs = sbody } :: _, _, _) ->
-        type_function_param env `Cases ~ret_ty:(type_expression env sbody)
+        type_function_param aenv `Cases ~ret_ty:(type_expression aenv sbody)
       | Pfunction_cases ([], _, _) ->
         (* This case is in fact not reachable. *)
         assert false))

--- a/typing/type_approx.mli
+++ b/typing/type_approx.mli
@@ -23,5 +23,15 @@
 
 open Types
 
-(** [type_expression env exp] computes a type approximation for [exp]. *)
-val type_expression : Env.t -> Parsetree.expression -> type_expr
+(** [type_expression ~env ?mono_lvl exp] computes a type approximation
+    for [exp] in environment [env].
+
+    The [mono_lvl] parameter specifies the level at which fresh type
+    variables are generated when precise typing information is unavailable
+    or deliberately approximated. If not provided, it defaults to the
+    current level. *)
+val type_expression
+  :  env:Env.t
+  -> ?mono_lvl:int
+  -> Parsetree.expression
+  -> type_expr

--- a/typing/type_approx.mli
+++ b/typing/type_approx.mli
@@ -1,0 +1,27 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Alistair O'Brien, University of Cambridge             *)
+(*                                                                        *)
+(*   Copyright 2026, Alistair O'Brien                                     *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Approximate typing
+
+    This module computes *best-effort* approximations of inferred types
+    without performing full type inference. It is intended for typing
+    recursive functions.
+
+    All functions are conservative and never raise errors: always
+    returning a fresh unknown type instead. *)
+
+open Types
+
+(** [type_expression env exp] computes a type approximation for [exp]. *)
+val type_expression : Env.t -> Parsetree.expression -> type_expr

--- a/typing/type_approx.mli
+++ b/typing/type_approx.mli
@@ -23,5 +23,19 @@
 
 open Types
 
-(** [type_expression env exp] computes a type approximation for [exp]. *)
-val type_expression : Env.t -> Parsetree.expression -> type_expr
+module Approx_env : sig
+  (** An environment for approximate typing.
+
+      It carries an environment together with a *monomorphic level*,
+      used to generate fresh type variables when precise typing information
+      is unabailable or deliberately approximated. *)
+  type t
+
+  (** [create ~env ?mono_lvl ()] creates a fresh environment.
+
+      If [mono_lvl] is not provided, it defaults to the current level. *)
+  val create : env:Env.t -> ?mono_lvl:int -> unit -> t
+end
+
+(** [type_expression aenv exp] computes a type approximation for [exp]. *)
+val type_expression : Approx_env.t -> Parsetree.expression -> type_expr

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -774,12 +774,12 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
              try
                match get_desc ty with
                | Tvar _ ->
-                   let ty' = Ctype.newvar () in
-                   Ctype.unify val_env (Ctype.newmono ty') ty;
-                   type_approx val_env sbody ty'
+                 let ty' = Type_approx.type_expression val_env sbody in
+                 Ctype.unify val_env (Ctype.newmono ty') ty
                | Tpoly (ty1, tl) ->
-                   let ty1' = Ctype.instance_poly tl ty1 in
-                   type_approx val_env sbody ty1'
+                 let ty1' = Ctype.instance_poly tl ty1 in
+                 let ty2' = Type_approx.type_expression val_env sbody in
+                 Ctype.unify val_env ty2' ty1'
                | _ -> assert false
              with Ctype.Unify err ->
                raise(Error(loc, val_env,

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -774,11 +774,17 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
              try
                match get_desc ty with
                | Tvar _ ->
-                 let ty' = Type_approx.type_expression val_env sbody in
+                 let ty' =
+                   Type_approx.(
+                     type_expression (Approx_env.create ~env:val_env ()) sbody)
+                 in
                  Ctype.unify val_env (Ctype.newmono ty') ty
                | Tpoly (ty1, tl) ->
                  let ty1' = Ctype.instance_poly tl ty1 in
-                 let ty2' = Type_approx.type_expression val_env sbody in
+                 let ty2' =
+                   Type_approx.(
+                     type_expression (Approx_env.create ~env:val_env ()) sbody)
+                 in
                  Ctype.unify val_env ty2' ty1'
                | _ -> assert false
              with Ctype.Unify err ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -801,14 +801,13 @@ let rec class_field_first_pass self_loc cl_num final sign self_scope acc cf =
            add_method loc val_env label.txt priv Concrete ty sign;
            begin
              try
+               let ty_approx = Type_approx.type_expression val_env sbody in
                match get_desc ty with
                | Tvar _ ->
-                   let ty' = Ctype.newvar () in
-                   Ctype.unify val_env (Ctype.newmono ty') ty;
-                   type_approx val_env sbody ty'
+                 Ctype.unify val_env (Ctype.newmono ty_approx) ty
                | Tpoly (ty1, tl) ->
-                   let ty1' = Ctype.instance_poly tl ty1 in
-                   type_approx val_env sbody ty1'
+                 let ty1' = Ctype.instance_poly tl ty1 in
+                 Ctype.unify val_env ty_approx ty1'
                | _ -> assert false
              with Ctype.Unify err ->
                Error.log_and_raise loc val_env

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -801,7 +801,9 @@ let rec class_field_first_pass self_loc cl_num final sign self_scope acc cf =
            add_method loc val_env label.txt priv Concrete ty sign;
            begin
              try
-               let ty_approx = Type_approx.type_expression val_env sbody in
+               let ty_approx =
+                 Type_approx.type_expression ~env:val_env sbody
+               in
                match get_desc ty with
                | Tvar _ ->
                  Ctype.unify val_env (Ctype.newmono ty_approx) ty

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4223,7 +4223,6 @@ and type_expect_
       let may_contain_modules =
         List.exists (fun pvb -> may_contain_modules pvb.pvb_pat) spat_sexp_list
       in
-      let outer_level = get_current_level () in
       let (pat_exp_list, body, _new_env) =
         (* If the patterns contain module unpacks, there is a possibility that
            the types of the let body or bound expressions mention types
@@ -4234,6 +4233,9 @@ and type_expect_
           let allow_modules =
             if may_contain_modules
             then
+              (* Create a fresh scope for all module variables introduced by
+                 unpacks. The scope ends at the end of the local
+                 [with_local_level_generalize_if may_contain_modules] region. *)
               let scope = create_scope () in
               Modules_allowed { scope }
             else Modules_rejected
@@ -4247,35 +4249,15 @@ and type_expect_
             | Recursive -> annotate_recursive_bindings env pat_exp_list
             | Nonrecursive -> pat_exp_list
           in
-          (* The "bound expressions" component of the scope escape check.
-
-             This kind of scope escape is relevant only for recursive
-             module definitions.
-          *)
-          if rec_flag = Recursive && may_contain_modules then begin
-            List.iter
-              (fun vb ->
-                 (* [type_let] already generalized bound expressions' types
-                    in-place. We first take an instance before checking scope
-                    escape at the outer level to avoid losing generality of
-                    types added to [new_env].
-                 *)
-                let bound_exp = vb.vb_expr in
-                let bound_exp_type = Ctype.instance bound_exp.exp_type in
-                let loc = proper_exp_loc bound_exp in
-                let outer_var = newvar2 outer_level in
-                (* Checking unification within an environment extended with the
-                   module bindings allows us to correctly accept more programs.
-                   This environment allows unification to identify more cases
-                   where a type introduced by the module is equal to a type
-                   introduced at an outer scope. *)
-                unify_exp_types loc new_env bound_exp_type outer_var)
-              pat_exp_list
-          end;
           (pat_exp_list, body, new_env)
         end
         ~before_generalize:(fun (_pat_exp_list, body, new_env) ->
-          (* The "body" component of the scope escape check. *)
+          (* Just before generalizing the local region, we link
+             the body's type to a fresh variable in the outer region.
+
+             This forces an eager scope check to occur, preventing
+             the body's type from mentioning any module variables
+             introduced by bindings in [pat_exp_list]. *)
           unify_exp ~sexp new_env body (newvar ()))
       in
       re {
@@ -6961,7 +6943,6 @@ and type_effect_cases
         end
 
 (* Typing of let bindings *)
-
 and type_let ?check ?check_strict
     existential_context env rec_flag spat_sexp_list allow_modules =
   let spatl =  List.map vb_pat_constraint spat_sexp_list in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2304,6 +2304,13 @@ let add_pattern_variables ?check ?check_as env pv =
     )
     pv env
 
+(** [add_let_pattern_vars] adds the pattern variables [pvs] to [env] for
+    a let bindings. Additionally binds any type vars used in the patterns. *)
+let add_let_pattern_vars env ~pvs ~bind_type_vars_delayed =
+  let new_env = add_pattern_variables env pvs in
+  List.iter (fun f -> f ()) bind_type_vars_delayed;
+  new_env
+
 let add_module_variables env module_variables =
   let module_variables_as_list =
     match module_variables with
@@ -4107,6 +4114,26 @@ type 'ret constraint_arg =
     (** Whether the thing being constrained is a [Val_self] ident. *)
   }
 
+(** Performs the relaxed value restriction on a list of typed
+    value bindings (unzipped). For more information, see
+    https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.pdf *)
+let do_relaxed_value_restriction env pat_list exp_list =
+  List.iter2
+    (fun (pat, _) (exp, vars) ->
+      if maybe_expansive exp
+      then (
+        lower_contravariant env pat.pat_type;
+        if vars <> None then lower_contravariant env exp.exp_type))
+    pat_list
+    exp_list
+
+let check_let_univars env pat_list exp_list =
+  List.iter2
+    (fun (_, expected_ty) (exp, vars) ->
+      Option.iter (check_univars env "definition" exp expected_ty) vars)
+    pat_list
+    exp_list
+
 let rec type_exp ?recarg env sexp =
   (* We now delegate everything to type_expect *)
   type_expect ?recarg env sexp (mk_expected (newvar ()))
@@ -4215,57 +4242,77 @@ and type_expect_
         {sexp with
          pexp_desc = Pexp_match (sval, [Ast_helper.Exp.case spat sbody])}
         ty_expected_explained
-  | Pexp_let(rec_flag, spat_sexp_list, sbody) ->
-      let existential_context =
-        if rec_flag = Recursive then In_rec
-        else if List.compare_length_with spat_sexp_list 1 > 0 then In_group
-        else With_attributes in
-      let may_contain_modules =
-        List.exists (fun pvb -> may_contain_modules pvb.pvb_pat) spat_sexp_list
-      in
-      let (pat_exp_list, body, _new_env) =
-        (* If the patterns contain module unpacks, there is a possibility that
-           the types of the let body or bound expressions mention types
-           introduced by those unpacks. The below code checks for scope escape
-           via both of these pathways (body, bound expressions).
-        *)
-        with_local_level_generalize_if may_contain_modules begin fun () ->
-          let allow_modules =
-            if may_contain_modules
-            then
-              (* Create a fresh scope for all module variables introduced by
-                 unpacks. The scope ends at the end of the local
-                 [with_local_level_generalize_if may_contain_modules] region. *)
-              let scope = create_scope () in
-              Modules_allowed { scope }
-            else Modules_rejected
-          in
-          let (pat_exp_list, new_env) =
-            type_let existential_context env rec_flag spat_sexp_list
-              allow_modules
-          in
+  | Pexp_let (rec_flag, spat_sexp_list, sbody) ->
+      let pat_exp_list, body =
+        match rec_flag with
+        | Recursive ->
+          let pat_exp_list, new_env = type_let_rec env spat_sexp_list in
           let body = type_expect new_env sbody ty_expected_explained in
-          let pat_exp_list = match rec_flag with
-            | Recursive -> annotate_recursive_bindings env pat_exp_list
-            | Nonrecursive -> pat_exp_list
+          let pat_exp_list =
+            annotate_recursive_bindings env pat_exp_list
           in
-          (pat_exp_list, body, new_env)
-        end
-        ~before_generalize:(fun (_pat_exp_list, body, new_env) ->
-          (* Just before generalizing the local region, we link
-             the body's type to a fresh variable in the outer region.
+          pat_exp_list, body
+        | Nonrecursive ->
+          let existential_context =
+            if List.compare_length_with spat_sexp_list 1 > 0
+            then In_group
+            else With_attributes
+          in
+          let may_contain_modules =
+            List.exists
+              (fun pvb -> may_contain_modules pvb.pvb_pat)
+              spat_sexp_list
+          in
+          let pat_exp_list, body, _new_env =
+            (* If the patterns contain module unpacks, there is a possibility
+               that the types of the let body or bound expressions mention
+               types introduced by those unpacks. The below code checks for
+               scope escape via both of these pathways (body, bound
+               expressions). *)
+            with_local_level_generalize_if
+              may_contain_modules
+              (fun () ->
+                let allow_modules =
+                  if may_contain_modules
+                  then (
+                    (* Create a fresh scope for all module variables
+                       introduced by unpacks. The scope ends at the end of the
+                       [with_local_level_generalize_if may_contain_modules]
+                       region. *)
+                    let scope = create_scope () in
+                    Modules_allowed { scope })
+                  else Modules_rejected
+                in
+                let pat_exp_list, new_env =
+                  type_let_nonrec
+                    ~existential_context
+                    ~allow_modules
+                    env
+                    spat_sexp_list
+                in
+                let body =
+                  type_expect new_env sbody ty_expected_explained
+                in
+                pat_exp_list, body, new_env)
+              ~before_generalize:(fun (_pat_exp_list, body, new_env) ->
+                (* Just before generalizing the local region, we link
+                   the body's type to a fresh variable in the outer region.
 
-             This forces an eager scope check to occur, preventing
-             the body's type from mentioning any module variables
-             introduced by bindings in [pat_exp_list]. *)
-          unify_exp ~sexp new_env body (newvar ()))
+                   This forces an eager scope check to occur, preventing
+                   the body's type from mentioning any module variables
+                   introduced by bindings in [pat_exp_list]. *)
+                unify_exp ~sexp new_env body (newvar ()))
+          in
+          pat_exp_list, body
       in
-      re {
-        exp_desc = Texp_let(rec_flag, pat_exp_list, body);
-        exp_loc = loc; exp_extra = [];
-        exp_type = body.exp_type;
-        exp_attributes = sexp.pexp_attributes;
-        exp_env = env }
+      re
+        { exp_desc = Texp_let (rec_flag, pat_exp_list, body)
+        ; exp_loc = loc
+        ; exp_extra = []
+        ; exp_type = body.exp_type
+        ; exp_attributes = sexp.pexp_attributes
+        ; exp_env = env
+        }
   | Pexp_function (params, body_constraint, body) ->
       let in_function = ty_expected_explained, loc in
       let exp_type, result_params, body, newtypes, contains_gadt =
@@ -6942,148 +6989,269 @@ and type_effect_cases
           cases
         end
 
-(* Typing of let bindings *)
-and type_let ?check ?check_strict
-    existential_context env rec_flag spat_sexp_list allow_modules =
-  let spatl =  List.map vb_pat_constraint spat_sexp_list in
-  let attrs_list = List.map fst spatl in
-  let is_recursive = (rec_flag = Recursive) in
-  if is_recursive then
-    List.iter
-      (fun { pvb_pat = pat; _ } ->
-        if not (is_var_pat pat)
-        then raise (Error (pat.ppat_loc, env, Illegal_letrec_pat)))
-      spat_sexp_list;
-  let (pat_list, exp_list, new_env, mvs) =
-    with_local_level_generalize begin fun () ->
-      if existential_context = At_toplevel then Typetexp.TyVarEnv.reset ();
-      let (pat_list, new_env, force, pvs, mvs) =
-        with_local_level_generalize_structure_if_principal begin fun () ->
-          let nvs = List.map (fun _ -> newvar ()) spatl in
-          let (pat_list, _new_env, _force, _pvs, _mvs as res) =
-            with_local_level_generalize_if is_recursive (fun () ->
-              type_pattern_list
-                Value existential_context env spatl nvs allow_modules)
-          in
-          (* If recursive, first unify with an approximation of the
-             expression *)
-          if is_recursive then
-            List.iter2
-              (fun pat binding ->
-                let pat =
-                  match get_desc pat.pat_type with
-                  | Tpoly (ty, tl) ->
-                      {pat with pat_type =
-                         instance_poly ~keep_names:true tl ty}
-                  | _ -> pat
-                in
-                let bound_expr = vb_exp_constraint binding in
-                type_approx env bound_expr pat.pat_type)
-              pat_list spat_sexp_list;
-          (* Polymorphic variant processing *)
-          List.iter
-            (fun pat ->
-              if has_variants pat then begin
-                Parmatch.pressure_variants env [pat];
-                finalize_variants pat
-              end)
-            pat_list;
-          res
-        end
-      in
-      (* Note [add_module_variables after checking expressions]
-         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-         Don't call [add_module_variables] here, because its use of
-         [type_module] will fail until after we have type-checked the expression
-         of the let. Example: [let m : (module S) = ... in let (module M) = m in
-         ...] We learn the signature [S] from the type of [m] in the RHS of the
-         second let, and we need that knowledge for [type_module] to succeed. If
-         we type-checked expressions before patterns, then we could call
-         [add_module_variables] here.
-      *)
-      let new_env = add_pattern_variables new_env pvs in
-      let pat_list =
-        List.map
-          (fun pat -> {pat with pat_type = instance pat.pat_type}, pat.pat_type)
-          pat_list
-      in
-      (* Only bind pattern variables after generalizing *)
-      List.iter (fun f -> f()) force;
-
-      let exp_list =
-        (* See Note [add_module_variables after checking expressions]
-           We can't defer type-checking module variables with recursive
-           definitions, so things like [let rec (module M) = m in ...] always
-           fail, even if the type of [m] is known.
-        *)
-        let exp_env =
-          if is_recursive then add_module_variables new_env mvs else env
-        in
-        type_let_def_wrap_warnings ?check ?check_strict ~is_recursive
-          ~exp_env ~new_env ~spat_sexp_list ~attrs_list ~pat_list ~pvs
-          (fun exp_env ({pvb_attributes; _} as vb) expected_ty ->
-            let sexp = vb_exp_constraint vb in
-            match get_desc expected_ty with
-            | Tpoly (ty, tl) ->
-                let vars, ty' =
-                  with_local_level_generalize_structure_if_principal
-                    (fun () -> instance_poly_fixed ~keep_names:true tl ty)
-                in
-                let exp =
-                  Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect exp_env sexp (mk_expected ty'))
-                in
-                exp, Some vars
-            | _ ->
-                let exp =
-                  Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect exp_env sexp (mk_expected expected_ty))
-                in
-                exp, None)
-      in
-      List.iter2
-        (fun (pat, _) (attrs, exp) ->
-          Builtin_attributes.warning_scope ~ppwarning:false attrs
-            (fun () ->
-              let case = Parmatch.typed_case (case pat exp) in
-              ignore(check_partial env pat.pat_type pat.pat_loc
-                       [case] : Typedtree.partial)
-            )
-        )
-        pat_list
-        (List.map2 (fun (attrs, _) (e, _) -> attrs, e) spatl exp_list);
-      (pat_list, exp_list, new_env, mvs)
-    end
-    ~before_generalize: begin fun (pat_list, exp_list, _, _) ->
-      List.iter2 (fun (pat, _) (exp, vars) ->
-        if maybe_expansive exp then begin
-          lower_contravariant env pat.pat_type;
-          if vars <> None then lower_contravariant env exp.exp_type
-        end)
-        pat_list exp_list
-    end
-  in
-  List.iter2
-    (fun (_, expected_ty) (exp, vars) ->
-      Option.iter (check_univars env "definition" exp expected_ty) vars)
-    pat_list exp_list;
+and value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list =
   let l = List.combine pat_list exp_list in
   let l =
     List.map2
       (fun ((p, _), (e, _)) pvb ->
         (* vb_rec_kind will be computed later for recursive bindings *)
-        {vb_pat=p; vb_expr=e; vb_attributes=pvb.pvb_attributes;
-         vb_loc=pvb.pvb_loc; vb_rec_kind = Dynamic;
+        {
+          vb_pat = p;
+          vb_expr = e;
+          vb_attributes = pvb.pvb_attributes;
+          vb_loc = pvb.pvb_loc;
+          vb_rec_kind = Dynamic;
         })
       l spat_sexp_list
   in
-  List.iter (fun vb ->
-      if pattern_needs_partial_application_check vb.vb_pat then
-        check_partial_application ~statement:false vb.vb_expr
-    ) l;
+  l
+
+and type_let_rec
+    ?check
+    ?check_strict
+    ?(reset_tyvarenv = false)
+    env
+    spat_sexp_list
+  =
+  let spatl = List.map vb_pat_constraint spat_sexp_list in
+  let attrs_list = List.map fst spatl in
+  (* Recursive patterns can only consist of (possibly annotated)
+     variables. *)
+  List.iter
+    (fun { pvb_pat = pat; _ } ->
+      if not (is_var_pat pat)
+      then raise (Error (pat.ppat_loc, env, Illegal_letrec_pat)))
+    spat_sexp_list;
+  let pat_list, exp_list, new_env =
+    with_local_level_generalize
+      begin fun () ->
+        (* We must reset the tyvarenv in this local region since it
+           resets the global level *)
+        if reset_tyvarenv then Typetexp.TyVarEnv.reset ();
+        let pat_list, new_env, bind_type_vars_delayed, pvs =
+          with_local_level_generalize_structure_if_principal begin fun () ->
+              (* Typecheck the patterns *)
+              let nvs = List.map (fun _ -> newvar ()) spatl in
+              let pat_list, new_env, force, pvs, _mvs =
+                with_local_level_generalize begin fun () ->
+                    type_pattern_list
+                      Value
+                      In_rec
+                      env
+                      spatl
+                      nvs
+                      Modules_rejected
+                end
+              in
+              (* Approximate the type of the recursive binding *)
+              List.iter2
+                (fun pat binding ->
+                  let pat =
+                    match get_desc pat.pat_type with
+                    | Tpoly (ty, tl) ->
+                      { pat with
+                        pat_type = instance_poly ~keep_names:true tl ty
+                      }
+                    | _ -> pat
+                  in
+                  let bound_expr = vb_exp_constraint binding in
+                  type_approx env bound_expr pat.pat_type)
+                pat_list
+                spat_sexp_list;
+              pat_list, new_env, force, pvs
+          end
+        in
+        let new_env =
+          add_let_pattern_vars new_env ~pvs ~bind_type_vars_delayed
+        in
+        let pat_list, exp_list =
+          type_let_exps
+            ?check
+            ?check_strict
+            ~is_recursive:true
+            ~exp_env:new_env
+            ~new_env
+            ~attrs_list
+            ~pat_list
+            ~pvs
+            spat_sexp_list
+        in
+        pat_list, exp_list, new_env
+      end
+      ~before_generalize:(fun (pat_list, exp_list, _) ->
+        do_relaxed_value_restriction env pat_list exp_list)
+  in
+  check_let_univars env pat_list exp_list;
+  value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list, new_env
+
+and type_let_nonrec
+    ?check
+    ?check_strict
+    ?(reset_tyvarenv = false)
+    ~existential_context
+    ~allow_modules
+    env
+    spat_sexp_list
+  =
+  let spatl = List.map vb_pat_constraint spat_sexp_list in
+  let attrs_list = List.map fst spatl in
+  let pat_list, exp_list, new_env, mvs =
+    with_local_level_generalize
+      begin fun () ->
+        (* We must reset the tyvarenv in this local region since it
+           resets the global level *)
+        if reset_tyvarenv then Typetexp.TyVarEnv.reset ();
+        let pat_list, new_env, bind_type_vars_delayed, pvs, mvs =
+          with_local_level_generalize_structure_if_principal begin fun () ->
+              let nvs = List.map (fun _ -> newvar ()) spatl in
+              let ((pat_list, _new_env, _bind_type_vars_delayed, _pvs, _mvs) as
+                  res)
+                =
+                type_pattern_list
+                  Value
+                  existential_context
+                  env
+                  spatl
+                  nvs
+                  allow_modules
+              in
+              (* Polymorphic variant processing *)
+              List.iter
+                (fun pat ->
+                  if has_variants pat
+                  then (
+                    Parmatch.pressure_variants env [ pat ];
+                    finalize_variants pat))
+                pat_list;
+              res
+          end
+        in
+        (* Note [add_module_variables after checking expressions]
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+           Don't call [add_module_variables] here, because its use of
+           [type_module] will fail until after we have type-checked the
+           expression of the let.
+
+           Consider:
+           {[
+            let m : (module S) = ... in let (module M) = m in ...
+           |}
+
+           When typing the *second* let binding, we only learn that the
+           signature of [M] is [S] from the RHS (by propagation of [m]'s
+           known type). We need this signature for [type_module] in
+           [add_module_variables] to succeed.
+
+           Namely [add_module_variables] attempts to typecheck [val m']
+           where [m'] is the bound pattern variable for the unpacked
+           [(module M)] (added in [add_pattern_variables]). [m']'s type is
+           unknown until we typecheck the RHS [m] and unify it's type with
+           [m]'s (i.e. [(module S)]).
+
+           If we type-checked expressions before patterns, then we could call
+           [add_module_variables] here.
+        *)
+        let new_env =
+          add_let_pattern_vars new_env ~pvs ~bind_type_vars_delayed
+        in
+        let pat_list, exp_list =
+          type_let_exps
+            ?check
+            ?check_strict
+            ~is_recursive:false
+            ~exp_env:env
+            ~new_env
+            ~attrs_list
+            ~pat_list
+            ~pvs
+            spat_sexp_list
+        in
+        (* Do exhaustiveness checks on patterns *)
+        List.iter2
+          (fun (pat, _) (attrs, exp) ->
+            Builtin_attributes.warning_scope ~ppwarning:false attrs (fun () ->
+                let case = Parmatch.typed_case (case pat exp) in
+                ignore
+                  (check_partial env pat.pat_type pat.pat_loc [ case ]
+                    : Typedtree.partial)))
+          pat_list
+          (List.map2 (fun (attrs, _) (e, _) -> attrs, e) spatl exp_list);
+        pat_list, exp_list, new_env, mvs
+      end
+      ~before_generalize:(fun (pat_list, exp_list, _, _) ->
+        do_relaxed_value_restriction env pat_list exp_list)
+  in
+  check_let_univars env pat_list exp_list;
+  let l = value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list in
+  List.iter
+    (fun vb ->
+      if pattern_needs_partial_application_check vb.vb_pat
+      then check_partial_application ~statement:false vb.vb_expr)
+    l;
   (* See Note [add_module_variables after checking expressions] *)
   let new_env = add_module_variables new_env mvs in
-  (l, new_env)
+  l, new_env
+
+and type_let_exps
+    ?check
+    ?check_strict
+    ~is_recursive
+    ~exp_env
+    ~new_env
+    ~attrs_list
+    ~pat_list
+    ~pvs
+    spat_sexp_list
+  =
+  (* Instantiate the pattern types.
+
+     Here, the instantiated type is used in [type_let_def_wrap_warnings] as
+     the pattern type, whereas the non-instantiated type is used as an
+     expected type in [check_let_univars]. This improves principality checks. *)
+  let pat_list =
+    List.map
+      (fun pat -> { pat with pat_type = instance pat.pat_type }, pat.pat_type)
+      pat_list
+  in
+  let exp_list =
+    type_let_def_wrap_warnings
+      ?check
+      ?check_strict
+      ~is_recursive
+      ~exp_env
+      ~new_env
+      ~spat_sexp_list
+      ~attrs_list
+      ~pat_list
+      ~pvs
+      (fun exp_env ({ pvb_attributes; _ } as vb) expected_ty ->
+        let sexp = vb_exp_constraint vb in
+        (* Type annotations of the form ['a ... 'c. tau] on patterns
+           (typically introduced in [let rec x : 'a ... 'c. tau = ...])
+           introduce polytypes.
+
+           Here, we must take particular care to instantiate the polytypes
+           and then check that the instantiated univars are generalized.
+           This is performed by [check_let_univars]. *)
+        match get_desc expected_ty with
+        | Tpoly (ty, tl) ->
+          let vars, ty' =
+            with_local_level_generalize_structure_if_principal (fun () ->
+                instance_poly_fixed ~keep_names:true tl ty)
+          in
+          let exp =
+            Builtin_attributes.warning_scope pvb_attributes (fun () ->
+                type_expect exp_env sexp (mk_expected ty'))
+          in
+          exp, Some vars
+        | _ ->
+          let exp =
+            Builtin_attributes.warning_scope pvb_attributes (fun () ->
+                type_expect exp_env sexp (mk_expected expected_ty))
+          in
+          exp, None)
+  in
+  pat_list, exp_list
 
 and type_let_def_wrap_warnings
     ?(check = fun s -> Warnings.Unused_var s)
@@ -7340,19 +7508,32 @@ let () = type_argument' := type_argument
 (* Typing of toplevel bindings *)
 
 let type_binding env rec_flag spat_sexp_list =
-  let (pat_exp_list, new_env) =
-    type_let
-      ~check:(fun s -> Warnings.Unused_value_declaration s)
-      ~check_strict:(fun s -> Warnings.Unused_value_declaration s)
-      At_toplevel
-      env rec_flag spat_sexp_list Modules_rejected
-  in
-  (pat_exp_list, new_env)
+  let check s = Warnings.Unused_value_declaration s in
+  let check_strict s = Warnings.Unused_value_declaration s in
+  match rec_flag with
+  | Recursive ->
+    type_let_rec ~check ~check_strict ~reset_tyvarenv:true env spat_sexp_list
+  | Nonrecursive ->
+    type_let_nonrec
+      ~check
+      ~check_strict
+      ~reset_tyvarenv:true
+      ~existential_context:At_toplevel
+      ~allow_modules:Modules_rejected
+      env
+      spat_sexp_list
 
-let type_let existential_ctx env rec_flag spat_sexp_list =
-  let (pat_exp_list, new_env) =
-    type_let existential_ctx env rec_flag spat_sexp_list Modules_rejected in
-  (pat_exp_list, new_env)
+let type_let existential_context env rec_flag spat_sexp_list =
+  let reset_tyvarenv = existential_context = At_toplevel in
+  match rec_flag with
+  | Recursive -> type_let_rec ~reset_tyvarenv env spat_sexp_list
+  | Nonrecursive ->
+    type_let_nonrec
+      ~reset_tyvarenv
+      ~existential_context
+      ~allow_modules:Modules_rejected
+      env
+      spat_sexp_list
 
 (* Typing of toplevel expressions *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3717,127 +3717,6 @@ let loc_rest_of_function
   | [], Pfunction_body pexp -> pexp.pexp_loc
   | [], Pfunction_cases (_, loc_cases, _) -> loc_cases
 
-(* Approximate the type of an expression, for better recursion *)
-
-let rec approx_type env sty =
-  match sty.ptyp_desc with
-  | Ptyp_arrow (p, ({ ptyp_desc = Ptyp_poly _ } as arg_sty), sty) ->
-    if is_optional p then newvar ()
-    else begin
-      let arg_ty =
-        (* Polymorphic types will only unify with types that match all of their
-         polymorphic parts, so we need to fully translate the type here
-         unlike in the monomorphic case *)
-        Typetexp.transl_simple_type env ~closed:false arg_sty
-      in
-      newty (Tarrow (p, arg_ty.ctyp_type, approx_type env sty, commu_ok))
-    end
-  | Ptyp_arrow (p, _, sty) ->
-      let ty1 = if is_optional p then type_option (newvar ()) else newvar () in
-      newty (Tarrow (p, newmono ty1, approx_type env sty, commu_ok))
-  | Ptyp_tuple args ->
-      newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
-  | Ptyp_constr (lid, ctl) ->
-      let path, decl = Env.lookup_type ~use:false ~loc:lid.loc lid.txt env in
-      if List.length ctl <> decl.type_arity then newvar ()
-      else begin
-        let tyl = List.map (approx_type env) ctl in
-        newconstr path tyl
-      end
-  | _ -> newvar ()
-
-let type_pattern_approx env spat ty_expected =
-  match spat.ppat_desc with
-  | Ppat_constraint (_, sty) ->
-      let inferred_ty =
-        match sty with
-        | {ptyp_desc=Ptyp_poly _} ->
-          let inferred_ty =
-            Typetexp.transl_simple_type env ~closed:false sty
-          in
-          inferred_ty.ctyp_type
-        | _ -> approx_type env sty
-      in
-      begin try unify_pat_types spat.ppat_loc env inferred_ty ty_expected
-        with Unify trace ->
-        Error.log_and_raise spat.ppat_loc env (Pattern_type_clash(trace, None))
-      end;
-  | _ -> ()
-
-let type_approx_fun_one_param
-  env label default spato ty_expected ~first ~in_function =
-  (* [spato] is [None] when approximating a [Pfunction_cases],
-     the parameter is implicit in that case. *)
-  let has_poly =
-    match spato with
-    | None -> false
-    | Some spat -> check_poly_constraint spat env label
-  in
-  let { ty_param; ty_ret } =
-    match
-      filter_arrow env ~in_apply:false ty_expected label ~param_hole:has_poly
-    with
-    | Ok filtered_arrow -> filtered_arrow
-    | Error err ->
-      let loc_fun, ty_fun = in_function in
-      let err =
-        error_of_filter_arrow_failure ~explanation:None ty_fun err ~first
-      in
-      let level = get_level (instance ty_expected) in
-      Error.log_or_raise loc_fun env err;
-      let ty_param = newty2 ~level (Tpoly (newvar2 level, [])) in
-      { ty_param; ty_ret = ty_expected}
-
-  in
-  begin
-    match spato with
-    | None -> ()
-    | Some spat ->
-        let ty_param =
-          match label, default with
-          | (Nolabel | Labelled _), _ -> ty_param
-          | Optional _, None ->
-            let var = newmono (type_option (newvar ())) in
-            unify_pat_types spat.ppat_loc env ty_param var;
-            ty_param
-          | Optional _, Some _ ->
-            let ty_opt_param = newvar () in
-            let ty_pat_param = newmono (type_option ty_opt_param) in
-            unify_pat_types spat.ppat_loc env ty_param ty_pat_param;
-            newmono ty_opt_param
-        in
-        let ty_param =
-          if has_poly || not (Btype.tpoly_is_mono ty_param) then ty_param
-          else Btype.tpoly_get_mono  ty_param
-        in
-        type_pattern_approx env spat ty_param;
-  end;
-  ty_ret
-
-let type_approx_constraint env constraint_ ~loc ty_expected =
-  match constraint_ with
-  | Pconstraint constrain ->
-      let ty_constrain = approx_type env constrain in
-      begin try unify env ty_constrain ty_expected with Unify err ->
-        Error.log_and_raise loc env (Expr_type_clash (err, None, None))
-      end;
-      ty_constrain
-  | Pcoerce (constrain, coerce) ->
-      let ty_constrain = match constrain with
-        | None -> newvar ()
-        | Some sty -> approx_type env sty
-      in
-      let ty_coerce = approx_type env coerce in
-      begin try unify env ty_coerce ty_expected with Unify err ->
-        Error.log_and_raise loc env (Expr_type_clash (err, None, None))
-      end;
-      ty_constrain
-
-let type_approx_constraint_opt env constraint_ ~loc ty_expected =
-  match constraint_ with
-  | None -> ty_expected
-  | Some constraint_ -> type_approx_constraint env constraint_ ~loc ty_expected
-
 let is_unpack pat =
   match pat.ppat_desc with
     Ppat_unpack ({ txt = Some _ }, _) -> true
@@ -3847,80 +3726,6 @@ let could_be_functor env ty =
   match get_desc (expand_head env ty) with
   | Tvar _ | Tfunctor _ -> true
   | _ -> false
-
-let rec type_approx env sexp ty_expected =
-  let loc = sexp.pexp_loc in
-  match sexp.pexp_desc with
-    Pexp_let (_, _, e) -> type_approx env e ty_expected
-  | Pexp_function (params, c, body) ->
-      let in_function = loc, ty_expected in
-      let first = true in
-      type_approx_function env params c body ty_expected ~in_function ~first
-  | Pexp_match (_, {pc_rhs=e}::_) -> type_approx env e ty_expected
-  | Pexp_try (e, _) -> type_approx env e ty_expected
-  | Pexp_tuple l -> type_tuple_approx env sexp.pexp_loc ty_expected l
-  | Pexp_ifthenelse (_,e,_) -> type_approx env e ty_expected
-  | Pexp_sequence (_,e) -> type_approx env e ty_expected
-  | Pexp_constraint (e, sty) ->
-      let ty_expected =
-        type_approx_constraint env (Pconstraint sty) ~loc ty_expected
-      in
-      type_approx env e ty_expected
-  | Pexp_coerce (_, sty1, sty2) ->
-      ignore @@
-      type_approx_constraint env (Pcoerce (sty1, sty2)) ~loc ty_expected
-  | Pexp_pack (_, Some ptyp) ->
-      let sty = Ast_helper.Typ.package ~loc ptyp in
-      ignore @@
-      type_approx_constraint env (Pconstraint sty) ~loc ty_expected
-  | _ -> ()
-
-and type_tuple_approx (env: Env.t) loc ty_expected l =
-  let labeled_tys = List.map (fun (label, _) -> label, newvar ()) l in
-  let ty = newty (Ttuple labeled_tys) in
-  begin try unify env ty ty_expected with Unify err ->
-    Error.log_and_raise loc env (Expr_type_clash (err, None, None))
-  end;
-  List.iter2
-    (fun (_, e) (_, ty) -> type_approx env e ty)
-    l labeled_tys
-
-and type_approx_function env params c body ty_expected ~in_function ~first =
-  let loc_function, _ = in_function in
-  let loc = loc_rest_of_function ~first ~loc_function params body in
-  (* We can approximate types up to the first newtype parameter or potential
-     dependent module argument, whereupon we give up.
-  *)
-  match params with
-    { pparam_desc = Pparam_val (label, None, pat)} :: _
-      when is_unpack pat && not (is_optional label) -> ()
-  | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
-      let ty_res =
-        type_approx_fun_one_param env label default (Some pat) ty_expected
-          ~first ~in_function
-      in
-      type_approx_function env params c body ty_res ~in_function ~first:false
-  | { pparam_desc = Pparam_newtype _ } :: _ -> ()
-  | [] ->
-      (* In the [Pconstraint] case, we override the [ty_expected] that
-         gets passed to the approximating of the rest of the type.
-      *)
-      let ty_expected =
-        type_approx_constraint_opt env c ty_expected ~loc
-      in
-      match body with
-      | Pfunction_body body ->
-          type_approx env body ty_expected
-      | Pfunction_cases ({pc_rhs = e} :: _, _, _) ->
-          let ty_res =
-            type_approx_fun_one_param env Nolabel None None ty_expected
-              ~in_function ~first
-          in
-          type_approx env e ty_res
-      | Pfunction_cases ([], _, _) ->
-          (* This case is in fact not reachable. Doing nothing would be the
-             correct thing to do if it were to be reachable in the future. *)
-          ()
 
 (* Check that all univars are safe in a type. Both ty_actual and
    ty_expected should already be generalized. *)
@@ -7604,7 +7409,8 @@ and type_let_rec
                     | _ -> pat
                   in
                   let bound_expr = vb_exp_constraint binding in
-                  type_approx env bound_expr pat.pat_type)
+                  let approx_ty = Type_approx.type_expression env bound_expr in
+                  unify_pat env pat approx_ty)
                 pat_list
                 spat_sexp_list;
               pat_list, new_env, force, pvs

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3866,25 +3866,52 @@ let may_lower_contravariant env exp =
 
 (* value binding elaboration *)
 
-let vb_exp_constraint {pvb_expr=expr; pvb_pat=pat; pvb_constraint=ct; _ } =
+
+let vb_exp_constraint { pvb_expr = expr; pvb_pat = pat; pvb_constraint = ct; _ }
+  =
   let open Ast_helper in
-  match ct with
-  | None -> expr
-  | Some (Pvc_constraint { locally_abstract_univars=[]; typ }) ->
-      begin match typ.ptyp_desc with
-      | Ptyp_poly _ -> expr
-      | _ ->
-          let loc = { expr.pexp_loc with Location.loc_ghost = true } in
-          Exp.constraint_ ~loc expr typ
-      end
-  | Some (Pvc_coercion { ground; coercion}) ->
-      let loc = { expr.pexp_loc with Location.loc_ghost = true } in
-      Exp.coerce ~loc expr ground coercion
-  | Some (Pvc_constraint { locally_abstract_univars=vars;typ}) ->
-      let loc_start = pat.ppat_loc.Location.loc_start in
-      let loc = { expr.pexp_loc with loc_start; loc_ghost=true } in
-      let expr = Exp.constraint_ ~loc expr typ in
-      List.fold_right (Exp.newtype ~loc) vars expr
+  match pat.ppat_desc, ct with
+  | Ppat_constraint (_, typ), None ->
+    let loc = { expr.pexp_loc with Location.loc_ghost = true } in
+    Exp.constraint_ ~loc expr typ
+  | _, None -> expr
+  | _, Some (Pvc_constraint { locally_abstract_univars = []; typ }) ->
+    (* Here we permit [Pexp_constraint] to carry a [Ptyp_poly],
+       since [typ] may be a [Ptyp_poly]. This will be typed
+       as expected and is required by [Type_approx] to give
+       the approximated type a *polymorphic* type. *)
+    let loc = { expr.pexp_loc with Location.loc_ghost = true } in
+    Exp.constraint_ ~loc expr typ
+  | _, Some (Pvc_coercion { ground; coercion }) ->
+    let loc = { expr.pexp_loc with Location.loc_ghost = true } in
+    Exp.coerce ~loc expr ground coercion
+  | _, Some (Pvc_constraint { locally_abstract_univars = vars; typ }) ->
+    (* For locally abstract types, we introduce [newtype]
+       binders and a polymorphic annotation. The [newtype]
+       binders introduce the locally abstract types in [expr]
+       and the polymorphic annotation ensures that locally abstract
+       types are indeed generalizable.
+
+       It is worth noting that the [newtype] binders alone are
+       insufficient, as in the following example:
+       {[
+       # let f = fun (type a) : a option ref -> ref None;;
+       val f : '_a option ref
+       ]}
+       Here, the locally abstract [a] isn't guaranteed to
+       be generalizable (in fact it cannot be generalized due
+       to the value restriction)
+    *)
+    let loc_start = pat.ppat_loc.Location.loc_start in
+    let loc = { expr.pexp_loc with loc_start; loc_ghost = true } in
+    let body =
+      List.fold_right
+        (Exp.newtype ~loc)
+        vars
+        (Exp.constraint_ ~loc expr typ)
+    in
+    let varified = Typ.varify_constructors vars typ in
+    Exp.constraint_ ~loc body (Typ.poly ~loc:typ.ptyp_loc vars varified)
 
 let vb_pat_constraint ({pvb_pat=pat; pvb_expr = exp; _ } as vb) =
   vb.pvb_attributes,
@@ -6916,6 +6943,29 @@ and value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list =
   in
   l
 
+and type_var_pattern_list ~env ~existential_restriction pat_list pat_types =
+  let pat_list, env, bind_type_vars_delayed, pvs, mvs =
+    type_pattern_list
+      Value
+      existential_restriction
+      env
+      pat_list
+      pat_types
+      Modules_rejected
+  in
+  (* The accumulated module variables [mvs] must be
+     empty, since module unpacking is forbidden in
+     'var'-patterns. *)
+  ignore mvs;
+  (* The updated environment [env] cannot introduce
+     any GADT equations, rigid type variables, etc
+     in 'var'-patterns. *)
+  ignore env;
+  (* HACK: It is useful to obtain the list of bound variables
+           in the order of patterns. This is in fact the
+           reverse of the list of variables in [pvs]. *)
+  pat_list, bind_type_vars_delayed, List.rev pvs
+
 and type_let_rec
     ?check
     ?check_strict
@@ -6923,7 +6973,9 @@ and type_let_rec
     env
     spat_sexp_list
   =
-  let spatl = List.map vb_pat_constraint spat_sexp_list in
+  let spatl =
+    List.map (fun vb -> vb.pvb_attributes, vb.pvb_pat) spat_sexp_list
+  in
   let attrs_list = List.map fst spatl in
   (* Recursive patterns can only consist of (possibly annotated)
      variables. *)
@@ -6934,68 +6986,75 @@ and type_let_rec
     spat_sexp_list;
   let pat_list, exp_list, new_env =
     with_local_level_generalize
-      begin fun () ->
+      (fun () ->
         (* We must reset the tyvarenv in this local region since it
            resets the global level *)
         if reset_tyvarenv then Typetexp.TyVarEnv.reset ();
-        let pat_list, new_env, bind_type_vars_delayed, pvs =
-          with_local_level_generalize_structure_if_principal begin fun () ->
-              (* Typecheck the patterns *)
-              let nvs = List.map (fun _ -> newvar ()) spatl in
-              let pat_list, new_env, force, pvs, _mvs =
-                with_local_level_generalize begin fun () ->
-                    type_pattern_list
-                      Value
-                      In_rec
-                      env
-                      spatl
-                      nvs
-                      Modules_rejected
-                end
-              in
-              (* Approximate the type of the recursive binding *)
-              List.iter2
-                (fun pat binding ->
-                  let pat =
-                    match get_desc pat.pat_type with
-                    | Tpoly (ty, tl) ->
-                      { pat with
-                        pat_type = instance_poly ~keep_names:true tl ty
-                      }
-                    | _ -> pat
-                  in
-                  let bound_expr = vb_exp_constraint binding in
-                  let approx_ty =
-                    Type_approx.(
-                      type_expression (Approx_env.create ~env ()) bound_expr)
-                  in
-                  unify_pat env pat approx_ty)
-                pat_list
-                spat_sexp_list;
-              pat_list, new_env, force, pvs
-          end
+        let pat_list, bind_type_vars_delayed, pvs =
+          let nvs = List.map (fun _ -> newvar ()) spatl in
+          type_var_pattern_list
+            ~env
+            ~existential_restriction:In_rec
+            spatl
+            nvs
         in
-        let new_env =
-          add_let_pattern_vars new_env ~pvs ~bind_type_vars_delayed
+        (* We create a [new_env] here which is used in [type_let_exps]
+           for the unused check. *)
+        let new_env = add_let_pattern_vars env ~pvs ~bind_type_vars_delayed in
+        (* We keep the type in [pat_list] as the 'expected' type
+           for the expression. But to typecheck recursive bindings,
+           we also introduce an approximation of the type of the
+           recursive binding. *)
+        let approx_env =
+          let approx_pvs =
+            List.map2
+              (fun pv vb ->
+                let exp = vb_exp_constraint vb in
+                let mono_lvl = get_current_level () in
+                with_local_level_generalize (fun () ->
+                    let approx_ty =
+                      Type_approx.(
+                        type_expression
+                          (Approx_env.create ~env ~mono_lvl ())
+                          exp)
+                    in
+                    { pv with pv_type = approx_ty }))
+              pvs
+              spat_sexp_list
+          in
+          add_let_pattern_vars env ~pvs:approx_pvs ~bind_type_vars_delayed:[]
         in
+        (* Ensure that the approximated environment is compatable with
+           the inferred types. *)
+        List.iter2
+          (fun pv { pvb_expr = sexp; _ } ->
+            let path = Path.Pident pv.pv_id in
+            let rec_vd = Env.find_value path approx_env in
+            let vd = Env.find_value path new_env in
+            unify_exp_types
+              sexp.pexp_loc
+              env
+              vd.val_type
+              (instance rec_vd.val_type))
+          pvs
+          spat_sexp_list;
+        (* Typecheck the expressions with the approximated environment. *)
         let pat_list, exp_list =
           type_let_exps
             ?check
             ?check_strict
             ~is_recursive:true
-            ~exp_env:new_env
+            ~exp_env:approx_env
             ~new_env
             ~attrs_list
             ~pat_list
             ~pvs
             spat_sexp_list
         in
-        pat_list, exp_list, new_env
-      end
+        pat_list, exp_list, new_env)
       ~before_generalize:(fun (pat_list, exp_list, _) ->
         do_relaxed_value_restriction env pat_list exp_list)
   in
-  check_let_univars env pat_list exp_list;
   value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list, new_env
 
 and type_let_nonrec
@@ -7218,6 +7277,8 @@ and type_let_def_wrap_warnings
        events on the bound identifiers and record them in a slot corresponding
        to the current definition (!current_slot).
        In effect, this creates a dependency graph between definitions.
+       This is captured using handlers on value definitions in [exp_env],
+       the environment used to typecheck bindings
 
      - After type checking the definition (!current_slot = None),
        when one of the bound identifier is effectively used, we trigger
@@ -7254,18 +7315,24 @@ and type_let_def_wrap_warnings
                         Location.prerr_warning vd.Types.val_loc
                           ((if !some_used then check_strict else check) name)
                     );
-                Env.set_value_used_callback
-                  vd
-                  (fun () ->
-                    match !current_slot with
-                    | Some slot ->
-                        slot := vd.val_uid :: !slot; rec_needed := true
-                    | None ->
-                        List.iter Env.mark_value_used (get_ref slot);
-                        used := true;
-                        some_used := true
-                  )
-              )
+                let on_value_used () =
+                  match !current_slot with
+                  | Some slot ->
+                    slot := vd.val_uid :: !slot;
+                    rec_needed := true
+                  | None ->
+                    List.iter Env.mark_value_used (get_ref slot);
+                    used := true;
+                    some_used := true
+                in
+                if is_recursive
+                then (
+                  (* If the `let` is recursive, we need to register
+                     handlers on the recursive bindings (which live in
+                     [exp_env]). *)
+                  let rec_vd = Env.find_value (Path.Pident id) exp_env in
+                  Env.set_value_used_callback rec_vd on_value_used);
+                Env.set_value_used_callback vd on_value_used)
               (Typedtree.pat_bound_idents pat);
               expected_ty, Some slot
            ))

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3447,122 +3447,6 @@ let loc_rest_of_function
   | [], Pfunction_body pexp -> pexp.pexp_loc
   | [], Pfunction_cases (_, loc_cases, _) -> loc_cases
 
-(* Approximate the type of an expression, for better recursion *)
-
-let rec approx_type env sty =
-  match sty.ptyp_desc with
-  | Ptyp_arrow (p, ({ ptyp_desc = Ptyp_poly _ } as arg_sty), sty) ->
-    if is_optional p then newvar ()
-    else begin
-      let arg_ty =
-        (* Polymorphic types will only unify with types that match all of their
-         polymorphic parts, so we need to fully translate the type here
-         unlike in the monomorphic case *)
-        Typetexp.transl_simple_type env ~closed:false arg_sty
-      in
-      newty (Tarrow (p, arg_ty.ctyp_type, approx_type env sty, commu_ok))
-    end
-  | Ptyp_arrow (p, _, sty) ->
-      let ty1 = if is_optional p then type_option (newvar ()) else newvar () in
-      newty (Tarrow (p, newmono ty1, approx_type env sty, commu_ok))
-  | Ptyp_tuple args ->
-      newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
-  | Ptyp_constr (lid, ctl) ->
-      let path, decl = Env.lookup_type ~use:false ~loc:lid.loc lid.txt env in
-      if List.length ctl <> decl.type_arity then newvar ()
-      else begin
-        let tyl = List.map (approx_type env) ctl in
-        newconstr path tyl
-      end
-  | _ -> newvar ()
-
-let type_pattern_approx env spat ty_expected =
-  match spat.ppat_desc with
-  | Ppat_constraint (_, sty) ->
-      let inferred_ty =
-        match sty with
-        | {ptyp_desc=Ptyp_poly _} ->
-          let inferred_ty =
-            Typetexp.transl_simple_type env ~closed:false sty
-          in
-          inferred_ty.ctyp_type
-        | _ -> approx_type env sty
-      in
-      begin try unify_pat_types spat.ppat_loc env inferred_ty ty_expected
-        with Unify trace ->
-        raise(Error(spat.ppat_loc, env, Pattern_type_clash(trace, None)))
-      end;
-  | _ -> ()
-
-let type_approx_fun_one_param
-  env label default spato ty_expected ~first ~in_function =
-  (* [spato] is [None] when approximating a [Pfunction_cases],
-     the parameter is implicit in that case. *)
-  let has_poly =
-    match spato with
-    | None -> false
-    | Some spat -> check_poly_constraint spat env label
-  in
-  let { ty_param; ty_ret } =
-    match
-      filter_arrow env ~in_apply:false ty_expected label ~param_hole:has_poly
-    with
-    | Ok filtered_arrow -> filtered_arrow
-    | Error err ->
-      let loc_fun, ty_fun = in_function in
-      let err =
-        error_of_filter_arrow_failure ~explanation:None ty_fun err ~first
-      in
-      raise (Error(loc_fun, env, err))
-  in
-  begin
-    match spato with
-    | None -> ()
-    | Some spat ->
-        let ty_param =
-          match label, default with
-          | (Nolabel | Labelled _), _ -> ty_param
-          | Optional _, None ->
-            let var = newmono (type_option (newvar ())) in
-            unify_pat_types spat.ppat_loc env ty_param var;
-            ty_param
-          | Optional _, Some _ ->
-            let ty_opt_param = newvar () in
-            let ty_pat_param = newmono (type_option ty_opt_param) in
-            unify_pat_types spat.ppat_loc env ty_param ty_pat_param;
-            newmono ty_opt_param
-        in
-        let ty_param =
-          if has_poly || not (Btype.tpoly_is_mono ty_param) then ty_param
-          else Btype.tpoly_get_mono  ty_param
-        in
-        type_pattern_approx env spat ty_param;
-  end;
-  ty_ret
-
-let type_approx_constraint env constraint_ ~loc ty_expected =
-  match constraint_ with
-  | Pconstraint constrain ->
-      let ty_constrain = approx_type env constrain in
-      begin try unify env ty_constrain ty_expected with Unify err ->
-        raise (Error (loc, env, Expr_type_clash (err, None, None)))
-      end;
-      ty_constrain
-  | Pcoerce (constrain, coerce) ->
-      let ty_constrain = match constrain with
-        | None -> newvar ()
-        | Some sty -> approx_type env sty
-      in
-      let ty_coerce = approx_type env coerce in
-      begin try unify env ty_coerce ty_expected with Unify err ->
-        raise (Error (loc, env, Expr_type_clash (err, None, None)))
-      end;
-      ty_constrain
-
-let type_approx_constraint_opt env constraint_ ~loc ty_expected =
-  match constraint_ with
-  | None -> ty_expected
-  | Some constraint_ -> type_approx_constraint env constraint_ ~loc ty_expected
 
 let is_unpack pat =
   match pat.ppat_desc with
@@ -3574,79 +3458,7 @@ let could_be_functor env ty =
   | Tvar _ | Tfunctor _ -> true
   | _ -> false
 
-let rec type_approx env sexp ty_expected =
-  let loc = sexp.pexp_loc in
-  match sexp.pexp_desc with
-    Pexp_let (_, _, e) -> type_approx env e ty_expected
-  | Pexp_function (params, c, body) ->
-      let in_function = loc, ty_expected in
-      let first = true in
-      type_approx_function env params c body ty_expected ~in_function ~first
-  | Pexp_match (_, {pc_rhs=e}::_) -> type_approx env e ty_expected
-  | Pexp_try (e, _) -> type_approx env e ty_expected
-  | Pexp_tuple l -> type_tuple_approx env sexp.pexp_loc ty_expected l
-  | Pexp_ifthenelse (_,e,_) -> type_approx env e ty_expected
-  | Pexp_sequence (_,e) -> type_approx env e ty_expected
-  | Pexp_constraint (e, sty) ->
-      let ty_expected =
-        type_approx_constraint env (Pconstraint sty) ~loc ty_expected
-      in
-      type_approx env e ty_expected
-  | Pexp_coerce (_, sty1, sty2) ->
-      ignore @@
-      type_approx_constraint env (Pcoerce (sty1, sty2)) ~loc ty_expected
-  | Pexp_pack (_, Some ptyp) ->
-      let sty = Ast_helper.Typ.package ~loc ptyp in
-      ignore @@
-      type_approx_constraint env (Pconstraint sty) ~loc ty_expected
-  | _ -> ()
 
-and type_tuple_approx (env: Env.t) loc ty_expected l =
-  let labeled_tys = List.map (fun (label, _) -> label, newvar ()) l in
-  let ty = newty (Ttuple labeled_tys) in
-  begin try unify env ty ty_expected with Unify err ->
-    raise(Error(loc, env, Expr_type_clash (err, None, None)))
-  end;
-  List.iter2
-    (fun (_, e) (_, ty) -> type_approx env e ty)
-    l labeled_tys
-
-and type_approx_function env params c body ty_expected ~in_function ~first =
-  let loc_function, _ = in_function in
-  let loc = loc_rest_of_function ~first ~loc_function params body in
-  (* We can approximate types up to the first newtype parameter or potential
-     dependent module argument, whereupon we give up.
-  *)
-  match params with
-    { pparam_desc = Pparam_val (label, None, pat)} :: _
-      when is_unpack pat && not (is_optional label) -> ()
-  | { pparam_desc = Pparam_val (label, default, pat) } :: params ->
-      let ty_res =
-        type_approx_fun_one_param env label default (Some pat) ty_expected
-          ~first ~in_function
-      in
-      type_approx_function env params c body ty_res ~in_function ~first:false
-  | { pparam_desc = Pparam_newtype _ } :: _ -> ()
-  | [] ->
-      (* In the [Pconstraint] case, we override the [ty_expected] that
-         gets passed to the approximating of the rest of the type.
-      *)
-      let ty_expected =
-        type_approx_constraint_opt env c ty_expected ~loc
-      in
-      match body with
-      | Pfunction_body body ->
-          type_approx env body ty_expected
-      | Pfunction_cases ({pc_rhs = e} :: _, _, _) ->
-          let ty_res =
-            type_approx_fun_one_param env Nolabel None None ty_expected
-              ~in_function ~first
-          in
-          type_approx env e ty_res
-      | Pfunction_cases ([], _, _) ->
-          (* This case is in fact not reachable. Doing nothing would be the
-             correct thing to do if it were to be reachable in the future. *)
-          ()
 
 (* Check that all univars are safe in a type. Both ty_actual and
    ty_expected should already be generalized. *)
@@ -7153,7 +6965,8 @@ and type_let_rec
                     | _ -> pat
                   in
                   let bound_expr = vb_exp_constraint binding in
-                  type_approx env bound_expr pat.pat_type)
+                  let approx_ty = Type_approx.type_expression env bound_expr in
+                  unify_pat env pat approx_ty)
                 pat_list
                 spat_sexp_list;
               pat_list, new_env, force, pvs

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3922,9 +3922,9 @@ and type_approx_function env params c body ty_expected ~in_function ~first =
              correct thing to do if it were to be reachable in the future. *)
           ()
 
-(* Check that all univars are safe in a type. Both exp.exp_type and
+(* Check that all univars are safe in a type. Both ty_actual and
    ty_expected should already be generalized. *)
-let check_univars env kind exp ty_expected vars =
+let check_univars ~env ~loc ~kind ty_actual ty_expected vars =
   let pty = instance ty_expected in
   let exp_ty, vars =
     with_local_level_generalize begin fun () ->
@@ -3934,8 +3934,8 @@ let check_univars env kind exp ty_expected vars =
              since body is not generic,  instance_poly_fixed only makes
              copies of nodes that have a Tunivar as descendant *)
           let _, ty' = instance_poly_fixed ~keep_names:true tl body in
-          let vars, exp_ty = instance_parameterized_type vars exp.exp_type in
-          unify_exp_types exp.exp_loc env exp_ty ty';
+          let vars, exp_ty = instance_parameterized_type vars ty_actual in
+          unify_exp_types loc env exp_ty ty';
           (exp_ty, vars)
       | _ -> assert false
     end
@@ -3946,7 +3946,7 @@ let check_univars env kind exp ty_expected vars =
     let diff = Ctype.expanded_diff env ~got:ty ~expected:ty_expected in
     let explanation = Errortrace.Univar (Quantification_mismatch errs) in
     let err = Errortrace.unification_error ~trace:[diff;explanation] in
-    Error.log_and_raise exp.exp_loc env (Less_general(kind,err))
+    Error.log_and_raise loc env (Less_general (kind, err))
 
 (* [check_statement] implements the [non-unit-statement] check.
 
@@ -4498,9 +4498,68 @@ let do_relaxed_value_restriction env pat_list exp_list =
 let check_let_univars env pat_list exp_list =
   List.iter2
     (fun (_, expected_ty) (exp, vars) ->
-      Option.iter (check_univars env "definition" exp expected_ty) vars)
+      Option.iter
+        (check_univars
+           ~env
+           ~loc:exp.exp_loc
+           ~kind:"definition"
+           exp.exp_type
+           expected_ty)
+        vars)
     pat_list
     exp_list
+
+(** [('s, 'r) poly_rule] encodes the behavior needed to type a possibly
+    polymorphic 'subject' ['s], producing a result ['r].
+    See [type_poly] for more details. *)
+type ('s, 'r) poly_rule =
+  { kind : string
+    (** A short label used in diagnostic messages (e.g. "expression",
+        "function cases", etc) *)
+  ; type_subject : Env.t -> 's -> type_expr -> 'r * type_expr
+    (** [type_subject env s ty_expected] types [s] with the
+        instanced expected type [ty_expected]. This type may
+        still be generalized, indicating that structures are
+        principally known. *)
+  ; is_expansive : 'r -> bool
+    (** [is_expansive r] returns [true] if [r] is part of an expansive
+        expression. *)
+  }
+
+let type_poly
+    (type s r)
+    ~(rule : (s, r) poly_rule)
+    ~env
+    ~loc
+    (subj : s)
+    (ty_expected : type_expr)
+    : r * type_expr
+  =
+  (* With principal typing / ambivalent types (for GADTs), we
+     need to unshare types (by generalizing) *)
+  let unshare = !Clflags.principal || Env.has_local_constraints env in
+  let is_poly = is_poly_Tpoly ty_expected in
+  let vars, ret, ret_ty =
+    (* Raise level to check univars *)
+    with_local_level_generalize_if
+      is_poly
+      (fun () ->
+        let vars, ty_subj_expected =
+          with_local_level_generalize_structure_if unshare (fun () ->
+              match get_desc ty_expected with
+              | Tpoly (sch, univars) ->
+                instance_poly_fixed ~keep_names:true univars sch
+              | _ -> [], ty_expected)
+        in
+        let ret, ret_ty = rule.type_subject env subj ty_subj_expected in
+        vars, ret, ret_ty)
+      ~before_generalize:(fun (_, ret, ret_ty) ->
+        if rule.is_expansive ret then lower_contravariant env ret_ty)
+  in
+  (* Check univars after generalizing *)
+  if is_poly
+  then check_univars ~env ~loc ~kind:rule.kind ret_ty ty_expected vars;
+  ret, instance ret_ty
 
 let rec type_exp ?recarg env sexp =
   (* We now delegate everything to type_expect *)
@@ -5195,13 +5254,19 @@ and type_expect_
         exp_type = instance Predef.type_unit;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
-  | Pexp_constraint (sarg, sty) ->
-      let (ty, exp_extra) = type_constraint env sty in
-      let arg = type_argument env sarg ty (instance ty) in
+  | Pexp_constraint (sarg, spt) ->
+      let (ty, exp_extra) = type_constraint env spt in
+      let arg = type_poly_argument env sarg ty in
+      let ty =
+        match get_desc ty with
+        | Tpoly (tybody, tyvars) ->
+          instance_poly ~keep_names:true tyvars tybody
+        | _ -> instance ty
+      in
       rue {
         exp_desc = arg.exp_desc;
         exp_loc = arg.exp_loc;
-        exp_type = instance ty;
+        exp_type = ty;
         exp_attributes = arg.exp_attributes;
         exp_env = env;
         exp_extra = (exp_extra, loc, sexp.pexp_attributes) :: arg.exp_extra;
@@ -5412,7 +5477,13 @@ and type_expect_
                 (exp, vars)
               end
             in
-            check_univars env "method" exp ty_expected vars;
+            check_univars
+              ~env
+              ~loc:exp.exp_loc
+              ~kind:"method"
+              exp.exp_type
+              ty_expected
+              vars;
             { exp with exp_type = instance ty }
         | Tvar _ ->
             let exp = type_exp env sbody in
@@ -6644,8 +6715,35 @@ and type_label_exp create env loc ty_expected
     end
     ~before_generalize:(fun (_,arg) -> may_lower_contravariant env arg)
   in
-  if is_poly then check_univars env "field value" arg label.lbl_arg vars;
+  if is_poly
+  then
+    check_univars
+      ~env
+      ~loc:arg.exp_loc
+      ~kind:"field value"
+      arg.exp_type
+      label.lbl_arg
+      vars;
   (lid, label, {arg with exp_type = instance arg.exp_type})
+
+and type_poly_argument env sarg ty_expected =
+  let arg, arg_type =
+    type_poly
+      ~rule:
+        { kind = "expression"
+        ; type_subject =
+            (fun env sarg ty_arg ->
+              let arg = type_argument env sarg ty_arg (instance ty_arg) in
+              arg, arg.exp_type)
+        ; is_expansive = maybe_expansive
+        }
+      ~env
+      ~loc:sarg.pexp_loc
+      sarg
+      ty_expected
+  in
+  { arg with exp_type = arg_type }
+
 
 and type_argument_ ?explanation ?recarg env sarg ty_expected' ty_expected =
   (* ty_expected' may be generic *)
@@ -6843,7 +6941,13 @@ and type_apply_arg env ~app_loc (lbl, arg) =
             ~before_generalize:(fun (arg, _, _) ->
                                   may_lower_contravariant env arg)
           in
-          check_univars env "argument" arg ty_arg vars;
+          check_univars
+            ~env
+            ~loc:arg.exp_loc
+            ~kind:"argument"
+            arg.exp_type
+            ty_arg
+            vars;
           {arg with exp_type = instance arg.exp_type}
         end
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7409,7 +7409,9 @@ and type_let_rec
                     | _ -> pat
                   in
                   let bound_expr = vb_exp_constraint binding in
-                  let approx_ty = Type_approx.type_expression env bound_expr in
+                  let approx_ty =
+                    Type_approx.type_expression ~env bound_expr
+                  in
                   unify_pat env pat approx_ty)
                 pat_list
                 spat_sexp_list;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6965,7 +6965,10 @@ and type_let_rec
                     | _ -> pat
                   in
                   let bound_expr = vb_exp_constraint binding in
-                  let approx_ty = Type_approx.type_expression env bound_expr in
+                  let approx_ty =
+                    Type_approx.(
+                      type_expression (Approx_env.create ~env ()) bound_expr)
+                  in
                   unify_pat env pat approx_ty)
                 pat_list
                 spat_sexp_list;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4227,25 +4227,52 @@ let may_lower_contravariant env exp =
 
 (* value binding elaboration *)
 
-let vb_exp_constraint {pvb_expr=expr; pvb_pat=pat; pvb_constraint=ct; _ } =
+
+let vb_exp_constraint { pvb_expr = expr; pvb_pat = pat; pvb_constraint = ct; _ }
+  =
   let open Ast_helper in
-  match ct with
-  | None -> expr
-  | Some (Pvc_constraint { locally_abstract_univars=[]; typ }) ->
-      begin match typ.ptyp_desc with
-      | Ptyp_poly _ -> expr
-      | _ ->
-          let loc = { expr.pexp_loc with Location.loc_ghost = true } in
-          Exp.constraint_ ~loc expr typ
-      end
-  | Some (Pvc_coercion { ground; coercion}) ->
-      let loc = { expr.pexp_loc with Location.loc_ghost = true } in
-      Exp.coerce ~loc expr ground coercion
-  | Some (Pvc_constraint { locally_abstract_univars=vars;typ}) ->
-      let loc_start = pat.ppat_loc.Location.loc_start in
-      let loc = { expr.pexp_loc with loc_start; loc_ghost=true } in
-      let expr = Exp.constraint_ ~loc expr typ in
-      List.fold_right (Exp.newtype ~loc) vars expr
+  match pat.ppat_desc, ct with
+  | Ppat_constraint (_, typ), None ->
+    let loc = { expr.pexp_loc with Location.loc_ghost = true } in
+    Exp.constraint_ ~loc expr typ
+  | _, None -> expr
+  | _, Some (Pvc_constraint { locally_abstract_univars = []; typ }) ->
+    (* Here we permit [Pexp_constraint] to carry a [Ptyp_poly],
+       since [typ] may be a [Ptyp_poly]. This will be typed
+       as expected and is required by [Type_approx] to give
+       the approximated type a *polymorphic* type. *)
+    let loc = { expr.pexp_loc with Location.loc_ghost = true } in
+    Exp.constraint_ ~loc expr typ
+  | _, Some (Pvc_coercion { ground; coercion }) ->
+    let loc = { expr.pexp_loc with Location.loc_ghost = true } in
+    Exp.coerce ~loc expr ground coercion
+  | _, Some (Pvc_constraint { locally_abstract_univars = vars; typ }) ->
+    (* For locally abstract types, we introduce [newtype]
+       binders and a polymorphic annotation. The [newtype]
+       binders introduce the locally abstract types in [expr]
+       and the polymorphic annotation ensures that locally abstract
+       types are indeed generalizable.
+
+       It is worth noting that the [newtype] binders alone are
+       insufficient, as in the following example:
+       {[
+       # let f = fun (type a) : a option ref -> ref None;;
+       val f : '_a option ref
+       ]}
+       Here, the locally abstract [a] isn't guaranteed to
+       be generalizable (in fact it cannot be generalized due
+       to the value restriction)
+    *)
+    let loc_start = pat.ppat_loc.Location.loc_start in
+    let loc = { expr.pexp_loc with loc_start; loc_ghost = true } in
+    let body =
+      List.fold_right
+        (Exp.newtype ~loc)
+        vars
+        (Exp.constraint_ ~loc expr typ)
+    in
+    let varified = Typ.varify_constructors vars typ in
+    Exp.constraint_ ~loc body (Typ.poly ~loc:typ.ptyp_loc vars varified)
 
 let vb_pat_constraint ({pvb_pat=pat; pvb_expr = exp; _ } as vb) =
   vb.pvb_attributes,
@@ -7360,6 +7387,30 @@ and value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list =
   in
   l
 
+and type_var_pattern_list ~env ~existential_restriction pat_list pat_types =
+  let pat_list, env, bind_type_vars_delayed, pvs, mvs =
+    type_pattern_list
+      Value
+      existential_restriction
+      env
+      pat_list
+      pat_types
+      Modules_rejected
+  in
+  (* The accumulated module variables [mvs] must be
+     empty, since module unpacking is forbidden in
+     'var'-patterns. *)
+  ignore mvs;
+  (* The updated environment [env] cannot introduce
+     any GADT equations, rigid type variables, etc
+     in 'var'-patterns. *)
+  ignore env;
+  (* HACK: It is useful to obtain the list of bound variables
+           in the order of patterns. This is in fact the
+           reverse of the list of variables in [pvs]. *)
+  (* Invariant: [List.length pat_list = List.length pvs] *)
+  pat_list, bind_type_vars_delayed, List.rev pvs
+
 and type_let_rec
     ?check
     ?check_strict
@@ -7367,78 +7418,97 @@ and type_let_rec
     env
     spat_sexp_list
   =
-  let spatl = List.map vb_pat_constraint spat_sexp_list in
-  let attrs_list = List.map fst spatl in
   (* Recursive patterns can only consist of (possibly annotated)
      variables. *)
-  List.iter
-    (fun { pvb_pat = pat; _ } ->
-      if not (is_var_pat pat)
-      then Error.log_or_raise pat.ppat_loc env Illegal_letrec_pat)
-    spat_sexp_list;
+  let spatl =
+    List.map
+      (fun vb ->
+        let pat = vb.pvb_pat in
+        if is_var_pat pat then
+          (vb.pvb_attributes, pat)
+        else begin
+          Error.log_or_raise pat.ppat_loc env Illegal_letrec_pat;
+          (* For typing recovery: replace invalid pattern with a
+             dummy variable.
+
+             Invariant: type_var_pattern_list expects variable patterns. *)
+          let dummy_var =
+            Ast_helper.Pat.var ~loc:pat.ppat_loc
+              (Location.mknoloc "*type-error*")
+          in
+          (vb.pvb_attributes, dummy_var)
+        end)
+      spat_sexp_list
+  in
+  let attrs_list = List.map fst spatl in
   let pat_list, exp_list, new_env =
     with_local_level_generalize
-      begin fun () ->
+      (fun () ->
         (* We must reset the tyvarenv in this local region since it
            resets the global level *)
         if reset_tyvarenv then Typetexp.TyVarEnv.reset ();
-        let pat_list, new_env, bind_type_vars_delayed, pvs =
-          with_local_level_generalize_structure_if_principal begin fun () ->
-              (* Typecheck the patterns *)
-              let nvs = List.map (fun _ -> newvar ()) spatl in
-              let pat_list, new_env, force, pvs, _mvs =
-                with_local_level_generalize begin fun () ->
-                    type_pattern_list
-                      Value
-                      In_rec
-                      env
-                      spatl
-                      nvs
-                      Modules_rejected
-                end
-              in
-              (* Approximate the type of the recursive binding *)
-              List.iter2
-                (fun pat binding ->
-                  let pat =
-                    match get_desc pat.pat_type with
-                    | Tpoly (ty, tl) ->
-                      { pat with
-                        pat_type = instance_poly ~keep_names:true tl ty
-                      }
-                    | _ -> pat
-                  in
-                  let bound_expr = vb_exp_constraint binding in
-                  let approx_ty =
-                    Type_approx.type_expression ~env bound_expr
-                  in
-                  unify_pat env pat approx_ty)
-                pat_list
-                spat_sexp_list;
-              pat_list, new_env, force, pvs
-          end
+        let pat_list, bind_type_vars_delayed, pvs =
+          let nvs = List.map (fun _ -> newvar ()) spatl in
+          type_var_pattern_list
+            ~env
+            ~existential_restriction:In_rec
+            spatl
+            nvs
         in
-        let new_env =
-          add_let_pattern_vars new_env ~pvs ~bind_type_vars_delayed
+        (* We create a [new_env] here which is used in [type_let_exps]
+           for the unused check. *)
+        let new_env = add_let_pattern_vars env ~pvs ~bind_type_vars_delayed in
+        (* We keep the type in [pat_list] as the 'expected' type
+           for the expression. But to typecheck recursive bindings,
+           we also introduce an approximation of the type of the
+           recursive binding. *)
+        let approx_env =
+          let approx_pvs =
+            let mono_lvl = get_current_level () in
+            List.map2
+              (fun pv vb ->
+                let exp = vb_exp_constraint vb in
+                with_local_level_generalize (fun () ->
+                    let approx_ty =
+                      Type_approx.type_expression ~env ~mono_lvl exp
+                    in
+                    { pv with pv_type = approx_ty }))
+              pvs
+              spat_sexp_list
+          in
+          add_let_pattern_vars env ~pvs:approx_pvs ~bind_type_vars_delayed:[]
         in
+        (* Ensure that the approximated environment is compatible with
+           the inferred types. *)
+        List.iter2
+          (fun pv { pvb_expr = sexp; _ } ->
+            let path = Path.Pident pv.pv_id in
+            let rec_vd = Env.find_value path approx_env in
+            let vd = Env.find_value path new_env in
+            unify_exp_types
+              sexp.pexp_loc
+              env
+              vd.val_type
+              (instance rec_vd.val_type))
+          pvs
+          spat_sexp_list;
+        (* Typecheck the expressions with the approximated environment. *)
         let pat_list, exp_list =
           type_let_exps
             ?check
             ?check_strict
             ~is_recursive:true
-            ~exp_env:new_env
+            ~exp_env:approx_env
             ~new_env
             ~attrs_list
             ~pat_list
             ~pvs
             spat_sexp_list
         in
-        pat_list, exp_list, new_env
-      end
+        pat_list, exp_list, new_env)
       ~before_generalize:(fun (pat_list, exp_list, _) ->
         do_relaxed_value_restriction env pat_list exp_list)
   in
-  check_let_univars env pat_list exp_list;
   value_bindings_of_pat_exp_lists pat_list exp_list ~spat_sexp_list, new_env
 
 and type_let_nonrec
@@ -7661,6 +7731,8 @@ and type_let_def_wrap_warnings
        events on the bound identifiers and record them in a slot corresponding
        to the current definition (!current_slot).
        In effect, this creates a dependency graph between definitions.
+       This is captured using handlers on value definitions in [exp_env],
+       the environment used to typecheck bindings
 
      - After type checking the definition (!current_slot = None),
        when one of the bound identifier is effectively used, we trigger
@@ -7697,18 +7769,24 @@ and type_let_def_wrap_warnings
                         Location.prerr_warning vd.Types.val_loc
                           ((if !some_used then check_strict else check) name)
                     );
-                Env.set_value_used_callback
-                  vd
-                  (fun () ->
-                    match !current_slot with
-                    | Some slot ->
-                        slot := vd.val_uid :: !slot; rec_needed := true
-                    | None ->
-                        List.iter Env.mark_value_used (get_ref slot);
-                        used := true;
-                        some_used := true
-                  )
-              )
+                let on_value_used () =
+                  match !current_slot with
+                  | Some slot ->
+                    slot := vd.val_uid :: !slot;
+                    rec_needed := true
+                  | None ->
+                    List.iter Env.mark_value_used (get_ref slot);
+                    used := true;
+                    some_used := true
+                in
+                if is_recursive
+                then (
+                  (* If the `let` is recursive, we need to register
+                     handlers on the recursive bindings (which live in
+                     [exp_env]). *)
+                  let rec_vd = Env.find_value (Path.Pident id) exp_env in
+                  Env.set_value_used_callback rec_vd on_value_used);
+                Env.set_value_used_callback vd on_value_used)
               (Typedtree.pat_bound_idents pat);
               expected_ty, Some slot
            ))

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3648,9 +3648,9 @@ and type_approx_function env params c body ty_expected ~in_function ~first =
              correct thing to do if it were to be reachable in the future. *)
           ()
 
-(* Check that all univars are safe in a type. Both exp.exp_type and
+(* Check that all univars are safe in a type. Both ty_actual and
    ty_expected should already be generalized. *)
-let check_univars env kind exp ty_expected vars =
+let check_univars ~env ~loc ~kind ty_actual ty_expected vars =
   let pty = instance ty_expected in
   let exp_ty, vars =
     with_local_level_generalize begin fun () ->
@@ -3660,8 +3660,8 @@ let check_univars env kind exp ty_expected vars =
              since body is not generic,  instance_poly_fixed only makes
              copies of nodes that have a Tunivar as descendant *)
           let _, ty' = instance_poly_fixed ~keep_names:true tl body in
-          let vars, exp_ty = instance_parameterized_type vars exp.exp_type in
-          unify_exp_types exp.exp_loc env exp_ty ty';
+          let vars, exp_ty = instance_parameterized_type vars ty_actual in
+          unify_exp_types loc env exp_ty ty';
           (exp_ty, vars)
       | _ -> assert false
     end
@@ -3672,7 +3672,7 @@ let check_univars env kind exp ty_expected vars =
     let diff = Ctype.expanded_diff env ~got:ty ~expected:ty_expected in
     let explanation = Errortrace.Univar (Quantification_mismatch errs) in
     let err = Errortrace.unification_error ~trace:[diff;explanation] in
-    raise (Error(exp.exp_loc, env, Less_general(kind,err)))
+    raise (Error(loc, env, Less_general(kind,err)))
 
 (* [check_statement] implements the [non-unit-statement] check.
 
@@ -4130,9 +4130,68 @@ let do_relaxed_value_restriction env pat_list exp_list =
 let check_let_univars env pat_list exp_list =
   List.iter2
     (fun (_, expected_ty) (exp, vars) ->
-      Option.iter (check_univars env "definition" exp expected_ty) vars)
+      Option.iter
+        (check_univars
+           ~env
+           ~loc:exp.exp_loc
+           ~kind:"definition"
+           exp.exp_type
+           expected_ty)
+        vars)
     pat_list
     exp_list
+
+(** [('s, 'r) poly_rule] encodes the behavior needed to type a possibly
+    polymorphic 'subject' ['s], producing a result ['r].
+    See [type_poly] for more details. *)
+type ('s, 'r) poly_rule =
+  { kind : string
+    (** A short label used in diagnostic messages (e.g. "expression",
+        "function cases", etc) *)
+  ; type_subject : Env.t -> 's -> type_expr -> 'r * type_expr
+    (** [type_subject env s ty_expected] types [s] with the
+        instanced expected type [ty_expected]. This type may
+        still be generalized, indicating that structures are
+        principally known. *)
+  ; is_expansive : 'r -> bool
+    (** [is_expansive r] returns [true] if [r] is part of an expansive
+        expression. *)
+  }
+
+let type_poly
+    (type s r)
+    ~(rule : (s, r) poly_rule)
+    ~env
+    ~loc
+    (subj : s)
+    (ty_expected : type_expr)
+    : r * type_expr
+  =
+  (* With principal typing / ambivalent types (for GADTs), we
+     need to unshare types (by generalizing) *)
+  let unshare = !Clflags.principal || Env.has_local_constraints env in
+  let is_poly = is_poly_Tpoly ty_expected in
+  let vars, ret, ret_ty =
+    (* Raise level to check univars *)
+    with_local_level_generalize_if
+      is_poly
+      (fun () ->
+        let vars, ty_subj_expected =
+          with_local_level_generalize_structure_if unshare (fun () ->
+              match get_desc ty_expected with
+              | Tpoly (sch, univars) ->
+                instance_poly_fixed ~keep_names:true univars sch
+              | _ -> [], ty_expected)
+        in
+        let ret, ret_ty = rule.type_subject env subj ty_subj_expected in
+        vars, ret, ret_ty)
+      ~before_generalize:(fun (_, ret, ret_ty) ->
+        if rule.is_expansive ret then lower_contravariant env ret_ty)
+  in
+  (* Check univars after generalizing *)
+  if is_poly
+  then check_univars ~env ~loc ~kind:rule.kind ret_ty ty_expected vars;
+  ret, instance ret_ty
 
 let rec type_exp ?recarg env sexp =
   (* We now delegate everything to type_expect *)
@@ -4855,13 +4914,13 @@ and type_expect_
         exp_type = instance Predef.type_unit;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
-  | Pexp_constraint (sarg, sty) ->
-      let (ty, exp_extra) = type_constraint env sty in
-      let arg = type_argument env sarg ty (instance ty) in
+  | Pexp_constraint (sarg, spt) ->
+      let (ty, exp_extra) = type_constraint env spt in
+      let arg = type_poly_argument env sarg ty in
       rue {
         exp_desc = arg.exp_desc;
         exp_loc = arg.exp_loc;
-        exp_type = instance ty;
+        exp_type = maybe_instance_poly ty;
         exp_attributes = arg.exp_attributes;
         exp_env = env;
         exp_extra = (exp_extra, loc, sexp.pexp_attributes) :: arg.exp_extra;
@@ -5060,7 +5119,13 @@ and type_expect_
                 (exp, vars)
               end
             in
-            check_univars env "method" exp ty_expected vars;
+            check_univars
+              ~env
+              ~loc:exp.exp_loc
+              ~kind:"method"
+              exp.exp_type
+              ty_expected
+              vars;
             { exp with exp_type = instance ty }
         | Tvar _ ->
             let exp = type_exp env sbody in
@@ -6245,8 +6310,35 @@ and type_label_exp create env loc ty_expected
     end
     ~before_generalize:(fun (_,arg) -> may_lower_contravariant env arg)
   in
-  if is_poly then check_univars env "field value" arg label.lbl_arg vars;
+  if is_poly
+  then
+    check_univars
+      ~env
+      ~loc:arg.exp_loc
+      ~kind:"field value"
+      arg.exp_type
+      label.lbl_arg
+      vars;
   (lid, label, {arg with exp_type = instance arg.exp_type})
+
+and type_poly_argument env sarg ty_expected =
+  let arg, arg_type =
+    type_poly
+      ~rule:
+        { kind = "expression"
+        ; type_subject =
+            (fun env sarg ty_arg ->
+              let arg = type_argument env sarg ty_arg (instance ty_arg) in
+              arg, arg.exp_type)
+        ; is_expansive = maybe_expansive
+        }
+      ~env
+      ~loc:sarg.pexp_loc
+      sarg
+      ty_expected
+  in
+  { arg with exp_type = arg_type }
+
 
 and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
   (* ty_expected' may be generic *)
@@ -6412,7 +6504,13 @@ and type_apply_arg env ~app_loc (lbl, arg) =
             ~before_generalize:(fun (arg, _, _) ->
                                   may_lower_contravariant env arg)
           in
-          check_univars env "argument" arg ty_arg vars;
+          check_univars
+            ~env
+            ~loc:arg.exp_loc
+            ~kind:"argument"
+            arg.exp_type
+            ty_arg
+            vars;
           {arg with exp_type = instance arg.exp_type}
         end
       in

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -130,10 +130,6 @@ val type_expect:
 val type_exp:
         Env.t -> Parsetree.expression -> Typedtree.expression
 
-(** [type_approx env exp ty_expectd] approximates the type of the expression
-    [expr] and unifies the result with [ty_expected]. *)
-val type_approx:
-        Env.t -> Parsetree.expression -> type_expr -> unit
 val type_argument:
         Env.t -> Parsetree.expression ->
         type_expr -> type_expr -> Typedtree.expression

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -87,6 +87,9 @@ module TyVarEnv : sig
   val with_local_scope : (unit -> 'a) -> 'a
   (* see mli file *)
 
+  val with_any_var_level : level:int -> (unit -> 'a) -> 'a
+  (* see mli file *)
+
   type poly_univars
   val with_univars : poly_univars -> (unit -> 'a) -> 'a
   (* evaluate with a locally extended set of univars *)
@@ -160,6 +163,15 @@ end = struct
   let used_variables =
     ref (TyVarMap.empty : (type_expr * Location.t * bool ref) TyVarMap.t)
 
+  let any_var_level = ref (None : int option)
+
+  let reset_any_var_level () = any_var_level := None
+
+  let get_any_var_level () =
+    match !any_var_level with
+    | None -> get_current_level ()
+    | Some level -> level
+
   (* These are variables we expect to become univars (they were introduced with
      e.g. ['a .]), but we need to make sure they don't unify first.  Why not
      just birth them as univars? Because they might successfully unify with a
@@ -185,6 +197,7 @@ end = struct
 
   let reset () =
     reset_global_level ();
+    reset_any_var_level ();
     type_variables := TyVarMap.empty
 
   let is_in_scope name =
@@ -206,6 +219,11 @@ end = struct
    Fun.protect
      f
      ~finally:(fun () -> widen context)
+
+  let with_any_var_level ~level f =
+    let old = !any_var_level in
+    any_var_level := Some level;
+    Fun.protect f ~finally:(fun () -> any_var_level := old)
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_global_type_variable name =
@@ -347,7 +365,10 @@ end = struct
   let new_any_var loc env = function
     | { extensibility = Fixed } ->
         Error.log_and_raise loc env No_type_wildcards
-    | policy -> new_var policy
+    | policy ->
+      let tv = newvar2 (get_any_var_level ()) in
+      add_pre_univar tv policy;
+      tv
 
   let globalize_used_variables { flavor; extensibility } env =
     let r = ref [] in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -64,6 +64,9 @@ module TyVarEnv : sig
   val with_local_scope : (unit -> 'a) -> 'a
   (* see mli file *)
 
+  val with_any_var_level : level:int -> (unit -> 'a) -> 'a
+  (* see mli file *)
+
   type poly_univars
   val with_univars : poly_univars -> (unit -> 'a) -> 'a
   (* evaluate with a locally extended set of univars *)
@@ -137,6 +140,15 @@ end = struct
   let used_variables =
     ref (TyVarMap.empty : (type_expr * Location.t * bool ref) TyVarMap.t)
 
+  let any_var_level = ref (None : int option)
+
+  let reset_any_var_level () = any_var_level := None
+
+  let get_any_var_level () =
+    match !any_var_level with
+    | None -> get_current_level ()
+    | Some level -> level
+
   (* These are variables we expect to become univars (they were introduced with
      e.g. ['a .]), but we need to make sure they don't unify first.  Why not
      just birth them as univars? Because they might successfully unify with a
@@ -162,6 +174,7 @@ end = struct
 
   let reset () =
     reset_global_level ();
+    reset_any_var_level ();
     type_variables := TyVarMap.empty
 
   let is_in_scope name =
@@ -183,6 +196,11 @@ end = struct
    Fun.protect
      f
      ~finally:(fun () -> widen context)
+
+  let with_any_var_level ~level f =
+    let old = !any_var_level in
+    any_var_level := Some level;
+    Fun.protect f ~finally:(fun () -> any_var_level := old)
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_global_type_variable name =
@@ -322,8 +340,12 @@ end = struct
     tv
 
   let new_any_var loc env = function
-    | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
-    | policy -> new_var policy
+    | { extensibility = Fixed; _ } ->
+      raise (Error (loc, env, No_type_wildcards))
+    | policy ->
+      let tv = newvar2 (get_any_var_level ()) in
+      add_pre_univar tv policy;
+      tv
 
   let globalize_used_variables { flavor; extensibility } env =
     let r = ref [] in

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -27,6 +27,9 @@ module TyVarEnv : sig
   val with_local_scope : (unit -> 'a) -> 'a
   (** Evaluate in a narrowed type-variable scope *)
 
+  val with_any_var_level : level:int -> (unit -> 'a) -> 'a
+  (** Evaluate with the level of wildcards (i.e. [Ptyp_any]) set to [level] *)
+
   type poly_univars
   val make_poly_univars : string list -> poly_univars
     (** remember that a list of strings connotes univars; this must

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -383,7 +383,21 @@ let case : type k . mapper -> k case -> _ = fun sub {c_lhs; c_guard; c_rhs} ->
 let value_binding sub vb =
   let loc = sub.location sub vb.vb_loc in
   let attrs = sub.attributes sub vb.vb_attributes in
+  (* This function does the minimum inverse elaboration of [vb_exp_constraint]
+     and [vb_pat_constraint] to produce a well-formed OCaml program.
+
+     It is NOT the inverse of [vb_exp_constraint] and [vb_pat_constraint].
+     For instance:
+     {[
+       let foo : type a. a -> a = fun x -> x
+     ]}
+     becomes
+     {[
+       let foo : 'a. 'a -> 'a = fun (type a) -> (fun x -> x : a -> a)
+     ]}
+  *)
   let pat = sub.pat sub vb.vb_pat in
+  let exp = sub.expr sub vb.vb_expr in
   let pat, value_constraint =
     match pat.ppat_desc with
     | Ppat_constraint (pat, ({ ptyp_desc = Ptyp_poly _; _ } as cty)) ->
@@ -393,7 +407,16 @@ let value_binding sub vb =
       pat, Some constr
     | _ -> pat, None
   in
-  Vb.mk ~loc ~attrs ?value_constraint pat (sub.expr sub vb.vb_expr)
+  let exp, value_constraint =
+    match exp.pexp_desc with
+    | Pexp_constraint (exp, ({ ptyp_desc = Ptyp_poly _; _ } as cty)) ->
+      let constr =
+        Pvc_constraint { locally_abstract_univars = []; typ = cty }
+      in
+      exp, Some constr
+    | _ -> exp, value_constraint
+  in
+  Vb.mk ~loc ~attrs ?value_constraint pat exp
 
 let expression sub exp =
   let loc = sub.location sub exp.exp_loc in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -394,7 +394,21 @@ let case : type k . mapper -> k case -> _ = fun sub {c_lhs; c_guard; c_rhs} ->
 let value_binding sub vb =
   let loc = sub.location sub vb.vb_loc in
   let attrs = sub.attributes sub vb.vb_attributes in
+  (* This function does the minimum inverse elaboration of [vb_exp_constraint]
+     and [vb_pat_constraint] to produce a well-formed OCaml program.
+
+     It is NOT the inverse of [vb_exp_constraint] and [vb_pat_constraint].
+     For instance:
+     {[
+       let foo : type a. a -> a = fun x -> x
+     ]}
+     becomes
+     {[
+       let foo : 'a. 'a -> 'a = fun (type a) -> (fun x -> x : a -> a)
+     ]}
+  *)
   let pat = sub.pat sub vb.vb_pat in
+  let exp = sub.expr sub vb.vb_expr in
   let pat, value_constraint =
     match pat.ppat_desc with
     | Ppat_constraint (pat, ({ ptyp_desc = Ptyp_poly _; _ } as cty)) ->
@@ -404,7 +418,16 @@ let value_binding sub vb =
       pat, Some constr
     | _ -> pat, None
   in
-  Vb.mk ~loc ~attrs ?value_constraint pat (sub.expr sub vb.vb_expr)
+  let exp, value_constraint =
+    match exp.pexp_desc with
+    | Pexp_constraint (exp, ({ ptyp_desc = Ptyp_poly _; _ } as cty)) ->
+      let constr =
+        Pvc_constraint { locally_abstract_univars = []; typ = cty }
+      in
+      exp, Some constr
+    | _ -> exp, value_constraint
+  in
+  Vb.mk ~loc ~attrs ?value_constraint pat exp
 
 let expression sub exp =
   let loc = sub.location sub exp.exp_loc in


### PR DESCRIPTION
# Context

This PR builds upon #14394 and a step towards fixing #14253. 

# Description

This PR refactors `type_approx` and it's integration with `type_let_rec`.
The main goals are correct approximations for polymorphic types. 

## Refactoring `type_approx`

`type_approx` (aka approximate typing) currently has two limitations:
1.  It only supports *monomorphic approximations*
2. It is written in such a way that it is difficult to recover cleanly from errors. 

To address (1), we require `type_approx` to be *level*-aware: any deliberately under-approximated types must not be accidentally generalized by any polymorphic approximations. To this end, this PR introduces an `Approx_env`, which threads a monomorphic level (`mono_lvl`) through approximation. Fresh "unknown" types produced by approximations are created at this level, ensuring they are never generalized across later when creating a polymorphic approximation. 

To fix (2), we simply under-approximate whenever `type_approx` encounters an error. In practice, this works well for all existing usecases and fixes some existing bugs in `type_approx`. Additionally, it significantly simplifies the error-handling logic in `type_approx`. 

As a result, much of this refactoring reverts parts of #13980. However, it importantly preserves its key benefit: improved error locations.

## Refactoring `type_let_rec`

`type_let_rec` suffers from the following: 
1. The use of `Tpoly` to support polymorphic recursion is rather hacky and gets in the way of approximating polymorphic types (which is required for #14253)
2. `vb_pat_constraint` and `vb_exp_constraint` are known cases of an anti-pattern (generating ghost `Parsetree` nodes). This PR makes progress towards removing the former. 

To fix some of this, we unfortunately have to introduce a little evil: *polymorphic annotations* i.e. `Pexp_constraint` expressions with `Ptyp_poly` types. 

# Reviewing 

This PR is best reviewed commit-by-commit:

  | Commit    | Description                                             |
  |-----------|---------------------------------------------------------|
  | 4c76f6c6f15da8ab42bdca1a1db16418e05a85b1 | Extends typing to handle `Ptyp_poly` in `Pexp_constraint`    |
  | 5f049134eab13242ed6cc307abe6a0fb9db665cc  | Extends `Typetexp` to allow typing wildcard types `_` at a particular level. Required to make `type_approx` level-aware.              |
  | f01b6ea4ea82882ce7125a1fe11164c6d329981c | Move `type_approx` into a dedicated `Type_approx` module. Incidentally, this commit makes approximation more robust to errors and  simplifies it (reverting many changes from #13980). In particular, this commit removes `approx_type` and instead uses `Typetexp` to translate types :)  |
  | 8837a1787d2a5c504f6ae27e4d0a69b436cfe0df | Make `Type_approx` level-aware (introduces `Approx_env`)     |
  | cbe1df932f874db47d3b596c8fde4b8d47cdc336 | Use a separate approximated environment in `type_let_rec` |
  
# Testing 

```sh
make -C testsuite parallel-typing
```
