### PR TITLE
WIP - Replace "thwarts comments" by explicit naming labels

### DIFF
--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -165,21 +165,21 @@ val is_empty : string -> bool
     @since 5.5 *)
 
 val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~prefix s] is [true] if and only if [s] starts with
+  prefix:string -> string -> bool
+(** [starts_with ~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
     @since 4.13 *)
 
 val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
+  suffix:string -> string -> bool
+(** [ends_with ~suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.13 *)
 
 val includes :
-  affix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [includes affix s] is [true] if and only if [affix] occurs in [s].
+  affix:string -> string -> bool
+(** [includes ~affix s] is [true] if and only if [affix] occurs in [s].
 
     {b Note.} To test the same [affix] string multiple times, partially
     applying the [~affix] argument and using the resulting function repeatedly
@@ -296,9 +296,9 @@ val cut_last_while : (char -> bool) -> string -> string * string
     resulting function repeatedly is more efficient. *)
 
 val split_first :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   string -> (string * string) option
-(** [split_first sep s] is the pair [Some (left, right)] made of the
+(** [split_first ~sep s] is the pair [Some (left, right)] made of the
     two (possibly empty) substrings of [s] that are delimited by the
     first match of the separator [sep] in [s] or [None] if [sep] can't
     be found. Search for [sep] starts at position [0] and uses
@@ -311,9 +311,9 @@ val split_first :
     @since 5.5 *)
 
 val split_last :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   string -> (string * string) option
-(** [split_last sep s] is the pair [Some (left, right)] made of the
+(** [split_last ~sep s] is the pair [Some (left, right)] made of the
     two (possibly empty) substrings of [s] that are delimited by the
     last match of the separator [sep] in [s] or [None] if [sep] can't
     be found. Search for [sep] starts at position [length s] and uses
@@ -326,9 +326,9 @@ val split_last :
     @since 5.5 *)
 
 val split_all :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   ?drop:(string -> bool) -> string -> string list
-(** [split_all sep s] is the list of all substrings of [s] that are
+(** [split_all ~sep s] is the list of all substrings of [s] that are
     delimited by non-overlapping matches of the separator [sep] or the
     list [[s]] if [sep] can't be found. Search for [sep] starts at
     position [0] in increasing indexing order and uses {!find_all}.
@@ -339,14 +339,14 @@ val split_all :
     If [sep] is [""], this is [[""; c0; ...; cn; ""]] with [ci]
     the string [of_char s.[i]].
 
-    The invariant [concat sep (split_all sep s) = s] holds.
+    The invariant [concat sep (split_all ~sep s) = s] holds.
 
     @since 5.5 *)
 
 val rsplit_all :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   ?drop:(string -> bool) -> string -> string list
-(** [rsplit_all sep s] is the list of all substrings of [s] that are
+(** [rsplit_all ~sep s] is the list of all substrings of [s] that are
     delimited by non-overlapping matches of the separator [sep] or
     [[s]] if [sep] can't be found. Search for [sep] starts at position
     [length s] in deacreasing indexing order and uses {!rfind_all}.
@@ -357,7 +357,7 @@ val rsplit_all :
     If [sep] is [""], this is [[""; c0; ...; cn; ""]] with [ci]
     the string [of_char s.[i]].
 
-    The invariant [concat sep (rsplit_all sep s) = s] holds.
+    The invariant [concat sep (rsplit_all ~sep s) = s] holds.
 
     @since 5.5 *)
 
@@ -538,9 +538,9 @@ val rindex_opt : string -> char -> int option
     resulting function repeatedly is more efficient *)
 
 val find_first :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   ?start:int -> string -> int option
-(** [find_first sub start s] is the starting position of the first
+(** [find_first ~sub start s] is the starting position of the first
     occurrence of [sub] in [s] at or after the index or position [start]
     (defaults to [0]).
 
@@ -553,9 +553,9 @@ val find_first :
     @since 5.5 *)
 
 val find_last :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   ?start:int -> string -> int option
-(** [find_last sub start s] is the starting position of the last
+(** [find_last ~sub start s] is the starting position of the last
     occurrence of [sub] in [s] at or before the index or position
     [start] (defaults to [String.length s]).
 
@@ -568,10 +568,10 @@ val find_last :
     @since 5.5 *)
 
 val find_all :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   (int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
-(** [find_all sub f start s acc], starting with [acc], folds [f] by
+(** [find_all ~sub f start s acc], starting with [acc], folds [f] by
     increasing index order over all non-overlapping starting positions
     of [sub] in [s] at or after the index or position [start]
     (defaults to [0]). The result is [acc] if [sub] could not be found
@@ -585,10 +585,10 @@ val find_all :
     @since 5.5 *)
 
 val rfind_all :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   (int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
-(** [rfind_all sub f start s acc], starting with [acc], folds [f] by
+(** [rfind_all ~sub f start s acc], starting with [acc], folds [f] by
     decreasing index order over all non-overlapping starting
     positions of [sub] in [s] at or before the index or position
     [start] (defaults to [String.length s]). The result is [acc] if
@@ -608,10 +608,10 @@ val rfind_all :
     resulting function repeatedly is more efficient. *)
 
 val replace_first :
-  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
-  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
+  by:string ->
   ?start:int -> string -> string
-(** [replace_first sub by start s] replaces by [by] the first
+(** [replace_first ~sub ~by start s] replaces by [by] the first
     occurrence of [sub] in [s] at or after the index or position
     [start] (defaults to [0]).
 
@@ -621,10 +621,10 @@ val replace_first :
     @since 5.5  *)
 
 val replace_last :
-  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
-  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
+  by:string ->
   ?start:int -> string -> string
-(** [replace_last sub by start s] replaces by [by] the last
+(** [replace_last ~sub ~by start s] replaces by [by] the last
     occurrence of [sub] in [s] at or after the index or position
     [start] (defaults to [String.length s]).
 
@@ -634,10 +634,10 @@ val replace_last :
     @since 5.5  *)
 
 val replace_all :
-  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
-  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
+  by:string ->
   ?start:int -> string -> string
-(** [replace_all sub by start s] replaces by [by] all non-overlapping
+(** [replace_all ~sub ~by start s] replaces by [by] all non-overlapping
     occurrences of [sub] in [s] at or after the index or position [start]
     (defaults to [0]). Occurences are found in increasing indexing order.
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -21,6 +21,8 @@
    stringLabels.mli instead.
  *)
 
+
+
 (** Strings.
 
     A string [s] of length [n] is an indexable and immutable sequence

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -165,20 +165,20 @@ val is_empty : string -> bool
     @since 5.5 *)
 
 val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~prefix s] is [true] if and only if [s] starts with
+  prefix:string -> string -> bool
+(** [starts_with ~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
     @since 4.13 *)
 
 val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
+  suffix:string -> string -> bool
+(** [ends_with ~suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.13 *)
 
 val includes :
-  affix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+  affix:string -> string -> bool
 (** [includes ~affix s] is [true] if and only if [affix] occurs in [s].
 
     {b Note.} To test the same [affix] string multiple times, partially
@@ -296,7 +296,7 @@ val cut_last_while : (char -> bool) -> string -> string * string
     resulting function repeatedly is more efficient. *)
 
 val split_first :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   string -> (string * string) option
 (** [split_first ~sep s] is the pair [Some (left, right)] made of the
     two (possibly empty) substrings of [s] that are delimited by the
@@ -311,7 +311,7 @@ val split_first :
     @since 5.5 *)
 
 val split_last :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   string -> (string * string) option
 (** [split_last ~sep s] is the pair [Some (left, right)] made of the
     two (possibly empty) substrings of [s] that are delimited by the
@@ -326,7 +326,7 @@ val split_last :
     @since 5.5 *)
 
 val split_all :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   ?drop:(string -> bool) -> string -> string list
 (** [split_all ~sep s] is the list of all substrings of [s] that are
     delimited by non-overlapping matches of the separator [sep] or the
@@ -344,7 +344,7 @@ val split_all :
     @since 5.5 *)
 
 val rsplit_all :
-  sep(* comment thwarts tools/sync_stdlib_docs *):string ->
+  sep:string ->
   ?drop:(string -> bool) -> string -> string list
 (** [rsplit_all ~sep s] is the list of all substrings of [s] that are
     delimited by non-overlapping matches of the separator [sep] or
@@ -538,7 +538,7 @@ val rindex_opt : string -> char -> int option
     resulting function repeatedly is more efficient *)
 
 val find_first :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   ?start:int -> string -> int option
 (** [find_first ~sub ~start s] is the starting position of the first
     occurrence of [sub] in [s] at or after the index or position [start]
@@ -553,7 +553,7 @@ val find_first :
     @since 5.5 *)
 
 val find_last :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   ?start:int -> string -> int option
 (** [find_last ~sub ~start s] is the starting position of the last
     occurrence of [sub] in [s] at or before the index or position
@@ -568,7 +568,7 @@ val find_last :
     @since 5.5 *)
 
 val find_all :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   f:(int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
 (** [find_all ~sub f ~start s acc], starting with [acc], folds [f] by
@@ -585,7 +585,7 @@ val find_all :
     @since 5.5 *)
 
 val rfind_all :
-  sub (* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
   f:(int -> 'acc -> 'acc) ->
   ?start:int -> string -> 'acc -> 'acc
 (** [rfind_all ~sub f ~start s acc], starting with [acc], folds [f] by
@@ -608,8 +608,8 @@ val rfind_all :
     resulting function repeatedly is more efficient. *)
 
 val replace_first :
-  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
-  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
+  by:string ->
   ?start:int -> string -> string
 (** [replace_first ~sub ~by ~start s] replaces by [by] the first
     occurrence of [sub] in [s] at or after the index or position
@@ -621,8 +621,8 @@ val replace_first :
     @since 5.5  *)
 
 val replace_last :
-  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
-  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
+  by:string ->
   ?start:int -> string -> string
 (** [replace_last ~sub ~by ~start s] replaces by [by] the last
     occurrence of [sub] in [s] at or after the index or position
@@ -634,8 +634,8 @@ val replace_last :
     @since 5.5  *)
 
 val replace_all :
-  sub(* comment thwarts tools/sync_stdlib_docs *) :string ->
-  by(* comment thwarts tools/sync_stdlib_docs *) :string ->
+  sub:string ->
+  by:string ->
   ?start:int -> string -> string
 (** [replace_all ~sub ~by ~start s] replaces by [by] all non-overlapping
     occurrences of [sub] in [s] at or after the index or position [start]

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -21,6 +21,24 @@
    stringLabels.mli instead.
  *)
 
+(* #KEEP-LABELS [
+        starts_with:prefix
+        ends_with:suffix
+        includes:affix
+        split_first:sep
+        split_last:sep
+        split_all:sep
+        rsplit_all:sep
+        find_first:sub
+        find_last:sub
+        find_all:sub
+        rfind_all:sub
+        replace_first:sub:by
+        replace_last:sub:by
+        replace_all:sub:by
+   ]
+*)
+
 (** Strings.
 
     A string [s] of length [n] is an indexable and immutable sequence

--- a/tools/replace_labels.pl
+++ b/tools/replace_labels.pl
@@ -12,7 +12,20 @@ my $last_val_name;
 
 sub handle_normal_comment {
     my $comment = shift(@_);
-    print $comment;
+
+    if ($comment =~ /\A\(\*\s+#KEEP-LABELS\s*\[([^\]]*)\]\s*\*\)\Z/) {
+        # This is a pragma comment
+        my @argv = split ' ', $1;
+	foreach my $arg (@argv) {
+	    my @a = split(/:/, $arg);
+	    my $name_of_val = shift(@a);
+	    for my $label (@a) {
+		$keep_labels{"${name_of_val}:${label}"} = 1;
+	    }
+	}
+    } else {
+         print $comment;
+    }
 }
 
 sub handle_whitespace {
@@ -89,16 +102,6 @@ sub process {
         } else {
             die "Unrecoginized token";
         }
-    }
-}
-
-# parse command line arguments
-foreach my $arg (@ARGV) {
-    my @a = split(/:/, $arg);
-    my $name_of_val = shift(@a);
-    # $keep_labels[$name_of_val] = \@a;
-    for my $label (@a) {
-        $keep_labels{"${name_of_val}:${label}"} = 1;
     }
 }
 

--- a/tools/replace_labels.pl
+++ b/tools/replace_labels.pl
@@ -1,0 +1,108 @@
+#!/usr/bin/env perl
+
+#
+# Hash which contains an entry "$valname:$label" to keep $label of $valname.
+#
+my %keep_labels;
+
+#
+# the last "val $name" that we have visited.
+#
+my $last_val_name;
+
+sub handle_normal_comment {
+    my $comment = shift(@_);
+    print $comment;
+}
+
+sub handle_whitespace {
+    my $ws = shift(@_);
+    print $ws;
+}
+
+sub handle_doc_comment {
+    my $comment = shift(@_);
+    if ($last_val_name) {
+        my $replacement = '$keep_labels{"$last_val_name:$1"} ? " ~$1" : " $1"';
+
+        # /ee treats $replacement as Perl code and evals it twice
+        $comment =~ s/ ~([a-z_]+(?=[ \]]))/$replacement/eeg;
+    }
+
+    print $comment;
+    $last_val_name = undef; # reset
+}
+
+sub handle_val {
+    my $val = shift(@_);
+    my $name = shift(@_);
+
+    my $replacement = '$keep_labels{"$name:$1"} ? " $1:$2" : " $2"';
+
+    # /ee treats $replacement as Perl code and evals it twice
+    $val =~ s/ ([a-z_]+):([A-Za-z\('])/$replacement/eeg;
+
+    print $val;
+
+    # keep state for doc comments
+    $last_val_name = $name;
+}
+
+sub handle_def {
+    my $def = shift(@_);
+
+    # Unconditionally replace labels in external or type definitions
+
+    # /ee treats $replacement as Perl code and evals it twice
+    $def =~ s/ ([a-z_]+):([A-Za-z\('])/ \2/g;
+
+    print $def;
+}
+
+sub process {
+    my $s = shift(@_);
+
+    while ($s) {
+        if ($s =~ /\A\(\*\*([^*]|\*[^)])*\*\)/m) {
+            $s = $'; handle_doc_comment($&);
+        } elsif ($s =~ /\A\(\*([^*]|\*[^)])*\*\)/m) {
+            $s = $'; handle_normal_comment($&);
+        } elsif ($s =~ /\A\s+/m) {
+            $s = $'; handle_whitespace($&);
+        } elsif ($s =~ /\A(val|type|external)\s+/) {
+            my $head = $&;
+            my $rest = $';
+            my $def;
+            # split at the next comment or "val|type|external".
+            if ($rest =~ /\(\*\*|((val|type|external)\s+)/m) {
+                $def = "$head$`";
+                $s = "$&$'";
+            } else {
+                $def = "$head$rest";
+                $s = "";
+            }
+            if ($def =~ /\Aval\s+([a-zA-Z0-9_]+)/) {
+                handle_val($def, $1);
+            } else {
+                handle_def($def);
+            }
+        } else {
+            die "Unrecoginized token";
+        }
+    }
+}
+
+# parse command line arguments
+foreach my $arg (@ARGV) {
+    my @a = split(/:/, $arg);
+    my $name_of_val = shift(@a);
+    # $keep_labels[$name_of_val] = \@a;
+    for my $label (@a) {
+        $keep_labels{"${name_of_val}:${label}"} = 1;
+    }
+}
+
+# process STDIN and output
+my @lines = <STDIN>;
+my $s = join("", @lines);
+process($s);

--- a/tools/sync_stdlib_docs
+++ b/tools/sync_stdlib_docs
@@ -48,14 +48,31 @@ LABELSDOTREGEX="s/([A-Z][a-z_]*)Labels\./\1./g"
 #Stdlib
 perl -p -e "$LABREGEX" stdlib/listLabels.mli > stdlib/list.temp.mli
 perl -p -e "$LABREGEX" stdlib/arrayLabels.mli > stdlib/array.temp.mli
-perl -p -e "$LABREGEX" stdlib/stringLabels.mli > stdlib/string.temp.mli
+#perl -p -e "$LABREGEX" stdlib/stringLabels.mli > stdlib/string.temp.mli
 perl -p -e "$LABREGEX" stdlib/bytesLabels.mli > stdlib/bytes.temp.mli
 
 #Stdlib tildes
 perl -p -e "$TILDEREGEX" stdlib/list.temp.mli > stdlib/list.mli
 perl -p -e "$TILDEREGEX" stdlib/array.temp.mli > stdlib/array.2temp.mli
-perl -p -e "$TILDEREGEX" stdlib/string.temp.mli > stdlib/string.mli
+#perl -p -e "$TILDEREGEX" stdlib/string.temp.mli > stdlib/string.mli
 perl -p -e "$TILDEREGEX" stdlib/bytes.temp.mli > stdlib/bytes.mli
+
+perl tools/replace_labels.pl \
+	starts_with:prefix \
+	ends_with:suffix \
+	includes:affix \
+	split_first:sep \
+	split_last:sep \
+	split_all:sep \
+	rsplit_all:sep \
+	find_first:sub \
+	find_last:sub \
+	find_all:sub \
+	rfind_all:sub \
+	replace_first:sub:by \
+	replace_last:sub:by \
+	replace_all:sub:by \
+	< stdlib/stringLabels.mli > stdlib/string.mli
 
 # Array
 

--- a/tools/sync_stdlib_docs
+++ b/tools/sync_stdlib_docs
@@ -57,22 +57,7 @@ perl -p -e "$TILDEREGEX" stdlib/array.temp.mli > stdlib/array.2temp.mli
 #perl -p -e "$TILDEREGEX" stdlib/string.temp.mli > stdlib/string.mli
 perl -p -e "$TILDEREGEX" stdlib/bytes.temp.mli > stdlib/bytes.mli
 
-perl tools/replace_labels.pl \
-	starts_with:prefix \
-	ends_with:suffix \
-	includes:affix \
-	split_first:sep \
-	split_last:sep \
-	split_all:sep \
-	rsplit_all:sep \
-	find_first:sub \
-	find_last:sub \
-	find_all:sub \
-	rfind_all:sub \
-	replace_first:sub:by \
-	replace_last:sub:by \
-	replace_all:sub:by \
-	< stdlib/stringLabels.mli > stdlib/string.mli
+perl tools/replace_labels.pl < stdlib/stringLabels.mli > stdlib/string.mli
 
 # Array
 


### PR DESCRIPTION
Implement a context-aware Perl script "replace_labels.pl" which keeps labels of specific "val" definitions, as specified as command line arguments.  For example:

   perl replace_labels.pl starts_with:prefix replace_all:sub:by \
	   < stdlib/stringLabels.mli > stdlib/string.mli

will keep the "prefix" label of "val starts_with", as well as the labels "sub" and "by" of "val replace_all".

It also keeps the specified "~labels" in the following doc comment.