### PR TITLE
Disable in-prefix tests with --enable-tsan on Inria CI

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -313,6 +313,8 @@ main_build() {
   $make --warn-undefined-variables install
   case $confoptions in
     *--disable-unix-lib*) ;;         # test-in-prefix needs Unix lib
+    *--enable-tsan*) ;;              # tsan currently breaks test-in-prefix
+                                     # (see #14280)
     *)
       $make -f Makefile.test -C testsuite/in_prefix test-in-prefix
       ;;


### PR DESCRIPTION
https://github.com/ocaml/ocaml/issues/14280 is preventing the use of the precheck-tsan job. I propose to disable in-prefix tests when `--enable-tsan` is set, and use the issue to keep track of the problem.