### PR TITLE
intern.c: fix handling of atoms with tag >= No_scan_tag

### DIFF
--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -663,7 +663,7 @@ static void intern_rec(struct caml_intern_state* s,
         header = (header_t) read32u(s);
         tag = Tag_hd(header);
         size = Wosize_hd(header);
-        if (CAMLunlikely(tag >= No_scan_tag
+        if (CAMLunlikely((tag >= No_scan_tag && size > 0)
                          || tag == Infix_tag || tag == Cont_tag))
           intern_cleanup_failwith2(s, fun_name, "invalid block32");
         goto read_block;
@@ -672,7 +672,7 @@ static void intern_rec(struct caml_intern_state* s,
         header = (header_t) read64u(s);
         tag = Tag_hd(header);
         size = Wosize_hd(header);
-        if (CAMLunlikely(tag >= No_scan_tag
+        if (CAMLunlikely((tag >= No_scan_tag && size > 0)
                          || tag == Infix_tag || tag == Cont_tag))
           intern_cleanup_failwith2(s, fun_name, "invalid block64");
         goto read_block;


### PR DESCRIPTION
The change 3aa27e4d2522950b2fe2acf868591209e93d1377 seems to have introduced a regression. That commit added a check when unmarshalling `CODE_BLOCK32` and `CODE_BLOCK64` "tags":

https://github.com/ocaml/ocaml/blob/a0ab87686082bc2ca4bebac04ce9315fe53eff88/runtime/intern.c#L662-L678

However, the condition `tag >= No_scan_tag` fails for atoms corresponding to tags in that range:

https://github.com/ocaml/ocaml/blob/a0ab87686082bc2ca4bebac04ce9315fe53eff88/runtime/extern.c#L806-L811

https://github.com/ocaml/ocaml/blob/a0ab87686082bc2ca4bebac04ce9315fe53eff88/runtime/extern.c#L604-L623

It is not completely trivial to trigger the bug because it is not easy to create atoms with tag `>= No_scan_tag`, but:
```
nicolasojedabar@LEXIFI-L6:~/ocaml$ rlwrap local/bin/ocaml
OCaml version 5.4.2+dev0-2026-02-17
Enter #help;; for help.

# Marshal.from_string (Marshal.to_string (Float.Array.sub [||] 0 0) []) 0;;
Exception: Failure "input_val_from_string: invalid block32".
```
NB: here we use `Float.Array.sub [||] 0 0` to create a block of size 0 and tag 254 (`>= No_scan_tag`). There is a related issue concerning this function, which is addressed in #14635.

The bug was discovered and investigated in collaboration with my colleague @mlasson.

cc @gasche @xavierleroy 