### PR TITLE
Testsuite: further filter/sanitize TSan output for portability

### DIFF
--- a/testsuite/tests/tsan/array_elt.reference
+++ b/testsuite/tests/tsan/array_elt.reference
@@ -1,40 +1,39 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlArray_elt$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlArray_elt$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlArray_elt$reader_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlArray_elt$entry <implemspecific> (<implemspecific>)
-    #2 caml_program <implemspecific> (<implemspecific>)
+    - camlArray_elt$reader_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlArray_elt$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlArray_elt$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlArray_elt$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlArray_elt$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlArray_elt$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlArray_elt$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -12,41 +12,40 @@ Called from Exn_from_c.f in file "exn_from_c.ml", line 53, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlExn_from_c$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlExn_from_c$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlExn_from_c$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlExn_from_c$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - camlExn_from_c$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlExn_from_c$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlExn_from_c$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlExn_from_c$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_from_c_stack_args.reference
+++ b/testsuite/tests/tsan/exn_from_c_stack_args.reference
@@ -12,41 +12,40 @@ Called from Exn_from_c_stack_args.f in file "exn_from_c_stack_args.ml", line 56,
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlExn_from_c_stack_args$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c_stack_args$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlExn_from_c_stack_args$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlExn_from_c_stack_args$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - camlExn_from_c_stack_args$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c_stack_args$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlExn_from_c_stack_args$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlExn_from_c_stack_args$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_from_c_stack_args$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c_stack_args$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -11,41 +11,40 @@ Called from Exn_in_callback.f in file "exn_in_callback.ml", line 52, characters 
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlExn_in_callback$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_in_callback$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlExn_in_callback$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlExn_in_callback$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlExn_in_callback$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - camlExn_in_callback$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_in_callback$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_in_callback$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlExn_in_callback$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlExn_in_callback$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlExn_in_callback$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_in_callback$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_in_callback$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -11,41 +11,40 @@ Called from Exn_reraise.f in file "exn_reraise.ml", line 47, characters 7-11
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlExn_reraise$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_reraise$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlExn_reraise$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlExn_reraise$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlExn_reraise$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - camlExn_reraise$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_reraise$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_reraise$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlExn_reraise$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlExn_reraise$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlExn_reraise$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlExn_reraise$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_reraise$writer_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/filter-locations.sh
+++ b/testsuite/tests/tsan/filter-locations.sh
@@ -8,6 +8,10 @@ set -eu
 # - Replace mutex IDs like 'M87' with 'M<implemspecific>'
 # - Replace the complete path of the program by '<systemspecific>/' followed by
 #   the program filename.
+# - Drop certain functions from the callstack that are known to create portability issues
+#   'caml_plat_thread_create' does not show on macosx (#14472)
+#   To avoid discrepancies when dropping stack entries,
+#   we also replace the `#NN` index by just a dash.
 script1='s/pid=[[:digit:]]+/pid=<implemspecific>/
 s/tid=[[:digit:]]+/tid=<implemspecific>/
 
@@ -19,8 +23,12 @@ s/tid=[[:digit:]]+/tid=<implemspecific>/
   s/M([0-9]+) \(0x[[:xdigit:]]+\)/M\1 (<implemspecific>)/
 }
 
+/caml_plat_thread_create/ {
+  d
+}
+
 /#[0-9]+/ {
-  s/(#[0-9]+) ([^ ]*) [^ ]*(\(discriminator [0-9]+\))? \(([^ ]*)\)/\1 \2 <implemspecific> (\4)/
+  s/(#[0-9]+) ([^ ]*) [^ ]*(\(discriminator [0-9]+\))? \(([^ ]*)\)/- \2 <implemspecific> (\4)/
   s/(caml[a-zA-Z_0-9]+)[$.]([a-zA-Z_0-9]+)_[[:digit:]]+/\1$\2_<implemspecific>/
   s/(caml[a-zA-Z_0-9]+)[$.]([a-zA-Z_0-9]+)/\1$\2/
   s/\((.+)+0x[[:xdigit:]]+\)/(<implemspecific>)/
@@ -37,7 +45,7 @@ s/ M[0-9]+/ M<implemspecific>/
 
 # To ignore differences in compiler function inlining, kill backtrace after
 # caml_start_program or caml_startup*.
-script2='/^[[:space:]]+#[[:digit:]]+ (caml_start_program|caml_startup)/, /^$/ {
+script2='/^[[:space:]]+- (caml_start_program|caml_startup)/, /^$/ {
   /^$/ !d
 }'
 

--- a/testsuite/tests/tsan/perform.reference
+++ b/testsuite/tests/tsan/perform.reference
@@ -6,42 +6,41 @@ In the effect handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlPerform$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlPerform$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlPerform$entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
+    - camlPerform$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlPerform$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlPerform$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform$race_<implemspecific>
 ==================
@@ -49,46 +48,45 @@ Resuming h
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlPerform$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlPerform$h_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlPerform$g_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlPerform$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 caml_runstack <implemspecific> (<implemspecific>)
-    #5 camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #6 camlPerform$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #7 camlPerform$entry <implemspecific> (<implemspecific>)
-    #8 caml_program <implemspecific> (<implemspecific>)
+    - camlPerform$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$h_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$g_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - caml_runstack <implemspecific> (<implemspecific>)
+    - camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlPerform$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlPerform$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform$race_<implemspecific>
 ==================
@@ -99,43 +97,42 @@ Value handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlPerform$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlPerform$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlPerform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    - camlPerform$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$fun_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlPerform$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlPerform$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlPerform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform$race_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/raise_through_handler.reference
+++ b/testsuite/tests/tsan/raise_through_handler.reference
@@ -5,41 +5,40 @@ In exception handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlRaise_through_handler$reader_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRaise_through_handler$reader_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlRaise_through_handler$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlRaise_through_handler$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlRaise_through_handler$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - camlRaise_through_handler$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRaise_through_handler$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRaise_through_handler$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlRaise_through_handler$reader_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlRaise_through_handler$reader_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlRaise_through_handler$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRaise_through_handler$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRaise_through_handler$reader_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/record_field.reference
+++ b/testsuite/tests/tsan/record_field.reference
@@ -1,41 +1,40 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlRecord_field$reader_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlRecord_field$entry <implemspecific> (<implemspecific>)
-    #2 caml_program <implemspecific> (<implemspecific>)
+    - camlRecord_field$reader_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRecord_field$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous write of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlRecord_field$writer_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRecord_field$writer_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlRecord_field$reader_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlRecord_field$entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlRecord_field$reader_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRecord_field$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlRecord_field$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlRecord_field$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRecord_field$reader_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/reperform.reference
+++ b/testsuite/tests/tsan/reperform.reference
@@ -5,92 +5,90 @@ E1 handler before continue
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlReperform$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlReperform$fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlReperform$fiber1_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlReperform$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlReperform$entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
+    - camlReperform$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$fun_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$fiber1_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlReperform$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlReperform$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform$race_<implemspecific>
 ==================
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlReperform$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlReperform$h_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlReperform$g_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlReperform$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 caml_runstack <implemspecific> (<implemspecific>)
-    #5 camlReperform$fiber2_<implemspecific> <implemspecific> (<implemspecific>)
-    #6 caml_runstack <implemspecific> (<implemspecific>)
-    #7 camlReperform$fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #8 camlReperform$fiber1_<implemspecific> <implemspecific> (<implemspecific>)
-    #9 camlReperform$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #10 camlReperform$entry <implemspecific> (<implemspecific>)
-    #11 caml_program <implemspecific> (<implemspecific>)
+    - camlReperform$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$h_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$g_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - caml_runstack <implemspecific> (<implemspecific>)
+    - camlReperform$fiber2_<implemspecific> <implemspecific> (<implemspecific>)
+    - caml_runstack <implemspecific> (<implemspecific>)
+    - camlReperform$fun_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$fiber1_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlReperform$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlReperform$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform$race_<implemspecific>
 ==================
@@ -103,40 +101,39 @@ Result=42
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlReperform$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlReperform$entry <implemspecific> (<implemspecific>)
-    #2 caml_program <implemspecific> (<implemspecific>)
+    - camlReperform$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlReperform$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlReperform$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlReperform$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform$race_<implemspecific>
 ==================

--- a/testsuite/tests/tsan/unhandled.reference
+++ b/testsuite/tests/tsan/unhandled.reference
@@ -2,41 +2,40 @@ Performing an unhandled effect from the main fiber
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlUnhandled$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlUnhandled$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - camlUnhandled$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlUnhandled$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlUnhandled$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled$race_<implemspecific>
 ==================
@@ -47,48 +46,47 @@ Entering h
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
-    #0 camlUnhandled$race_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlUnhandled$h_<implemspecific> <implemspecific> (<implemspecific>)
-    #2 camlUnhandled$g_<implemspecific> <implemspecific> (<implemspecific>)
-    #3 camlUnhandled$f_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 caml_runstack <implemspecific> (<implemspecific>)
-    #5 camlUnhandled$fiber2_<implemspecific> <implemspecific> (<implemspecific>)
-    #6 caml_runstack <implemspecific> (<implemspecific>)
-    #7 camlUnhandled$fiber1_<implemspecific> <implemspecific> (<implemspecific>)
-    #8 camlUnhandled$main_<implemspecific> <implemspecific> (<implemspecific>)
-    #9 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #10 caml_program <implemspecific> (<implemspecific>)
+    - camlUnhandled$race_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$h_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$g_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$f_<implemspecific> <implemspecific> (<implemspecific>)
+    - caml_runstack <implemspecific> (<implemspecific>)
+    - camlUnhandled$fiber2_<implemspecific> <implemspecific> (<implemspecific>)
+    - caml_runstack <implemspecific> (<implemspecific>)
+    - camlUnhandled$fiber1_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$main_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by thread T2 (mutexes: write M<implemspecific>):
-    #0 camlUnhandled$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$body_<implemspecific> <implemspecific> (<implemspecific>)
 
   As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 wg_wait <implemspecific> (<implemspecific>)
-    #2 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #3 caml_program <implemspecific> (<implemspecific>)
+    - nanosleep <implemspecific> (<implemspecific>)
+    - wg_wait <implemspecific> (<implemspecific>)
+    - camlUnhandled$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
-    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
-    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
-    #2 caml_init_domains <implemspecific> (<implemspecific>)
-    #3 caml_init_gc <implemspecific> (<implemspecific>)
+    - pthread_mutex_init <implemspecific> (<implemspecific>)
+    - caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    - caml_init_domains <implemspecific> (<implemspecific>)
+    - caml_init_gc <implemspecific> (<implemspecific>)
 
   Thread T2 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_plat_thread_create <implemspecific> (<implemspecific>)
-    #2 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #3 caml_c_call <implemspecific> (<implemspecific>)
-    #4 camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlUnhandled$entry <implemspecific> (<implemspecific>)
-    #6 caml_program <implemspecific> (<implemspecific>)
+    - pthread_create <implemspecific> (<implemspecific>)
+    - caml_domain_spawn <implemspecific> (<implemspecific>)
+    - caml_c_call <implemspecific> (<implemspecific>)
+    - camlStdlib__Domain$spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    - camlUnhandled$entry <implemspecific> (<implemspecific>)
+    - caml_program <implemspecific> (<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled$race_<implemspecific>
 ==================


### PR DESCRIPTION
This is a proposed alternative to #14587 to try to fix #14472 (TSan testsuite failure on macosx due to fragile reference outputs), with less ocamltest and more sed.