### PR TITLE
[actually an issue] Tfunctor FIXMEs

### DIFF
--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -629,6 +629,7 @@ let instr_break ppf lexbuf =
           let (v, ty) = Eval.expression !selected_event env expr in
           match get_desc ty with
           | Tarrow _ ->
+             (* FIXME: Tfunctor *)
               add_breakpoint_after_pc (Remote_value.closure_code v)
           | _ ->
               eprintf "Not a function.@.";

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -530,9 +530,10 @@ module Analyser =
             in
             let real_type =
               match get_desc met_type with
-              Tarrow (_, _, t, _) ->
+              | Tarrow (_, _, t, _) ->
+                (* FIXME: Tfunctor? *)
                 t
-            |  _ ->
+              |  _ ->
                 (* ?!? : not an arrow type ! return the original type *)
                 met_type
           in

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -115,7 +115,8 @@ let dummy_parameter_list typ =
 let is_function v =
   let rec f t =
     match Types.get_desc t with
-      Types.Tarrow _ ->
+    | Types.Tarrow _ ->
+        (* FIXME: Tfunctor *)
         true
     | Types.Tlink t ->
         f t

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -41,7 +41,7 @@ let dir_trace ppf lid =
           && (match
                 Types.get_desc
                   (Ctype.expand_head !Topcommon.toplevel_env desc.val_type)
-              with Tarrow _ -> true | _ -> false)
+             with Tarrow _ -> (* FIXME: Tfunctor *) true | _ -> false)
           then begin
           match is_traced clos with
           | Some opath ->

--- a/toplevel/byte/trace.ml
+++ b/toplevel/byte/trace.ml
@@ -69,6 +69,7 @@ let print_label ppf l =
 let rec instrument_result env name ppf clos_typ =
   match get_desc (Ctype.expand_head env clos_typ) with
   | Tarrow(l, t1, t2, _) ->
+      (* FIXME: Tfunctor *)
       let starred_name =
         match name with
         | Lident s -> Lident(s ^ "*" )
@@ -112,6 +113,7 @@ let _ = Dummy
 let instrument_closure env name ppf clos_typ =
   match get_desc (Ctype.expand_head env clos_typ) with
   | Tarrow(l, t1, t2, _) ->
+      (* FIXME: Tfunctor *)
       let trace_res = instrument_result env name ppf t2 in
       (fun actual_code closure arg ->
         if not !may_trace then begin

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -75,6 +75,9 @@ let match_simple_printer_type env ty ~is_old_style =
       then Some (Old ty_arg)
       else Some (Simple ty_arg)
 
+(* Note: these functions do not need to support
+   [Tfunctor] arrows (module-dependent functors),
+   as those do not occur in toplevel printer types. *)
 let filter_arrow env ty =
   let ty = Ctype.expand_head env ty in
   match Types.get_desc ty with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6221,6 +6221,7 @@ let arrow_spine env ty =
     then (
       match get_desc ty with
       | Tarrow (label, ty_arg, ty_ret, _commu) ->
+        (* FIXME: Tfunctor *)
         arrow_spine_rec ~mark ((label, ty_arg) :: labels) ty_ret
       | _ -> List.rev labels, `Return ty)
     else List.rev labels, `Cycle

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -135,6 +135,7 @@ let unifiable env ty1 ty2 =
   Btype.backtrack snap;
   res
 
+(* FIXME: consider the Tfunctor case *)
 let explanation_diff env t3 t4 =
   match Types.get_desc t3, Types.get_desc t4 with
   | Tarrow (_, ty1, ty2, _), _

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3721,6 +3721,7 @@ let check_partial_application ~statement exp =
     let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
     match ty with
     | Tarrow _ ->
+       (* FIXME: Tfunctor *)
         let rec check {exp_desc; exp_loc; exp_extra; _} =
           if List.exists (function
               | (Texp_constraint _, _, _) -> true
@@ -4373,7 +4374,8 @@ and type_expect_
         let ty = expand_head env ty_fun in
         if TypeSet.mem ty seen then () else
           match get_desc ty with
-            Tarrow (_l, ty_arg, ty_fun, _com) ->
+          | Tarrow (_l, ty_arg, ty_fun, _com) ->
+             (* FIXME: Tfunctor ? *)
               (try Ctype.unify_var env (newvar2 outer_level) ty_arg
                with Unify _ -> assert false);
               lower_args (TypeSet.add ty seen) ty_fun
@@ -6223,7 +6225,8 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
     let work () =
       let te = expand_head env ty_expected' in
       match get_desc te with
-        Tarrow(Nolabel,_,ty_res0,_) ->
+      | Tarrow(Nolabel,_,ty_res0,_) ->
+         (* FIXME: Tfunctor? *)
           Some (no_labels ty_res0, get_level te)
       | _ -> None
     in
@@ -6249,6 +6252,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
             in
             make_args ((l, Arg ty) :: args) ty_fun
         | Tarrow (l,_,ty_res',_) when l = Nolabel || !Clflags.classic ->
+           (* FIXME: Tfunctor? *)
             List.rev args, ty_fun, no_labels ty_res'
         | Tvar _ ->  List.rev args, ty_fun, false
         |  _ -> [], texp.exp_type, false
@@ -7498,6 +7502,7 @@ let report_partial_application = function
   | Some tr -> begin
       match get_desc tr.Errortrace.got.Errortrace.expanded with
       | Tarrow _ ->
+         (* FIXME: Tfunctor? *)
           [ Location.msg
               "@[@{<hint>Hint@}:@ This function application is partial,@ \
                maybe@ some@ arguments@ are missing.@]" ]
@@ -7703,7 +7708,8 @@ let report_error ~loc env = function
       funct; func_ty; res_ty; previous_arg_loc; extra_arg_loc
     } ->
       begin match get_desc func_ty with
-        Tarrow _ ->
+      | Tarrow _ ->
+         (* FIXME: Tfunctor? *)
           let returns_unit = match get_desc res_ty with
             | Tconstr (p, _, _) -> Path.same p Predef.path_unit
             | _ -> false

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -45,7 +45,9 @@ let scrape env ty =
 
 let is_function_type env ty =
   match scrape env ty with
-  | Some (Tarrow (_, lhs, rhs, _)) -> Some (lhs, rhs)
+  | Some (Tarrow (_, lhs, rhs, _)) ->
+     (* FIXME: Tfunctor *)
+     Some (lhs, rhs)
   | _ -> None
 
 let is_base_type env ty base_ty_path =


### PR DESCRIPTION
After #14622 was reported, @johnyob and myself reviewed the uses of `Tarrow` in pattern-matching across the compiler codebase, to find places that should be fixed to also handle `Tfunctor`. There are actually quite a few, pinpointed by FIXME comments in the present not-really-a-PR.