### PR TITLE
Ensure the Jenkins workers always clean up the installation

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -314,7 +314,11 @@ main_build() {
   case $confoptions in
     *--disable-unix-lib*) ;;         # test-in-prefix needs Unix lib
     *)
-      $make -f Makefile.test -C testsuite/in_prefix test-in-prefix
+      if ! $make -f Makefile.test -C testsuite/in_prefix test-in-prefix; then
+        # Ensure the worker is cleaned up
+        rm -rf "$instdir"
+        exit 1
+      fi
       ;;
   esac
   rm -rf "$instdir"


### PR DESCRIPTION
If the test-in-prefix tests fail on Jenkins, the installation isn't cleaned up which, erm, leads to running out of disk space on workers 🫣