### PR TITLE
runtime: introduce a fatal_error when unjoined domains remain at cleanup-on-exit

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -264,9 +264,6 @@ void caml_global_barrier_release_as_final(barrier_status status);
  * Termination helpers.
  */
 
-/* Force all other domains to stop their operation. */
-void caml_stop_all_domains(void);
-
 /* Try and release all synchronisation resources set up by
    caml_init_domains(). Returns whether all resources could be released. */
 bool caml_free_domains(void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2426,52 +2426,6 @@ void caml_domain_terminate(bool last)
     atomic_fetch_add(&caml_num_domains_running, -1);
 }
 
-/* Try and terminate the currently running domain.
-   This is only invoked when extra domains are left running while the
-   main one is terminating. In this case, we are not in a state where
-   we can safely release resources. The best we can do is cancel the
-   extra running threads. */
-static void stw_terminate_domain(caml_domain_state *domain, void *data,
-  int participating_count,
-  caml_domain_state **participating)
-{
-  if (!caml_plat_thread_equal(domain_self->tid, *(caml_plat_thread *)data)) {
-    if (caml_bt_is_self()) {
-      /* If this STW request is handled by the backup thread, the
-         domain thread is currently running C code. */
-      domain_self->domain_canceled = true;
-      (void)caml_plat_thread_cancel(domain_self->tid);
-      /* We are intentionally not waiting for the thread to terminate here,
-         and not decrementing the number of running domains either, since
-         we don't know the state of the various locks and condition
-         variables in this state. */
-      atomic_store_release(&domain_self->backup_thread_msg, BT_INIT);
-    } else {
-      /* Domain threads forced to exit here will not have a chance to
-         run caml_domain_terminate() on their own, so we need to ask
-         the backup thread to terminate here. */
-      terminate_backup_thread(domain_self);
-      caml_plat_unlock(&domain_self->domain_lock);
-      /* No particular memory resource cleanup is attempted here, for we
-         have no idea which state each domain is in. */
-    }
-    caml_plat_thread_exit();
-  }
-}
-
-void caml_stop_all_domains(void)
-{
-  atomic_store_relaxed(&domains_exiting, 1);
-
-  caml_plat_thread myself = caml_plat_thread_self();
-  do {} while (!caml_try_run_on_all_domains(
-               &stw_terminate_domain, &myself, NULL));
-
-  terminate_backup_thread(domain_self);
-  caml_plat_unlock(&domain_self->domain_lock);
-
-  caml_plat_assert_all_locks_unlocked();
-}
 
 bool caml_free_domains(void)
 {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -241,7 +241,6 @@ static atomic_uintnat /* dom_internal* */ stw_leader = 0;
 static uintnat stw_requests_suspended = 0; /* protected by all_domains_lock */
 static caml_plat_cond requests_suspended_cond = CAML_PLAT_COND_INITIALIZER;
 static dom_internal* all_domains;
-static atomic_intnat domains_exiting = 0;
 
 CAMLexport atomic_uintnat caml_num_domains_running = 0;
 
@@ -1061,7 +1060,6 @@ CAMLexport void caml_reset_domain_lock(void)
 
 void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
 {
-  atomic_store_relaxed(&domains_exiting, 0);
   atomic_store_relaxed(&caml_num_domains_running, 0);
 
   /* Use [caml_stat_calloc_noexc] to zero initialize [all_domains]. */
@@ -1481,10 +1479,6 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   struct domain_startup_params p;
   caml_plat_thread th;
   int err;
-
-  if (atomic_load_relaxed(&domains_exiting) != 0) {
-    caml_failwith("domain creation not allowed during shutdown");
-  }
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -230,8 +230,7 @@ CAMLexport void caml_shutdown(void)
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
   if (!caml_domain_alone()) {
-    caml_gc_log("Some domains have not been joined prior to shutdown");
-    caml_stop_all_domains();
+    caml_fatal_error("Some domains have not been joined prior to shutdown");
   } else {
     /* These calls are not safe to use if there are domains left running */
     caml_domain_terminate(true);

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -33,7 +33,7 @@ let wait_ready () =
       Domain.cpu_relax ()
     done
 
-let _ =
+let producer_dom =
   Domain.spawn (fun () ->
     Runtime_events.start ();
     wait_ready ();
@@ -61,4 +61,5 @@ let ()
       Runtime_events.read_poll cursor callbacks None
       |> ignore
     done
-  done
+  done;
+  Domain.join producer_dom

--- a/testsuite/tests/lib-sync/prodcons.ml
+++ b/testsuite/tests/lib-sync/prodcons.ml
@@ -54,11 +54,12 @@ let rec consume buff cur max =
 let _ =
   let buff1 = create 20 0 and buff2 = create 30 0 in
   let ok1 = ref false and ok2 = ref false in
-  let _p1 = Domain.spawn (fun () -> produce buff1 0 10000)
-  and _p2 = Domain.spawn (fun () -> produce buff2 0 8000)
+  let p1 = Domain.spawn (fun () -> produce buff1 0 10000)
+  and p2 = Domain.spawn (fun () -> produce buff2 0 8000)
   and c1 = Domain.spawn (fun () -> ok1 := consume buff1 0 10000) in
   ok2 := consume buff2 0 8000;
   Domain.join c1;
   if !ok1 && !ok2
   then print_string "passed\n"
-  else print_string "FAILED\n"
+  else print_string "FAILED\n";
+  List.iter Domain.join [p1; p2]

--- a/testsuite/tests/parallel/backup_thread.ml
+++ b/testsuite/tests/parallel/backup_thread.ml
@@ -13,8 +13,12 @@ let _ =
   (* start a dummy domain and shut it down to cause a domain reuse *)
   let d = Domain.spawn (fun _ -> ()) in
   Domain.join d;
-  let _d = Domain.spawn (fun _ ->
-    Unix.sleep 10;
-    print_endline "Should not reach here!") in
+  let finished = Atomic.make false in
+  let d = Domain.spawn (fun _ ->
+    Unix.sleep 1;
+    if not (Atomic.get finished) then
+      print_endline "Should not reach here!") in
   Gc.full_major ();
-  print_endline "OK"
+  print_endline "OK";
+  Atomic.set finished true;
+  Domain.join d

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -32,11 +32,12 @@ let _ =
 
 (* test to force domain to do a full GC while another is blocking *)
 let _ =
-  let _ = Domain.spawn (fun _ ->
-    Unix.sleep 10000
+  let d = Domain.spawn (fun _ ->
+    Unix.sleep 10
   ) in
   Gc.full_major ();
   let n = major_collections () in
   ignore (make 24);
   assert ((major_collections ()) > n);
-  print_endline "sleep OK"
+  print_endline "sleep OK";
+  Domain.join d

--- a/testsuite/tests/parallel/max_domains1.ml
+++ b/testsuite/tests/parallel/max_domains1.ml
@@ -4,5 +4,6 @@
 
 let _ =
   try
-    Domain.spawn (fun _ -> print_endline "Expect failure") |> ignore
+    Domain.spawn (fun _ -> print_endline "Expect failure")
+    |> Domain.join
   with Failure _ -> print_string "ok\n"

--- a/testsuite/tests/parallel/max_domains2.ml
+++ b/testsuite/tests/parallel/max_domains2.ml
@@ -10,6 +10,8 @@ let _ =
   (* The default max domains limit is 128. In this test, we make this limit 129
      and spawn 128 domains in addition to the main domain. *)
   for i = 1 to 128 do
-    Domain.spawn (fun _ -> Mutex.lock m) |> ignore
+    let d = Domain.spawn (fun _ -> Mutex.lock m; Mutex.unlock m) in
+    at_exit (fun () -> Domain.join d)
   done;
+  Mutex.unlock m;
   print_endline "ok"

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -177,24 +177,36 @@ struct
 
   let enqueue k = Q.push pqueue k; Gc.minor ()
 
+  (* count the number of domains that are currently
+     active doing a task from the queue. *)
+  let active = Atomic.make 0
+
   let rec dequeue () =
     match Q.pop pqueue with
       | Some k ->
+          Atomic.incr active;
           continue k ()
       | None ->
-          ignore (Unix.select [] [] [] 0.01);
-          dequeue ()
+          (* If no task is available we can wait a bit and recheck if
+             another task has spawned new subtasks in the
+             meantime. But if no other task is active we know that if
+             are collectively done. *)
+          if Atomic.get active = 0 then ()
+          else begin
+            ignore (Unix.select [] [] [] 0.01);
+            dequeue ()
+          end
 
   let rec exec f =
     let pid = get_free_pid () in
       match_with f ()
-      { retc = (fun () -> dequeue ());
-        exnc = (fun e -> raise e);
+      { retc = (fun () -> return ());
+        exnc = (fun e -> fail e);
         effc = fun (type a) (e : a t) ->
           match e with
           | Suspend f -> Some (fun (k : (a, _) continuation) ->
               match f k with
-                | None -> dequeue ()
+                | None -> return ()
                 | Some v -> continue k v)
         | Resume (t, v) -> Some (fun (k : (a, _) continuation) ->
             enqueue k;
@@ -206,17 +218,28 @@ struct
             exec f)
         | Yield -> Some (fun (k : (a, _) continuation) ->
             enqueue k;
-            dequeue ())
+            return ())
         | _ -> None }
+
+  and return () =
+    Atomic.decr active;
+    (* when a task returns we immediately start working on a nother. *)
+    dequeue ()
+
+  and fail e =
+    Atomic.decr active;
+    raise e
 
   let num_threads = 2
 
   let start f =
+    let doms = Queue.create () in
     for i = 1 to num_threads - 1 do
-      ignore (Domain.spawn dequeue)
+      let dom = Domain.spawn dequeue in
+      Queue.push dom doms;
     done;
-    exec f
-
+    exec f;
+    Queue.iter Domain.join doms
 
 end
 


### PR DESCRIPTION
This PR is the result of a design discussion with @stedolan in https://github.com/ocaml/ocaml/issues/14594#issuecomment-3979841954. Currently the cleanup-on-exit mode tries do something when the main domain terminates but other threads and domains remain around -- it tries to cancel/interrupt other domains, this has been implemented by Miod in #12964. This segfaults in some cases as reported by @OlivierNicole in #14594. @stedolan argues that trying to cancel/interrupt other domains will never work reliably, and that we should instead consider this a programming error -- to terminate the main domain with other domains remaining, and expect cleanup-at-exit to work.

In the present PR I turn this scenario (cleanup-at-exit + unjoined domains remaining) as a fatal error and fix the fallout in the testsuite. (mctest.ml had the only non-trivial change required.)

Another approach would be to give up on the cleanup-at-exit policy in this case but _not_ fatal error (ignore the cleanup request silently). In the opposite direction, one could also decide that if having unjoined domains is a programming error, then this should emit a runtime warning in normal mode as well.