### PR TITLE
runtime: ignore cleanup-at-exit / `caml_shutdown` when other domains remain running

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,11 @@ Working version
   symbols from the runtime. The declarations were removed in 5.0.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 
+- #14642: Ignore cleanup-at-exit / caml_shutdown when other domains remain
+  running
+  (Gabriel Scherer and Olivier Nicole, report by Olivier Nicole, review by Miod
+   Vallat and Damien Doligez)
+
 - #14570, #14616, #14665: Distinguish between prefetching for read and write
   access in the runtime. Significant performance benefit for some multi-domain
   programs.

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1925,6 +1925,11 @@ have used "caml_stat_*" incorrectly, this behaviour is only enabled if the
 runtime is started with a specialized "caml_startup_pooled" function.
 \end{itemize}
 
+One should make sure to join all domains into the main domain before calling
+"caml_shutdown". If there are more than one domain alive when calling
+"caml_shutdown", a warning will be issued and no attempt will be made to
+terminate other domains.
+
 As a shared library may have several clients simultaneously, it is made for
 convenience that "caml_startup" (and "caml_startup_pooled") may be called
 multiple times, given that each such call is paired with a corresponding call

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -132,10 +132,12 @@ The following environment variables are also consulted:
         startup time instead of at backtrace printing time. "b=2" can be used if
         the runtime is unable to load debugging information at backtrace
         printing time, for example if there are no file descriptors available.
-  \item[c] ("cleanup_on_exit") Shut the runtime down gracefully on exit (see
-        "caml_shutdown" in section~\ref{ss:c-embedded-code}). The option also enables
-        pooling (as in "caml_startup_pooled"). This mode can be used to detect
-        leaks with a third-party memory debugger.
+  \item[c] ("cleanup_on_exit") If set to 1, the runtime will be shut down
+        gracefully on exit (see "caml_shutdown" in
+        section~\ref{ss:c-embedded-code}). The option also enables pooling (as
+        in "caml_startup_pooled"). This mode can be used to detect leaks with a
+        third-party memory debugger. No attempt is made to shut down the
+        runtime if there is more than one domain alive at exit.
   \item[d] ("max_domains") Maximum number of domains that can be active
         concurrently. Defaults to 128 on 64-bit platforms and 16 on 32-bit
         platforms.

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -264,9 +264,6 @@ void caml_global_barrier_release_as_final(barrier_status status);
  * Termination helpers.
  */
 
-/* Force all other domains to stop their operation. */
-void caml_stop_all_domains(void);
-
 /* Try and release all synchronisation resources set up by
    caml_init_domains(). Returns whether all resources could be released. */
 bool caml_free_domains(void);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -264,6 +264,10 @@ void caml_global_barrier_release_as_final(barrier_status status);
  * Termination helpers.
  */
 
+/* Set a flag informing that the program is exiting or that [caml_shutdown] has
+ * been called, and that new domains should not be spawned. */
+void caml_set_domains_exiting(void);
+
 /* Try and release all synchronisation resources set up by
    caml_init_domains(). Returns whether all resources could be released. */
 bool caml_free_domains(void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -241,6 +241,7 @@ static atomic_uintnat /* dom_internal* */ stw_leader = 0;
 static uintnat stw_requests_suspended = 0; /* protected by all_domains_lock */
 static caml_plat_cond requests_suspended_cond = CAML_PLAT_COND_INITIALIZER;
 static dom_internal* all_domains;
+static atomic_intnat domains_exiting = 0;
 
 CAMLexport atomic_uintnat caml_num_domains_running = 0;
 
@@ -1060,6 +1061,7 @@ CAMLexport void caml_reset_domain_lock(void)
 
 void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
 {
+  atomic_store_relaxed(&domains_exiting, 0);
   atomic_store_relaxed(&caml_num_domains_running, 0);
 
   /* Use [caml_stat_calloc_noexc] to zero initialize [all_domains]. */
@@ -1479,6 +1481,10 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   struct domain_startup_params p;
   caml_plat_thread th;
   int err;
+
+  if (atomic_load_relaxed(&domains_exiting) != 0) {
+    caml_failwith("domain creation not allowed during shutdown");
+  }
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)
@@ -2420,6 +2426,10 @@ void caml_domain_terminate(bool last)
     atomic_fetch_add(&caml_num_domains_running, -1);
 }
 
+void caml_set_domains_exiting(void)
+{
+  atomic_store_relaxed(&domains_exiting, 1);
+}
 
 bool caml_free_domains(void)
 {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2426,52 +2426,6 @@ void caml_domain_terminate(bool last)
     atomic_fetch_add(&caml_num_domains_running, -1);
 }
 
-/* Try and terminate the currently running domain.
-   This is only invoked when extra domains are left running while the
-   main one is terminating. In this case, we are not in a state where
-   we can safely release resources. The best we can do is cancel the
-   extra running threads. */
-static void stw_terminate_domain(caml_domain_state *domain, void *data,
-  int participating_count,
-  caml_domain_state **participating)
-{
-  if (!caml_plat_thread_equal(domain_self->tid, *(caml_plat_thread *)data)) {
-    if (caml_bt_is_self()) {
-      /* If this STW request is handled by the backup thread, the
-         domain thread is currently running C code. */
-      domain_self->domain_canceled = true;
-      (void)caml_plat_thread_cancel(domain_self->tid);
-      /* We are intentionally not waiting for the thread to terminate here,
-         and not decrementing the number of running domains either, since
-         we don't know the state of the various locks and condition
-         variables in this state. */
-      atomic_store_release(&domain_self->backup_thread_msg, BT_INIT);
-    } else {
-      /* Domain threads forced to exit here will not have a chance to
-         run caml_domain_terminate() on their own, so we need to ask
-         the backup thread to terminate here. */
-      terminate_backup_thread(domain_self);
-      caml_plat_unlock(&domain_self->domain_lock);
-      /* No particular memory resource cleanup is attempted here, for we
-         have no idea which state each domain is in. */
-    }
-    caml_plat_thread_exit();
-  }
-}
-
-void caml_stop_all_domains(void)
-{
-  atomic_store_relaxed(&domains_exiting, 1);
-
-  caml_plat_thread myself = caml_plat_thread_self();
-  do {} while (!caml_try_run_on_all_domains(
-               &stw_terminate_domain, &myself, NULL));
-
-  terminate_backup_thread(domain_self);
-  caml_plat_unlock(&domain_self->domain_lock);
-
-  caml_plat_assert_all_locks_unlocked();
-}
 
 bool caml_free_domains(void)
 {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -241,7 +241,6 @@ static atomic_uintnat /* dom_internal* */ stw_leader = 0;
 static uintnat stw_requests_suspended = 0; /* protected by all_domains_lock */
 static caml_plat_cond requests_suspended_cond = CAML_PLAT_COND_INITIALIZER;
 static dom_internal* all_domains;
-static atomic_intnat domains_exiting = 0;
 
 CAMLexport atomic_uintnat caml_num_domains_running = 0;
 
@@ -1061,7 +1060,6 @@ CAMLexport void caml_reset_domain_lock(void)
 
 void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
 {
-  atomic_store_relaxed(&domains_exiting, 0);
   atomic_store_relaxed(&caml_num_domains_running, 0);
 
   /* Use [caml_stat_calloc_noexc] to zero initialize [all_domains]. */
@@ -1481,10 +1479,6 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   struct domain_startup_params p;
   caml_plat_thread th;
   int err;
-
-  if (atomic_load_relaxed(&domains_exiting) != 0) {
-    caml_failwith("domain creation not allowed during shutdown");
-  }
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -234,6 +234,7 @@ CAMLexport void caml_shutdown(void)
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
   if (!caml_domain_alone()) {
+    caml_set_domains_exiting();
     /* Give up on cleanup on shutdown */
     if (caml_runtime_warnings_active()) {
       fprintf(stderr,

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -234,8 +234,13 @@ CAMLexport void caml_shutdown(void)
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
   if (!caml_domain_alone()) {
-    caml_gc_log("Some domains have not been joined prior to shutdown");
-    caml_stop_all_domains();
+    /* Give up on cleanup on shutdown */
+    if (caml_runtime_warnings_active()) {
+      fprintf(stderr,
+              "[ocaml] 'cleanup_on_exit'/caml_shutdown cannot be performed, "
+              "as some other domains remain active on program termination.\n");
+    }
+    return;
   } else {
     /* These calls are not safe to use if there are domains left running */
     caml_domain_terminate(true);


### PR DESCRIPTION
This PR is an alternative to #14614, replacing a fatal-error by a mere runtime warning (not shown by default).

Thes PRs are the result of a design discussion with @stedolan in https://github.com/ocaml/ocaml/issues/14594#issuecomment-3979841954. Currently the cleanup-on-exit mode tries do something when the main domain terminates but other threads and domains remain around -- it tries to cancel/interrupt other domains, this has been implemented by Miod in #12964. This segfaults in some cases as reported by @OlivierNicole in #14594. @stedolan argues that trying to cancel/interrupt other domains will never work reliably, and that we cannot expect cleanup-at-exit to work on programs that leave domains unjoined.

In #14614 I propose to consider it a programming error when unjoined domains remain in cleanup-at-exit mode, and turn this into a fatal error. Several tests from the testsuite need to be updated to keep working in cleanup-at-exit mode (which is tested by our CI), by forcing them to join their domains.

In the present PR I propose itself to emit a meek warning in this situation and give up on trying to release runtime resources in this situation. (So: no fatal error, at worst some form of resource leak.) The testsuite does not need to be adapted -- in particular because runtime warnings are not shown by default, so reference outputs are not modified unless OCAMLRUNPARAM=W is also used.

In light of the discussion suggesting that most people do _not_ consider unjoined domains as a programming error, I suppose that the present PR is more acceptable than #14614.

Note: yet another possible alternative would be to distinguish normal program termination when OCAMLRUNPARAM=c=1 is set, which is what our CI tests, and when users explicitly call `caml_shutdown`. When `c=1` is set we currently call `caml_shutdown`, but we could possibly decide to ignore c=1 softly on program termination (in presence of unjoined domains) and on the other hand have a hard error if `caml_shutdown` is called explicitly.