### PR TITLE
Re-add missing commit from #14547

### DIFF
--- a/testsuite/tools/environment.ml
+++ b/testsuite/tools/environment.ml
@@ -316,10 +316,9 @@ let run_one (~runtime, ~quiet, ~fails, ~program, ~argv0, ~args,
         (* Convert SIGABRT to exit code 134 *)
         Unix.WEXITED 134
     | Unix.WSIGNALED n
-      when n = Sys.sigsegv
-           && List.mem Config.architecture ["s390x"; "riscv"] ->
-        (* cf. ocaml/ocaml#13693 - s390x executables might segfault, so this
-           gets converted to Docker's exit code so it can be skipped *)
+      when n = Sys.sigsegv && Config.architecture = "riscv" ->
+        (* riscv executables might segfault, so this gets converted to Docker's
+           exit code so it can be skipped *)
         Unix.WEXITED 139
     | status ->
         status

--- a/testsuite/tools/environment.mli
+++ b/testsuite/tools/environment.mli
@@ -149,7 +149,7 @@ val run_process :
     - If [Unix.create_process] fails with [ENOENT] for a {v #! v}-style bytecode
       image, this is translated to exit code 127
     - [SIGABRT] is converted to exit code 134
-    - On s390x and riscv, [SIGSEGV] is converted to exit code 139 *)
+    - On riscv, [SIGSEGV] is converted to exit code 139 *)
 
 val run_process_with_test_env :
   ?runtime:bool

--- a/testsuite/tools/testLinkModes.ml
+++ b/testsuite/tools/testLinkModes.ml
@@ -122,8 +122,7 @@ let () =
      but the value of stdlib_exists_when_renamed is used in the Renamed phase
    The program must terminate with [expected_exit_code]. [~may_segfault] is an
    escape hatch permitting exit code 139 to be silently ignored. This works
-   around some problems with shared runtimes on s390x and riscv which don't
-   reliably fail.
+   around a problem with shared runtimes on riscv which doesn't reliably fail.
 *)
 let run_program env config =
   let prefix = Environment.prefix env in
@@ -555,7 +554,7 @@ let compile_test usr_bin_sh config env test test_program description =
       | Output_obj(C_ocamlopt, Shared) ->
           (* cf. ocaml/ocaml#13693 - on Fedora/RHEL, this executable
              segfaults *)
-          let may_segfault = List.mem Config.architecture ["s390x"; "riscv"] in
+          let may_segfault = (Config.architecture = "riscv") in
           (* Shared compilation isn't available on native Windows and fails on
              Cygwin *)
           let linker_exit_code = fails_if (Sys.win32 || Sys.cygwin) in


### PR DESCRIPTION
This commit got blown away in https://github.com/ocaml/ocaml/pull/14547#event-23011151914.