### PR TITLE
increase timeout for other-configs CI job

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -32,6 +32,7 @@
 # -patch1 file-name       apply patch with -p1
 # -no-native              do not build "opt" and "opt.opt"
 # -jNN                    pass "-jNN" option to make for parallel builds
+# -with-bootstrap         perform a bootstrap
 
 error () {
   echo "$1" >&2

--- a/tools/ci/inria/other-configs/Jenkinsfile
+++ b/tools/ci/inria/other-configs/Jenkinsfile
@@ -20,7 +20,7 @@
 pipeline {
   agent { label 'ocaml-linux-64' }
   options {
-    timeout(time: 45, unit: 'MINUTES')
+    timeout(time: 90, unit: 'MINUTES')
   }
   stages {
     stage('Testing various other compiler configurations') {

--- a/tools/ci/inria/other-configs/script
+++ b/tools/ci/inria/other-configs/script
@@ -22,7 +22,7 @@ set -e
 mainjob=./tools/ci/inria/main
 main="${mainjob} -j8"
 
-echo "============== minimal build ================="
+echo "============== minimal build ================= `date`"
 # The "MIN_BUILD" (formerly on Travis) builds with everything disabled (apart
 # from ocamltest). Its goals:
 #  - Ensure that the system builds correctly without native compilation
@@ -40,19 +40,22 @@ ${main} -conf --disable-native-compiler \
         -conf --disable-dependency-generation \
         -no-native
 
-echo "============== no flat float arrays, clang, C23 ================="
+echo "============== no flat float arrays, clang, C23 ================= `date`"
 ${main} -conf --disable-flat-float-array \
         -conf CC=clang-18 \
         -conf CFLAGS=-std=gnu2x
 
-echo "============== flambda ================="
+echo "============== flambda ================= `date`"
 ${main} -conf --enable-flambda
 
-echo "============== frame pointers, reserved header bits ================="
+echo "============== frame pointers, reserved header bits =================\
+ `date`"
 ${main} -conf --enable-frame-pointers -conf --enable-reserved-header-bits=27
 
-echo "============== bootstrap, pic ================="
+echo "============== bootstrap, pic ================= `date`"
 ${main} -with-bootstrap -conf --with-pic
 
-echo "============== cleanup at exit, clang ================="
+echo "============== cleanup at exit, clang ================= `date`"
 OCAMLRUNPARAM="c=1" ${main} -conf CC=clang-18
+
+echo "============== done ================= `date`"


### PR DESCRIPTION
The CI script `tools/ci/inria/other-configs/script` takes anywhere between 40 and 52 minutes to run on our CI machine. Timeout for this job is 45 minutes, which leads to a lot of random failures.

I also added a bit of instrumentation to the script itself, and fixed a missing comment in another CI script.
