### PR TITLE
Remove `caml_startup_exn` from stack traces in native debugger tests.

### DIFF
--- a/testsuite/tests/native-debugger/gdb.linux.amd64.reference
+++ b/testsuite/tests/native-debugger/gdb.linux.amd64.reference
@@ -3,52 +3,48 @@ Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 Breakpoint 1, <signal handler called>
-frame 0: caml_start_program
-frame 1: caml_startup_common
-frame 2: caml_startup_common
-frame 3: caml_startup_exn
-frame 4: caml_startup
-frame 5: caml_main
-frame 6: main
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 2, 0x00000000000000 in caml_program ()
-frame 0: caml_program
-frame 1: caml_start_program
-frame 2: caml_startup_common
-frame 3: caml_startup_common
-frame 4: caml_startup_exn
-frame 5: caml_startup
-frame 6: caml_main
-frame 7: main
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
-frame 0: ocaml_to_c
-frame 1: caml_c_call
-frame 2: camlMeander.omain
-frame 3: camlMeander.entry
-frame 4: caml_program
-frame 5: caml_start_program
-frame 6: caml_startup_common
-frame 7: caml_startup_common
-frame 8: caml_startup_exn
-frame 9: caml_startup
-frame 10: caml_main
-frame 11: main
+frame X: ocaml_to_c
+frame X: caml_c_call
+frame X: camlMeander.omain
+frame X: camlMeander.entry
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander.c_to_ocaml
-frame 1: caml_start_program
-frame 2: caml_callback_exn
-frame 3: caml_callback
-frame 4: ocaml_to_c
-frame 5: caml_c_call
-frame 6: camlMeander.omain
-frame 7: camlMeander.entry
-frame 8: caml_program
-frame 9: caml_start_program
-frame 10: caml_startup_common
-frame 11: caml_startup_common
-frame 12: caml_startup_exn
-frame 13: caml_startup
-frame 14: caml_main
-frame 15: main
+frame X: camlMeander.c_to_ocaml
+frame X: caml_start_program
+frame X: caml_callback_exn
+frame X: caml_callback
+frame X: ocaml_to_c
+frame X: caml_c_call
+frame X: camlMeander.omain
+frame X: camlMeander.entry
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 [Inferior 1 (process XXXX) exited normally]

--- a/testsuite/tests/native-debugger/gdb.linux.arm64.reference
+++ b/testsuite/tests/native-debugger/gdb.linux.arm64.reference
@@ -3,52 +3,48 @@ Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 Breakpoint 1, <signal handler called>
-frame 0: caml_start_program
-frame 1: caml_startup_common
-frame 2: caml_startup_common
-frame 3: caml_startup_exn
-frame 4: caml_startup
-frame 5: caml_main
-frame 6: main
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 2, 0x00000000000000 in caml_program ()
-frame 0: caml_program
-frame 1: caml_start_program
-frame 2: caml_startup_common
-frame 3: caml_startup_common
-frame 4: caml_startup_exn
-frame 5: caml_startup
-frame 6: caml_main
-frame 7: main
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
-frame 0: ocaml_to_c
-frame 1: caml_c_call
-frame 2: camlMeander.omain
-frame 3: camlMeander.entry
-frame 4: caml_program
-frame 5: caml_start_program
-frame 6: caml_startup_common
-frame 7: caml_startup_common
-frame 8: caml_startup_exn
-frame 9: caml_startup
-frame 10: caml_main
-frame 11: main
+frame X: ocaml_to_c
+frame X: caml_c_call
+frame X: camlMeander.omain
+frame X: camlMeander.entry
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander.c_to_ocaml
-frame 1: caml_start_program
-frame 2: caml_callback_exn
-frame 3: caml_callback
-frame 4: ocaml_to_c
-frame 5: caml_c_call
-frame 6: camlMeander.omain
-frame 7: camlMeander.entry
-frame 8: caml_program
-frame 9: caml_start_program
-frame 10: caml_startup_common
-frame 11: caml_startup_common
-frame 12: caml_startup_exn
-frame 13: caml_startup
-frame 14: caml_main
-frame 15: main
+frame X: camlMeander.c_to_ocaml
+frame X: caml_start_program
+frame X: caml_callback_exn
+frame X: caml_callback
+frame X: ocaml_to_c
+frame X: caml_c_call
+frame X: camlMeander.omain
+frame X: camlMeander.entry
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 [Inferior 1 (process XXXX) exited normally]

--- a/testsuite/tests/native-debugger/gdb.linux.riscv.reference
+++ b/testsuite/tests/native-debugger/gdb.linux.riscv.reference
@@ -3,52 +3,48 @@ Breakpoint 2 at 0x00000000000000
 Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
 Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
 Breakpoint 1, <signal handler called>
-frame 0: caml_start_program
-frame 1: caml_startup_common
-frame 2: caml_startup_common
-frame 3: caml_startup_exn
-frame 4: caml_startup
-frame 5: caml_main
-frame 6: main
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 2, 0x00000000000000 in caml_program ()
-frame 0: caml_program
-frame 1: caml_start_program
-frame 2: caml_startup_common
-frame 3: caml_startup_common
-frame 4: caml_startup_exn
-frame 5: caml_startup
-frame 6: caml_main
-frame 7: main
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
-frame 0: ocaml_to_c
-frame 1: caml_c_call
-frame 2: camlMeander.omain
-frame 3: camlMeander.entry
-frame 4: caml_program
-frame 5: caml_start_program
-frame 6: caml_startup_common
-frame 7: caml_startup_common
-frame 8: caml_startup_exn
-frame 9: caml_startup
-frame 10: caml_main
-frame 11: main
+frame X: ocaml_to_c
+frame X: caml_c_call
+frame X: camlMeander.omain
+frame X: camlMeander.entry
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander.c_to_ocaml
-frame 1: caml_start_program
-frame 2: caml_callback_exn
-frame 3: caml_callback
-frame 4: ocaml_to_c
-frame 5: caml_c_call
-frame 6: camlMeander.omain
-frame 7: camlMeander.entry
-frame 8: caml_program
-frame 9: caml_start_program
-frame 10: caml_startup_common
-frame 11: caml_startup_common
-frame 12: caml_startup_exn
-frame 13: caml_startup
-frame 14: caml_main
-frame 15: main
+frame X: camlMeander.c_to_ocaml
+frame X: caml_start_program
+frame X: caml_callback_exn
+frame X: caml_callback
+frame X: ocaml_to_c
+frame X: caml_c_call
+frame X: camlMeander.omain
+frame X: camlMeander.entry
+frame X: caml_program
+frame X: caml_start_program
+frame X: caml_startup_common
+frame X: caml_startup_common
+frame X: caml_startup
+frame X: caml_main
+frame X: main
 [Inferior 1 (process XXXX) exited normally]

--- a/testsuite/tests/native-debugger/lldb.linux.amd64.reference
+++ b/testsuite/tests/native-debugger/lldb.linux.amd64.reference
@@ -19,33 +19,31 @@ Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
 (lldb) backtrace
-frame 0: meander`caml_start_program
-frame 1: meander`caml_startup_common
-frame 2: meander`caml_startup_common
-frame 3: meander`caml_startup_exn
-frame 4: meander`caml_startup
-frame 5: meander`caml_main
-frame 6: meander`main
-frame 7: libc.so.6`__libc_start_call_main
-frame 8: libc.so.6`__libc_start_mainXXXX
-frame 9: meander`_start
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 2.1
     frame #0: 0x00000000000000 meander`caml_program
 (lldb) backtrace
-frame 0: meander`caml_program
-frame 1: meander`caml_start_program
-frame 2: meander`caml_startup_common
-frame 3: meander`caml_startup_common
-frame 4: meander`caml_startup_exn
-frame 5: meander`caml_startup
-frame 6: meander`caml_main
-frame 7: meander`main
-frame 8: libc.so.6`__libc_start_call_main
-frame 9: libc.so.6`__libc_start_mainXXXX
-frame 10: meander`_start
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -60,21 +58,20 @@ Process XXXX stopped
    7   	    return Val_int(0);
    8   	}
 (lldb) backtrace
-frame 0: meander`ocaml_to_c
-frame 1: meander`caml_c_call
-frame 2: meander`camlMeander.omain
-frame 3: meander`camlMeander.entry
-frame 4: meander`caml_program
-frame 5: meander`caml_start_program
-frame 6: meander`caml_startup_common
-frame 7: meander`caml_startup_common
-frame 8: meander`caml_startup_exn
-frame 9: meander`caml_startup
-frame 10: meander`caml_main
-frame 11: meander`main
-frame 12: libc.so.6`__libc_start_call_main
-frame 13: libc.so.6`__libc_start_mainXXXX
-frame 14: meander`_start
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander.omain
+frame X: meander`camlMeander.entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -89,23 +86,22 @@ Process XXXX stopped
    7   	          "c_to_ocaml" c_to_ocaml
    8   	let omain () =
 (lldb) backtrace
-frame 0: meander`camlMeander.c_to_ocaml
-frame 1: meander`caml_start_program
-frame 2: meander`caml_callback_exn
-frame 3: meander`caml_callback
-frame 4: meander`ocaml_to_c
-frame 5: meander`caml_c_call
-frame 6: meander`camlMeander.omain
-frame 7: meander`camlMeander.entry
-frame 8: meander`caml_program
-frame 9: meander`caml_start_program
-frame 10: meander`caml_startup_common
-frame 11: meander`caml_startup_common
-frame 12: meander`caml_startup_exn
-frame 13: meander`caml_startup
-frame 14: meander`caml_main
-frame 15: meander`main
-frame 16: libc.so.6`__libc_start_call_main
-frame 17: libc.so.6`__libc_start_mainXXXX
-frame 18: meander`_start
+frame X: meander`camlMeander.c_to_ocaml
+frame X: meander`caml_start_program
+frame X: meander`caml_callback_exn
+frame X: meander`caml_callback
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander.omain
+frame X: meander`camlMeander.entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) quit

--- a/testsuite/tests/native-debugger/lldb.linux.arm64.reference
+++ b/testsuite/tests/native-debugger/lldb.linux.arm64.reference
@@ -19,33 +19,31 @@ Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 1.1
     frame #0: 0x00000000000000 meander`caml_start_program
 (lldb) backtrace
-frame 0: meander`caml_start_program
-frame 1: meander`caml_startup_common
-frame 2: meander`caml_startup_common
-frame 3: meander`caml_startup_exn
-frame 4: meander`caml_startup
-frame 5: meander`caml_main
-frame 6: meander`main
-frame 7: libc.so.6`__libc_start_call_main
-frame 8: libc.so.6`__libc_start_mainXXXX
-frame 9: meander`_start
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 2.1
     frame #0: 0x00000000000000 meander`caml_program
 (lldb) backtrace
-frame 0: meander`caml_program
-frame 1: meander`caml_start_program
-frame 2: meander`caml_startup_common
-frame 3: meander`caml_startup_common
-frame 4: meander`caml_startup_exn
-frame 5: meander`caml_startup
-frame 6: meander`caml_main
-frame 7: meander`main
-frame 8: libc.so.6`__libc_start_call_main
-frame 9: libc.so.6`__libc_start_mainXXXX
-frame 10: meander`_start
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -60,21 +58,20 @@ Process XXXX stopped
    6   	                  ("c_to_ocaml"), Val_unit);
    7   	    return Val_int(0);
 (lldb) backtrace
-frame 0: meander`ocaml_to_c
-frame 1: meander`caml_c_call
-frame 2: meander`camlMeander.omain
-frame 3: meander`camlMeander.entry
-frame 4: meander`caml_program
-frame 5: meander`caml_start_program
-frame 6: meander`caml_startup_common
-frame 7: meander`caml_startup_common
-frame 8: meander`caml_startup_exn
-frame 9: meander`caml_startup
-frame 10: meander`caml_main
-frame 11: meander`main
-frame 12: libc.so.6`__libc_start_call_main
-frame 13: libc.so.6`__libc_start_mainXXXX
-frame 14: meander`_start
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander.omain
+frame X: meander`camlMeander.entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) continue
 This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
 Process XXXX resuming
@@ -89,23 +86,22 @@ Process XXXX stopped
    7   	          "c_to_ocaml" c_to_ocaml
    8   	let omain () =
 (lldb) backtrace
-frame 0: meander`camlStd_exit.code_end
-frame 1: meander`caml_start_program
-frame 2: meander`caml_callback_exn
-frame 3: meander`caml_callback
-frame 4: meander`ocaml_to_c
-frame 5: meander`caml_c_call
-frame 6: meander`camlMeander.omain
-frame 7: meander`camlMeander.entry
-frame 8: meander`caml_program
-frame 9: meander`caml_start_program
-frame 10: meander`caml_startup_common
-frame 11: meander`caml_startup_common
-frame 12: meander`caml_startup_exn
-frame 13: meander`caml_startup
-frame 14: meander`caml_main
-frame 15: meander`main
-frame 16: libc.so.6`__libc_start_call_main
-frame 17: libc.so.6`__libc_start_mainXXXX
-frame 18: meander`_start
+frame X: meander`camlStd_exit.code_end
+frame X: meander`caml_start_program
+frame X: meander`caml_callback_exn
+frame X: meander`caml_callback
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander.omain
+frame X: meander`camlMeander.entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: libc.so.6`__libc_start_call_main
+frame X: libc.so.6`__libc_start_mainXXXX
+frame X: meander`_start
 (lldb) quit

--- a/testsuite/tests/native-debugger/lldb.macosx.amd64.reference
+++ b/testsuite/tests/native-debugger/lldb.macosx.amd64.reference
@@ -20,13 +20,12 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`caml_start_program
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`caml_start_program
-frame 1: meander`caml_startup_common
-frame 2: meander`caml_startup_exn
-frame 3: meander`caml_startup
-frame 4: meander`caml_main
-frame 5: meander`main
-frame 6: dyld`start
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -34,14 +33,13 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`caml_program
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`caml_program
-frame 1: meander`caml_start_program
-frame 2: meander`caml_startup_common
-frame 3: meander`caml_startup_exn
-frame 4: meander`caml_startup
-frame 5: meander`caml_main
-frame 6: meander`main
-frame 7: dyld`start
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -57,18 +55,17 @@ Process XXXX stopped
    8   	}
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`ocaml_to_c
-frame 1: meander`caml_c_call
-frame 2: meander`camlMeander$omain
-frame 3: meander`camlMeander$entry
-frame 4: meander`caml_program
-frame 5: meander`caml_start_program
-frame 6: meander`caml_startup_common
-frame 7: meander`caml_startup_exn
-frame 8: meander`caml_startup
-frame 9: meander`caml_main
-frame 10: meander`main
-frame 11: dyld`start
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander$omain
+frame X: meander`camlMeander$entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -76,20 +73,19 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`camlMeander$c_to_ocaml
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`camlMeander$c_to_ocaml
-frame 1: meander`caml_start_program
-frame 2: meander`caml_callback_exn
-frame 3: meander`caml_callback
-frame 4: meander`ocaml_to_c
-frame 5: meander`caml_c_call
-frame 6: meander`camlMeander$omain
-frame 7: meander`camlMeander$entry
-frame 8: meander`caml_program
-frame 9: meander`caml_start_program
-frame 10: meander`caml_startup_common
-frame 11: meander`caml_startup_exn
-frame 12: meander`caml_startup
-frame 13: meander`caml_main
-frame 14: meander`main
-frame 15: dyld`start
+frame X: meander`camlMeander$c_to_ocaml
+frame X: meander`caml_start_program
+frame X: meander`caml_callback_exn
+frame X: meander`caml_callback
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander$omain
+frame X: meander`camlMeander$entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) quit

--- a/testsuite/tests/native-debugger/lldb.macosx.arm64.reference
+++ b/testsuite/tests/native-debugger/lldb.macosx.arm64.reference
@@ -20,13 +20,12 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`caml_start_program
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`caml_start_program
-frame 1: meander`caml_startup_common
-frame 2: meander`caml_startup_exn
-frame 3: meander`caml_startup
-frame 4: meander`caml_main
-frame 5: meander`main
-frame 6: dyld`start
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -34,14 +33,13 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`caml_program
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`caml_program
-frame 1: meander`caml_start_program
-frame 2: meander`caml_startup_common
-frame 3: meander`caml_startup_exn
-frame 4: meander`caml_startup
-frame 5: meander`caml_main
-frame 6: meander`main
-frame 7: dyld`start
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -57,18 +55,17 @@ Process XXXX stopped
    8   	}
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`ocaml_to_c
-frame 1: meander`caml_c_call
-frame 2: meander`camlMeander$omain
-frame 3: meander`camlMeander$entry
-frame 4: meander`caml_program
-frame 5: meander`caml_start_program
-frame 6: meander`caml_startup_common
-frame 7: meander`caml_startup_exn
-frame 8: meander`caml_startup
-frame 9: meander`caml_main
-frame 10: meander`main
-frame 11: dyld`start
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander$omain
+frame X: meander`camlMeander$entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -76,20 +73,19 @@ Process XXXX stopped
     frame #0: 0x00000000000000 meander`camlMeander$c_to_ocaml
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`camlMeander$c_to_ocaml
-frame 1: meander`caml_start_program
-frame 2: meander`caml_callback_exn
-frame 3: meander`caml_callback
-frame 4: meander`ocaml_to_c
-frame 5: meander`caml_c_call
-frame 6: meander`camlMeander$omain
-frame 7: meander`camlMeander$entry
-frame 8: meander`caml_program
-frame 9: meander`caml_start_program
-frame 10: meander`caml_startup_common
-frame 11: meander`caml_startup_exn
-frame 12: meander`caml_startup
-frame 13: meander`caml_main
-frame 14: meander`main
-frame 15: dyld`start
+frame X: meander`camlMeander$c_to_ocaml
+frame X: meander`caml_start_program
+frame X: meander`caml_callback_exn
+frame X: meander`caml_callback
+frame X: meander`ocaml_to_c
+frame X: meander`caml_c_call
+frame X: meander`camlMeander$omain
+frame X: meander`camlMeander$entry
+frame X: meander`caml_program
+frame X: meander`caml_start_program
+frame X: meander`caml_startup_common
+frame X: meander`caml_startup
+frame X: meander`caml_main
+frame X: meander`main
+frame X: dyld`start
 (lldb) quit

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -44,6 +44,10 @@
     # Replace line number when setting breakpoints in GDB.
     gsub(/line [0-9]+/, "line XXX")
 
+    # erase caml_startup_exn from stack traces, and remove frame numbers
+    gsub(/frame [0-9]+: .*caml_startup_exn/, "")
+    gsub(/frame [0-9]+/, "frame X")
+
     # Work around inconsistent name mangling
     gsub(/c_to_ocaml_[0-9]+/, "c_to_ocaml")
 


### PR DESCRIPTION
This is because gcc sometimes decides to inline `caml_startup_exn` within `caml_startup`. This behaviour is currently triggered by the `other-configs` CI job when configuring with `--with-pic`.

We also have to erase the frame numbers from the gdb session logs because the stack frames are off by one.
