### PR TITLE
[4.14] Fix linking with libasmrun_shared.so on Risc-V

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,12 @@ OCaml 4.14 maintenance version
   (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
   Sébastien Hinderer)
 
+### Bug fixes:
+
+- #14607: Fix linking with libasmrun_shared.so on Risc-V (undefined symbol
+  declared riscv.o)
+  (David Allsopp, review by ???)
+
 OCaml 4.14.3 (17 February 2026)
 ------------------------------
 

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -245,9 +245,6 @@ FUNCTION(caml_raise_exn)
         j       1b
 END_FUNCTION(caml_raise_exn)
 
-        .globl  caml_reraise_exn
-        .type   caml_reraise_exn, @function
-
 /* Raise an exception from C */
 
 FUNCTION(caml_raise_exception)


### PR DESCRIPTION
riscv.S declares the global `caml_reraise_exn`, but it doesn't actually exist which causes a linking failure with libasmrun_shared.so (using `hello.ml` and `main.c` from #13693):

```console
$ ocamlopt -output-obj -o ocaml.o -I +compiler-libs ocamlcommon.cmxa hello.ml
$ gcc -c -I $(ocamlopt -where) main.c
$ gcc -Wl,--no-relax -Wl,-E -o hello -L $(ocamlopt -where) ocaml.o main.o -lasmrun_shared -lm
/usr/bin/ld: ~/ocaml/install/lib/ocaml/libasmrun_shared.so: undefined reference to `caml_reraise_exn'
collect2: error: ld returned 1 exit status
```

The problem is these two lines in runtime/riscv.S:
https://github.com/ocaml/ocaml/blob/8f3833c4d0ef656c826359f4137c1eb3d46ea0ef/runtime/riscv.S#L225-L226

which declare `caml_reraise_exn`. However, the 4.x emitter's never needed it:
https://github.com/ocaml/ocaml/blob/8f3833c4d0ef656c826359f4137c1eb3d46ea0ef/asmcomp/riscv/emit.mlp#L552-L554

#11418 _does_ implement `caml_reraise_exn` for the 5.x version, which also had an error with libasmrun\_shared.so in #12252 (but this is unrelated to the issue here).