### PR TITLE
runtime_events: add @since to documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,6 +71,8 @@ Working version
 
 ### Manual and documentation:
 
+- #14598: Add `@since` annotations to `Runtime_events`. (Raphaël Proust)
+
 ### Compiler user-interface and warnings:
 
 - #14205: Make inclusion check error message reference the user-written file

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -549,6 +549,8 @@ module Timestamp : sig
 end
 
 module Type : sig
+  (** @since 5.1 *)
+
   type 'a t
   (** The type for a user event content type. *)
 
@@ -576,7 +578,9 @@ end
 module User : sig
   (** User events is a way for libraries to provide runtime events that can be
       consumed by other tools. These events can carry known data types or custom
-      values. The current maximum number of user events is 8192. *)
+      values. The current maximum number of user events is 8192.
+
+      @since 5.1 *)
 
   type tag = ..
   (** The type for a user event tag. Tags are used to discriminate between
@@ -637,7 +641,9 @@ module Callbacks : sig
                         t -> t
   (** [add_user_event ty callback t] extends [t] to additionally subscribe to
       user events of type [ty]. When such an event happens, [callback] is called
-      with the corresponding event and payload. *)
+      with the corresponding event and payload.
+
+      @since 5.1 *)
 end
 
 val start : unit -> unit
@@ -650,7 +656,9 @@ val start : unit -> unit
 
 val path : unit -> string option
 (** If runtime events are being collected, [path ()] returns [Some p] where [p]
-  is a path to the runtime events file. Otherwise, it returns None. *)
+  is a path to the runtime events file. Otherwise, it returns None.
+
+  @since 5.3 *)
 
 val pause : unit -> unit
 (** [pause ()] will pause the collection of events in the runtime.


### PR DESCRIPTION
Add missing `@since` annotations to `runtime_events.mli`. Prompted by https://github.com/ocaml/opam-repository/pull/29471#issuecomment-3971323300 but with obviously wider reach.