### PR TITLE
Document values given to MSVC prefetch intrinsics

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,9 +23,10 @@ Working version
   symbols from the runtime. The declarations were removed in 5.0.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 
-- #14570: Distinguish between prefetching for read and write access in the
-  runtime. Significant performance benefit for some multi-domain programs. For
-  maximum benefit on AMD64, pass -mprfchw to the C compiler.
+- #14570, #14616: Distinguish between prefetching for read and write access in
+  the runtime. Significant performance benefit for some multi-domain
+  programs. For maximum benefit on AMD64, pass `-mprfchw` or `-march=native` to
+  the C compiler.
   (Nick Barnes, review by Gabriel Scherer, Damien Doligez, and Antonin Décimo)
 
 - #14651: Remove S390x TSan (Thread Sanitizer) support.

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -179,25 +179,23 @@ CAMLdeprecated_typedef(addr, char *);
 #ifdef CAML_INTERNALS
 
 #if (__has_builtin(__builtin_prefetch) || defined(__GNUC__))
-#define caml_prefetchr(p) __builtin_prefetch((p), 0, 3)
-/* 0 = intent to read; 3 = all cache levels */
-#define caml_prefetchw(p) __builtin_prefetch((p), 1, 3)
-/* 1 = intent to write; 3 = all cache levels */
+#define caml_prefetchr(p) \
+  __builtin_prefetch((p), 0 /* rw: read */,  3 /* locality: all cache levels */)
+#define caml_prefetchw(p) \
+  __builtin_prefetch((p), 1 /* rw: write */, 3 /* locality: all cache levels */)
 
 #elif defined(_MSC_VER)
 #include <intrin.h>
 #if (defined(_M_IX86) || defined(_M_AMD64))
-/* MSVC Intel. See #14570.
-   0 - PREFETCHNTA; 1 - PREFETCHT0; 2 - PREFETCHT1; 3 - PREFETCHT2
-   4 - PREFETCHW; 5 - PREFETCHNTA */
-#define caml_prefetchr(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
-/* PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, p) */
-#define caml_prefetchw(p) _mm_prefetch((char const *) p, 4)
+#define caml_prefetchr(p) \
+  _mm_prefetch((char const *)(p), _MM_HINT_T0)   /* prefetcht0 */
+#define caml_prefetchw(p) \
+  _mm_prefetch((char const *)(p), _MM_HINT_ENTA) /* prefetchw  */
+/* We would like to use _ET0 here, but it is not defined in Windows headers. */
 
 #elif defined(_M_ARM64)
-/* MSVC ARM64. See #14570 */
-#define caml_prefetchr(p) __prefetch2(p, 0)
-#define caml_prefetchw(p) __prefetch2(p, 16)
+#define caml_prefetchr(p) __prefetch2((p), 0)  /* prfm pldl1keep */
+#define caml_prefetchw(p) __prefetch2((p), 16) /* prfm pstl1keep */
 #endif
 #endif
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -186,14 +186,14 @@ CAMLdeprecated_typedef(addr, char *);
 
 #elif defined(_MSC_VER)
 #include <intrin.h>
-#if (defined(_M_IX86) || defined(_M_AMD64))
+#if (defined(_M_IX86) || defined(_M_AMD64)) && !defined(_M_ARM64EC)
 #define caml_prefetchr(p) \
   _mm_prefetch((char const *)(p), _MM_HINT_T0)   /* prefetcht0 */
 #define caml_prefetchw(p) \
   _mm_prefetch((char const *)(p), _MM_HINT_ENTA) /* prefetchw  */
 /* We would like to use _ET0 here, but it is not defined in Windows headers. */
 
-#elif defined(_M_ARM64)
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
 #define caml_prefetchr(p) __prefetch2((p), 0)  /* prfm pldl1keep */
 #define caml_prefetchw(p) __prefetch2((p), 16) /* prfm pstl1keep */
 #endif


### PR DESCRIPTION
I was loosing sleep over these magic values and decided to document them better. MSVC doesn't have a builtin for these intrinsics so we have to use the `<intrin.h>` header, but convenience macros are not defined. I've hunted down what their names and values are.
- for x86 the macro we miss is `_MM_HINT_ET0`: [`_mm_prefetch`](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_prefetch&ig_expand=5152). There is however a single instruction for the write hint, regardless of the locality: `prefetchw`. MSVC defines the `_MM_HINT_ENTA` macro instead. 
- for ARM there are no macros, but convenient names would be `_PREFETCH_READ`, `_PREFETCH_WRITE`, `_PREFETCH_LOCALITY3`. See the encoding at [`prfm`](https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/PRFM--register---Prefetch-memory--register--DJ). It is a bit cumbersome to decompose the encoding of `prfop`, so I've written it in decimal. 

See also Rust's [x86_64 `_mm_prefetch`](https://doc.rust-lang.org/core/arch/x86_64/fn._mm_prefetch.html) and [aarch64 `_prefetch`](https://doc.rust-lang.org/core/arch/aarch64/fn._prefetch.html) intrinsics.

cc @NickBarnes 