### PR TITLE
runtime/array: fix control flow in caml_floatarray_gather

### DIFF
--- a/Changes
+++ b/Changes
@@ -107,7 +107,7 @@ Working version
 
 - #14635: Fix a bug in `caml_floatarray_gather` that would cause
   the result of `Float.Array.sub`, `Float.Array.append`, `Float.Array.concat`
-  (when empty) not to be equal (per `=` or `==`) to `[||]`.
+  (when empty) not to be equal to `[||]`.
   (Marc Lasson, review by Gabriel Scherer)
 
 - #14492: Fix Obj.dup on closures.

--- a/Changes
+++ b/Changes
@@ -105,11 +105,6 @@ Working version
 
 ### Bug fixes:
 
-- #14635: Fix a bug in `caml_floatarray_gather` that would cause
-  the result of `Float.Array.sub`, `Float.Array.append`, `Float.Array.concat`
-  (when empty) not to be equal to `[||]`.
-  (Marc Lasson, review by Gabriel Scherer)
-
 - #14492: Fix Obj.dup on closures.
   (Mark Shinwell and Nick Barnes, review by Gabriel Scherer and Damien Doligez)
 
@@ -852,6 +847,11 @@ OCaml 5.5.0
   polymorphic types and unboxed constructors.
   (Gabriel Scherer and Stefan Muenzel, report by Brandon Stride,
    review by Florian Angeletti)
+
+- #14635: Fix a bug in `caml_floatarray_gather` that would cause
+  the result of `Float.Array.sub`, `Float.Array.append`, `Float.Array.concat`
+  (when empty) not to be equal to `[||]`.
+  (Marc Lasson, review by Gabriel Scherer)
 
 OCaml 5.4.0 (9 October 2025)
 ----------------------------

--- a/Changes
+++ b/Changes
@@ -105,9 +105,9 @@ Working version
 
 ### Bug fixes:
 
-- #14635: Fix a control-flow bug in `caml_floatarray_gather` that could make
-  empty `Float.Array.sub`, `Float.Array.append`, and `Float.Array.concat`
-  results use a non-canonical runtime representation.
+- #14635: Fix a bug in `caml_floatarray_gather` that would cause
+  the result of `Float.Array.sub`, `Float.Array.append`, `Float.Array.concat`
+  (when empty) not to be equal (per `=` or `==`) to `[||]`.
   (Marc Lasson, review by Gabriel Scherer)
 
 - #14492: Fix Obj.dup on closures.

--- a/Changes
+++ b/Changes
@@ -105,6 +105,11 @@ Working version
 
 ### Bug fixes:
 
+- #14635: Fix a control-flow bug in `caml_floatarray_gather` that could make
+  empty `Float.Array.sub`, `Float.Array.append`, and `Float.Array.concat`
+  results use a non-canonical runtime representation.
+  (Marc Lasson, review by Gabriel Scherer)
+
 - #14492: Fix Obj.dup on closures.
   (Mark Shinwell and Nick Barnes, review by Gabriel Scherer and Damien Doligez)
 

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -506,21 +506,22 @@ static value caml_floatarray_gather(intnat num_arrays,
   if (size == 0) {
     /* If total size = 0, just return empty array */
     res = Atom(0);
+  } else {
+    /* This is an array of floats.  We can use memcpy directly. */
+    if (size > Max_wosize/Double_wosize) caml_invalid_argument("Array.concat");
+    mlsize_t wsize = size * Double_wosize; /* total size, in words */
+    res = caml_alloc(wsize, Double_array_tag);
+    mlsize_t pos = 0;
+    for (mlsize_t i = 0; i < num_arrays; i++) {
+      /* [res] is freshly allocated, and no other domain has a reference to it.
+         Hence, a plain [memcpy] is sufficient. */
+      memcpy((double *)res + pos,
+             (double *)arrays[i] + offsets[i],
+             lengths[i] * sizeof(double));
+      pos += lengths[i];
+    }
+    CAMLassert(pos == size);
   }
-  /* This is an array of floats.  We can use memcpy directly. */
-  if (size > Max_wosize/Double_wosize) caml_invalid_argument("Array.concat");
-  mlsize_t wsize = size * Double_wosize; /* total size, in words */
-  res = caml_alloc(wsize, Double_array_tag);
-  mlsize_t pos = 0;
-  for (mlsize_t i = 0; i < num_arrays; i++) {
-    /* [res] is freshly allocated, and no other domain has a reference to it.
-       Hence, a plain [memcpy] is sufficient. */
-    memcpy((double *)res + pos,
-           (double *)arrays[i] + offsets[i],
-           lengths[i] * sizeof(double));
-    pos += lengths[i];
-  }
-  CAMLassert(pos == size);
   CAMLreturn(res);
 }
 

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -505,23 +505,22 @@ static value caml_floatarray_gather(intnat num_arrays,
   }
   if (size == 0) {
     /* If total size = 0, just return empty array */
-    res = Atom(0);
-  } else {
-    /* This is an array of floats.  We can use memcpy directly. */
-    if (size > Max_wosize/Double_wosize) caml_invalid_argument("Array.concat");
-    mlsize_t wsize = size * Double_wosize; /* total size, in words */
-    res = caml_alloc(wsize, Double_array_tag);
-    mlsize_t pos = 0;
-    for (mlsize_t i = 0; i < num_arrays; i++) {
-      /* [res] is freshly allocated, and no other domain has a reference to it.
-         Hence, a plain [memcpy] is sufficient. */
-      memcpy((double *)res + pos,
-             (double *)arrays[i] + offsets[i],
-             lengths[i] * sizeof(double));
-      pos += lengths[i];
-    }
-    CAMLassert(pos == size);
+    CAMLreturn(Atom(0));
   }
+  /* This is an array of floats.  We can use memcpy directly. */
+  if (size > Max_wosize/Double_wosize) caml_invalid_argument("Array.concat");
+  mlsize_t wsize = size * Double_wosize; /* total size, in words */
+  res = caml_alloc(wsize, Double_array_tag);
+  mlsize_t pos = 0;
+  for (mlsize_t i = 0; i < num_arrays; i++) {
+    /* [res] is freshly allocated, and no other domain has a reference to it.
+       Hence, a plain [memcpy] is sufficient. */
+    memcpy((double *)res + pos,
+           (double *)arrays[i] + offsets[i],
+           lengths[i] * sizeof(double));
+    pos += lengths[i];
+  }
+  CAMLassert(pos == size);
   CAMLreturn(res);
 }
 

--- a/testsuite/tests/lib-floatarray/floatarray.ml
+++ b/testsuite/tests/lib-floatarray/floatarray.ml
@@ -74,6 +74,11 @@ end
 module Test (A : S) : sig end = struct
 
   (* auxiliary functions *)
+  let empty = A.create 0 in
+
+  let check_empty a =
+    assert (a = empty)
+  in
 
   let neg_zero = 1.0 /. neg_infinity in
 
@@ -126,6 +131,23 @@ module Test (A : S) : sig end = struct
   check_i a;
   check_inval (fun i -> A.init i Float.of_int) (-1);
   check_inval (fun i -> A.init i Float.of_int) (A.max_length + 1);
+
+  (* empty constructors *)
+  check_empty (A.create 0);
+  check_empty (A.make 0 42.0);
+  check_empty (A.init 0 (fun _ -> assert false));
+  check_empty (A.of_list []);
+  check_empty (A.of_seq Seq.empty);
+  check_empty (A.concat []); (* X *)
+  check_empty (A.concat [empty]); (* X *)
+  check_empty (A.append empty empty);
+  check_empty (A.sub (A.create 1) 0 0); (* X *)
+  check_empty (A.sub (A.create 1) 1 0); (* X *)
+  check_empty (A.copy empty);
+  check_empty (A.map (fun _ -> assert false) empty);
+  check_empty (A.mapi (fun _ _ -> assert false) empty);
+  check_empty (A.map2 (fun _ _ -> assert false) empty empty);
+  check_empty (A.map_from_array (fun _ -> assert false) [| |]);
 
   (* [make_matrix] *)
   let check_make_matrix m n =


### PR DESCRIPTION
The empty-array case in `caml_floatarray_gather` currently falls through to the non-empty allocation path.

This is clearly a control flow bug. When `size == 0`, the function assigns `res = Atom(0)`, but then continues and  allocates a `Double_array_tag` block anyway because there is no `else` or early  return.

Without this PR the result is an allocated block of size 0 with tag 254. After, the PR the result uses the "shared static atomic" block of size 0 with tag 0. 

Related PR #14633.


