### PR TITLE
Use `LN_S`, `AR`, `ARFLAGS` in configure script and Makefiles

### DIFF
--- a/Changes
+++ b/Changes
@@ -326,6 +326,10 @@ Working version
 
 ### Build system:
 
+- #14552: Export `AR` and `ARFLAGS` in Makefile.config.
+  Deprecate `ARCMD`.
+  (Antonin Décimo, review by David Allsopp)
+
 - #14676: Security fix: prevent shell injection in Github Actions workflows
   (Austin Thierault, review by Antonin Décimo, Edwin Török, David Allsopp and
    Olivier Nicole)

--- a/Changes
+++ b/Changes
@@ -328,7 +328,7 @@ Working version
 
 - #14552: Export `AR` and `ARFLAGS` in Makefile.config.
   Deprecate `ARCMD`.
-  (Antonin Décimo, review by David Allsopp)
+  (Antonin Décimo, review by David Allsopp and Samuel Hym)
 
 - #14676: Security fix: prevent shell injection in Github Actions workflows
   (Austin Thierault, review by Antonin Décimo, Edwin Török, David Allsopp and

--- a/Makefile
+++ b/Makefile
@@ -721,7 +721,7 @@ coldstart: boot/ocamlrun$(EXE) runtime/libcamlrun.$(A)
 	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' USE_BOOT_OCAMLC=true all
 	rm -f $(addprefix boot/, libcamlrun.$(A) $(LIBFILES))
 	cp $(addprefix stdlib/, $(LIBFILES)) boot
-	cd boot; $(LN) ../runtime/libcamlrun.$(A) .
+	cd boot && $(LN_S) ../runtime/libcamlrun.$(A) .
 
 # Recompile the core system using the bootstrap compiler
 .PHONY: coreall
@@ -914,7 +914,7 @@ flexlink.opt$(EXE): \
 	  flexlink.exe
 	cp $(FLEXDLL_SOURCE_DIR)/flexlink.exe $@
 	rm -f $(OPT_BINDIR)/flexlink$(EXE)
-	cd $(OPT_BINDIR); $(LN) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
+	cd $(OPT_BINDIR) && $(LN_S) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
 
 else
 
@@ -1108,7 +1108,7 @@ endif
 # to add otherlibs/dynlink/native to the search path as well
 
 otherlibs/dynlink/dynlink.cmx : otherlibs/dynlink/native/dynlink.cmx
-	cd otherlibs/dynlink; $(LN) native/dynlink.cmx .
+	cd otherlibs/dynlink && $(LN_S) native/dynlink.cmx .
 
 DYNLINK_DEPEND_DUMMY_FILES = \
   otherlibs/dynlink/dynlink.ml \
@@ -1153,28 +1153,28 @@ beforedepend:: lambda/runtimedef.ml
 # Choose the right machine-dependent files
 
 asmcomp/arch.mli: asmcomp/$(ARCH)/arch.mli
-	@cd asmcomp; $(LN) $(ARCH)/arch.mli .
+	@cd asmcomp && $(LN_S) $(ARCH)/arch.mli .
 
 asmcomp/arch.ml: asmcomp/$(ARCH)/arch.ml
-	@cd asmcomp; $(LN) $(ARCH)/arch.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/arch.ml .
 
 asmcomp/proc.ml: asmcomp/$(ARCH)/proc.ml
-	@cd asmcomp; $(LN) $(ARCH)/proc.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/proc.ml .
 
 asmcomp/selection.ml: asmcomp/$(ARCH)/selection.ml
-	@cd asmcomp; $(LN) $(ARCH)/selection.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/selection.ml .
 
 asmcomp/CSE.ml: asmcomp/$(ARCH)/CSE.ml
-	@cd asmcomp; $(LN) $(ARCH)/CSE.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/CSE.ml .
 
 asmcomp/reload.ml: asmcomp/$(ARCH)/reload.ml
-	@cd asmcomp; $(LN) $(ARCH)/reload.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/reload.ml .
 
 asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
-	@cd asmcomp; $(LN) $(ARCH)/scheduling.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/scheduling.ml .
 
 asmcomp/stackframe.ml: asmcomp/$(ARCH)/stackframe.ml
-	@cd asmcomp; $(LN) $(ARCH)/stackframe.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/stackframe.ml .
 
 # Preprocess the code emitters
 cvt_emit = tools/cvt_emit$(EXE)
@@ -1699,7 +1699,7 @@ runtime: stdlib/libcamlrun.$(A)
 .PHONY: makeruntime
 makeruntime: runtime-all
 stdlib/libcamlrun.$(A): runtime-all
-	cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libcamlrun.$(A) .
 clean::
 	rm -f $(addprefix runtime/, *.o *.obj *.a *.lib *.so *.dll)
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
@@ -1720,9 +1720,9 @@ runtimeopt: stdlib/libasmrun.$(A)
 .PHONY: makeruntimeopt
 makeruntimeopt: runtime-allopt
 stdlib/libasmrun.$(A): runtime-allopt
-	cd stdlib; $(LN) ../runtime/libasmrun.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libasmrun.$(A) .
 stdlib/libcomprmarsh.$(A): runtime/libcomprmarsh.$(A)
-	cd stdlib; $(LN) ../runtime/libcomprmarsh.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libcomprmarsh.$(A) .
 
 clean::
 	rm -f stdlib/libasmrun.a stdlib/libasmrun.lib

--- a/Makefile
+++ b/Makefile
@@ -721,7 +721,7 @@ coldstart: boot/ocamlrun$(EXE) runtime/libcamlrun.$(A)
 	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' USE_BOOT_OCAMLC=true all
 	rm -f $(addprefix boot/, libcamlrun.$(A) $(LIBFILES))
 	cp $(addprefix stdlib/, $(LIBFILES)) boot
-	cd boot && $(LN_S) ../runtime/libcamlrun.$(A) .
+	$(call LINK_IN, boot, ../runtime/libcamlrun.$(A))
 
 # Recompile the core system using the bootstrap compiler
 .PHONY: coreall
@@ -1108,7 +1108,7 @@ endif
 # to add otherlibs/dynlink/native to the search path as well
 
 otherlibs/dynlink/dynlink.cmx : otherlibs/dynlink/native/dynlink.cmx
-	cd otherlibs/dynlink && $(LN_S) native/dynlink.cmx .
+	$(call LINK_IN, otherlibs/dynlink, native/dynlink.cmx)
 
 DYNLINK_DEPEND_DUMMY_FILES = \
   otherlibs/dynlink/dynlink.ml \
@@ -1153,28 +1153,28 @@ beforedepend:: lambda/runtimedef.ml
 # Choose the right machine-dependent files
 
 asmcomp/arch.mli: asmcomp/$(ARCH)/arch.mli
-	@cd asmcomp && $(LN_S) $(ARCH)/arch.mli .
+	@$(call LINK_IN, asmcomp, $(ARCH)/arch.mli)
 
 asmcomp/arch.ml: asmcomp/$(ARCH)/arch.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/arch.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/arch.ml)
 
 asmcomp/proc.ml: asmcomp/$(ARCH)/proc.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/proc.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/proc.ml)
 
 asmcomp/selection.ml: asmcomp/$(ARCH)/selection.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/selection.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/selection.ml)
 
 asmcomp/CSE.ml: asmcomp/$(ARCH)/CSE.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/CSE.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/CSE.ml)
 
 asmcomp/reload.ml: asmcomp/$(ARCH)/reload.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/reload.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/reload.ml)
 
 asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/scheduling.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/scheduling.ml)
 
 asmcomp/stackframe.ml: asmcomp/$(ARCH)/stackframe.ml
-	@cd asmcomp && $(LN_S) $(ARCH)/stackframe.ml .
+	@$(call LINK_IN, asmcomp, $(ARCH)/stackframe.ml)
 
 # Preprocess the code emitters
 cvt_emit = tools/cvt_emit$(EXE)
@@ -1699,7 +1699,7 @@ runtime: stdlib/libcamlrun.$(A)
 .PHONY: makeruntime
 makeruntime: runtime-all
 stdlib/libcamlrun.$(A): runtime-all
-	cd stdlib && $(LN_S) ../runtime/libcamlrun.$(A) .
+	$(call LINK_IN, stdlib, ../runtime/libcamlrun.$(A))
 clean::
 	rm -f $(addprefix runtime/, *.o *.obj *.a *.lib *.so *.dll)
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
@@ -1720,9 +1720,9 @@ runtimeopt: stdlib/libasmrun.$(A)
 .PHONY: makeruntimeopt
 makeruntimeopt: runtime-allopt
 stdlib/libasmrun.$(A): runtime-allopt
-	cd stdlib && $(LN_S) ../runtime/libasmrun.$(A) .
+	$(call LINK_IN, stdlib, ../runtime/libasmrun.$(A))
 stdlib/libcomprmarsh.$(A): runtime/libcomprmarsh.$(A)
-	cd stdlib && $(LN_S) ../runtime/libcomprmarsh.$(A) .
+	$(call LINK_IN, stdlib, ../runtime/libcomprmarsh.$(A))
 
 clean::
 	rm -f stdlib/libasmrun.a stdlib/libasmrun.lib

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -210,7 +210,7 @@ BUILD_TRIPLET = @build@
 ZINC_RUNTIME_ID = @zinc_runtime_id@
 
 # Platform-dependent command to create symbolic links
-LN = @ln@
+LN_S = @LN_S@
 
 # Tool to generate manifests for managed assemblies and unmanaged side-by-side
 # assemblies, for the Windows targets.

--- a/Makefile.common
+++ b/Makefile.common
@@ -220,7 +220,7 @@ INSTALL_DESPATCH_install_MKDIR = \
 
 MK_LINK = \
   (cd "$(INSTALL_SECTION_$(2))$(addprefix /,$(3))" && \
-    $(LN) $(call QUOTE_SINGLE,$(1)) $(call QUOTE_SINGLE,$(4)))
+    $(LN_S) $(call QUOTE_SINGLE,$(1)) $(call QUOTE_SINGLE,$(4)))
 
 INSTALL_DESPATCH_install_ITEM = \
   $(INSTALL_CMD_$(2)) $(1) \
@@ -243,7 +243,7 @@ INSTALL_DESPATCH_display_MKDIR = \
     -> MKDIR $(INSTALL_SECTION_$(1))$(addprefix /,$(2))) $(SH_AND)
 
 MKLINK_display = \
-  echo $(call QUOTE_SINGLE,-> LN \
+  echo $(call QUOTE_SINGLE,-> LN_S \
          $(abspath $(INSTALL_SECTION_$(2))$(addprefix /,$(3))/$(1)) -> \
          $(if $(4),$(4),$(notdir $(1))))
 
@@ -311,7 +311,7 @@ ADD_LINE = $(call INVOKE, echo, $(2)) >> $(1)
 # These can then be munged to a cd + ln combination in the fixup script.
 # If symlinks are not supported, $1 is instead used to create an additional copy
 # of the file, using the .install file.
-ifeq "$(firstword $(LN))" "ln"
+ifeq "$(firstword $(LN_S))" "ln"
 RECORD_SYMLINK_TO_INSTALL = \
   $(call ADD_LINE, $(ROOTDIR)/create-symlinks, \
     $(patsubst lib%,lib,$(2))$(addprefix /,$(3)) $(4) $(5))
@@ -402,7 +402,7 @@ INSTALL_DESPATCH_opam_BEGIN = \
 # then munge clone-* and create-symlinks into the fixup script.
 INSTALL_DESPATCH_opam_END = \
   $(OCAMLRUN) ./ocaml$(EXE) $(STDLIBFLAGS) \
-    tools/opam/generate.ml $(INSTALL_MODE) $(OPAM_PACKAGE_NAME) '$(LN)'
+    tools/opam/generate.ml $(INSTALL_MODE) $(OPAM_PACKAGE_NAME) '$(LN_S)'
 
 # Generate $(OPAM_PACKAGE_NAME)-clone.sh (INSTALL_MODE=clone)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -218,6 +218,8 @@ INSTALL_DESPATCH_install_MKDIR = \
   $(MKDIR) $(call QUOTE_SINGLE,$(INSTALL_SECTION_$(1))$(addprefix /,$(2))) \
     $(SH_AND)
 
+LINK_IN = cd $(1) && $(LN_S) $(2) .
+
 MK_LINK = \
   (cd "$(INSTALL_SECTION_$(2))$(addprefix /,$(3))" && \
     $(LN_S) $(call QUOTE_SINGLE,$(1)) $(call QUOTE_SINGLE,$(4)))

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -75,7 +75,8 @@ LDFLAGS?=@LDFLAGS@
 CPP=@CPP@
 
 ### How to invoke ar
-ARCMD=@AR@
+AR=@AR@
+ARFLAGS=@ARFLAGS@
 
 ### Extension of object files
 O=@OBJEXT@
@@ -225,6 +226,10 @@ BYTECODE_RUNTIME_ID=@bytecode_runtime_id@
 NATIVE_RUNTIME_ID=@native_runtime_id@
 
 # Deprecated variables
+
+## Variables deprecated since OCaml 5.6
+
+ARCMD=$(AR)
 
 ## Variables deprecated since OCaml 5.3
 

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -99,13 +99,13 @@ cross-flexdll: | $(BYTE_BINDIR) $(OPT_BINDIR)
 	rm -f $(FLEXDLL_SOURCE_DIR)/flexlink.exe
 	$(MAKE) -C $(FLEXDLL_SOURCE_DIR) $(FLEXLINK_BUILD_ENV) \
 	  NATDYNLINK=false LINKFLAGS= flexlink.exe support
-	$(LN) $(FLEXDLL_SOURCE_DIR)/flexlink.exe flexlink.opt.exe
-	$(LN) flexlink.opt.exe flexlink.byte.exe
+	$(LN_S) $(FLEXDLL_SOURCE_DIR)/flexlink.exe flexlink.opt.exe
+	$(LN_S) flexlink.opt.exe flexlink.byte.exe
 	cp flexlink.byte.exe $(BYTE_BINDIR)/flexlink
-	cd $(BYTE_BINDIR) && $(LN) flexlink flexlink.exe
+	cd $(BYTE_BINDIR) && $(LN_S) flexlink flexlink.exe
 	cp $(addprefix $(FLEXDLL_SOURCE_DIR)/, $(FLEXDLL_OBJECTS)) $(ROOTDIR)
 	cp flexlink.opt.exe $(OPT_BINDIR)/flexlink
-	cd $(OPT_BINDIR) && $(LN) flexlink flexlink.exe
+	cd $(OPT_BINDIR) && $(LN_S) flexlink flexlink.exe
 
 INSTALL_OVERRIDES=build_ocamldoc=false WITH_DEBUGGER= OCAMLRUN=ocamlrun
 
@@ -116,6 +116,6 @@ installcross:
 	  $(addprefix toplevel/, \
 	    $(foreach ext,cmi cmt cmti cmx, native/nat__dummy__.$(ext)) \
 	      all__dummy__.cmx topstart.o native/tophooks.cmi)
-	$(LN) `command -v ocamllex` lex/ocamllex.opt$(EXE)
+	cd lex && $(LN_S) `command -v ocamllex` ocamllex.opt$(EXE)
 	# Real installation
 	$(MAKE) install $(INSTALL_OVERRIDES)

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -633,8 +633,8 @@ AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
   AS_IF([m4_normalize(MSYS=winsymlinks:nativestrict
                       CYGWIN=winsymlinks:nativestrict
                       ln -sf configure conftestLink 2>/dev/null)],
-    [ln='ln -sf'],
-    [ln='cp -pf']
+    [LN_S='ln -sf'],
+    [LN_S='cp -pRf']
   )
   AC_MSG_RESULT([$ln])
 ])

--- a/configure
+++ b/configure
@@ -15233,10 +15233,7 @@ fi
       mklib="link -lib -nologo $machine /out:\$(1) \$(2)"
      ;; #(
   *) :
-
-    : ${ARFLAGS:=rc}
-    mklib="rm -f \$(1) && ${AR} ${ARFLAGS} \$(1) \$(2)"
-   ;;
+    mklib="rm -f \$(1) && ${AR} c${ARFLAGS:=r} \$(1) \$(2)" ;;
 esac
 
 ## In cross-compilation mode, can we run executables produced?

--- a/configure
+++ b/configure
@@ -756,7 +756,6 @@ ac_ct_AR
 DLLTOOL
 OBJDUMP
 FILECMD
-LN_S
 NM
 ac_ct_DUMPBIN
 DUMPBIN
@@ -924,7 +923,7 @@ syslib
 outputobj
 outputexe
 ocamlyacc_wstr_module
-ln
+LN_S
 unix_or_win32
 ocamlsrcdir
 systhread_support
@@ -15318,9 +15317,9 @@ case $cygwin_build_env,$host in #(
 printf %s "checking for a workable solution for ln -sf... " >&6; }
   if MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict ln -sf configure conftestLink 2>/dev/null
 then :
-  ln='ln -sf'
+  LN_S='ln -sf'
 else $as_nop
-  ln='cp -pf'
+  LN_S='cp -pRf'
 
 fi
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ln" >&5
@@ -15328,7 +15327,7 @@ printf "%s\n" "$ln" >&6; }
 
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$srcdir_abs")" ;; #(
   *) :
-    ln='ln -sf'
+    LN_S='ln -sf'
   ocamlsrcdir="$srcdir_abs" ;;
 esac
 

--- a/configure
+++ b/configure
@@ -1818,17 +1818,17 @@ Optional Packages:
   --with-odoc
 
 Some influential environment variables:
-  AR          Archive-maintaining program
-  ARFLAGS     Flags to give the archive-maintaining program
-  AS          which assembler to use
-  ASPP        which assembler (with preprocessor) to use
+  AR          archive-maintaining program
+  ARFLAGS     flags to give the archive-maintaining program
+  AS          program for compiling assembly files
+  ASPP        program for preprocessing and compiling assembly files
   PARTIALLD   how to build partial (relocatable) object files
-  RC          which resource compiler to use
+  RC          program for compiling Windows Resource files
   MANIFEST_TOOL
-              which manifest generator to use
-  STRIP       Program used to perform stripping
+              program used to generate manifests (Windows)
+  STRIP       program used to perform stripping
   FLEXLINKFLAGS
-              Supplementary flags passed to flexlink (Windows targets)
+              extra flags to give to flexlink (Windows targets)
   COMPILER_BYTECODE_CFLAGS
               CFLAGS for compiling C files to be linked with bytecode
   COMPILER_BYTECODE_CPPFLAGS
@@ -1852,7 +1852,7 @@ Some influential environment variables:
   WINDOWS_UNICODE_MODE
               how to handle Unicode under Windows: ansi, compatible
   DEFAULT_STRING
-
+              obsolete
   CC          C compiler command
   CFLAGS      C compiler flags
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a

--- a/configure
+++ b/configure
@@ -751,7 +751,6 @@ NMEDIT
 DSYMUTIL
 AWK
 RANLIB
-STRIP
 ac_ct_AR
 DLLTOOL
 OBJDUMP
@@ -784,6 +783,7 @@ COMPILER_NATIVE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
 COMPILER_BYTECODE_CFLAGS
 FLEXLINKFLAGS
+STRIP
 MANIFEST_TOOL
 RC
 PARTIALLD
@@ -1091,6 +1091,7 @@ ASPP
 PARTIALLD
 RC
 MANIFEST_TOOL
+STRIP
 FLEXLINKFLAGS
 COMPILER_BYTECODE_CFLAGS
 COMPILER_BYTECODE_CPPFLAGS
@@ -1825,6 +1826,7 @@ Some influential environment variables:
   RC          which resource compiler to use
   MANIFEST_TOOL
               which manifest generator to use
+  STRIP       Program used to perform stripping
   FLEXLINKFLAGS
               Supplementary flags passed to flexlink (Windows targets)
   COMPILER_BYTECODE_CFLAGS

--- a/configure
+++ b/configure
@@ -892,6 +892,7 @@ natdynlinkopts
 natdynlink
 supports_shared_libraries
 mklib
+ARFLAGS
 AR
 launch_method_target
 launch_method
@@ -1083,6 +1084,8 @@ enable_libtool_lock
       ac_precious_vars='build_alias
 host_alias
 target_alias
+AR
+ARFLAGS
 AS
 ASPP
 PARTIALLD
@@ -1814,6 +1817,8 @@ Optional Packages:
   --with-odoc
 
 Some influential environment variables:
+  AR          Archive-maintaining program
+  ARFLAGS     Flags to give the archive-maintaining program
   AS          which assembler to use
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
@@ -3594,6 +3599,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L038
 
 
 
+
  # TODO: rename this variable
 
 
@@ -4073,6 +4079,8 @@ case $target in #(
 esac
 
 # Environment variables that are taken into account
+
+
 
 
 
@@ -15206,7 +15214,7 @@ case $target in #(
   # In config/Makefile.mingw*, we had:
   # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
   # TOOLPREF=$(TARGET)-
-  # ARCMD=$(TOOLPREF)ar
+  # AR=$(TOOLPREF)ar
   # However autoconf and libtool seem to use ar
   # So we let them do, at the moment
   *-pc-windows) :
@@ -15224,7 +15232,8 @@ fi
      ;; #(
   *) :
 
-    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
+    : ${ARFLAGS:=rc}
+    mklib="rm -f \$(1) && ${AR} ${ARFLAGS} \$(1) \$(2)"
    ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -484,16 +484,15 @@ AS_CASE([$target],
 
 # Environment variables that are taken into account
 
-AC_ARG_VAR([AR], [Archive-maintaining program])
-AC_ARG_VAR([ARFLAGS], [Flags to give the archive-maintaining program])
-AC_ARG_VAR([AS], [which assembler to use])
-AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
+AC_ARG_VAR([AR], [archive-maintaining program])
+AC_ARG_VAR([ARFLAGS], [flags to give the archive-maintaining program])
+AC_ARG_VAR([AS], [program for compiling assembly files])
+AC_ARG_VAR([ASPP], [program for preprocessing and compiling assembly files])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
-AC_ARG_VAR([RC], [which resource compiler to use])
-AC_ARG_VAR([MANIFEST_TOOL], [which manifest generator to use])
-AC_ARG_VAR([STRIP], [Program used to perform stripping])
-AC_ARG_VAR([FLEXLINKFLAGS],
-  [Supplementary flags passed to flexlink (Windows targets)])
+AC_ARG_VAR([RC], [program for compiling Windows Resource files])
+AC_ARG_VAR([MANIFEST_TOOL], [program used to generate manifests (Windows)])
+AC_ARG_VAR([STRIP], [program used to perform stripping])
+AC_ARG_VAR([FLEXLINKFLAGS], [extra flags to give to flexlink (Windows targets)])
 
 AC_ARG_VAR([COMPILER_BYTECODE_CFLAGS],
   [CFLAGS for compiling C files to be linked with bytecode])
@@ -712,7 +711,7 @@ AC_ARG_ENABLE([force-safe-string], [],
     [AC_MSG_ERROR([Support for mutable strings was removed in OCaml 5.0.])])],
   [])
 
-AC_ARG_VAR([DEFAULT_STRING], [])
+AC_ARG_VAR([DEFAULT_STRING], [obsolete])
 AS_IF([test x"$DEFAULT_STRING" = "xunsafe"],
   [AC_MSG_ERROR([Support for mutable strings was removed in OCaml 5.0.])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AC_SUBST([oc_native_cppflags])
 AC_SUBST([systhread_support])
 AC_SUBST([ocamlsrcdir])
 AC_SUBST([unix_or_win32])
-AC_SUBST([ln])
+AC_SUBST([LN_S])
 AC_SUBST([ocamlyacc_wstr_module])
 AC_SUBST([outputexe])
 AC_SUBST([outputobj])
@@ -967,7 +967,7 @@ AS_CASE([$cygwin_build_env,$host],
   [true,*-w64-mingw32*|true,*-pc-windows],
     [OCAML_CHECK_LN_ON_WINDOWS
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$srcdir_abs")"],
-  [ln='ln -sf'
+  [LN_S='ln -sf'
   ocamlsrcdir="$srcdir_abs"])
 
 # Whether ar supports @FILE arguments

--- a/configure.ac
+++ b/configure.ac
@@ -918,10 +918,7 @@ AS_CASE([$target],
         [machine=""])
       mklib="link -lib -nologo $machine /out:\$(1) \$(2)"
     ],
-  [
-    : ${ARFLAGS:=rc}
-    mklib="rm -f \$(1) && ${AR} ${ARFLAGS} \$(1) \$(2)"
-  ])
+  [mklib="rm -f \$(1) && ${AR} c${ARFLAGS:=r} \$(1) \$(2)"])
 
 ## In cross-compilation mode, can we run executables produced?
 # At the moment, it's required, but the fact is used in C99 function detection

--- a/configure.ac
+++ b/configure.ac
@@ -491,7 +491,7 @@ AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
 AC_ARG_VAR([RC], [which resource compiler to use])
 AC_ARG_VAR([MANIFEST_TOOL], [which manifest generator to use])
-
+AC_ARG_VAR([STRIP], [Program used to perform stripping])
 AC_ARG_VAR([FLEXLINKFLAGS],
   [Supplementary flags passed to flexlink (Windows targets)])
 

--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,7 @@ AC_SUBST([shebangscripts])
 AC_SUBST([launch_method])
 AC_SUBST([launch_method_target])
 AC_SUBST([AR])
+AC_SUBST([ARFLAGS])
 AC_SUBST([mklib])
 AC_SUBST([supports_shared_libraries])
 AC_SUBST([natdynlink])
@@ -483,6 +484,8 @@ AS_CASE([$target],
 
 # Environment variables that are taken into account
 
+AC_ARG_VAR([AR], [Archive-maintaining program])
+AC_ARG_VAR([ARFLAGS], [Flags to give the archive-maintaining program])
 AC_ARG_VAR([AS], [which assembler to use])
 AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
@@ -903,7 +906,7 @@ AS_CASE([$target],
   # In config/Makefile.mingw*, we had:
   # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
   # TOOLPREF=$(TARGET)-
-  # ARCMD=$(TOOLPREF)ar
+  # AR=$(TOOLPREF)ar
   # However autoconf and libtool seem to use ar
   # So we let them do, at the moment
   [*-pc-windows],
@@ -917,7 +920,8 @@ AS_CASE([$target],
       mklib="link -lib -nologo $machine /out:\$(1) \$(2)"
     ],
   [
-    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
+    : ${ARFLAGS:=rc}
+    mklib="rm -f \$(1) && ${AR} ${ARFLAGS} \$(1) \$(2)"
   ])
 
 ## In cross-compilation mode, can we run executables produced?

--- a/testsuite/in_prefix/Makefile.test
+++ b/testsuite/in_prefix/Makefile.test
@@ -55,10 +55,10 @@ endif
 
 test-in-prefix: $(DRIVER) ../tools/main_in_c.$(O) ../tools/poisonedruntime$(EXE)
 	@rm -f ocamlrun*
-	@$(LN) $(ROOTDIR)/runtime/ocamlrun$(EXE) test-$(RUNTIME_NAME)
+	@$(LN_S) $(ROOTDIR)/runtime/ocamlrun$(EXE) test-$(RUNTIME_NAME)
 	@$(MKDIR) poisoned-runtime
 	@cd poisoned-runtime \
-	  && $(LN) ../../tools/poisonedruntime$(EXE) $(RUNTIME_NAME)
+	  && $(LN_S) ../../tools/poisonedruntime$(EXE) $(RUNTIME_NAME)
 	@$< $(DRIVER_ARGS)
 	@rm -rf poisoned-runtime
 	@rm -f test-ocamlrun*

--- a/tools/opam/generate.ml
+++ b/tools/opam/generate.ml
@@ -18,7 +18,7 @@
    Parameters are the following Makefile variables:
      $1 = $(INSTALL_MODE) (opam or clone)
      $2 = $(OPAM_PACKAGE_NAME)
-     $3 = $(LN) *)
+     $3 = $(LN_S) *)
 
 let exit_because fmt = Printf.ksprintf (fun s -> prerr_endline s; exit 1) fmt
 


### PR DESCRIPTION
- [Idiomatic use of `LN_S` in configure and Makefiles](https://github.com/ocaml/ocaml/commit/74dd40306a6f011e0e52e3529dd6a0dc2176f1e7)

  `LN_S` is the variable produced by Autoconf's [`AC_PROG_LN_S`][1]. It is less surprising, and more idiomatic to find this spelling than `LN`.

  The manual also recommends calling `(cd /x && $(LN_S) foo bar)` instead of `$(LN_S) foo /x/bar`.

[1]: https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Particular-Programs.html#index-AC_005fPROG_005fLN_005fS-1

- [`Makefile.config`: define `AR` rather than `ARCMD`, define `ARFLAGS`](https://github.com/ocaml/ocaml/commit/4d5a3d40c4775efb9b04eb28a19f46c667f010ea)

  Both [`AR`][2] and [`ARFLAGS`][3] are GNU Make variables used by implicit rules and are commonly used to select a build toolchain, as in:

  ```sh
  ./configure AR=llvm-ar ARFLAGS=rcvs
  ```

  Deprecate `ARCMD` (~I've marked "as of OCaml 5.5" but I can change that to~ "as of OCaml 5.6"), which is not "standard". Though `ARCMD` was exported in `Makefile.config`, it was `AR` which was used in the scripts. Export `AR` and `ARFLAGS` into `Makefile.config`.

[2]: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#index-AR
[3]: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#index-ARFLAGS

~no change entry needed.~