### PR TITLE
Add missing @since annotations in stdlib

### DIFF
--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -39,7 +39,9 @@ val make : 'a -> 'a t
     modifying these disjoint memory regions simultaneously becomes impossible,
     which can create a bottleneck. Hence, as a general guideline, if an atomic
     reference is experiencing contention, assigning it its own cache line may
-    enhance performance. *)
+    enhance performance.
+
+    @since 5.2 *)
 val make_contended : 'a -> 'a t
 
 (** Get the current value of the atomic reference. *)
@@ -68,7 +70,9 @@ val incr : int t -> unit
 (** [decr r] atomically decrements the value of [r] by [1]. *)
 val decr : int t -> unit
 
-(** Atomic "locations", such as record fields. *)
+(** Atomic "locations", such as record fields.
+
+    @since 5.4 *)
 module Loc : sig
   (** This module exposes a dedicated type ['a Atomic.Loc.t] for
       atomic locations (storing a value of type ['a]) inside objects

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -197,7 +197,9 @@ val blit : src:'a t -> src_pos:int -> dst:'a t -> dst_pos:int -> len:int -> unit
 
     @raise Invalid_argument if [src_pos] and [len] do not designate
     a valid subarray of [src], or if [dst_pos] is strictly below [0]
-    or strictly above [length dst]. *)
+    or strictly above [length dst].
+
+    @since 5.3 *)
 
 (** {1:removing Removing elements} *)
 
@@ -626,7 +628,9 @@ val unsafe_to_iarray : capacity:int -> ('a t -> unit) -> 'a iarray
 
     This function is unsafe because type safety may be broken by concurrent
     writes to the dynarray from other domains, without proper synchronization,
-    before [f] returns. *)
+    before [f] returns.
+
+    @since 5.4 *)
 
 
 (** {1:examples Code examples}


### PR DESCRIPTION
Adds missing `@since` annotations for four stdlib items that were introduced in earlier releases but never got the tag:

- `Atomic.make_contended` — `@since` 5.2
- `Atomic.Loc` — `@since` 5.4
- `Dynarray.blit` — `@since` 5.3
- `Dynarray.unsafe_to_iarray` — `@since` 5.4

Relates to #11666.