### PR TITLE
Detect Linux ppc64 set architecture, model and system.

### DIFF
--- a/configure
+++ b/configure
@@ -18960,6 +18960,8 @@ case $target in #(
     has_native_backend=yes; arch=power; model=ppc64le; system=linux ;; #(
   powerpc64*-*-linux-musl*) :
     has_native_backend=yes; arch=power; model=ppc64; system=linux ;; #(
+  powerpc64*-*-linux*) :
+    arch=power; model=ppc64; system=linux ;; #(
   s390x*-*-linux*) :
     has_native_backend=yes; arch=s390x; model=z10; system=linux ;; #(
   # expected to match "gnueabihf" as well as "musleabihf"

--- a/configure.ac
+++ b/configure.ac
@@ -1656,6 +1656,8 @@ AS_CASE([$target],
     [has_native_backend=yes; arch=power; model=ppc64le; system=linux],
   [[powerpc64*-*-linux-musl*]],
     [has_native_backend=yes; arch=power; model=ppc64; system=linux],
+  [[powerpc64*-*-linux*]],
+    [arch=power; model=ppc64; system=linux],
   [[s390x*-*-linux*]],
     [has_native_backend=yes; arch=s390x; model=z10; system=linux],
   # expected to match "gnueabihf" as well as "musleabihf"


### PR DESCRIPTION
Matches Linux distros targeting ELFv1 (like debian and Centos) and sets the arch configure variable to power. Similar behaviour to other bytecode-only architectures like 32-bit arm and x86. This gets used in ocamltest when detecting the architecture a test should run on. For example this will be skipped incorrectly because the `Ocamltest_config.arch` value will be `none` 
```
arch_power;
bytecode;
```

I don't think this merits a Changes entry.