### PR TITLE
avoid portability issues in Lazy.Mutexed testsuite (2)

### DIFF
--- a/testsuite/tests/lib-lazy/test-mutexed.ml
+++ b/testsuite/tests/lib-lazy/test-mutexed.ml
@@ -1,4 +1,5 @@
 (* TEST
+ shared-libraries;
  hassysthreads;
  flags = "-I ${ocamlsrcdir}/otherlibs/unix -I ${ocamlsrcdir}/otherlibs/systhreads";
  include systhreads;


### PR DESCRIPTION
A follow-up to #14591: the CI still fails on Cygwin64 as predicted by @Octachron, with the following error:

```
@@ -8,6 +8,10 @@
 #load "unix.cma";;
 #load "threads.cma";;
 [%%expect{|
+Cannot load required shared library dllunixbyt-x86_64-pc-cygwin-d106.
+Reason: dllunixbyt-x86_64-pc-cygwin-d106.so: dynamic loading not supported on this platform.
+Cannot load required shared library dllthreads-x86_64-pc-cygwin-d106.
+Reason: dllthreads-x86_64-pc-cygwin-d106.so: dynamic loading not supported on this platform.
 |}]
 
 module LazyM = Lazy.Mutexed
@@ -137,7 +141,12 @@
   status, results
 
 [%%expect{|
-val it : string * (int, exn) result list = ("pass", [Ok 0; Ok 0; Ok 0])
+Line 1:
+Error: Reference to undefined compilation unit "`Thread'"
+Hint: This means that the interface of a module is loaded, but its implementation is not.
+      Found "/cygdrive/c/builds/workspace/slow-machines/label/ocaml-cygwin-64/otherlibs/systhreads/thread.cmo"
+      in the load paths. Did you mean to load it using "#load "thread.cmo""
+      or by passing it as an argument to the toplevel?
 |}]
```

My best guess is that cygwin64 currently does not like `#load "unix.cma"` from a toplevel script. The fix is then to add a `shared-libraries;` predicate to the test, to disable it on plateform that don't know how to load shared libraries.