### PR TITLE
[minor] Typeopt.is_function_type: accept Tfunctor and forget dependency

### DIFF
--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -109,6 +109,7 @@ val new_global_var: ?name:string -> unit -> type_expr
 val newobj: type_expr -> type_expr
 val newconstr: Path.t -> type_expr list -> type_expr
 val newmono : type_expr -> type_expr
+val newmono_package : ?level:int -> package -> type_expr
         (* Create a new, monomorphic type *)
 val none: type_expr
         (* A dummy type expression *)

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -45,8 +45,13 @@ let scrape env ty =
 
 let is_function_type env ty =
   match scrape env ty with
-  | Some (Tarrow (_, lhs, rhs, _)) -> Some (lhs, rhs)
-  | _ -> None
+  | Some (Tarrow (_, lhs, rhs, _)) ->
+    Some (lhs, rhs)
+  | Some (Tfunctor (_, _id, package, rhs)) ->
+    let lhs = Ctype.newmono_package package in
+    Some (lhs, rhs)
+  | _ ->
+    None
 
 let is_base_type env ty base_ty_path =
   match scrape env ty with


### PR DESCRIPTION
This is part of the potential issues discussed in #14624.

In https://github.com/ocaml/ocaml/pull/14624#discussion_r2896922062 @Octachron remarks that `Typeopt.is_function_type` is currently never called with a Tfunctor argument, because it is currently only used on the type of `external` primitives and those reject Tfunctor types (it is `Typedecl.parse_native_repr_attributes` that will reject those with an error). But I personally prefer to not specialize `Typeopt.is_function_type` for its caller, as this risks having code become subtly wrong if we extend it later on; I don't see a clear reason to reject type-dependent functions for external primitives (but this PR does not add support for them). So instead I propose to make the function do something reasonable and not-wrong in the Tfunctor case as well, and have this function behave on `(module M : S) -> ty` exactly like `(module S) -> ty`.