### PR TITLE
fix modular explicits test interaction with flat-float-array

### DIFF
--- a/testsuite/tests/typing-modular-explicits/typedefs-flat.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs-flat.ml
@@ -1,0 +1,21 @@
+(* TEST
+  flat-float-array;
+  expect;
+*)
+
+(* Check interaction of module-dependent functions with separability. *)
+module type T =  sig type !'a t end
+type 'a t = 'b constraint 'a = (module M:T) -> 'b M.t
+type any = Any: 'a t -> any [@@unboxed]
+
+[%%expect{|
+module type T = sig type !'a t end
+type 'a t = 'b constraint 'a = (module M : T) -> 'b M.t
+Line 3, characters 0-39:
+3 | type any = Any: 'a t -> any [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of an unnamed existential variable.
+       You should annotate it with "[@@ocaml.boxed]".
+|}]

--- a/testsuite/tests/typing-modular-explicits/typedefs.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs.ml
@@ -292,20 +292,3 @@ Error: This variant or record definition does not match that of type "typ1"
          "(module A : Add with type t = int) -> float -> int"
        Type "int" is not equal to type "float"
 |}]
-
-(* Check interaction of module-dependent functions with separability. *)
-module type T =  sig type !'a t end
-type 'a t = 'b constraint 'a = (module M:T) -> 'b M.t
-type any = Any: 'a t -> any [@@unboxed]
-
-[%%expect{|
-module type T = sig type !'a t end
-type 'a t = 'b constraint 'a = (module M : T) -> 'b M.t
-Line 3, characters 0-39:
-3 | type any = Any: 'a t -> any [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of an unnamed existential variable.
-       You should annotate it with "[@@ocaml.boxed]".
-|}]


### PR DESCRIPTION
The tests for modular explicits includes a test for failing to unbox because of flat float arrays. When OCaml is configured with --disable-flat-float-array, the unboxing doesn't fail and the test fails.

AFAICT, this is the last remaining failure on 5.5 for the `other-configs` job on Inria CI.
