### PR TITLE
compiler development flags: make the "ocaml_deprecated_cli" alert fatal

### DIFF
--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -194,8 +194,8 @@ DEFAULT_BUILD_TARGET = @default_build_target@
 # added to both XXX_YYY_COMPFLAGS and XXX_YYY_LINKFLAGS.
 
 OC_COMMON_COMPFLAGS = -g -strict-sequence -principal -absname \
-  -w +a-4-9-40-41-42-44-45-48 -warn-error +a -bin-annot \
-  -strict-formats
+  -w +a-4-9-40-41-42-44-45-48 -warn-error +a -alert @ocaml_deprecated_cli \
+  -bin-annot -strict-formats
 OC_COMMON_LINKFLAGS = $(INCLUDES)
 
 OC_BYTECODE_LINKFLAGS =

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -45,7 +45,8 @@ else
 CAMLC = $(BOOT_OCAMLC)
 endif
 COMPFLAGS = -strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
-            -g -warn-error +A -bin-annot -nostdlib -principal
+            -g -warn-error +A -alert @ocaml_deprecated_cli \
+            -bin-annot -nostdlib -principal
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -75,7 +75,7 @@ exception Finally_raised of exn
 type todo
 [@@deprecated "Do not use this type as it may be removed in the future"]
 
-exception Todo of todo [@warning "-deprecated"]
+exception Todo of todo [@alert "-deprecated"]
 (** Exception raised when a functionality is unimplemented. Notably raised by
     {!Fun.todo}.
 


### PR DESCRIPTION
The `deprecated` alert is not really a warning anymore, thus attempting to silence it using
```ocaml
type u = A of t[@warning "-deprecated"]
```
ends up silencing all warnings (and the `deprecated` alert) because the warning attribute is read as 
 `[@warning "-d-e-p-r-e-c-a-t-e-d"]` which happens to disable all warnings due to `-a`.
 
 This PR fixes the use of such attribute in the standard library and raise the `ocaml_deprecated_cli` alert to the "fatal alert" level on the compiler codebase to avoid missing the alert in the future.