### PR TITLE
[minor] remove Typeopt.is_function_type

### DIFF
--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -454,12 +454,21 @@ let glb_array_type t1 t2 =
 
 (* Specialize a primitive from available type information. *)
 
+let find_arrow_type ty =
+  (* Note: [external] declarations do not support module-dependent
+     functors for now, so we do not need to handle [Tfunctor] here. *)
+  match Types.get_desc ty with
+  | Tarrow (_lab, lhs, rhs, _commu) ->
+    Some (lhs, rhs)
+  | _ ->
+    None
+
 let specialize_primitive env ty ~has_constant_constructor prim =
   let param_tys =
-    match is_function_type env ty with
+    match find_arrow_type ty with
     | None -> []
     | Some (p1, rhs) ->
-      match is_function_type env rhs with
+      match find_arrow_type rhs with
       | None -> [p1]
       | Some (p2, _) -> [p1;p2]
   in
@@ -471,7 +480,7 @@ let specialize_primitive env ty ~has_constant_constructor prim =
     end
   | Primitive (Pfield (n, Pointer, mut), arity), _ ->
       (* try strength reduction based on the *result type* *)
-      let is_int = match is_function_type env ty with
+      let is_int = match find_arrow_type ty with
         | None -> Pointer
         | Some (_p1, rhs) -> maybe_pointer_type env rhs in
       Some (Primitive (Pfield (n, is_int, mut), arity))

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -43,11 +43,6 @@ let scrape_ty env ty =
 let scrape env ty =
   Option.map get_desc (scrape_ty env ty)
 
-let is_function_type env ty =
-  match scrape env ty with
-  | Some (Tarrow (_, lhs, rhs, _)) -> Some (lhs, rhs)
-  | _ -> None
-
 let is_base_type env ty base_ty_path =
   match scrape env ty with
   | Some (Tconstr(p, _, _)) -> Path.same p base_ty_path

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -15,8 +15,6 @@
 
 (* Auxiliaries for type-based optimizations, e.g. array kinds *)
 
-val is_function_type :
-      Env.t -> Types.type_expr -> (Types.type_expr * Types.type_expr) option
 val is_base_type : Env.t -> Types.type_expr -> Path.t -> bool
 
 val maybe_pointer_type : Env.t -> Types.type_expr


### PR DESCRIPTION
This PR is a proposed alternative to #14631.

Currently `Typeopt.is_function_type` is a function with no clear specification and a single user.

I believe that its natural specification is "if this is a function, collect the argument and return types", and it is incorrect with respect to that specification as it does not correctly support module-dependent functions.

In #14631 I propose to extend this function to module-dependent functions, but that results in a return type with a free module variable and @Octachron does not like that.

In the present PR I propose to remove the function from Typeopt instead, and move the logic to the user module (lambda/Translprim) where the limitation that it does not support module-dependent functions are clear and make more (local) sense.