### PR TITLE
linear scan: fix bug in spilling heuristic

### DIFF
--- a/Changes
+++ b/Changes
@@ -231,6 +231,10 @@ OCaml 5.5.0
 
 ### Code generation and optimizations:
 
+- #14583: fix bug in linear scan spilling heuristic that in certain situations
+  could lead to miscompilations.
+  (Nicolás Ojeda Bär, review by Vincent Laviron)
+
 ### Standard library:
 
 - #14437: Add String.split_{first,last,all} and String.rsplit_all

--- a/asmcomp/linscan.ml
+++ b/asmcomp/linscan.ml
@@ -104,17 +104,16 @@ let release_expired_inactive ci pos =
   ci.ci_inactive <- inactive;
   ci.ci_active <- IntervalSet.union active ci.ci_active
 
-(* Allocate a stack slot to the interval. [evicting] indicates whether we are
-   evicting an active interval (which requires a new stack slot) or allocating a
-   stack slot for a new interval, in which case we may reuse an expired stack
-   slot. *)
+(* Allocate a stack slot to the interval. [existing] indicates whether we are
+   spilling an already allocated interval (which requires a new stack slot) or
+   spilling a new interval, in which case we may reuse an expired stack slot. *)
 
-let allocate_stack_slot ~evicting num_stack_slots i =
+let allocate_stack_slot ~existing num_stack_slots i =
   let cl = Proc.register_class i.reg in
   let ci = active.(cl) in
   let ss =
     match
-      if evicting then None else SlotSet.min_elt_opt ci.ci_free_slots
+      if existing then None else SlotSet.min_elt_opt ci.ci_free_slots
     with
     | Some ss ->
         ci.ci_free_slots <- SlotSet.remove ss ci.ci_free_slots;
@@ -136,7 +135,7 @@ let allocate_free_register num_stack_slots i =
   begin match i.reg.loc, i.reg.spill with
     Unknown, true ->
       (* Allocate a stack slot for the already spilled interval *)
-      allocate_stack_slot ~evicting:false num_stack_slots i
+      allocate_stack_slot ~existing:false num_stack_slots i
   | Unknown, _ ->
       (* We need to allocate a register to this interval somehow *)
       let cl = Proc.register_class i.reg in
@@ -206,12 +205,12 @@ let allocate_blocked_register num_stack_slots i =
       (* Remove the last interval from active and insert the current *)
       ci.ci_active <- IntervalSet.add i il;
       (* Now get a new stack slot for the spilled register *)
-      allocate_stack_slot ~evicting:true num_stack_slots ilast
+      allocate_stack_slot ~existing:true num_stack_slots ilast
   | _ ->
       (* Either the current interval is last and we have to spill it,
          or there are no registers at all in the register class (i.e.
          floating point class on i386). *)
-      allocate_stack_slot ~evicting:false num_stack_slots i
+      allocate_stack_slot ~existing:false num_stack_slots i
 
 let walk_interval num_stack_slots i =
   let pos = i.ibegin land (lnot 0x01) in

--- a/asmcomp/linscan.ml
+++ b/asmcomp/linscan.ml
@@ -104,14 +104,17 @@ let release_expired_inactive ci pos =
   ci.ci_inactive <- inactive;
   ci.ci_active <- IntervalSet.union active ci.ci_active
 
-(* Allocate a new stack slot to the interval. *)
+(* Allocate a stack slot to the interval. [evicting] indicates whether we are
+   evicting an active interval (which requires a new stack slot) or allocating a
+   stack slot for a new interval, in which case we may reuse an expired stack
+   slot. *)
 
-let allocate_stack_slot ~reuse num_stack_slots i =
+let allocate_stack_slot ~evicting num_stack_slots i =
   let cl = Proc.register_class i.reg in
   let ci = active.(cl) in
   let ss =
     match
-      if reuse then SlotSet.min_elt_opt ci.ci_free_slots else None
+      if evicting then None else SlotSet.min_elt_opt ci.ci_free_slots
     with
     | Some ss ->
         ci.ci_free_slots <- SlotSet.remove ss ci.ci_free_slots;
@@ -133,7 +136,7 @@ let allocate_free_register num_stack_slots i =
   begin match i.reg.loc, i.reg.spill with
     Unknown, true ->
       (* Allocate a stack slot for the already spilled interval *)
-      allocate_stack_slot ~reuse:true num_stack_slots i
+      allocate_stack_slot ~evicting:false num_stack_slots i
   | Unknown, _ ->
       (* We need to allocate a register to this interval somehow *)
       let cl = Proc.register_class i.reg in
@@ -202,15 +205,13 @@ let allocate_blocked_register num_stack_slots i =
       i.reg.loc <- ilast.reg.loc;
       (* Remove the last interval from active and insert the current *)
       ci.ci_active <- IntervalSet.add i il;
-      (* Now get a new stack slot for the spilled register.
-         As [ilast] started before the current position, we must not reuse a
-         stack slot as it may not be available for the whole life of [ilast]. *)
-      allocate_stack_slot ~reuse:false num_stack_slots ilast
+      (* Now get a new stack slot for the spilled register *)
+      allocate_stack_slot ~evicting:true num_stack_slots ilast
   | _ ->
       (* Either the current interval is last and we have to spill it,
          or there are no registers at all in the register class (i.e.
          floating point class on i386). *)
-      allocate_stack_slot ~reuse:true num_stack_slots i
+      allocate_stack_slot ~evicting:false num_stack_slots i
 
 let walk_interval num_stack_slots i =
   let pos = i.ibegin land (lnot 0x01) in

--- a/asmcomp/linscan.ml
+++ b/asmcomp/linscan.ml
@@ -106,11 +106,13 @@ let release_expired_inactive ci pos =
 
 (* Allocate a new stack slot to the interval. *)
 
-let allocate_stack_slot num_stack_slots i =
+let allocate_stack_slot ~reuse num_stack_slots i =
   let cl = Proc.register_class i.reg in
   let ci = active.(cl) in
   let ss =
-    match SlotSet.min_elt_opt ci.ci_free_slots with
+    match
+      if reuse then SlotSet.min_elt_opt ci.ci_free_slots else None
+    with
     | Some ss ->
         ci.ci_free_slots <- SlotSet.remove ss ci.ci_free_slots;
         ss
@@ -131,7 +133,7 @@ let allocate_free_register num_stack_slots i =
   begin match i.reg.loc, i.reg.spill with
     Unknown, true ->
       (* Allocate a stack slot for the already spilled interval *)
-      allocate_stack_slot num_stack_slots i
+      allocate_stack_slot ~reuse:true num_stack_slots i
   | Unknown, _ ->
       (* We need to allocate a register to this interval somehow *)
       let cl = Proc.register_class i.reg in
@@ -200,13 +202,15 @@ let allocate_blocked_register num_stack_slots i =
       i.reg.loc <- ilast.reg.loc;
       (* Remove the last interval from active and insert the current *)
       ci.ci_active <- IntervalSet.add i il;
-      (* Now get a new stack slot for the spilled register *)
-      allocate_stack_slot num_stack_slots ilast
+      (* Now get a new stack slot for the spilled register.
+         As [ilast] started before the current position, we must not reuse a
+         stack slot as it may not be available for the whole life of [ilast]. *)
+      allocate_stack_slot ~reuse:false num_stack_slots ilast
   | _ ->
       (* Either the current interval is last and we have to spill it,
          or there are no registers at all in the register class (i.e.
          floating point class on i386). *)
-      allocate_stack_slot num_stack_slots i
+      allocate_stack_slot ~reuse:true num_stack_slots i
 
 let walk_interval num_stack_slots i =
   let pos = i.ibegin land (lnot 0x01) in


### PR DESCRIPTION
After switching from 5.3.0 to 5.4.1 at LexiFi, we encountered a bug in the linear scan allocator (`ocamlopt -linscan`). The bug itself appears to have been introduced by #11686 in 2022, but it is tricky to trigger. Some changes in 5.4 (my guess is #13878) appear to have made it easier for the bug to manifest itself.

The context: in linear scan, the liveness of compiler temporaries are approximated by a single interval. During allocation, each interval needs to be assigned either to a hardware register or a stack slot. To avoid excessive stack usage when spilling (see #11686), the allocator tries to reuse stack slots for intervals which are disjoint. Independently of this "reuse" optimization, when no hardware registers are left and the current interval must be spilled, linear scan applies a heuristic which consists in spilling an already allocated interval instead (we say that the interval is "evicted"), if this interval ends "later" than the current interval.

The problem (and the bug) is that this heuristic is incompatible with the reuse of stack slots as implemented in #11686: indeed, the allocator keeps track, at any given time, of the stack slots that may be reused (due to the intervals that had previously been assigned to them no longer being "live"). But when an already allocated interval is "evicted" and spilled instead, one would need to know that the chosen stack slot was available for reuse throughout the interval's lifetime, and this information is not available.

Here, we fix the issue by disabling the reuse of stack slots when spilling an interval that had previously been assigned to a hardware register.

Repro:
```
let concat first =
  let r = Bytes.create 3 in
  String.unsafe_blit first 0 r 0 1;
  let pos = ref 1 in
  for _ = 0 to 0 do
    let s = Array.unsafe_get [|"b"|] 0 in
    let l = String.length s in
    Bytes.unsafe_set r !pos ' ';
    String.unsafe_blit s 0 r (!pos + 1) l;
    pos := !pos + l + 1
  done;
  r

let () =
  print_bytes (concat "a")
```
This program prints `"a b"` (the correct result) with the graph coloring allocator but prints `"\000 b"` with `-linscan`:
```
nicolasojedabar@LEXIFI-L6:~/mlfi/build$ ocamlopt -linscan test.ml && ./a.out | xxd
00000000: 0020 62                                  . b
nicolasojedabar@LEXIFI-L6:~/mlfi/build$ ocamlopt test.ml && ./a.out | xxd
00000000: 6120 62                                  a b
```
The bug is also present in 5.3 but it does not trigger with this test program. The reason seems to be that the code for `Bytes.unsafe_set r !pos ' '` after the first round of register allocation in 5.3 is
```
       unsigned int8[spilled-r/31[s0] + I/48[%rbx]] := I/49[%rdi] (assign){test.ml:8,4-31}
```
which is a memory load where the address is also in memory; this triggers a second round of register allocation which "hides" the bug.

However, in 5.4 the generated code after the first round of register allocation is:
```
       I/50[%rdi] := spilled-r/31[s0]
       I/50[%rdi] := I/50[%rdi] + I/49[%rbx]{test.ml:8,4-31}
       I/51[%rbx] := 32
       unsigned int8[I/50[%rdi]] := I/51[%rbx] (assign){test.ml:8,4-31}
```
which does not require a second round of register allocation, and which as a side-effect reveals the bug.

After spending some time looking at the Git history between 5.3 and 5.4 my hunch is that the difference is due to #13878, but am not completely sure.

cc @lthls who as a backend expert may have some insight about the issues discussed above.