### PR TITLE
Finally remove `caml_fatal_error_arg` and `caml_fatal_error_arg2`

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
   legibility and correctness (fixes one bug, in weak.c).
   (Nick Barnes, review by Gabriel Scherer)
 
+* #14559: Remove `caml_fatal_error_arg` and `caml_fatal_error_arg2`
+  symbols from the runtime. The declarations were removed in 5.0.
+  (Antonin Décimo, review by Nicolás Ojeda Bär)
+
 ### Code generation and optimizations:
 
 * #13919: optimize `lazy v` when `v` is a structured constant

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -127,20 +127,6 @@ CAMLexport void caml_fatal_error (const char *msg, ...)
   abort();
 }
 
-CAMLexport void caml_fatal_error_arg (const char *fmt, const char *arg)
-{
-  fprintf (stderr, fmt, arg);
-  exit(2);
-}
-
-CAMLexport void caml_fatal_error_arg2 (const char *fmt1, const char *arg1,
-                                       const char *fmt2, const char *arg2)
-{
-  fprintf (stderr, fmt1, arg1);
-  fprintf (stderr, fmt2, arg2);
-  exit(2);
-}
-
 #ifdef ARCH_SIXTYFOUR
 #define MAX_EXT_TABLE_CAPACITY INT_MAX
 #else


### PR DESCRIPTION
The definitions were removed from the headers in 5.0 in 39d3b525e762672d9dde4b389ef326fff6e34b96 and were before that removed from byterun in 4.08 in 51a91be319993edaac89c3550d9469f73c3a6e19. I hope people would have complained since then.