### PR TITLE
ARM in Thumb mode: do not use TBH instruction

### DIFF
--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -797,39 +797,15 @@ let emit_instr env i =
         end;
         4
     | Lswitch jumptbl ->
-        if !arch > ARMv6 && !thumb then begin
-          (* The Thumb-2 TBH instruction supports only forward branches,
-             so we need to generate appropriate trampolines for all labels
-             that appear before this switch instruction (PR#5623) *)
-          let tramtbl = Array.copy jumptbl in
-          `	tbh	[pc, {emit_reg i.arg.(0)}, lsl #1]\n`;
-          for j = 0 to Array.length tramtbl - 1 do
-            let rec label i =
-              match i.desc with
-                Lend -> new_label()
-              | Llabel lbl when lbl = tramtbl.(j) -> lbl
-              | _ -> label i.next in
-            tramtbl.(j) <- label i.next;
-            `	.short	({emit_label tramtbl.(j)}-.)/2+{emit_int j}\n`
-          done;
-          let sz = ref (1 + (Array.length jumptbl + 1) / 2) in
-          (* Generate the necessary trampolines *)
-          for j = 0 to Array.length tramtbl - 1 do
-            if tramtbl.(j) <> jumptbl.(j) then begin
-              `{emit_label tramtbl.(j)}:	b	{emit_label jumptbl.(j)}\n`;
-              incr sz
-            end
-          done;
-          !sz
-        end else if not !Clflags.pic_code then begin
-          `	ldr	pc, [pc, {emit_reg i.arg.(0)}, lsl #2]\n`;
-          `	nop\n`;
+        if !thumb then begin
+          `	lsl	r12, {emit_reg i.arg.(0)}, #2\n`;
+          `	add	pc, r12\n`;   (* 16-bit encoding *)
+          `	nop\n`;               (* 16-bit encoding *)
           for j = 0 to Array.length jumptbl - 1 do
-            `	.word	{emit_label jumptbl.(j)}\n`
+            `	b.w	{emit_label jumptbl.(j)}\n` (* 32-bit encoding *)
           done;
           2 + Array.length jumptbl
         end else begin
-          (* Slightly slower, but position-independent *)
           `	add	pc, pc, {emit_reg i.arg.(0)}, lsl #2\n`;
           `	nop\n`;
           for j = 0 to Array.length jumptbl - 1 do

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -314,6 +314,8 @@ let destroyed_at_oper = function
   | Iop(Iintoffloat | Ifloatofint
   | Iload(Single, _, _) | Istore(Single, _, _)) ->
       [| phys_reg 107 |]            (* d7 (s14-s15) destroyed *)
+  | Iswitch _ when !thumb ->
+      [| phys_reg 8 |]              (* r12 destroyed *)
   | _ -> [||]
 
 let destroyed_at_raise = all_phys_regs


### PR DESCRIPTION
The TBH instruction only supports 16-bit relative offsets for branches, which can overflow for large enough code.

This PR replaces the use of TBH by a more robust instruction sequence with 24-bit relative offsets.  It's the same instruction sequence used by CompCert for ARM-Thumb, so it received some testing there.

The PR also simplifies the non-Thumb compilation of jump tables by always using the position-independent instruction sequence, whether we're in PIC mode or not.  Again, this follows what CompCert does.

Fixes: #11948