### PR TITLE
[4.14] Correct backport of #12372

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,16 @@
+OCaml 4.14 maintenance version
+------------------------------
+
+### Build system:
+
+- #12372, #14572: Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  so that code sections remain readable, as needed for closure marshaling.
+  Originally backported in 4.14.2, but the flag was accidentally not passed when
+  linking the .so versions of the OCaml runtime libraries or when linking .cmxs
+  files.
+  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+  Sébastien Hinderer)
+
 OCaml 4.14.3 (17 February 2026)
 ------------------------------
 

--- a/configure
+++ b/configure
@@ -14135,7 +14135,7 @@ esac ;; #(
 esac
        case $host in #(
   *-*-openbsd7.[3-9]|*-*-openbsd[89].*) :
-    mkdll_flags="${mkdll_flags} -Wl,--no-execute-only" ;; #(
+    mksharedlib="${mksharedlib} -Wl,--no-execute-only" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -993,7 +993,7 @@ AS_IF([test x"$enable_shared" != "xno"],
            [mksharedlib="$CC -shared \$(LDFLAGS)"])
        AS_CASE([$host],
            [[*-*-openbsd7.[3-9]|*-*-openbsd[89].*]],
-           [mkdll_flags="${mkdll_flags} -Wl,--no-execute-only"])
+           [mksharedlib="${mksharedlib} -Wl,--no-execute-only"])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"


### PR DESCRIPTION
I've noticed while testing other things that tests/lib-dynlink-native/main.ml was consistently segfaulting on the Inria OpenBSD worker (which is running OpenBSD 7.6) for OCaml 4.14. It can be seen failing on a job of mine [precheck#1126](https://ci.inria.fr/ocaml/job/precheck/flambda=false,label=ocaml-openbsd-64/1126/console) and on the current 4.14.3 tip of branch 4.14 in [precheck#1136](https://ci.inria.fr/ocaml/job/precheck/1136/flambda=false,label=ocaml-openbsd-64/console).

The issue is that the backport of #12372 isn't quite right - `$mkdll_flags` was introduced in `configure.ac` in #11254 in 5.0.0: prior to then the variable which needed updating was `$mksharedlib`.

The effect is that libcamlrun\_shared.so and libasmrun\_shared.so will have been linked without `-Wl,--no-execute-only`, but it also means that `Config.mkdll` will not have contained it, which means `ocamlopt -shared` won't have been passing it either.

That's a convincing enough explanation for why the lib-dynlink-native test was failing - I don't have an explanation for why none of the other natdynlink tests appear to be _working_, although on my OpenBSD 7.8 VM, I can't even repro this problem at all (but I haven't tried very hard to understand why just the one test was affected).