### PR TITLE
Remove caml_get_header_val, as not needed.

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -95,7 +95,6 @@ extern void caml_empty_minor_heaps_once(void); /* out STW */
 void caml_alloc_small_dispatch (caml_domain_state* domain,
                                 intnat wosize, int flags,
                                 int nallocs, unsigned char* encoded_alloc_lens);
-header_t caml_get_header_val(value v);
 void caml_alloc_table (struct caml_ref_table *tbl, asize_t sz, asize_t rsv);
 extern void caml_realloc_ref_table (struct caml_ref_table *);
 extern void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *);

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -241,7 +241,7 @@ static void generic_final_minor_update
   for (uintnat i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val) &&
-        !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
+        !Is_promoted_hd(Hd_val(final->table[i].val))) {
       ++ todo_count;
     }
   }
@@ -264,7 +264,7 @@ static void generic_final_minor_update
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
       if (Is_young(final->table[i].val) &&
-          !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
+          !Is_promoted_hd(Hd_val(final->table[i].val))) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */
@@ -286,7 +286,7 @@ static void generic_final_minor_update
   for (uintnat i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val)) {
-      CAMLassert (Is_promoted_hd(caml_get_header_val(final->table[i].val)));
+      CAMLassert (Is_promoted_hd(Hd_val(final->table[i].val)));
       final->table[i].val = Field(final->table[i].val, 0);
     }
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -184,11 +184,6 @@ Caml_inline header_t get_header_val(value v) {
   return spin_on_header(v);
 }
 
-header_t caml_get_header_val(value v) {
-  return get_header_val(v);
-}
-
-
 static int try_update_object_header(value v, volatile value *p, value result,
                                     mlsize_t infix_offset) {
   int success = 0;
@@ -802,7 +797,7 @@ static void custom_finalize_minor (caml_domain_state * domain)
        elt++) {
     value *v = &elt->block;
     if (Is_block(*v) && Is_young(*v)) {
-      if (Is_promoted_hd(get_header_val(*v))) { /* value promoted */
+      if (Is_promoted_hd(Hd_val(*v))) { /* value copied to major heap */
         caml_adjust_gc_speed(elt->mem, elt->max);
       } else {
         void (*final_fun)(value) = Custom_ops_val(*v)->finalize;


### PR DESCRIPTION
`caml_get_header_val` and `get_header_val` only differ from `Hd_val` in that they will spin if they see an in-progress header, i.e. if some domain is in the process of promoting the block. This can only happen between the barriers of a minor collection; there are very few places outside `minor_gc.c` where it might be possible, and certainly not while updating finalizer data structures after a minor GC. So the extern declaration of `caml_get_header_val` is not needed, and its uses become `Hd_val`.

Upstreaming from oxcaml/oxcaml#4189 and oxcaml/oxcaml#5454