### PR TITLE
Fix surplus argument in Fun.protect test

### DIFF
--- a/testsuite/tests/lib-fun/test.ml
+++ b/testsuite/tests/lib-fun/test.ml
@@ -31,7 +31,7 @@ let test_protect () =
   let double_raise () =
     let f () = raise Exit in
     try
-      Fun.protect ~finally:f f ()
+      Fun.protect ~finally:f f
     with
     | Exit -> ()
   in


### PR DESCRIPTION
Remove extra () argument from `Fun.protect` call in test_protect. `Fun.protect ~finally:f f` is already a complete application; the surplus () is rejected by OxCaml's stricter application checking.

See https://github.com/oxcaml/oxcaml/pull/4830/changes#r2487327794.