### PR TITLE
Document Buffer reallocation strategy

### DIFF
--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -32,17 +32,18 @@
 
 (** {1:capacity Capacity and reallocation strategy}
 
-    Internally, a buffer uses a {b backing byte sequence} whose size, called the
-    {b capacity}, is greater or equal to the number of characters stored in the
-    buffer (its {b length}).
+    Internally, a buffer uses a {b backing store} (a byte sequence) whose size,
+    called the {b capacity}, is greater or equal to the number of characters
+    stored in the buffer (its {b length}).
 
     The implementation uses a standard exponential reallocation strategy which
-    guarantees amortized constant-time operation; in particular, the total
-    capacity of all backing byte sequences allocated over the lifetime of a
-    buffer is at worst proportional to the total number of characters added.
+    guarantees amortized constant-time operation; in particular, the total size
+    of all backing stores allocated over the lifetime of a buffer is at worst
+    proportional to the total number of characters added.
 
-    {!clear} preserves the current backing byte sequence, while {!reset}
-    restores the original backing byte sequence.
+    {!clear} preserves the current backing store (so no memory is freed), while
+    {!reset} frees the current backing store, releasing memory at the price of
+    potentially having to reallocate more memory later on.
 *)
 
 (** {b Unsynchronized accesses} *)

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -36,19 +36,13 @@
     called the {b capacity}, is greater or equal to the number of
     characters stored in the buffer (its {b length}).
 
-    When an operation needs to add more characters than the remaining
-    capacity allows, the backing byte sequence is reallocated. The new
-    capacity is the smallest power-of-two multiple of the initial size [n]
-    (as given to {!create}) that is large enough to hold the resulting
-    contents. In other words, the capacity is always [n * 2{^k}] for
-    some non-negative integer [k], up to a maximum of
-    {!Sys.max_string_length}.
+    The implementation uses a standard exponential reallocation strategy which
+    guarantees amortized constant-time operation; in particular, the total
+    capacity of all backing byte sequences allocated over the lifetime of a
+    buffer is at worst proportional to the total number of characters added.
 
-    This exponential reallocation strategy ensures that appending
-    characters has amortized constant-time cost.
-
-    {!clear} preserves the current capacity, while {!reset} returns
-    the capacity to its initial value [n].
+    {!clear} preserves the current backing byte sequence, while {!reset}
+    restores the original backing byte sequence.
 *)
 
 (** {b Unsynchronized accesses} *)

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -32,9 +32,9 @@
 
 (** {1:capacity Capacity and reallocation strategy}
 
-    Internally, a buffer uses a {b backing byte sequence} whose length,
-    called the {b capacity}, is greater or equal to the number of
-    characters stored in the buffer (its {b length}).
+    Internally, a buffer uses a {b backing byte sequence} whose size, called the
+    {b capacity}, is greater or equal to the number of characters stored in the
+    buffer (its {b length}).
 
     The implementation uses a standard exponential reallocation strategy which
     guarantees amortized constant-time operation; in particular, the total

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -30,6 +30,27 @@
 
 *)
 
+(** {1:capacity Capacity and reallocation strategy}
+
+    Internally, a buffer uses a {b backing byte sequence} whose length,
+    called the {b capacity}, is greater or equal to the number of
+    characters stored in the buffer (its {b length}).
+
+    When an operation needs to add more characters than the remaining
+    capacity allows, the backing byte sequence is reallocated. The new
+    capacity is the smallest power-of-two multiple of the initial size [n]
+    (as given to {!create}) that is large enough to hold the resulting
+    contents. In other words, the capacity is always [n * 2{^k}] for
+    some non-negative integer [k], up to a maximum of
+    {!Sys.max_string_length}.
+
+    This exponential reallocation strategy ensures that appending
+    characters has amortized constant-time cost.
+
+    {!clear} preserves the current capacity, while {!reset} returns
+    the capacity to its initial value [n].
+*)
+
 (** {b Unsynchronized accesses} *)
 
 [@@@alert unsynchronized_access

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -43,7 +43,7 @@
 
     {!clear} preserves the current backing store (so no memory is freed), while
     {!reset} frees the current backing store, releasing memory at the price of
-    potentially having to reallocate more memory later on.
+    potentially having to reallocate later on.
 *)
 
 (** {b Unsynchronized accesses} *)


### PR DESCRIPTION
Documents the `Buffer` module's internal reallocation strategy, as requested in #14080.

The `Dynarray` module already documents its reallocation strategy in detail. This adds a similar (but more concise) section to `Buffer`, describing the exponential doubling approach and how `clear` vs `reset` interact with capacity.

Fixes #14080