### PR TITLE
Fix Load_path.remove_dir destroying auto_include_callback

### DIFF
--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -131,11 +131,13 @@ let remove_dir dir =
   let hidden = List.filter (fun d -> Dir.path d <> dir) !hidden_dirs in
   if    List.compare_lengths visible !visible_dirs <> 0
      || List.compare_lengths hidden !hidden_dirs <> 0 then begin
+    let saved_auto_include = !auto_include_callback in
     reset ();
     visible_dirs := visible;
     hidden_dirs := hidden;
     List.iter prepend_add hidden;
-    List.iter prepend_add visible
+    List.iter prepend_add visible;
+    auto_include_callback := saved_auto_include
   end
 
 (* General purpose version of function to add a new entry to load path: We only


### PR DESCRIPTION
In a toplevel, we have
```
# open Str;;
Alert ocaml_deprecated_auto_include: 
OCaml's lib directory layout changed in 5.0. The str subdirectory has been
automatically added to the search path, but you should add -I +str to the
command-line to silence this alert (e.g. by adding str to the list of
libraries in your dune file, or adding use_str to your _tags file for
ocamlbuild, or using -package str for ocamlfind).

```
but the behavior is different if you `#remove_directory` before.
```
#directory "test"
#remove_directory "test"
open Str
Error: Unbound module Str
```

The fix is to save and restore auto_include_callback across the reset call in `remove_dir`.
