### PR TITLE
Expand doc of Float.Array

### DIFF
--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -502,15 +502,20 @@ module Array : sig
   (** The type of "flat" float arrays.
 
       A [floatarray] is an array data structure that contains a fixed number of
-      elements of type [float]. The elements of a [floatarray] are stored
-      contiguously in memory, without any boxing.
+      elements of type [float]. The elements of a [floatarray] are guaranteed to
+      be stored contiguously in memory, without any boxing.
 
-      This is also the case for the built-in type [float array] if the compiler
-      has not been configured with [--disable-flat-float-array]. However,
-      [floatarray] is guaranteed to maintain an unboxed representation at runtime
-      even if the compiler is configured with [--disable-flat-float-array].
-      Furthermore, operations on [floatarray] are a bit more efficient than those
-      on [float array], which require an extra dynamic check.
+      Currently, the built-in type [float array] is optimized by default to also
+      use an unboxed representation. However, this optimization may be disabled at
+      configure-time when building the compiler. Furthermore, operations on
+      [floatarray] are a bit more efficient than those on [float array], which
+      require an extra dynamic check.
+
+      Array literals of type [floatarray] can be written using the same syntax as
+      those of type [float array] as long as there is enough typing information in
+      the environment so that the compiler can disambiguate between the two cases.
+      See Section 12.25 'Type-directed disambiguation of array literals' of the
+      manual for more details.
 
       @since 4.08
     *)
@@ -897,15 +902,20 @@ module ArrayLabels : sig
   (** The type of "flat" float arrays.
 
       A [floatarray] is an array data structure that contains a fixed number of
-      elements of type [float]. The elements of a [floatarray] are stored
-      contiguously in memory, without any boxing.
+      elements of type [float]. The elements of a [floatarray] are guaranteed to
+      be stored contiguously in memory, without any boxing.
 
-      This is also the case for the built-in type [float array] if the compiler
-      has not been configured with [--disable-flat-float-array]. However,
-      [floatarray] is guaranteed to maintain an unboxed representation at runtime
-      even if the compiler is configured with [--disable-flat-float-array].
-      Furthermore, operations on [floatarray] are a bit more efficient than those
-      on [float array], which require an extra dynamic check.
+      Currently, the built-in type [float array] is optimized by default to also
+      use an unboxed representation. However, this optimization may be disabled at
+      configure-time when building the compiler. Furthermore, operations on
+      [floatarray] are a bit more efficient than those on [float array], which
+      require an extra dynamic check.
+
+      Array literals of type [floatarray] can be written using the same syntax as
+      those of type [float array] as long as there is enough typing information in
+      the environment so that the compiler can disambiguate between the two cases.
+      See Section 12.25 'Type-directed disambiguation of array literals' of the
+      manual for more details.
 
       @since 4.08
     *)

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -499,7 +499,19 @@ val hash : t -> int
 
 module Array : sig
   type t = floatarray
-  (** The type of float arrays with packed representation.
+  (** The type of "flat" float arrays.
+
+      A [floatarray] is an array data structure that contains a fixed number of
+      elements of type [float]. The elements of a [floatarray] are stored
+      contiguously in memory, without any boxing.
+
+      This is also the case for the built-in type [float array] if the compiler
+      has not been configured with [--disable-flat-float-array]. However,
+      [floatarray] is guaranteed to maintain an unboxed representation at runtime
+      even if the compiler is configured with [--disable-flat-float-array].
+      Furthermore, operations on [floatarray] are a bit more efficient than those
+      on [float array], which require an extra dynamic check.
+
       @since 4.08
     *)
 
@@ -882,7 +894,19 @@ end
 
 module ArrayLabels : sig
   type t = floatarray
-  (** The type of float arrays with packed representation.
+  (** The type of "flat" float arrays.
+
+      A [floatarray] is an array data structure that contains a fixed number of
+      elements of type [float]. The elements of a [floatarray] are stored
+      contiguously in memory, without any boxing.
+
+      This is also the case for the built-in type [float array] if the compiler
+      has not been configured with [--disable-flat-float-array]. However,
+      [floatarray] is guaranteed to maintain an unboxed representation at runtime
+      even if the compiler is configured with [--disable-flat-float-array].
+      Furthermore, operations on [floatarray] are a bit more efficient than those
+      on [float array], which require an extra dynamic check.
+
       @since 4.08
     *)
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -501,21 +501,21 @@ module Array : sig
   type t = floatarray
   (** The type of "flat" float arrays.
 
-      A [floatarray] is an array data structure that contains a fixed number of
-      elements of type [float]. The elements of a [floatarray] are guaranteed to
-      be stored contiguously in memory, without any boxing.
+      A [floatarray] is an array data structure that contains a fixed number
+      of elements of type [float]. The elements of a [floatarray] are
+      guaranteed to be stored contiguously in memory, without any boxing.
 
-      Currently, the built-in type [float array] is optimized by default to also
-      use an unboxed representation. However, this optimization may be disabled at
-      configure-time when building the compiler. Furthermore, operations on
-      [floatarray] are a bit more efficient than those on [float array], which
-      require an extra dynamic check.
+      Currently, the built-in type [float array] is optimized by default to
+      also use an unboxed representation. However, this optimization may be
+      disabled at configure-time when building the compiler. Furthermore,
+      operations on [floatarray] are a bit more efficient than those on
+      [float array], which require an extra dynamic check.
 
-      Array literals of type [floatarray] can be written using the same syntax as
-      those of type [float array] as long as there is enough typing information in
-      the environment so that the compiler can disambiguate between the two cases.
-      See Section 12.25 'Type-directed disambiguation of array literals' of the
-      manual for more details.
+      Array literals of type [floatarray] can be written using the same syntax
+      as those of type [float array] as long as there is enough typing
+      information in the environment so that the compiler can disambiguate
+      between the two cases. See Section 12.25 'Type-directed disambiguation
+      of array literals' of the manual for more details.
 
       @since 4.08
     *)
@@ -901,21 +901,21 @@ module ArrayLabels : sig
   type t = floatarray
   (** The type of "flat" float arrays.
 
-      A [floatarray] is an array data structure that contains a fixed number of
-      elements of type [float]. The elements of a [floatarray] are guaranteed to
-      be stored contiguously in memory, without any boxing.
+      A [floatarray] is an array data structure that contains a fixed number
+      of elements of type [float]. The elements of a [floatarray] are
+      guaranteed to be stored contiguously in memory, without any boxing.
 
-      Currently, the built-in type [float array] is optimized by default to also
-      use an unboxed representation. However, this optimization may be disabled at
-      configure-time when building the compiler. Furthermore, operations on
-      [floatarray] are a bit more efficient than those on [float array], which
-      require an extra dynamic check.
+      Currently, the built-in type [float array] is optimized by default to
+      also use an unboxed representation. However, this optimization may be
+      disabled at configure-time when building the compiler. Furthermore,
+      operations on [floatarray] are a bit more efficient than those on
+      [float array], which require an extra dynamic check.
 
-      Array literals of type [floatarray] can be written using the same syntax as
-      those of type [float array] as long as there is enough typing information in
-      the environment so that the compiler can disambiguate between the two cases.
-      See Section 12.25 'Type-directed disambiguation of array literals' of the
-      manual for more details.
+      Array literals of type [floatarray] can be written using the same syntax
+      as those of type [float array] as long as there is enough typing
+      information in the environment so that the compiler can disambiguate
+      between the two cases. See Section 12.25 'Type-directed disambiguation
+      of array literals' of the manual for more details.
 
       @since 4.08
     *)

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -15,7 +15,19 @@
 (**************************************************************************)
 
 type t = floatarray
-(** The type of float arrays with packed representation.
+(** The type of "flat" float arrays.
+
+    A [floatarray] is an array data structure that contains a fixed number of
+    elements of type [float]. The elements of a [floatarray] are stored
+    contiguously in memory, without any boxing.
+
+    This is also the case for the built-in type [float array] if the compiler
+    has not been configured with [--disable-flat-float-array]. However,
+    [floatarray] is guaranteed to maintain an unboxed representation at runtime
+    even if the compiler is configured with [--disable-flat-float-array].
+    Furthermore, operations on [floatarray] are a bit more efficient than those
+    on [float array], which require an extra dynamic check.
+
     @since 4.08
   *)
 

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -18,15 +18,20 @@ type t = floatarray
 (** The type of "flat" float arrays.
 
     A [floatarray] is an array data structure that contains a fixed number of
-    elements of type [float]. The elements of a [floatarray] are stored
-    contiguously in memory, without any boxing.
+    elements of type [float]. The elements of a [floatarray] are guaranteed to
+    be stored contiguously in memory, without any boxing.
 
-    This is also the case for the built-in type [float array] if the compiler
-    has not been configured with [--disable-flat-float-array]. However,
-    [floatarray] is guaranteed to maintain an unboxed representation at runtime
-    even if the compiler is configured with [--disable-flat-float-array].
-    Furthermore, operations on [floatarray] are a bit more efficient than those
-    on [float array], which require an extra dynamic check.
+    Currently, the built-in type [float array] is optimized by default to also
+    use an unboxed representation. However, this optimization may be disabled at
+    configure-time when building the compiler. Furthermore, operations on
+    [floatarray] are a bit more efficient than those on [float array], which
+    require an extra dynamic check.
+
+    Array literals of type [floatarray] can be written using the same syntax as
+    those of type [float array] as long as there is enough typing information in
+    the environment so that the compiler can disambiguate between the two cases.
+    See Section 12.25 'Type-directed disambiguation of array literals' of the
+    manual for more details.
 
     @since 4.08
   *)

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -17,21 +17,21 @@
 type t = floatarray
 (** The type of "flat" float arrays.
 
-    A [floatarray] is an array data structure that contains a fixed number of
-    elements of type [float]. The elements of a [floatarray] are guaranteed to
-    be stored contiguously in memory, without any boxing.
+    A [floatarray] is an array data structure that contains a fixed number
+    of elements of type [float]. The elements of a [floatarray] are
+    guaranteed to be stored contiguously in memory, without any boxing.
 
-    Currently, the built-in type [float array] is optimized by default to also
-    use an unboxed representation. However, this optimization may be disabled at
-    configure-time when building the compiler. Furthermore, operations on
-    [floatarray] are a bit more efficient than those on [float array], which
-    require an extra dynamic check.
+    Currently, the built-in type [float array] is optimized by default to
+    also use an unboxed representation. However, this optimization may be
+    disabled at configure-time when building the compiler. Furthermore,
+    operations on [floatarray] are a bit more efficient than those on
+    [float array], which require an extra dynamic check.
 
-    Array literals of type [floatarray] can be written using the same syntax as
-    those of type [float array] as long as there is enough typing information in
-    the environment so that the compiler can disambiguate between the two cases.
-    See Section 12.25 'Type-directed disambiguation of array literals' of the
-    manual for more details.
+    Array literals of type [floatarray] can be written using the same syntax
+    as those of type [float array] as long as there is enough typing
+    information in the environment so that the compiler can disambiguate
+    between the two cases. See Section 12.25 'Type-directed disambiguation
+    of array literals' of the manual for more details.
 
     @since 4.08
   *)


### PR DESCRIPTION
It was pointed out in Discuss https://discuss.ocaml.org/t/language-manual-floatarray-documentation/17844/6 that nowhere in the manual there is an explanation of what `floatarray` _is_.

Here is a first attempt in this direction. Suggestions welcome.