### PR TITLE
add a test for "escaping" Ctype.Tags error

### DIFF
--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -441,6 +441,16 @@ Error: Variant tags "`azdwbie" and "`c7diagq" have the same hash value.
        Change one of them.
 |}]
 
+let _ = object(_ : < x : [ `azdwbie ] -> unit; .. >)
+  method x : [ `c7diagq ] -> unit = fun _ -> ()
+end
+
+[%%expect{|
+Line 1:
+Error: In this program, variant constructors "`azdwbie" and "`c7diagq"
+       have the same hash value. Change one of them.
+|}]
+
 
 type t = {x:unit}
 type s = {y:unit}


### PR DESCRIPTION
It's not really escaping as ctype registers a printer for that error, but there was no test for it.
The existing tests triggering that error go through typecore or typetexp which both catch the error and produce a "more precise" one (i.e. with a precise location), which made me think that the printer in ctype was actually dead code.
It's not: the error can also be triggered from typeclass (and perhaps somewhere else), which does not care for it.

The current situation seems suboptimal, but tracking all the places where `Ctype.Tags` can "leak" seems like a lot of work, so instead of fixing it I'm just adding a test for the case I know, to serve as a reminder.