### PR TITLE
Fix documentation errors in stdlib templates

### DIFF
--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -39,7 +39,7 @@
 *)
 
 val zero : float
-(** The floating point 0.
+(** The floating-point number 0.
    @since 4.08 *)
 
 val one : float
@@ -73,7 +73,7 @@ external fma : float -> float -> float -> float =
    emulation.
 
    On 64-bit Cygwin, 64-bit mingw-w64 and MSVC 2017 and earlier, this function
-   may be emulated owing to known bugs on limitations on these platforms.
+   may be emulated owing to known bugs or limitations on these platforms.
    Note: since software emulation of the fma is costly, make sure that you are
    using hardware fma support if performance matters.
 
@@ -302,15 +302,15 @@ external hypot : float -> float -> float = "caml_hypot_float" "caml_hypot"
 
 external cosh : float -> float = "caml_cosh_float" "cosh"
 [@@unboxed] [@@noalloc]
-(** Hyperbolic cosine.  Argument is in radians. *)
+(** Hyperbolic cosine. *)
 
 external sinh : float -> float = "caml_sinh_float" "sinh"
 [@@unboxed] [@@noalloc]
-(** Hyperbolic sine.  Argument is in radians. *)
+(** Hyperbolic sine. *)
 
 external tanh : float -> float = "caml_tanh_float" "tanh"
 [@@unboxed] [@@noalloc]
-(** Hyperbolic tangent.  Argument is in radians. *)
+(** Hyperbolic tangent. *)
 
 external acosh : float -> float = "caml_acosh_float" "caml_acosh"
   [@@unboxed] [@@noalloc]
@@ -649,9 +649,9 @@ module Array : sig
       @since 5.1 *)
 
   val fold_left : ('acc -> float -> 'acc) -> 'acc -> t -> 'acc
-  (** [fold_left f x init] computes
-      [f (... (f (f x init.(0)) init.(1)) ...) init.(n-1)],
-      where [n] is the length of the floatarray [init]. *)
+  (** [fold_left f init a] computes
+      [f (... (f (f init a.(0)) a.(1)) ...) a.(n-1)],
+      where [n] is the length of the floatarray [a]. *)
 
   val fold_right : (float -> 'acc -> 'acc) -> t -> 'acc -> 'acc
   (** [fold_right f a init] computes
@@ -661,7 +661,7 @@ module Array : sig
   (** {1 Iterators on two arrays} *)
 
   val iter2 : (float -> float -> unit) -> t -> t -> unit
-  (** [Array.iter2 f a b] applies function [f] to all the elements of [a]
+  (** [iter2 f a b] applies function [f] to all the elements of [a]
       and [b].
       @raise Invalid_argument if the floatarrays are not the same size. *)
 
@@ -987,14 +987,14 @@ module ArrayLabels : sig
   (** {1:comparison Comparison} *)
 
   val equal : eq:(float -> float -> bool) -> t -> t -> bool
-  (** [equal eq a b] is [true] if and only if [a] and [b] have the
+  (** [equal ~eq a b] is [true] if and only if [a] and [b] have the
       same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
       is [true].
 
       @since 5.4 *)
 
   val compare : cmp:(float -> float -> int) -> t -> t -> int
-  (** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+  (** [compare ~cmp a b] compares [a] and [b] according to the shortlex order,
       that is, shorter arrays are smaller and equal-sized arrays are compared
       in lexicographic order using [cmp] to compare elements.
 
@@ -1017,7 +1017,7 @@ module ArrayLabels : sig
       and builds a floatarray with the results returned by [f]. *)
 
   val map_inplace : f:(float -> float) -> t -> unit
-  (** [map_inplace f a] applies function [f] to all elements of [a],
+  (** [map_inplace ~f a] applies function [f] to all elements of [a],
       and updates their values in place.
       @since 5.1 *)
 
@@ -1032,19 +1032,19 @@ module ArrayLabels : sig
       @since 5.1 *)
 
   val fold_left : f:('acc -> float -> 'acc) -> init:'acc -> t -> 'acc
-  (** [fold_left ~f x ~init] computes
-      [f (... (f (f x init.(0)) init.(1)) ...) init.(n-1)],
-      where [n] is the length of the floatarray [init]. *)
+  (** [fold_left ~f ~init a] computes
+      [f (... (f (f init a.(0)) a.(1)) ...) a.(n-1)],
+      where [n] is the length of the floatarray [a]. *)
 
   val fold_right : f:(float -> 'acc -> 'acc) -> t -> init:'acc -> 'acc
-  (** [fold_right f a init] computes
+  (** [fold_right ~f a ~init] computes
       [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
       where [n] is the length of the floatarray [a]. *)
 
   (** {1 Iterators on two arrays} *)
 
   val iter2 : f:(float -> float -> unit) -> t -> t -> unit
-  (** [Array.iter2 ~f a b] applies function [f] to all the elements of [a]
+  (** [iter2 ~f a b] applies function [f] to all the elements of [a]
       and [b].
       @raise Invalid_argument if the floatarrays are not the same size. *)
 
@@ -1062,7 +1062,7 @@ module ArrayLabels : sig
       [(f a1) && (f a2) && ... && (f an)]. *)
 
   val exists : f:(float -> bool) -> t -> bool
-  (** [exists f [|a1; ...; an|]] checks if at least one element of
+  (** [exists ~f [|a1; ...; an|]] checks if at least one element of
       the floatarray satisfies the predicate [f]. That is, it returns
       [(f a1) || (f a2) || ... || (f an)]. *)
 

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -51,7 +51,7 @@
 
  (**
     Unsynchronized accesses to a hash table may lead to an invalid hash table
-    state. Thus, concurrent accesses to a hash tables must be synchronized
+    state. Thus, concurrent accesses to a hash table must be synchronized
     (for instance with a {!Mutex.t}).
 *)
 
@@ -187,9 +187,9 @@ val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
 val filter_map_inplace: ('a -> 'b -> 'b option) -> ('a, 'b) t ->
     unit
 (** [Hashtbl.filter_map_inplace f tbl] applies [f] to all bindings in
-    table [tbl] and update each binding depending on the result of
+    table [tbl] and updates each binding depending on the result of
     [f].  If [f] returns [None], the binding is discarded.  If it
-    returns [Some new_val], the binding is update to associate the key
+    returns [Some new_val], the binding is updated to associate the key
     to [new_val].
 
     Other comments for {!iter} apply as well.

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -68,7 +68,7 @@ module Hashtbl : sig
 
    (**
       Unsynchronized accesses to a hash table may lead to an invalid hash table
-      state. Thus, concurrent accesses to a hash tables must be synchronized
+      state. Thus, concurrent accesses to a hash table must be synchronized
       (for instance with a {!Mutex.t}).
   *)
 
@@ -204,9 +204,9 @@ module Hashtbl : sig
   val filter_map_inplace: f:(key:'a -> data:'b -> 'b option) -> ('a, 'b) t ->
       unit
   (** [Hashtbl.filter_map_inplace ~f tbl] applies [f] to all bindings in
-      table [tbl] and update each binding depending on the result of
+      table [tbl] and updates each binding depending on the result of
       [f].  If [f] returns [None], the binding is discarded.  If it
-      returns [Some new_val], the binding is update to associate the key
+      returns [Some new_val], the binding is updated to associate the key
       to [new_val].
 
       Other comments for {!iter} apply as well.
@@ -1233,7 +1233,7 @@ module Set : sig
           with respect to the ordering over the type of the elements. *)
 
       val fold: f:(elt -> 'acc -> 'acc) -> t -> init:'acc -> 'acc
-      (** [fold ~f s init] computes [(f xN ... (f x2 (f x1 init))...)],
+      (** [fold ~f s ~init] computes [(f xN ... (f x2 (f x1 init))...)],
           where [x1 ... xN] are the elements of [s], in increasing order. *)
 
       (** {1:transforming Transforming} *)
@@ -1252,7 +1252,7 @@ module Set : sig
 
       val filter: f:(elt -> bool) -> t -> t
       (** [filter ~f s] returns the set of all elements in [s]
-          that satisfy predicate [f]. If [f] satisfies every element in [s],
+          that satisfy predicate [f]. If every element in [s] satisfies [f],
           [s] is returned unchanged (the result of the function is then
           physically equal to [s]).
           @before 4.03 Physical equality was not ensured.*)

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -220,7 +220,7 @@ module type S =
 
     val filter: (elt -> bool) -> t -> t
     (** [filter f s] returns the set of all elements in [s]
-        that satisfy predicate [f]. If [f] satisfies every element in [s],
+        that satisfy predicate [f]. If every element in [s] satisfies [f],
         [s] is returned unchanged (the result of the function is then
         physically equal to [s]).
         @before 4.03 Physical equality was not ensured.*)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -520,15 +520,15 @@ external hypot : float -> float -> float = "caml_hypot_float" "caml_hypot"
 
 external cosh : float -> float = "caml_cosh_float" "cosh"
   [@@unboxed] [@@noalloc]
-(** Hyperbolic cosine.  Argument is in radians. *)
+(** Hyperbolic cosine. *)
 
 external sinh : float -> float = "caml_sinh_float" "sinh"
   [@@unboxed] [@@noalloc]
-(** Hyperbolic sine.  Argument is in radians. *)
+(** Hyperbolic sine. *)
 
 external tanh : float -> float = "caml_tanh_float" "tanh"
   [@@unboxed] [@@noalloc]
-(** Hyperbolic tangent.  Argument is in radians. *)
+(** Hyperbolic tangent. *)
 
 external acosh : float -> float = "caml_acosh_float" "caml_acosh"
   [@@unboxed] [@@noalloc]

--- a/stdlib/templates/float.template.mli
+++ b/stdlib/templates/float.template.mli
@@ -39,7 +39,7 @@
 *)
 
 val zero : float
-(** The floating point 0.
+(** The floating-point number 0.
    @since 4.08 *)
 
 val one : float
@@ -73,7 +73,7 @@ external fma : float -> float -> float -> float =
    emulation.
 
    On 64-bit Cygwin, 64-bit mingw-w64 and MSVC 2017 and earlier, this function
-   may be emulated owing to known bugs on limitations on these platforms.
+   may be emulated owing to known bugs or limitations on these platforms.
    Note: since software emulation of the fma is costly, make sure that you are
    using hardware fma support if performance matters.
 
@@ -302,15 +302,15 @@ external hypot : float -> float -> float = "caml_hypot_float" "caml_hypot"
 
 external cosh : float -> float = "caml_cosh_float" "cosh"
 [@@unboxed] [@@noalloc]
-(** Hyperbolic cosine.  Argument is in radians. *)
+(** Hyperbolic cosine. *)
 
 external sinh : float -> float = "caml_sinh_float" "sinh"
 [@@unboxed] [@@noalloc]
-(** Hyperbolic sine.  Argument is in radians. *)
+(** Hyperbolic sine. *)
 
 external tanh : float -> float = "caml_tanh_float" "tanh"
 [@@unboxed] [@@noalloc]
-(** Hyperbolic tangent.  Argument is in radians. *)
+(** Hyperbolic tangent. *)
 
 external acosh : float -> float = "caml_acosh_float" "caml_acosh"
   [@@unboxed] [@@noalloc]

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -120,14 +120,14 @@ val of_list : float list -> t
 (** {1:comparison Comparison} *)
 
 val equal : eq:(float -> float -> bool) -> t -> t -> bool
-(** [equal eq a b] is [true] if and only if [a] and [b] have the
+(** [equal ~eq a b] is [true] if and only if [a] and [b] have the
     same length [n] and for all [i] in \[[0];[n-1]\], [eq a.(i) b.(i)]
     is [true].
 
     @since 5.4 *)
 
 val compare : cmp:(float -> float -> int) -> t -> t -> int
-(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+(** [compare ~cmp a b] compares [a] and [b] according to the shortlex order,
     that is, shorter arrays are smaller and equal-sized arrays are compared
     in lexicographic order using [cmp] to compare elements.
 
@@ -150,7 +150,7 @@ val map : f:(float -> float) -> t -> t
     and builds a floatarray with the results returned by [f]. *)
 
 val map_inplace : f:(float -> float) -> t -> unit
-(** [map_inplace f a] applies function [f] to all elements of [a],
+(** [map_inplace ~f a] applies function [f] to all elements of [a],
     and updates their values in place.
     @since 5.1 *)
 
@@ -165,19 +165,19 @@ val mapi_inplace : f:(int -> float -> float) -> t -> unit
     @since 5.1 *)
 
 val fold_left : f:('acc -> float -> 'acc) -> init:'acc -> t -> 'acc
-(** [fold_left ~f x ~init] computes
-    [f (... (f (f x init.(0)) init.(1)) ...) init.(n-1)],
-    where [n] is the length of the floatarray [init]. *)
+(** [fold_left ~f ~init a] computes
+    [f (... (f (f init a.(0)) a.(1)) ...) a.(n-1)],
+    where [n] is the length of the floatarray [a]. *)
 
 val fold_right : f:(float -> 'acc -> 'acc) -> t -> init:'acc -> 'acc
-(** [fold_right f a init] computes
+(** [fold_right ~f a ~init] computes
     [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
     where [n] is the length of the floatarray [a]. *)
 
 (** {1 Iterators on two arrays} *)
 
 val iter2 : f:(float -> float -> unit) -> t -> t -> unit
-(** [Array.iter2 ~f a b] applies function [f] to all the elements of [a]
+(** [iter2 ~f a b] applies function [f] to all the elements of [a]
     and [b].
     @raise Invalid_argument if the floatarrays are not the same size. *)
 
@@ -195,7 +195,7 @@ val for_all : f:(float -> bool) -> t -> bool
     [(f a1) && (f a2) && ... && (f an)]. *)
 
 val exists : f:(float -> bool) -> t -> bool
-(** [exists f [|a1; ...; an|]] checks if at least one element of
+(** [exists ~f [|a1; ...; an|]] checks if at least one element of
     the floatarray satisfies the predicate [f]. That is, it returns
     [(f a1) || (f a2) || ... || (f an)]. *)
 

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -51,7 +51,7 @@
 
  (**
     Unsynchronized accesses to a hash table may lead to an invalid hash table
-    state. Thus, concurrent accesses to a hash tables must be synchronized
+    state. Thus, concurrent accesses to a hash table must be synchronized
     (for instance with a {!Mutex.t}).
 *)
 
@@ -187,9 +187,9 @@ val iter : f:(key:'a -> data:'b -> unit) -> ('a, 'b) t -> unit
 val filter_map_inplace: f:(key:'a -> data:'b -> 'b option) -> ('a, 'b) t ->
     unit
 (** [Hashtbl.filter_map_inplace ~f tbl] applies [f] to all bindings in
-    table [tbl] and update each binding depending on the result of
+    table [tbl] and updates each binding depending on the result of
     [f].  If [f] returns [None], the binding is discarded.  If it
-    returns [Some new_val], the binding is update to associate the key
+    returns [Some new_val], the binding is updated to associate the key
     to [new_val].
 
     Other comments for {!iter} apply as well.

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -201,7 +201,7 @@ module type S =
         with respect to the ordering over the type of the elements. *)
 
     val fold: f:(elt -> 'acc -> 'acc) -> t -> init:'acc -> 'acc
-    (** [fold ~f s init] computes [(f xN ... (f x2 (f x1 init))...)],
+    (** [fold ~f s ~init] computes [(f xN ... (f x2 (f x1 init))...)],
         where [x1 ... xN] are the elements of [s], in increasing order. *)
 
     (** {1:transforming Transforming} *)
@@ -220,7 +220,7 @@ module type S =
 
     val filter: f:(elt -> bool) -> t -> t
     (** [filter ~f s] returns the set of all elements in [s]
-        that satisfy predicate [f]. If [f] satisfies every element in [s],
+        that satisfy predicate [f]. If every element in [s] satisfies [f],
         [s] is returned unchanged (the result of the function is then
         physically equal to [s]).
         @before 4.03 Physical equality was not ensured.*)


### PR DESCRIPTION
Various small documentation fixes across stdlib templates and their derived files:

- **float**: "floating point" -> "floating-point" for consistency, "bugs on limitations" -> "bugs or limitations", remove incorrect "Argument is in radians" from `cosh`/`sinh`/`tanh` (hyperbolic functions don't take radians)
- **hashtbl**: "a hash tables" -> "a hash table", "update" -> "updates"/"updated" in `filter_map_inplace` doc
- **set**: fix backwards predicate logic in `filter` doc ("If [f] satisfies every element" -> "If every element satisfies [f]"), add missing `~init` label in `fold` doc
- **floatarraylabeled**: add missing `~` on labels in `equal`, `compare`, `map_inplace`, `fold_left`, `fold_right`, `exists` docs; fix `fold_left` doc using `init` as both the accumulator and array name; fix `Array.iter2` -> `iter2`
- **stdlib**: remove incorrect "Argument is in radians" from `cosh`/`sinh`/`tanh` (not generated from templates, edited directly)