### PR TITLE
Save ~45min per run on Jenkins on Risc-V

### DIFF
--- a/testsuite/tools/testLinkModes.ml
+++ b/testsuite/tools/testLinkModes.ml
@@ -193,6 +193,17 @@ let link_with_main_in_c env ~use_shared_runtime ~linker_exit_code mode
     in
     clibs @ libraries
   in
+  let flags =
+    if Config.architecture = "riscv" then
+      (* Running linker relaxation over the objects produced by
+         -output-complete-obj far too readily hits quadratic behaviour in ld.
+         For the purposes of these tests, we simply disable it. Binutils 2.41+
+         supports a more specific --no-relax-gp, but we'd have to detect it in
+         configure. *)
+      "-Wl,--no-relax" :: flags
+    else
+      flags
+  in
   let exit_code =
     let summarise f () =
       let pp x =


### PR DESCRIPTION
Amongst the battery of tests in #14014 are C programs linked against the objects produced by `-output-obj` and `-output-complete-obj`. Linking these programs is taking an incredibly long time. I added a timing check which can be seen by searching for `Duration:` in [precheck#1138](https://ci.inria.fr/ocaml/job/precheck/1138/flambda=false,label=ocaml-riscv/consoleFull). On that run, the worker spent 46 minutes linking 12 test programs.

It appears the problem is relatively well-known with Risc-V Linker Relaxation (there's [some nice info here](https://maskray.me/blog/2021-03-14-the-dark-side-of-riscv-linker-relaxation)). For these tests, I've simply added the appropriate linker flag to disable it, and in [precheck#1140](https://ci.inria.fr/ocaml/job/precheck/1140/flambda=false,label=ocaml-riscv/consoleFull) those same programs now only take 26 seconds to link.

The problem appears to be even worse with newer versions of binutils than the Jenkins worker is running.