### PR TITLE
Fix typos in stdlib documentation

### DIFF
--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1422,7 +1422,7 @@ val sprintf : ('a, unit, string) format -> 'a
   Note that the pretty-printer queue is flushed at the end of {e each
   call} to [sprintf]. Note that you likely want to use {!asprintf} which can
   reuse [%a]-printers defined for {!fprintf}. Contrarily, [sprintf] requires to
-  redefine new [%a]-printers, and is kept only for backward compatility.
+  redefine new [%a]-printers, and is kept only for backward compatibility.
 
   In case of multiple and related calls to [sprintf] to output
   material on a single string, you should consider using [fprintf]

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -365,7 +365,7 @@ val rsplit_all :
 (** [rsplit_all sep s] is the list of all substrings of [s] that are
     delimited by non-overlapping matches of the separator [sep] or
     [[s]] if [sep] can't be found. Search for [sep] starts at position
-    [length s] in deacreasing indexing order and uses {!rfind_all}.
+    [length s] in decreasing indexing order and uses {!rfind_all}.
 
     Substrings [sub] for which [drop sub] is [true] are not included
     in the result. [drop] defaults to [Fun.const false].
@@ -619,7 +619,7 @@ val rfind_all :
 
 (** {1:replacing Replacing substrings}
 
-    {b Note.} To replace the same [sub] string multiple time, partially
+    {b Note.} To replace the same [sub] string multiple times, partially
     applying the [~sub] argument of these functions and using the
     resulting function repeatedly is more efficient. *)
 
@@ -655,7 +655,7 @@ val replace_all :
   ?start:int -> string -> string
 (** [replace_all sub by start s] replaces by [by] all non-overlapping
     occurrences of [sub] in [s] at or after the index or position [start]
-    (defaults to [0]). Occurences are found in increasing indexing order.
+    (defaults to [0]). Occurrences are found in increasing indexing order.
 
     If [sub] is [""], this inserts [by] on all positions from [start] on.
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -365,7 +365,7 @@ val rsplit_all :
 (** [rsplit_all ~sep s] is the list of all substrings of [s] that are
     delimited by non-overlapping matches of the separator [sep] or
     [[s]] if [sep] can't be found. Search for [sep] starts at position
-    [length s] in deacreasing indexing order and uses {!rfind_all}.
+    [length s] in decreasing indexing order and uses {!rfind_all}.
 
     Substrings [sub] for which [drop sub] is [true] are not included
     in the result. [drop] defaults to [Fun.const false].
@@ -619,7 +619,7 @@ val rfind_all :
 
 (** {1:replacing Replacing substrings}
 
-    {b Note.} To replace the same [sub] string multiple time, partially
+    {b Note.} To replace the same [sub] string multiple times, partially
     applying the [~sub] argument of these functions and using the
     resulting function repeatedly is more efficient. *)
 
@@ -655,7 +655,7 @@ val replace_all :
   ?start:int -> string -> string
 (** [replace_all ~sub ~by ~start s] replaces by [by] all non-overlapping
     occurrences of [sub] in [s] at or after the index or position [start]
-    (defaults to [0]). Occurences are found in increasing indexing order.
+    (defaults to [0]). Occurrences are found in increasing indexing order.
 
     If [sub] is [""], this inserts [by] on all positions from [start] on.
 


### PR DESCRIPTION
Fixes a handful of typos in String and Format docstrings:

- "deacreasing" -> "decreasing" (string.mli)
- "Occurences" -> "Occurrences" (string.mli)
- "multiple time" -> "multiple times" (string.mli)
- "compatility" -> "compatibility" (format.mli)