### PR TITLE
Use the recommended macros in globroots test

### DIFF
--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -22,55 +22,52 @@
 #include <caml/shared_heap.h>
 #include <caml/callback.h>
 
-struct block { value header; value v; };
-
-#define Block_val(v) ((struct block*) &((value*) v)[-1])
-#define Val_block(b) ((value) &((b)->v))
-
 value gb_get(value vblock)
 {
-  return Block_val(vblock)->v;
+  return Field(vblock, 0);
 }
 
 value gb_classic_register(value v)
 {
-  struct block * b = caml_stat_alloc(sizeof(struct block));
-  b->header = Make_header(1, 0, NOT_MARKABLE);
-  b->v = v;
-  caml_register_global_root(&(b->v));
-  return Val_block(b);
+  char *b = caml_stat_alloc(Bhsize_wosize(1));
+  value val = Val_hp(b);
+  Hd_hp(Hp_val(val)) = Make_header(1, 0, NOT_MARKABLE);
+  Field(val, 0) = v;
+  caml_register_global_root((value *)&Field(val, 0));
+  return val;
 }
 
 value gb_classic_set(value vblock, value newval)
 {
-  Block_val(vblock)->v = newval;
+  Field(vblock, 0) = newval;
   return Val_unit;
 }
 
 value gb_classic_remove(value vblock)
 {
-  caml_remove_global_root(&(Block_val(vblock)->v));
+  caml_remove_global_root((value *)&Field(vblock, 0));
   return Val_unit;
 }
 
 value gb_generational_register(value v)
 {
-  struct block * b = caml_stat_alloc(sizeof(struct block));
-  b->header = Make_header(1, 0, NOT_MARKABLE);
-  b->v = v;
-  caml_register_generational_global_root(&(b->v));
-  return Val_block(b);
+  char * b = caml_stat_alloc(Bhsize_wosize(1));
+  value val = Val_hp(b);
+  Hd_hp(Hp_val(val)) = Make_header(1, 0, NOT_MARKABLE);
+  Field(val, 0) = v;
+  caml_register_generational_global_root((value *)&Field(val, 0));
+  return val;
 }
 
 value gb_generational_set(value vblock, value newval)
 {
-  caml_modify_generational_global_root(&(Block_val(vblock)->v), newval);
+  caml_modify_generational_global_root((value *)&Field(vblock, 0), newval);
   return Val_unit;
 }
 
 value gb_generational_remove(value vblock)
 {
-  caml_remove_generational_global_root(&(Block_val(vblock)->v));
+  caml_remove_generational_global_root((value *)&Field(vblock, 0));
   return Val_unit;
 }
 


### PR DESCRIPTION
The `gc-roots` tests in the test suite do some hackish casts in C to perform operations on OCaml values instead of using the recommended macros. It turns out that when using TSan it actually matters.
To quote @gasche[^1]:

> Looking at it, I think that part of the culprit here is the code of tests/gc-roots/globrootsprim.c, which hackishly creates OCaml objects by writing stuff from C:
> ```ocaml
> struct block { value header; value v; };
> 
> #define Block_val(v) ((struct block*) &((value*) v)[-1])
> #define Val_block(b) ((value) &((b)->v))
> 
> value gb_generational_register(value v)
> {
>   struct block * b = caml_stat_alloc(sizeof(struct block));
>   b->header = Make_header(1, 0, NOT_MARKABLE);
>   b->v = v;
>   caml_register_generational_global_root(&(b->v));
>   return Val_block(b);
> }
> ```
> 
> In the rest of the runtime code, we are careful to use `Hd_hp(...)` to write to the header, and `Field(...)` to write to the fields, which both use some `volatile` stuff underneath, and I understand that this has an impact on the TSan instrumentation. So I would reformulate this function (and `gb_classic_register` above) to follow that discipline.

This is an attempt to rewrite these functions using the proper macros. I’m not sure it will have an impact on the original data race report, but it’s the right thing to do and may avoid future problems.

[^1]: https://github.com/ocaml/ocaml/issues/13214#issuecomment-3891431390