### PR TITLE
Use Iarray.t rather than iarray in Iarray API

### DIFF
--- a/stdlib/iarray.mli
+++ b/stdlib/iarray.mli
@@ -40,12 +40,12 @@
 open! Stdlib
 
 type +'a t = 'a iarray
-(** An alias for the type of immutable arrays. *)
+(** The type of immutable arrays. *)
 
-external length : 'a iarray -> int = "%array_length"
+external length : 'a t -> int = "%array_length"
 (** Return the length (number of elements) of the given immutable array. *)
 
-external get : 'a iarray -> int -> 'a = "%array_safe_get"
+external get : 'a t -> int -> 'a = "%array_safe_get"
 (** [get a n] returns the element number [n] of immutable array [a].
    The first element has number 0.
    The last element has number [length a - 1].
@@ -53,7 +53,7 @@ external get : 'a iarray -> int -> 'a = "%array_safe_get"
    @raise Invalid_argument
    if [n] is outside the range 0 to [(length a - 1)]. *)
 
-val init : int -> (int -> 'a) -> 'a iarray
+val init : int -> (int -> 'a) -> 'a t
 (** [init n f] returns a fresh immutable array of length [n],
    with element number [i] initialized to the result of [f i].
    In other terms, [init n f] tabulates the results of [f]
@@ -63,16 +63,16 @@ val init : int -> (int -> 'a) -> 'a iarray
    If the return type of [f] is [float], then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
-val append : 'a iarray -> 'a iarray -> 'a iarray
+val append : 'a t -> 'a t -> 'a t
 (** [append v1 v2] returns a fresh immutable array containing the
    concatenation of the immutable arrays [v1] and [v2].
    @raise Invalid_argument if
    [length v1 + length v2 > Sys.max_array_length]. *)
 
-val concat : 'a iarray list -> 'a iarray
+val concat : 'a t list -> 'a t
 (** Same as {!append}, but concatenates a list of immutable arrays. *)
 
-val sub : 'a iarray -> pos:int -> len:int -> 'a iarray
+val sub : 'a t -> pos:int -> len:int -> 'a t
 (** [sub a ~pos ~len] returns a fresh immutable array of length [len],
    containing the elements number [pos] to [pos + len - 1]
    of immutable array [a].  This creates a copy of the selected
@@ -82,10 +82,10 @@ val sub : 'a iarray -> pos:int -> len:int -> 'a iarray
    designate a valid subarray of [a]; that is, if
    [pos < 0], or [len < 0], or [pos + len > length a]. *)
 
-val to_list : 'a iarray -> 'a list
+val to_list : 'a t -> 'a list
 (** [to_list a] returns the list of all the elements of [a]. *)
 
-val of_list : 'a list -> 'a iarray
+val of_list : 'a list -> 'a t
 (** [of_list l] returns a fresh immutable array containing the elements
    of [l].
 
@@ -94,22 +94,22 @@ val of_list : 'a list -> 'a iarray
 
 (** {1 Converting to and from mutable arrays} *)
 
-val to_array : 'a iarray -> 'a array
+val to_array : 'a t -> 'a array
 (** [to_array a] returns a mutable copy of the immutable array [a]; that is, a
    fresh (mutable) array containing the same elements as [a] *)
 
-val of_array : 'a array -> 'a iarray
+val of_array : 'a array -> 'a t
 (** [of_array ma] returns an immutable copy of the mutable array [ma]; that is,
    a fresh immutable array containing the same elements as [ma] *)
 
 (** {1 Comparison} *)
 
-val equal : ('a -> 'a -> bool) -> 'a iarray -> 'a iarray -> bool
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 (** [eq [|a1; ...; an|] [|b1; ..; bm|]] holds when the two input immutable
     arrays have the same length, and for each pair of elements [ai, bi] at the
     same position we have [eq ai bi]. *)
 
-val compare : ('a -> 'a -> int) -> 'a iarray -> 'a iarray -> int
+val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
 (** Provided the function [cmp] defines a preorder on elements,
     [compare cmp a b] compares first [a] and [b] by their length, and then, if
       equal, by their elements according to the lexicographic preorder.
@@ -118,37 +118,37 @@ val compare : ('a -> 'a -> int) -> 'a iarray -> 'a iarray -> int
 
 (** {1 Iterators} *)
 
-val iter : ('a -> unit) -> 'a iarray -> unit
+val iter : ('a -> unit) -> 'a t -> unit
 (** [iter f a] applies function [f] in turn to all
    the elements of [a].  It is equivalent to
    [f (get a 0); f (get a 1); ...; f (get a (length a - 1)); ()]. *)
 
-val iteri : (int -> 'a -> unit) -> 'a iarray -> unit
+val iteri : (int -> 'a -> unit) -> 'a t -> unit
 (** Same as {!iter}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
-val map : ('a -> 'b) -> 'a iarray -> 'b iarray
+val map : ('a -> 'b) -> 'a t -> 'b t
 (** [map f a] applies function [f] to all the elements of [a],
    and builds an immutable array with the results returned by [f]:
    [[| f (get a 0); f (get a 1); ...; f (get a (length a - 1)) |]]. *)
 
-val mapi : (int -> 'a -> 'b) -> 'a iarray -> 'b iarray
+val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
 (** Same as {!map}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
-val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b iarray -> 'a
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** [fold_left f init a] computes
    [f (... (f (f init (get a 0)) (get a 1)) ...) (get a n-1)],
    where [n] is the length of the immutable array [a]. *)
 
 val fold_left_map :
-  ('a -> 'b -> 'a * 'c) -> 'a -> 'b iarray -> 'a * 'c iarray
+  ('a -> 'b -> 'a * 'c) -> 'a -> 'b t -> 'a * 'c t
 (** [fold_left_map] is a combination of {!fold_left} and {!map} that threads an
     accumulator through calls to [f]. *)
 
-val fold_right : ('b -> 'a -> 'a) -> 'b iarray -> 'a -> 'a
+val fold_right : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a
 (** [fold_right f a init] computes
    [f (get a 0) (f (get a 1) ( ... (f (get a (n-1)) init) ...))],
    where [n] is the length of the immutable array [a]. *)
@@ -157,13 +157,13 @@ val fold_right : ('b -> 'a -> 'a) -> 'b iarray -> 'a -> 'a
 (** {1 Iterators on two arrays} *)
 
 
-val iter2 : ('a -> 'b -> unit) -> 'a iarray -> 'b iarray -> unit
+val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
 (** [iter2 f a b] applies function [f] to all the elements of [a]
    and [b].
    @raise Invalid_argument if the immutable arrays are not the same size.
    *)
 
-val map2 : ('a -> 'b -> 'c) -> 'a iarray -> 'b iarray -> 'c iarray
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f a b] applies function [f] to all the elements of [a]
    and [b], and builds an immutable array with the results returned by [f]:
    [[| f (get a 0) (get b 0);
@@ -174,70 +174,70 @@ val map2 : ('a -> 'b -> 'c) -> 'a iarray -> 'b iarray -> 'c iarray
 
 (** {1 Array scanning} *)
 
-val for_all : ('a -> bool) -> 'a iarray -> bool
+val for_all : ('a -> bool) -> 'a t -> bool
 (** [for_all f [|a1; ...; an|]] checks if all elements
    of the immutable array satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)]. *)
 
-val exists : ('a -> bool) -> 'a iarray -> bool
+val exists : ('a -> bool) -> 'a t -> bool
 (** [exists f [|a1; ...; an|]] checks if at least one element of
     the immutable array satisfies the predicate [f]. That is, it returns
     [(f a1) || (f a2) || ... || (f an)]. *)
 
-val for_all2 : ('a -> 'b -> bool) -> 'a iarray -> 'b iarray -> bool
+val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 (** Same as {!for_all}, but for a two-argument predicate.
    @raise Invalid_argument if the two immutable arrays have different
    lengths. *)
 
-val exists2 : ('a -> 'b -> bool) -> 'a iarray -> 'b iarray -> bool
+val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 (** Same as {!exists}, but for a two-argument predicate.
    @raise Invalid_argument if the two immutable arrays have different
    lengths. *)
 
-val mem : 'a -> 'a iarray -> bool
+val mem : 'a -> 'a t -> bool
 (** [mem a set] is true if and only if [a] is structurally equal
     to an element of [set] (i.e. there is an [x] in [set] such that
     [compare a x = 0]). *)
 
-val memq : 'a -> 'a iarray -> bool
+val memq : 'a -> 'a t -> bool
 (** Same as {!mem}, but uses physical equality instead of structural equality
     to compare array elements. *)
 
-val find_opt : ('a -> bool) -> 'a iarray -> 'a option
+val find_opt : ('a -> bool) -> 'a t -> 'a option
 (** [find_opt f a] returns the first element of the immutable array [a] that
     satisfies the predicate [f], or [None] if there is no value that satisfies
     [f] in the array [a]. *)
 
-val find_index : ('a -> bool) -> 'a iarray -> int option
+val find_index : ('a -> bool) -> 'a t -> int option
 (** [find_index f a] returns [Some i], where [i] is the index of the first
     element of the array [a] that satisfies [f x], if there is such an
     element.
 
     It returns [None] if there is no such element. *)
 
-val find_map : ('a -> 'b option) -> 'a iarray -> 'b option
+val find_map : ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist. *)
 
-val find_mapi : (int -> 'a -> 'b option) -> 'a iarray -> 'b option
+val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
 (** Same as [find_map], but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument. *)
 
 (** {1 Arrays of pairs} *)
 
-val split : ('a * 'b) iarray -> 'a iarray * 'b iarray
+val split : ('a * 'b) t -> 'a t * 'b t
 (** [split [|(a1,b1); ...; (an,bn)|]] is
     [([|a1; ...; an|], [|b1; ...; bn|])]. *)
 
-val combine : 'a iarray -> 'b iarray -> ('a * 'b) iarray
+val combine : 'a t -> 'b t -> ('a * 'b) t
 (** [combine [|a1; ...; an|] [|b1; ...; bn|]] is [[|(a1,b1); ...; (an,bn)|]].
     Raise [Invalid_argument] if the two immutable arrays have different
     lengths. *)
 
 (** {1 Sorting} *)
 
-val sort : ('a -> 'a -> int) -> 'a iarray -> 'a iarray
+val sort : ('a -> 'a -> int) -> 'a t -> 'a t
 (** Sort an immutable array in increasing order according to a comparison
    function.  The comparison function must return 0 if its arguments
    compare as equal, a positive integer if the first is greater,
@@ -263,7 +263,7 @@ val sort : ('a -> 'a -> int) -> 'a iarray -> 'a iarray
 -   [cmp (get a' i) (get a' j)] >= 0 if and only if i >= j
 *)
 
-val stable_sort : ('a -> 'a -> int) -> 'a iarray -> 'a iarray
+val stable_sort : ('a -> 'a -> int) -> 'a t -> 'a t
 (** Same as {!sort}, but the sorting algorithm is stable (i.e.
    elements that compare equal are kept in their original order) and
    not guaranteed to run in constant heap space.
@@ -273,20 +273,20 @@ val stable_sort : ('a -> 'a -> int) -> 'a iarray -> 'a iarray
    faster than the current implementation of {!sort}.
 *)
 
-val fast_sort : ('a -> 'a -> int) -> 'a iarray -> 'a iarray
+val fast_sort : ('a -> 'a -> int) -> 'a t -> 'a t
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input. *)
 
 (** {1 Iterators} *)
 
-val to_seq : 'a iarray -> 'a Seq.t
+val to_seq : 'a t -> 'a Seq.t
 (** Iterate on the immutable array, in increasing order. *)
 
-val to_seqi : 'a iarray -> (int * 'a) Seq.t
+val to_seqi : 'a t -> (int * 'a) Seq.t
 (** Iterate on the immutable array, in increasing order, yielding indices along
     elements. *)
 
-val of_seq : 'a Seq.t -> 'a iarray
+val of_seq : 'a Seq.t -> 'a t
 (** Create an immutable array from the generator *)
 
 (**/**)
@@ -295,4 +295,4 @@ val of_seq : 'a Seq.t -> 'a iarray
 
 (* The following is for system use only. Do not call directly. *)
 
-external unsafe_get : 'a iarray -> int -> 'a = "%array_unsafe_get"
+external unsafe_get : 'a t -> int -> 'a = "%array_unsafe_get"

--- a/testsuite/tests/lib-array/test_iarray.ml
+++ b/testsuite/tests/lib-array/test_iarray.ml
@@ -90,29 +90,29 @@ Exception: Invalid_argument "index out of bounds".
 
 Iarray.init 10 (fun x -> x * 2);;
 [%%expect{|
-- : int iarray = [|0; 2; 4; 6; 8; 10; 12; 14; 16; 18|]
+- : int Iarray.t = [|0; 2; 4; 6; 8; 10; 12; 14; 16; 18|]
 |}];;
 
 Iarray.append iarray iarray;;
 [%%expect{|
-- : int iarray = [|1; 2; 3; 4; 5; 1; 2; 3; 4; 5|]
+- : int Iarray.t = [|1; 2; 3; 4; 5; 1; 2; 3; 4; 5|]
 |}];;
 
 Iarray.concat [];;
 [%%expect{|
-- : 'a iarray = [||]
+- : 'a Iarray.t = [||]
 |}];;
 
 Iarray.concat [ Iarray.init 1 (fun x ->   1 + x)
               ; Iarray.init 2 (fun x ->  20 + x)
               ; Iarray.init 3 (fun x -> 300 + x) ];;
 [%%expect{|
-- : int iarray = [|1; 20; 21; 300; 301; 302|]
+- : int Iarray.t = [|1; 20; 21; 300; 301; 302|]
 |}];;
 
 Iarray.sub iarray ~pos:0 ~len:2, Iarray.sub iarray ~pos:2 ~len:3;;
 [%%expect{|
-- : int iarray * int iarray = ([|1; 2|], [|3; 4; 5|])
+- : int Iarray.t * int Iarray.t = ([|1; 2|], [|3; 4; 5|])
 |}];;
 
 Iarray.sub iarray ~pos:(-1) ~len:3;;
@@ -137,7 +137,7 @@ Iarray.to_list iarray;;
 
 Iarray.of_list [10;20;30];;
 [%%expect{|
-- : int iarray = [|10; 20; 30|]
+- : int Iarray.t = [|10; 20; 30|]
 |}];;
 
 
@@ -148,7 +148,7 @@ Iarray.to_array iarray;;
 
 Iarray.of_array mfarray;;
 [%%expect{|
-- : float iarray = [|1.5; 2.5; 3.5; 4.5; 5.5|]
+- : float Iarray.t = [|1.5; 2.5; 3.5; 4.5; 5.5|]
 |}];;
 
 (* [Iarray.to_array] creates a fresh mutable array every time *)
@@ -185,12 +185,12 @@ Iarray.iteri (fun i x -> total := !total + i*x) iarray;
 
 Iarray.map Int.neg iarray;;
 [%%expect{|
-- : int iarray = [|-1; -2; -3; -4; -5|]
+- : int Iarray.t = [|-1; -2; -3; -4; -5|]
 |}];;
 
 Iarray.mapi (fun i x -> i, 10.*.x) ifarray;;
 [%%expect{|
-- : (int * float) iarray =
+- : (int * float) Iarray.t =
 [|(0, 15.); (1, 25.); (2, 35.); (3, 45.); (4, 55.)|]
 |}];;
 
@@ -201,13 +201,13 @@ Iarray.fold_left (fun acc x -> -x :: acc) [] iarray;;
 
 Iarray.fold_left_map (fun acc x -> acc + x, string_of_int x) 0 iarray;;
 [%%expect{|
-- : int * string iarray = (15, [|"1"; "2"; "3"; "4"; "5"|])
+- : int * string Iarray.t = (15, [|"1"; "2"; "3"; "4"; "5"|])
 |}];;
 
 (* Confirm the function isn't called on the empty immutable array *)
 Iarray.fold_left_map (fun _ _ -> assert false) 0 [||];;
 [%%expect{|
-- : int * 'a iarray = (0, [||])
+- : int * 'a Iarray.t = (0, [||])
 |}];;
 
 Iarray.fold_right (fun x acc -> -.x :: acc) ifarray [];;
@@ -230,7 +230,7 @@ Iarray.iter2
 
 Iarray.map2 (fun i f -> f, i) iarray ifarray;;
 [%%expect{|
-- : (float * int) iarray =
+- : (float * int) Iarray.t =
 [|(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5)|]
 |}];;
 
@@ -333,23 +333,23 @@ Iarray.find_map (fun x -> if Float.rem x 7. = 0.5
 
 Iarray.split [| 1, "a"; 2, "b"; 3, "c" |];;
 [%%expect{|
-- : int iarray * string iarray = ([|1; 2; 3|], [|"a"; "b"; "c"|])
+- : int Iarray.t * string Iarray.t = ([|1; 2; 3|], [|"a"; "b"; "c"|])
 |}];;
 
 Iarray.split [||];;
 [%%expect{|
-- : 'a iarray * 'b iarray = ([||], [||])
+- : 'a Iarray.t * 'b Iarray.t = ([||], [||])
 |}];;
 
 Iarray.combine iarray ifarray;;
 [%%expect{|
-- : (int * float) iarray =
+- : (int * float) Iarray.t =
 [|(1, 1.5); (2, 2.5); (3, 3.5); (4, 4.5); (5, 5.5)|]
 |}];;
 
 Iarray.combine [||] [||];;
 [%%expect{|
-- : ('a * 'b) iarray = [||]
+- : ('a * 'b) Iarray.t = [||]
 |}];;
 
 Iarray.combine iarray [| "wrong length" |];;
@@ -360,14 +360,14 @@ Exception: Invalid_argument "Iarray.combine".
 Iarray.sort (Fun.flip Int.compare) iarray,
 Iarray.sort (Fun.flip Float.compare) ifarray;;
 [%%expect{|
-- : int iarray * Float.t iarray =
+- : int Iarray.t * Float.t Iarray.t =
 ([|5; 4; 3; 2; 1|], [|5.5; 4.5; 3.5; 2.5; 1.5|])
 |}];;
 
 Iarray.stable_sort (Fun.flip Int.compare) iarray,
 Iarray.stable_sort (Fun.flip Float.compare) ifarray;;
 [%%expect{|
-- : int iarray * Float.t iarray =
+- : int Iarray.t * Float.t Iarray.t =
 ([|5; 4; 3; 2; 1|], [|5.5; 4.5; 3.5; 2.5; 1.5|])
 |}];;
 
@@ -378,7 +378,7 @@ Iarray.stable_sort
      "five"; "six"; "seven"; "eight"; "nine";
      "ten" |];;
 [%%expect{|
-- : string iarray =
+- : string Iarray.t =
 [|"one"; "two"; "six"; "ten"; "zero"; "four"; "five"; "nine"; "three";
   "seven"; "eight"|]
 |}];;
@@ -386,7 +386,7 @@ Iarray.stable_sort
 Iarray.fast_sort (Fun.flip Int.compare) iarray,
 Iarray.fast_sort (Fun.flip Float.compare) ifarray;;
 [%%expect{|
-- : int iarray * Float.t iarray =
+- : int Iarray.t * Float.t Iarray.t =
 ([|5; 4; 3; 2; 1|], [|5.5; 4.5; 3.5; 2.5; 1.5|])
 |}];;
 
@@ -402,7 +402,7 @@ Iarray.to_seqi ifarray |> List.of_seq;;
 
 ["hello"; "world"] |> List.to_seq |> Iarray.of_seq;;
 [%%expect{|
-- : string iarray = [|"hello"; "world"|]
+- : string Iarray.t = [|"hello"; "world"|]
 |}];;
 
 (** Confirm that we haven't edited the immutable arrays, and that editing


### PR DESCRIPTION
In the MLI file of Iarray, and therefore in the manual, it would be best to expose `'a Iarray.t` in the functions’ types, rather than `'a iarray`, to reflect the fact that the built-in `iarray` type is rather an implementation detail.