### PR TITLE
Add reference to AST definitions in ocamltest doc

### DIFF
--- a/ocamltest/OCAMLTEST.adoc
+++ b/ocamltest/OCAMLTEST.adoc
@@ -813,6 +813,9 @@ variable+="string"
 
 === Actions, hooks and tests
 
+The precise syntax of test headers has yet to be documented thoroughly. For
+now, you can look at `tsl_ast.mli` to explore the concrete syntax.
+
 === Semantics of a test block
 
 === Variables, environments and how they are inherited


### PR DESCRIPTION
@gasche has added comments to document the concrete syntax of ocamltest headers in its code. Ideally, the ocamltest documentation would be completed with a detailed description of the syntax and semantics; however, I’m not volunteering to do this as it does not seem to me to be a priority. I propose to add a sentence in the file to refer readers to the documented source code.