### PR TITLE
Fix small errors in stdlib documentation

### DIFF
--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -313,7 +313,7 @@ val add_int64_be : t -> int64 -> unit
 *)
 
 val add_int64_le : t -> int64 -> unit
-(** [add_int64_ne b i] appends a binary little-endian 64-bit integer
+(** [add_int64_le b i] appends a binary little-endian 64-bit integer
     [i] to [b].
     @since 4.08
 *)

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -414,7 +414,7 @@ external copy_sign : float -> float -> float
 external sign_bit : (float [@unboxed]) -> bool
   = "caml_signbit_float" "caml_signbit" [@@noalloc]
 (** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
-    For example [sign_bit 1.] and [signbit 0.] are [false] while
+    For example [sign_bit 1.] and [sign_bit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true].
 
     @since 4.08 *)

--- a/stdlib/iarray.mli
+++ b/stdlib/iarray.mli
@@ -196,7 +196,7 @@ val exists2 : ('a -> 'b -> bool) -> 'a iarray -> 'b iarray -> bool
 
 val mem : 'a -> 'a iarray -> bool
 (** [mem a set] is true if and only if [a] is structurally equal
-    to an element of [l] (i.e. there is an [x] in [l] such that
+    to an element of [set] (i.e. there is an [x] in [set] such that
     [compare a x = 0]). *)
 
 val memq : 'a -> 'a iarray -> bool

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -144,10 +144,10 @@ external shift_right : int -> int -> int = "%asrint"
     [n > ]{!Sys.int_size}. *)
 
 external shift_right_logical : int -> int -> int = "%lsrint"
-(** [shift_right x n] shifts [x] to the right by [n] bits. This is a
-    logical shift: zeroes are inserted in the vacated bits regardless
-    of the sign of [x]. The result is unspecified if [n < 0] or
-    [n > ]{!Sys.int_size}. *)
+(** [shift_right_logical x n] shifts [x] to the right by [n] bits.
+    This is a logical shift: zeroes are inserted in the vacated bits
+    regardless of the sign of [x]. The result is unspecified if [n < 0]
+    or [n > ]{!Sys.int_size}. *)
 
 (** {1:preds Predicates and comparisons} *)
 

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -257,7 +257,7 @@ module type S =
 
     val filter: (key -> 'a -> bool) -> 'a t -> 'a t
     (** [filter f m] returns the map with all the bindings in [m]
-        that satisfy predicate [p]. If every binding in [m] satisfies [f],
+        that satisfy predicate [f]. If every binding in [m] satisfies [f],
         [m] is returned unchanged (the result of the function is then
         physically equal to [m])
         @since 3.12

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -928,7 +928,7 @@ module Map : sig
 
       val filter: f:(key -> 'a -> bool) -> 'a t -> 'a t
       (** [filter ~f m] returns the map with all the bindings in [m]
-          that satisfy predicate [p]. If every binding in [m] satisfies [f],
+          that satisfy predicate [f]. If every binding in [m] satisfies [f],
           [m] is returned unchanged (the result of the function is then
           physically equal to [m])
           @since 3.12
@@ -1350,7 +1350,7 @@ module Set : sig
           @since 4.07 *)
 
       val of_seq : elt Seq.t -> t
-      (** Build a set from the given bindings
+      (** Build a set from the given elements
           @since 4.07 *)
     end
   (** Output signature of the functor {!Make}. *)

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -66,7 +66,7 @@ val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 (** [map f r] is [Ok (f v)] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 
 val product : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
-(** [product r0 r1] is [Ok (v0, v1)] if [r0] is [Ok v0] and [r1] is [Ok v2]
+(** [product r0 r1] is [Ok (v0, v1)] if [r0] is [Ok v0] and [r1] is [Ok v1]
     and otherwise returns the error of [r0], if any, or the error of [r1].
 
     @since 5.4 *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -777,9 +777,9 @@ val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
     [filter p xs, filter (fun x -> not (p x)) xs].
 
     Consuming both of the sequences returned by [partition p xs] causes
-    [xs] to be consumed twice and causes the function [f] to be applied
-    twice to each element of the list.
-    Therefore, [f] should be pure and cheap.
+    [xs] to be consumed twice and causes the function [p] to be applied
+    twice to each element of the sequence.
+    Therefore, [p] should be pure and cheap.
     Furthermore, [xs] should be persistent and cheap.
     If that is not the case, use [partition p (memoize xs)].
 

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -318,7 +318,7 @@ module type S =
         @since 4.07 *)
 
     val of_seq : elt Seq.t -> t
-    (** Build a set from the given bindings
+    (** Build a set from the given elements
         @since 4.07 *)
   end
 (** Output signature of the functor {!Make}. *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -436,7 +436,7 @@ val escaped : string -> string
     sequences, following the lexical conventions of OCaml.
 
     All characters outside the US-ASCII printable range \[0x20;0x7E\] are
-    escaped, as well as backslash (0x2F) and double-quote (0x22).
+    escaped, as well as backslash (0x5C) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
     i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -436,7 +436,7 @@ val escaped : string -> string
     sequences, following the lexical conventions of OCaml.
 
     All characters outside the US-ASCII printable range \[0x20;0x7E\] are
-    escaped, as well as backslash (0x2F) and double-quote (0x22).
+    escaped, as well as backslash (0x5C) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
     i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless

--- a/stdlib/templates/float.template.mli
+++ b/stdlib/templates/float.template.mli
@@ -414,7 +414,7 @@ external copy_sign : float -> float -> float
 external sign_bit : (float [@unboxed]) -> bool
   = "caml_signbit_float" "caml_signbit" [@@noalloc]
 (** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
-    For example [sign_bit 1.] and [signbit 0.] are [false] while
+    For example [sign_bit 1.] and [sign_bit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true].
 
     @since 4.08 *)

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -257,7 +257,7 @@ module type S =
 
     val filter: f:(key -> 'a -> bool) -> 'a t -> 'a t
     (** [filter ~f m] returns the map with all the bindings in [m]
-        that satisfy predicate [p]. If every binding in [m] satisfies [f],
+        that satisfy predicate [f]. If every binding in [m] satisfies [f],
         [m] is returned unchanged (the result of the function is then
         physically equal to [m])
         @since 3.12

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -318,7 +318,7 @@ module type S =
         @since 4.07 *)
 
     val of_seq : elt Seq.t -> t
-    (** Build a set from the given bindings
+    (** Build a set from the given elements
         @since 4.07 *)
   end
 (** Output signature of the functor {!Make}. *)


### PR DESCRIPTION
Fixes incorrect information in stdlib docstrings across 9 files:

- `String.escaped`: wrong hex code for backslash (0x2F is `/`, fixed to 0x5C)
- `Int.shift_right_logical`: doc said `[shift_right x n]` instead of `[shift_right_logical x n]`
- `Buffer.add_int64_le`: doc said `[add_int64_ne b i]` instead of `[add_int64_le b i]`
- `Result.product`: doc said `[Ok v2]` instead of `[Ok v1]`
- `Iarray.mem`: doc referred to `[l]` (copy-pasted from List) instead of `[set]`
- `Float.sign_bit`: doc used C name `[signbit]` instead of `[sign_bit]`
- `Set.S.of_seq`: doc said "bindings" (copy-pasted from Map) instead of "elements"
- `Seq.partition`: doc used `[f]` instead of parameter name `[p]`, and said "list" instead of "sequence"
- `Map.S.filter`: doc mixed parameter names `[f]` and `[p]`

Most of those seemed like copy-paste mistakes to me. 