### PR TITLE
fix #14455: `getuid` must not fail 

### DIFF
--- a/Changes
+++ b/Changes
@@ -629,8 +629,8 @@ OCaml 5.5.0
 - #13224: Clarify barriers and spin macros with delayed expansion.
   (Antonin Décimo, review by David Allsopp and Gabriel Scherer)
 
-- #14435, #14455: Add the not-root builtin ocamltest action. This allows to skip
-  tests that fail if the current user is root (superuser).
+- #14435, #14455, #14550: Add the not-root builtin ocamltest action. This
+  allows to skip tests that fail if the current user is root (superuser).
   (Kate Deplaix, review by Gabriel Scherer, Nicolás Ojeda Bär, and
    Antonin Décimo)
 

--- a/ocamltest/ocamltest_unix_dummy.ml
+++ b/ocamltest/ocamltest_unix_dummy.ml
@@ -17,4 +17,4 @@ let has_symlink () = false
 let symlink ?to_dir:_ _ _ = invalid_arg "symlink not available"
 let chmod _ _ = invalid_arg "chmod not available"
 let gettimeofday () = invalid_arg "gettimeofday not available"
-let getuid () = invalid_arg "getuid not available"
+let getuid () = 0


### PR DESCRIPTION
`getuid` must not fail because it is used at initialization time by `ocamltest`.

If `getuid` fails, `ocamltest` does not work at all, as you can see by searching for `Invalid_argument` in https://ci.inria.fr/ocaml/job/other-configs/3205/consoleFull

The funny part is that `ocamltest` doesn't even get to report an error, so the CI job is marked as "success"...
