### PR TITLE
interp.c: Fix missing root for continuation in reperform

### DIFF
--- a/Changes
+++ b/Changes
@@ -865,6 +865,10 @@ OCaml 5.5.0
   (when empty) not to be equal to `[||]`.
   (Marc Lasson, review by Gabriel Scherer)
 
+- #14644, #14647: Fix a bug related to unhandled effects in bytecode.
+  (Vincent Laviron, report by Thibaut Mattio,
+   review by Nicolás Ojeda Bär, Stephen Dolan and Olivier Nicole)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -752,8 +752,8 @@ let rec comp_expr stack_info env exp sz cont =
   | Lprim(Preperform, args, _) ->
       let nargs = List.length args - 1 in
       assert (nargs = 1);
-      (* Reperformterm pushes at most 1 word *)
-      check_stack stack_info (sz + 1);
+      (* Reperformterm resets the stack before pushing 3 words *)
+      check_stack stack_info 3;
       if is_tailcall cont then
         comp_args stack_info env args sz
           (Kreperformterm(sz + nargs) :: discard_dead_code cont)

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1380,8 +1380,15 @@ do_resume: {
       sp[1] = Val_long(extra_args);
 
       if (parent == NULL) {
+        /* Save cont across the allocation in caml_make_unhandled_effect_exn */
+        sp -= 1;
+        sp[0] = cont;
         Setup_for_c_call;
         resume_arg = caml_make_unhandled_effect_exn(eff);
+        Restore_after_c_call;
+        cont = sp[0];
+        sp += 1;
+        Setup_for_c_call;
         accu = caml_continuation_use(cont);
         Restore_after_c_call;
         resume_fn = raise_unhandled_effect;


### PR DESCRIPTION
This PR fixes #14644 by saving the continuation on the stack across the call to `caml_make_unhandled_effect_exn`. This is a bit more code than @nojb's proposal, but I think it fits better with the style of the rest of the interpreter.
In theory the result of `caml_make_unhandled_effect_exn` should be saved across `caml_continuation_use` too, but that function doesn't seem to allocate (although it can raise) so we might be fine.
Having two `Setup_for_c_call`/`Restore_after_c_call` pairs is unfortunate but it's the simplest way I found to make the fix obviously correct. It's also one of the least performance critical parts of the interpreter so I'm not worried about execution time.