### PR TITLE
Runtime prefetching: distinguish between read and write

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,11 @@ Working version
   symbols from the runtime. The declarations were removed in 5.0.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 
+- #14570: Distinguish between prefetching for read and write access in the
+  runtime. Significant performance benefit for some multi-domain programs. For
+  maximum benefit on AMD64, pass -mprfchw to the C compiler.
+  (Nick Barnes, review by Gabriel Scherer, Damien Doligez, and Antonin Décimo)
+
 ### Code generation and optimizations:
 
 * #13919: optimize `lazy v` when `v` is a structured constant

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -178,14 +178,18 @@ CAMLdeprecated_typedef(addr, char *);
 
 #ifdef CAML_INTERNALS
 #if (__has_builtin(__builtin_prefetch) || defined(__GNUC__))
-#define caml_prefetch(p) __builtin_prefetch((p), 1, 3)
+#define caml_prefetchr(p) __builtin_prefetch((p), 0, 3)
+/* 0 = intent to read; 3 = all cache levels */
+#define caml_prefetchw(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
 #elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))
 #include <intrin.h>
-#define caml_prefetch(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
+#define caml_prefetchr(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
 /* PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, p) */
+#define caml_prefetchw(p) caml_prefetchr(p)
 #else
-#define caml_prefetch(p)
+#define caml_prefetchr(p)
+#define caml_prefetchw(p)
 #endif
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -177,19 +177,34 @@ CAMLdeprecated_typedef(addr, char *);
 /* Prefetching */
 
 #ifdef CAML_INTERNALS
+
 #if (__has_builtin(__builtin_prefetch) || defined(__GNUC__))
 #define caml_prefetchr(p) __builtin_prefetch((p), 0, 3)
 /* 0 = intent to read; 3 = all cache levels */
 #define caml_prefetchw(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
-#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))
+
+#elif defined(_MSC_VER)
 #include <intrin.h>
+#if (defined(_M_IX86) || defined(_M_AMD64))
+/* MSVC Intel. See #14570.
+   0 - PREFETCHNTA; 1 - PREFETCHT0; 2 - PREFETCHT1; 3 - PREFETCHT2
+   4 - PREFETCHW; 5 - PREFETCHNTA */
 #define caml_prefetchr(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
 /* PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, p) */
-#define caml_prefetchw(p) caml_prefetchr(p)
-#else
-#define caml_prefetchr(p)
-#define caml_prefetchw(p)
+#define caml_prefetchw(p) _mm_prefetch((char const *) p, 4)
+
+#elif defined(_M_ARM64)
+/* MSVC ARM64. See #14570 */
+#define caml_prefetchr(p) __prefetch2(p, 0)
+#define caml_prefetchw(p) __prefetch2(p, 16)
+#endif
+#endif
+
+#if !defined(caml_prefetchr)
+/* Not GCC or Clang or MSVC */
+#define caml_prefetchr(p) ((void)(p))
+#define caml_prefetchw(p) ((void)(p))
 #endif
 #endif /* CAML_INTERNALS */
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1574,7 +1574,7 @@ again:
       /* Didn't finish scanning this object, either because budget <= 0,
          or the prefetch buffer filled up. Leave the rest on the stack. */
       mark_stack_push_range(stk, me.start, me.end);
-      caml_prefetchw((void*)(me.start + 1));
+      caml_prefetchr((void*)(me.start + 1));
 
       if (pb_size(&pb) > PREFETCH_BUFFER_MIN) {
         /* We may have just discovered more work when we were about to run out.

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -230,9 +230,14 @@ Caml_inline void prefetch_block(value v)
      already marked, not markable, or extremely short, then we waste
      somewhere between 1/8-1/2 of a prefetch operation (in expectation,
      depending on alignment, word size, and cache line size), which is
-     cheap enough to make this worthwhile. */
-  caml_prefetch((const void *)Hp_val(v));
-  caml_prefetch((const void *)&Field(v, 3));
+     cheap enough to make this worthwhile.
+
+     The prefetches are prefetchr (read), not prefetchw (write). The
+     major GC often writes mark bits but is readonly if no marking
+     need be done (because a block is already marked, or statically
+     allocated). In such cases, a prefetchw causes contention. */
+  caml_prefetchr((const void *)Hp_val(v));
+  caml_prefetchr((const void *)&Field(v, 3));
 }
 
 /*******************************************************************************
@@ -1569,7 +1574,7 @@ again:
       /* Didn't finish scanning this object, either because budget <= 0,
          or the prefetch buffer filled up. Leave the rest on the stack. */
       mark_stack_push_range(stk, me.start, me.end);
-      caml_prefetch((void*)(me.start + 1));
+      caml_prefetchw((void*)(me.start + 1));
 
       if (pb_size(&pb) > PREFETCH_BUFFER_MIN) {
         /* We may have just discovered more work when we were about to run out.

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -557,7 +557,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
       header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
 
       if( (char*)p + caml_plat_pagesize < (char*)end ) {
-        caml_prefetch((char*)p + caml_plat_pagesize);
+        caml_prefetchr((char*)p + caml_plat_pagesize);
       }
 
       /* The pools mark a block as being free by setting the tag to No_scan_tag


### PR DESCRIPTION
For the forthcoming `faster oldify` PR (performance boost to minor GC) we need to distinguish between `prefetchr` (prefetching for read) and `prefetchw` (prefetching for write). See oxcaml/oxcaml#5163 (introducing and using the two different macros), oxcaml/oxcaml#5359 (fixing preprocessor use for older GCCs), and oxcaml/oxcaml#5416 (switching major GC to use `prefetchr`).