### PR TITLE
install.adoc: minor edits around 'common problems' section

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -199,7 +199,7 @@ After installation, do *not* strip the `ocamldebug` executables.
 
 * On some systems, localization causes build problems.  You should try to set
   the C locale (`export LC_ALL=C`) before compiling if you have strange errors
-  while compiling OCaml.
+  while compiling OCaml. If this occurs, please report it using the issue tracker.
 
 * In the unlikely case that a platform does not offer all C99 float operations
   that the runtime needs, a configuration error will result.  Users

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -193,8 +193,6 @@ After installation, do *not* strip the `ocamldebug` executables.
 
 == If something goes wrong
 
-== Common problems
-
 * The Makefiles assume that make executes commands by calling `/bin/sh`. They
   won't work if `/bin/csh` is called instead.  You may have to unset the `SHELL`
   environment variable, or set it to `/bin/sh`.
@@ -212,27 +210,25 @@ After installation, do *not* strip the `ocamldebug` executables.
   handling of mathematical corner cases and error conditions may need to
   consider running their code on a platform with better C99 support.
 
-== Additional hints
+* Check the files `m.h` and `s.h` in `runtime/caml/`. Wrong endianness or
+  alignment constraints in `m.h` will immediately crash the bytecode
+  interpreter.
 
-Check the files `m.h` and `s.h` in `runtime/caml/`.
-Wrong endianness or alignment constraints in `m.h` will
-immediately crash the bytecode interpreter.
+* If you get a "segmentation violation" signal, check the limits on the
+  stack size and data segment size (type `limit` under csh or `ulimit -a`
+  under bash). Make sure the limit on the stack size is at least 4M.
 
-If you get a "segmentation violation" signal, check the limits on the stack size
-and data segment size (type `limit` under csh or `ulimit -a` under bash). Make
-sure the limit on the stack size is at least 4M.
+* Try recompiling the runtime system with optimizations turned off (change
+  `OC_CFLAGS` in `Makefile.build_config`). The runtime system contains some
+  complex, atypical pieces of C code which can uncover bugs in optimizing
+  compilers.  Alternatively, try another C compiler (e.g. `gcc` instead of
+  the vendor-supplied `cc`).
 
-Try recompiling the runtime system with optimizations turned off (change
-`OC_CFLAGS` in `Makefile.build_config`). The runtime system
-contains some complex, atypical pieces of C code which can uncover bugs in
-optimizing compilers.  Alternatively, try another C compiler (e.g. `gcc` instead
-of the vendor-supplied `cc`).
-
-You can also use the debug version of the runtime system which is
-normally built and installed by default. Run the bytecode program
-that causes troubles with `ocamlrund` rather than with `ocamlrun`.
-This version of the runtime system contains lots of assertions
-and sanity checks that could help you pinpoint the problem.
+* You can also use the debug version of the runtime system which is normally
+  built and installed by default. Run the bytecode program that causes
+  troubles with `ocamlrund` rather than with `ocamlrun`. This version of the
+  runtime system contains lots of assertions and sanity checks that could
+  help you pinpoint the problem.
 
 == (experimental) Building a cross compiler
 

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -212,6 +212,8 @@ After installation, do *not* strip the `ocamldebug` executables.
   handling of mathematical corner cases and error conditions may need to
   consider running their code on a platform with better C99 support.
 
+== Additional hints
+
 Check the files `m.h` and `s.h` in `runtime/caml/`.
 Wrong endianness or alignment constraints in `m.h` will
 immediately crash the bytecode interpreter.

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -193,8 +193,7 @@ After installation, do *not* strip the `ocamldebug` executables.
 
 == If something goes wrong
 
-Read the "common problems" and "machine-specific hints" section at the end of
-this file.
+Read the "common problems" at the end of this file.
 
 Check the files `m.h` and `s.h` in `runtime/caml/`.
 Wrong endianness or alignment constraints in `m.h` will

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -193,7 +193,24 @@ After installation, do *not* strip the `ocamldebug` executables.
 
 == If something goes wrong
 
-Read the "common problems" at the end of this file.
+== Common problems
+
+* The Makefiles assume that make executes commands by calling `/bin/sh`. They
+  won't work if `/bin/csh` is called instead.  You may have to unset the `SHELL`
+  environment variable, or set it to `/bin/sh`.
+
+* On some systems, localization causes build problems.  You should try to set
+  the C locale (`export LC_ALL=C`) before compiling if you have strange errors
+  while compiling OCaml.
+
+* In the unlikely case that a platform does not offer all C99 float operations
+  that the runtime needs, a configuration error will result.  Users
+  can work around this problem by calling `configure` with the flag
+  `--enable-imprecise-c99-float-ops`.  This will enable simple but potentially
+  imprecise implementations of C99 float operations.  Users with exacting
+  requirements for mathematical accuracy, numerical precision, and proper
+  handling of mathematical corner cases and error conditions may need to
+  consider running their code on a platform with better C99 support.
 
 Check the files `m.h` and `s.h` in `runtime/caml/`.
 Wrong endianness or alignment constraints in `m.h` will
@@ -214,25 +231,6 @@ normally built and installed by default. Run the bytecode program
 that causes troubles with `ocamlrund` rather than with `ocamlrun`.
 This version of the runtime system contains lots of assertions
 and sanity checks that could help you pinpoint the problem.
-
-== Common problems
-
-* The Makefiles assume that make executes commands by calling `/bin/sh`. They
-  won't work if `/bin/csh` is called instead.  You may have to unset the `SHELL`
-  environment variable, or set it to `/bin/sh`.
-
-* On some systems, localization causes build problems.  You should try to set
-  the C locale (`export LC_ALL=C`) before compiling if you have strange errors
-  while compiling OCaml.
-
-* In the unlikely case that a platform does not offer all C99 float operations
-  that the runtime needs, a configuration error will result.  Users
-  can work around this problem by calling `configure` with the flag
-  `--enable-imprecise-c99-float-ops`.  This will enable simple but potentially
-  imprecise implementations of C99 float operations.  Users with exacting
-  requirements for mathematical accuracy, numerical precision, and proper
-  handling of mathematical corner cases and error conditions may need to
-  consider running their code on a platform with better C99 support.
 
 == (experimental) Building a cross compiler
 


### PR DESCRIPTION
Closes #14541 

This PR removes reference to a now removed section on machine-specific hints and rearranges the common problems section since its no longer at the end of the file