### PR TITLE
Optimize the `Utf8_lexeme` module

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -138,6 +138,7 @@ testsuite/tests/typing-unicode/*.ml                     typo.non-ascii
 testsuite/tests/tool-toplevel/strings.ml                typo.non-ascii
 testsuite/tests/win-unicode/*.ml                        typo.non-ascii
 testsuite/tests/unicode/見.ml                           typo.non-ascii
+testsuite/tests/unicode/utf8_lexeme.ml                  typo.non-ascii
 testsuite/tests/lib-format/unicode.ml                   typo.non-ascii
 testsuite/tests/lib-string/test_string.ml               typo.non-ascii
 testsuite/tests/lib-uchar/test.ml                       typo.non-ascii

--- a/Changes
+++ b/Changes
@@ -88,6 +88,10 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #14620: optimize utf8 normalization and (un)capitalization functions
+  (Gabriel Scherer, review by Stefan Muenzel and Florian Angeletti,
+   report by Stefan Muenzel)
+
 - #14601, remove an unreachable path for unbound type variables in extension
   constructor declarations.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/testsuite/tests/unicode/utf8_lexeme.ml
+++ b/testsuite/tests/unicode/utf8_lexeme.ml
@@ -1,0 +1,179 @@
+(* TEST
+ flags = "-I ${ocamlsrcdir}/utils";
+ include ocamlcommon;
+ expect;
+*)
+
+module Utf8 = Misc.Utf8_lexeme
+type 'a mismatch = { output: 'a; expected: 'a }
+type test_result = (unit, (Utf8.t, Utf8.t) Result.t mismatch) result
+let test f input expected : test_result =
+  let output = f input in
+  if output = expected then Ok ()
+  else Error { output; expected }
+[%%expect {|
+module Utf8 = Misc.Utf8_lexeme
+type 'a mismatch = { output : 'a; expected : 'a; }
+type test_result = (unit, (Utf8.t, Utf8.t) Result.t mismatch) result
+val test :
+  ('a -> (Utf8.t, Utf8.t) Result.t) ->
+  'a -> (Utf8.t, Utf8.t) Result.t -> test_result = <fun>
+|}];;
+
+
+(* empty string *)
+
+test Utf8.normalize "" (Ok "");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "" (Ok "");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "" (Ok "");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+
+
+(* ascii-only fast path *)
+
+test Utf8.normalize "hello" (Ok "hello");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "hello" (Ok "Hello");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "Hello" (Ok "Hello");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "hello" (Ok "hello");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "Hello" (Ok "hello");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+
+(* non-ascii-only, no normalization *)
+
+test Utf8.normalize "helloÀ" (Ok "helloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "helloÀ" (Ok "HelloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "HelloÀ" (Ok "HelloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "helloÀ" (Ok "helloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "HelloÀ" (Ok "helloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+(* non-ascii-only, normalization on first char *)
+test Utf8.normalize "A\xcc\x80" (Ok "À");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "A\xcc\x80" (Ok "À");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "a\xcc\x80" (Ok "À");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "A\xcc\x80" (Ok "à");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "a\xcc\x80" (Ok "à");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+
+(* non-ascii-only, normalization on non-first char *)
+
+test Utf8.normalize "helloA\xcc\x80" (Ok "helloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "helloA\xcc\x80" (Ok "HelloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "HelloA\xcc\x80" (Ok "HelloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "helloA\xcc\x80" (Ok "helloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "HelloA\xcc\x80" (Ok "helloÀ");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+
+
+(* outside the ascii-only fast path: error *)
+
+test Utf8.normalize "hello\255" (Error "hello\u{FFFD}");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "hello\255" (Error "Hello\u{FFFD}");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.capitalize "Hello\255" (Error "Hello\u{FFFD}");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "hello\255" (Error "hello\u{FFFD}");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;
+
+test Utf8.uncapitalize "Hello\255" (Error "hello\u{FFFD}");;
+[%%expect {|
+- : test_result = Ok ()
+|}];;

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -365,10 +365,7 @@ module Utf8_lexeme = struct
        applied to the first character of [s] only.*)
     if s = "" then Ok ""
     else
-      let only_ascii =
-        let ascii_limit = 128 in
-        String.for_all (fun x -> Char.code x < ascii_limit) s
-      in
+      let only_ascii = String.for_all Char.Ascii.is_valid s in
       (* get the first character of [s] *)
       let d = String.get_utf_8_uchar s 0 in
       let u0 = Uchar.utf_decode_uchar d in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -378,7 +378,19 @@ module Utf8_lexeme = struct
         (* If the first character is unchanged by the [first] transformation,
            and the string is ascii-only, we can return it unchanged. *)
         Ok s
-      else begin
+      else if only_ascii then begin
+        (* If the first character is changed but the rest
+           of the string is ascii-only, we can concatenate
+           the new first character with the rest. *)
+        let ulen = Uchar.utf_8_byte_length u0' in
+        let restlen = String.length s - i0 in
+        let res = Bytes.create (ulen + restlen) in
+        let ulen' = Bytes.set_utf_8_uchar res 0 u0' in
+        assert (ulen = ulen');
+        BytesLabels.blit_string
+          ~src:s ~src_pos:i0 ~dst:res ~dst_pos:ulen ~len:restlen;
+        Ok (Bytes.unsafe_to_string res)
+      end else begin
         (* Otherwise we are in the slow path where each character
            must be normalized. *)
         let buf = Buffer.create (String.length s) in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -360,10 +360,10 @@ module Utf8_lexeme = struct
     ('s', 0x30c, 0x161); (* š *)   ('z', 0x30c, 0x17e); (* ž *)
   ]
 
-  let normalize_generic ~keep_ascii transform s =
+  let normalize_generic ?first s =
     let rec norm check buf prev i =
       if i >= String.length s then begin
-        Buffer.add_utf_8_uchar buf (transform prev)
+        Buffer.add_utf_8_uchar buf prev
       end else begin
         let d = String.get_utf_8_uchar s i in
         let u = Uchar.utf_decode_uchar d in
@@ -373,12 +373,12 @@ module Utf8_lexeme = struct
         | Some u' ->
             norm check buf u' i'
         | None ->
-            Buffer.add_utf_8_uchar buf (transform prev);
+            Buffer.add_utf_8_uchar buf prev;
             norm check buf u i'
       end in
     let ascii_limit = 128 in
     if s = ""
-    || keep_ascii && String.for_all (fun x -> Char.code x < ascii_limit) s
+    || Option.is_none first && String.for_all (fun x -> Char.code x < ascii_limit) s
     then Ok s
     else
       let buf = Buffer.create (String.length s) in
@@ -389,7 +389,8 @@ module Utf8_lexeme = struct
       let d = String.get_utf_8_uchar s 0 in
       let u = Uchar.utf_decode_uchar d in
       check d u;
-      norm check buf u (Uchar.utf_decode_length d);
+      let u' = match first with None -> u | Some transform -> transform u in
+      norm check buf u' (Uchar.utf_decode_length d);
       let contents = Buffer.contents buf in
       if !valid then
         Ok contents
@@ -397,7 +398,7 @@ module Utf8_lexeme = struct
         Error contents
 
   let normalize s =
-    normalize_generic ~keep_ascii:true (fun u -> u) s
+    normalize_generic s
 
   (* Capitalization *)
 
@@ -427,16 +428,10 @@ module Utf8_lexeme = struct
       | _ -> u
 
   let capitalize s =
-    let first = ref true in
-    normalize_generic ~keep_ascii:false
-      (fun u -> if !first then (first := false; uchar_uppercase u) else u)
-      s
+    normalize_generic ~first:uchar_uppercase s
 
   let uncapitalize s =
-    let first = ref true in
-    normalize_generic ~keep_ascii:false
-      (fun u -> if !first then (first := false; uchar_lowercase u) else u)
-      s
+    normalize_generic ~first:uchar_lowercase s
 
   let is_capitalized s =
     s <> "" &&

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -361,41 +361,54 @@ module Utf8_lexeme = struct
   ]
 
   let normalize_generic ?first s =
-    let rec norm check buf prev i =
-      if i >= String.length s then begin
-        Buffer.add_utf_8_uchar buf prev
-      end else begin
-        let d = String.get_utf_8_uchar s i in
-        let u = Uchar.utf_decode_uchar d in
-        check d u;
-        let i' = i + Uchar.utf_decode_length d in
-        match Hashtbl.find_opt known_pairs (prev, u) with
-        | Some u' ->
-            norm check buf u' i'
-        | None ->
-            Buffer.add_utf_8_uchar buf prev;
-            norm check buf u i'
-      end in
-    let ascii_limit = 128 in
-    if s = ""
-    || Option.is_none first && String.for_all (fun x -> Char.code x < ascii_limit) s
-    then Ok s
+    (* [first : Uchar.t -> Uchar.t] is an optional function to be
+       applied to the first character of [s] only.*)
+    if s = "" then Ok ""
     else
-      let buf = Buffer.create (String.length s) in
-      let valid = ref true in
-      let check d u =
-        valid := !valid && Uchar.utf_decode_is_valid d && u <> Uchar.rep
+      let only_ascii =
+        let ascii_limit = 128 in
+        String.for_all (fun x -> Char.code x < ascii_limit) s
       in
+      (* get the first character of [s] *)
       let d = String.get_utf_8_uchar s 0 in
-      let u = Uchar.utf_decode_uchar d in
-      check d u;
-      let u' = match first with None -> u | Some transform -> transform u in
-      norm check buf u' (Uchar.utf_decode_length d);
-      let contents = Buffer.contents buf in
-      if !valid then
-        Ok contents
-      else
-        Error contents
+      let u0 = Uchar.utf_decode_uchar d in
+      let i0 = Uchar.utf_decode_length d in
+      let u0' = match first with None -> u0 | Some transform -> transform u0 in
+      if u0' = u0 && only_ascii then
+        (* If the first character is unchanged by the [first] transformation,
+           and the string is ascii-only, we can return it unchanged. *)
+        Ok s
+      else begin
+        (* Otherwise we are in the slow path where each character
+           must be normalized. *)
+        let buf = Buffer.create (String.length s) in
+        let valid = ref true in
+        let check d u =
+          valid := !valid && Uchar.utf_decode_is_valid d && u <> Uchar.rep
+        in
+        check d u0;
+        let rec norm prev i =
+          if i >= String.length s then begin
+            Buffer.add_utf_8_uchar buf prev
+          end else begin
+            let d = String.get_utf_8_uchar s i in
+            let u = Uchar.utf_decode_uchar d in
+            check d u;
+            let i' = i + Uchar.utf_decode_length d in
+            match Hashtbl.find_opt known_pairs (prev, u) with
+            | Some u' ->
+                norm u' i'
+            | None ->
+                Buffer.add_utf_8_uchar buf prev;
+                norm u i'
+          end in
+        norm u0' i0;
+        let contents = Buffer.contents buf in
+        if !valid then
+          Ok contents
+        else
+          Error contents
+      end
 
   let normalize s =
     normalize_generic s


### PR DESCRIPTION
@smuenzel found something odd while profiling the type-checker, with compilation profiles where 30% of the time was being consumed by misc/Utf8_lexeme.normalize_generic, a function which is evolved in lexing identifiers and processing module names. (See https://github.com/smuenzel/ocaml/pull/1#issuecomment-4001322567 , #14618.)

I now believe that I understand what is going on:
- the surprising profile shows up for files that are super-quick to typecheck in the compiler distributions
- for these files, initializing the load path takes a significant portion of the time
- we call capitalization/uncapitalization functions on all filenames encountered in the load path
- the logic to have a fast path in `normalize_generic` was disabled for the uncapitalization function

The present PR optimizes Utf8_lexeme by extending the fast path to work correctly, first for all inputs that are preserved by (un)capitalization, and then for all ASCII-only inputs. On the test file, the time portion spent in this module goes from 32% to 7% then to 1.5%.

(This PR is independent/orthogonal/combinable with #14618 from @smuenzel, which optimizes the normalization logic which is necessary when we are _not_ in the fast path.)

cc @smuenzel, @Octachron, @garrigue 