### PR TITLE
error messages: remove impossible unbound error

### DIFF
--- a/Changes
+++ b/Changes
@@ -88,6 +88,10 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #14601, remove an unreachable path for unbound type variables in extension
+  constructor declarations.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -780,18 +780,6 @@ let closed_type_decl decl =
     Some ty
   end
 
-let closed_extension_constructor ext =
-  with_type_mark begin fun mark -> try
-    List.iter (mark_type mark) ext.ext_type_params;
-    begin match ext.ext_ret_type with
-    | Some _ -> ()
-    | None -> iter_type_expr_cstr_args (closed_type mark) ext.ext_args
-    end;
-    None
-  with Non_closed (ty, _) ->
-    Some ty
-  end
-
 type closed_class_failure = {
   free_variable: type_expr * variable_kind;
   meth: string;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -524,7 +524,6 @@ val free_variables_list: ?env:Env.t -> type_expr list -> type_expr list
 val contains_nongen_variables: ?env:Env.t -> type_expr -> bool
 val closed_type_expr: ?env:Env.t -> type_expr -> bool
 val closed_type_decl: type_declaration -> type_expr option
-val closed_extension_constructor: extension_constructor -> type_expr option
 val closed_class:
         type_expr list -> class_signature ->
         closed_class_failure option

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -68,7 +68,6 @@ type error =
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error
   | Unavailable_type_constructor of Path.t
-  | Unbound_type_var_ext of type_expr * extension_constructor
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
@@ -1476,14 +1475,6 @@ let transl_type_extension extend env loc styext =
       (ttype_params, type_params, constructors)
     end
   in
-  (* Check that all type variables are closed *)
-  List.iter
-    (fun (ext, _shape) ->
-       match Ctype.closed_extension_constructor ext.ext_type with
-         Some ty ->
-           raise(Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
-       | None -> ())
-    constructors;
   (* Check variances are correct *)
   List.iter
     (fun (ext, _shape) ->
@@ -1530,12 +1521,6 @@ let transl_exception env sext =
         transl_extension_constructor ~scope env
           Predef.path_exn [] [] Asttypes.Public sext)
   in
-  (* Check that all type variables are closed *)
-  begin match Ctype.closed_extension_constructor ext.ext_type with
-    Some ty ->
-      raise (Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
-  | None -> ()
-  end;
   let rebind = is_rebind ext in
   let newenv =
     Env.add_extension ~check:true ~shape ~rebind ext.ext_id ext.ext_type env
@@ -2228,14 +2213,6 @@ let report_error ~loc = function
       Location.errorf ~loc
         "A type variable is unbound in this type declaration%t"
         (explain_unbounded params var decl)
-  | Unbound_type_var_ext (ty, ext) ->
-      let explain ppf =
-        let args = tys_of_constr_args ext.ext_args in
-        explain_unbound ppf ~params:[] ty args (fun c -> c) "type" (fun _ -> "")
-      in
-      Location.errorf ~loc
-        "A type variable is unbound in this extension constructor%t"
-        explain
   | Cannot_extend_private_type path ->
       Location.errorf ~loc
         "Cannot extend private type definition@ %a"

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -113,7 +113,6 @@ type error =
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error
   | Unavailable_type_constructor of Path.t
-  | Unbound_type_var_ext of type_expr * extension_constructor
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind


### PR DESCRIPTION
This PR removes an unreachable error path when typechecking the declaration of an extension constructor
```ocaml
type ('a,'b) e += A of $arg 
```
The error was supposed to be raised when checking if `A of $arg` is a closed constructor under 
the global type variable environment (`'a, 'b`). However,  this tests only occur after we have already typechecked
`$arg` in the `closed` mode which checks that `$arg` is a closed type expression under the global type environment.
The constructor check is thus fully redundant.

The current code was probably duplicating the non-extensible sum type case where we check that the type expression `$arg`
```ocaml
type ('a,'b) t = X of $arg
  constraint 'c = 'a * 'b * 'u
```
is closed in an environment which contains both the type parameters and the global type variables introduced by the list of constraints. And thus, it is make sense there to recheck that the `X of $arg` constructor is closed under only the type parameters. However, when declaring an extension constructor there are not constraints, and the second check is redundant.