### PR TITLE
Document a corner case in ephemeron marking.

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -499,6 +499,13 @@ static intnat ephe_mark (intnat budget, uintnat round,
         } else if (Tag_val (key) == Infix_tag) {
           key -= Infix_offset_val (key);
         }
+        /* Ephemerons with young keys cannot be in the todo set because
+           they were allocated after last minor GC, which is after the
+           start of the major GC cycle.
+           Weak arrays can have young keys but they have no data, so it
+           doesn't matter whether we decide to erase their data.
+        */
+        CAMLassert (!Is_young(key) || Ephe_data(ephe) == caml_ephe_none);
         if (is_unmarked (key))
           preserve_data = false;
       }


### PR DESCRIPTION
The ephemeron marking code calls `is_unmarked` on all keys, even those found in the minor heap. The minor allocations use the color `0`, which is equal to `UNMARKED` once every 3 major GC cycles.

Why does the ephemeron marking work despite `is_unmarked` returning a "random" value in the case of minor heap keys? @OlivierNicole and I spent a few hours finding out. A key can be young in two cases:
1) The key was modified after the ephemeron was allocated
2) The ephemeron was allocated (directly in the major heap) since the last minor GC

In case 1, the ephemeron must be a `Weak` array (because `Ephemeron`s are immutable) and its data field is `caml_ephe_none`. In this case, it doesn't matter whether the marking code decides to erase the data or not.

In case 2, the ephemeron is not in the `todo` list, it must be in the `live` list. It will go into the `todo` list on the next major GC cycle, which start with an empty minor heap, so the young key will be promoted before we can see it.
