### PR TITLE
modular explicit: elide optional arguments for functional arguments to higher-order function in the Lambda IR

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -213,7 +213,8 @@ let iter_on_occurrences
       | Texp_extension_constructor (lid, path) ->
           f ~namespace:Extension_constructor exp_env path lid
       | Texp_constant _ | Texp_let _ | Texp_function _ | Texp_apply _
-      | Texp_match _ | Texp_try _ | Texp_tuple _ | Texp_variant _ | Texp_array _
+      | Texp_elide_opt_thunk _ | Texp_match _ | Texp_try _
+      | Texp_tuple _ | Texp_variant _ | Texp_array _
       | Texp_ifthenelse _ | Texp_sequence _ | Texp_while _ | Texp_for _
       | Texp_send _
       | Texp_assert _ | Texp_lazy _

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -252,6 +252,26 @@ and transl_exp0 ~in_new_scope ~scopes e =
       event_after ~scopes e
         (transl_apply ~scopes ~tailcall ~inlined ~specialised
            (transl_exp ~scopes funct) oargs (of_location ~scopes e.exp_loc))
+  | Texp_elide_opt_thunk { f; n_options } ->
+      (* [let arg = f in fun eta -> arg ?_:None ?_:None ... eta] *)
+      let param = Ident.create_local "eta" in
+      let def = Ident.create_local "arg" in
+      let none = Lconst (Const_int 0) in
+      let loc = of_location ~scopes e.exp_loc in
+      let body = Lapply {
+          ap_loc = loc;
+          ap_func = Lvar def;
+          ap_args = List.init n_options (fun _ -> none) @ [Lvar param];
+          ap_tailcall = Default_tailcall;
+          ap_inlined = Default_inline;
+          ap_specialised = Default_specialise
+        }
+      in
+      let eta_kind, return = Typeopt.function_kinds e.exp_env e.exp_type in
+      Llet(Strict, Pgenval, def, transl_exp ~scopes f,
+           lfunction ~kind:Curried ~params:[param, eta_kind]
+             ~return ~body ~attr:default_function_attribute ~loc
+          )
   | Texp_match(arg, pat_expr_list, [], partial) ->
       transl_match ~scopes e arg pat_expr_list partial
   | Texp_match(arg, pat_expr_list, eff_pat_expr_list, partial) ->

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -113,4 +113,22 @@ type t =
   | (::)
 let f (x : t) = match x with | (::) -> 4
 - : unit = ()
+|}];;
+
+
+run {|module type T = sig type t val x: t end
+let higher
+  (f: (module X:T with type t = int) -> X.t)
+  (module X:T with type t = int) =
+  f (module X)
+let g ?(x=()) (module M:T with type t = int) = M.x
+let tfunctor_coerced = higher g
+|}
+[%%expect{|
+module type T  = sig type t val x : t end
+let higher (f : (module X : T with type t = int) -> X.t)
+  (module X : T with type t = int) = f (module X)
+let g ?(x= ()) (module M : T with type t = int) = M.x
+let tfunctor_coerced = higher g
+- : unit = ()
 |}]

--- a/testsuite/tests/typing-modular-explicits/opt_coercion.ml
+++ b/testsuite/tests/typing-modular-explicits/opt_coercion.ml
@@ -1,0 +1,95 @@
+(*TEST
+  expect;
+*)
+
+(* Optional argument elision in argument of higher-order function *)
+module type T = sig type t val x: t end
+let higher (f: (module X:T) -> X.t) (module X:T) = f (module X)
+
+let g ?(x=()) (module M:T) = M.x
+[%%expect {|
+module type T = sig type t val x : t end
+val higher : ((module X : T) -> X.t) -> (module X : T) -> X.t = <fun>
+val g : ?x:unit -> (module M : T) -> M.t = <fun>
+|}]
+
+let tfunctor_coerced = higher g
+[%%expect {|
+val tfunctor_coerced : (module X : T) -> X.t = <fun>
+|}]
+
+module A = struct type t = int let x = 0 end
+module B = struct type t = string let x = "hello" end
+let x = tfunctor_coerced (module A)
+let y = tfunctor_coerced (module B)
+[%%expect {|
+module A : sig type t = int val x : int end
+module B : sig type t = string val x : string end
+val x : A.t = 0
+val y : B.t = "hello"
+|}]
+
+
+(** Immediate hidden inside the module type *)
+module type Imm = sig type t [@@immediate] val x: t end
+let f ?x (module M:Imm) = M.x
+let higher_imm (f: (module X:Imm) -> X.t) (module X:Imm) = f (module X)
+let u = higher_imm f
+let w = u (module struct type t = int let x = 0 end)
+[%%expect {|
+module type Imm = sig type t [@@immediate] val x : t end
+val f : ?x:'a -> (module M : Imm) -> M.t = <fun>
+val higher_imm : ((module X : Imm) -> X.t) -> (module X : Imm) -> X.t = <fun>
+val u : (module X : Imm) -> X.t = <fun>
+val w : int = 0
+|}]
+
+
+(** Effect order *)
+let f ~x =
+  Format.printf "First apply@.---------------------------------------@.";
+  (fun ?y ->
+     Format.printf "Opt apply@.";
+     fun (module M:T) ->
+       Format.printf "Last apply@.----------------@.";
+       M.x
+  )
+let () = Format.printf "--(before u)------------@."
+let u = higher (f ~x:0)
+let () = Format.eprintf "--(after u)----------------------------@."
+let w = u (module A)
+let () = Format.eprintf "--(after w)-----@."
+[%%expect {|
+val f : x:'a -> ?y:'b -> (module M : T) -> M.t = <fun>
+--(before u)------------
+First apply
+---------------------------------------
+val u : (module X : T) -> X.t = <fun>
+--(after u)----------------------------
+Opt apply
+Last apply
+----------------
+val w : A.t = 0
+--(after w)-----
+|}]
+
+module type L = sig type t = x:int -> int end
+
+let higher_lbl (f: (module M:L) -> M.t ) (module M:L) = f (module M)
+let g ?x (module M:L): M.t = fun ~x -> x
+
+(** No elision in presence of labeled arguments*)
+let should_fail = higher_lbl g
+
+[%%expect{|
+module type L = sig type t = x:int -> int end
+val higher_lbl : ((module M : L) -> M.t) -> (module M : L) -> M.t = <fun>
+val g : ?x:'a -> (module M : L) -> M.t = <fun>
+Line 7, characters 29-30:
+7 | let should_fail = higher_lbl g
+                                 ^
+Error: The value "g" has type "?x:'a -> (module M : L) -> M.t"
+       but an expression was expected of type "(module M : L) -> M.t"
+       The first argument is labeled "?x",
+       but an unlabeled argument was expected
+|}]

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -381,6 +381,9 @@ and expression i ppf x =
       line i ppf "Texp_apply\n";
       expression i ppf e;
       list i label_x_apply_arg ppf l;
+  | Texp_elide_opt_thunk r ->
+      line i ppf "Texp_elide_opt_thunk (%d)\n" r.n_options;
+      expression i ppf r.f;
   | Texp_match (e, l1, l2, partial) ->
       line i ppf "Texp_match%a\n" fmt_partiality partial;
       expression i ppf e;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -327,6 +327,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
         | (_, Arg exp) -> sub.expr sub exp
         | (_, Omitted ()) -> ())
         list
+  | Texp_elide_opt_thunk { f; _ } ->  sub.expr sub f
   | Texp_match (exp, cases, effs, _) ->
       sub.expr sub exp;
       List.iter (sub.case sub) cases;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -381,6 +381,8 @@ let expr sub x =
           sub.expr sub exp,
           List.map (tuple2 id (Typedtree.map_apply_arg (sub.expr sub))) list
         )
+    | Texp_elide_opt_thunk r ->
+        Texp_elide_opt_thunk { r with f = sub.expr sub r.f }
     | Texp_match (exp, cases, eff_cases, p) ->
         Texp_match (
           sub.expr sub exp,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3271,6 +3271,7 @@ let rec is_nonexpansive exp =
       is_nonexpansive body
   | Texp_apply(e, (_,Omitted ())::el) ->
       is_nonexpansive e && List.for_all is_nonexpansive_arg (List.map snd el)
+  | Texp_elide_opt_thunk f -> is_nonexpansive f.f
   | Texp_match(e, cases, _, _) ->
      (* Not sure this is necessary, if [e] is nonexpansive then we shouldn't
          care if there are exception patterns. But the previous version enforced
@@ -3734,7 +3735,7 @@ let check_partial_application ~statement exp =
             | Texp_setinstvar _ | Texp_override _ | Texp_assert _
             | Texp_lazy _ | Texp_object _ | Texp_pack _ | Texp_unreachable
             | Texp_extension_constructor _ | Texp_ifthenelse (_, _, None)
-            | Texp_function _ ->
+            | Texp_function _ | Texp_elide_opt_thunk _ ->
                 check_statement ()
             | Texp_match (_, cases, eff_cases, _) ->
                 List.iter (fun {c_rhs; _} -> check c_rhs) cases;
@@ -3748,7 +3749,8 @@ let check_partial_application ~statement exp =
             | Texp_let (_, _, e) | Texp_sequence (_, e)
             | Texp_struct_item (_, e) ->
                 check e
-            | Texp_apply _ | Texp_send _ | Texp_new _ | Texp_letop _ ->
+            | Texp_apply _ | Texp_send _ | Texp_new _
+            | Texp_letop _ ->
                 Location.prerr_warning exp_loc
                   Warnings.Ignored_partial_application
           end
@@ -6217,7 +6219,7 @@ and type_label_exp create env loc ty_expected
 
 and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
   (* ty_expected' may be generic *)
-  let no_labels ty =
+  let no_labels env ty =
     let ls, ~is_ret_tvar = arrow_labels env ty in
     not is_ret_tvar && List.for_all ((=) Nolabel) ls
   in
@@ -6227,7 +6229,12 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
       let te = expand_head env ty_expected' in
       match get_desc te with
         Tarrow(Nolabel,_,ty_res0,_) ->
-          Some (no_labels ty_res0, get_level te)
+          Some (no_labels env ty_res0, get_level te)
+      | Tfunctor(Nolabel,id,arg,ty_res0)->
+          let env, ty_res0 =
+            Ctype.open_tfunctor env ~loc:Location.none id arg ty_res0
+          in
+          Some (no_labels env ty_res0, get_level te)
       | _ -> None
     in
     (* Need to be careful not to expand local constraints here *)
@@ -6244,19 +6251,22 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
         with_local_level_generalize_structure_if_principal
           (fun () -> type_exp env sarg)
       in
-      let rec make_args args ty_fun =
+      let rec make_args (nargs,lbls) ty_fun =
         match get_desc (expand_head env ty_fun) with
-        | Tarrow (l,ty_arg,ty_fun,_) when is_optional l ->
-            let ty =
-              option_none env (instance (tpoly_get_mono ty_arg)) sarg.pexp_loc
+        | Tarrow (l,_,ty_fun,_) when is_optional l ->
+            make_args (1 + nargs, l :: lbls) ty_fun
+        | Tarrow (l,_, ty_res',_) when l = Nolabel || !Clflags.classic ->
+            nargs, List.rev lbls, ty_fun, no_labels env ty_res'
+        | Tfunctor (l,id,arg, ty_res') when l = Nolabel || !Clflags.classic ->
+            let env, ty =
+              Ctype.open_tfunctor env ~loc:Location.none id arg ty_res'
             in
-            make_args ((l, Arg ty) :: args) ty_fun
-        | Tarrow (l,_,ty_res',_) when l = Nolabel || !Clflags.classic ->
-            List.rev args, ty_fun, no_labels ty_res'
-        | Tvar _ ->  List.rev args, ty_fun, false
-        |  _ -> [], texp.exp_type, false
+            nargs, List.rev lbls, ty_fun, no_labels env ty
+        | Tvar _ ->  nargs, List.rev lbls, ty_fun, false
+        |  _ -> 0, [],
+                texp.exp_type, false
       in
-      let args, ty_fun', simple_res = make_args [] texp.exp_type
+      let n_options, lbls, ty_fun', simple_res = make_args (0,[]) texp.exp_type
       and texp = {texp with exp_type = instance texp.exp_type} in
       if not (simple_res || safe_expect) then begin
         unify_exp ~sexp:sarg env texp ty_expected;
@@ -6265,67 +6275,17 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
       let warn = !Clflags.principal &&
         (lv <> generic_level || get_level ty_fun' <> generic_level)
       and ty_fun = instance ty_fun' in
-      let ty_arg, ty_res =
-        match get_desc (expand_head env ty_expected) with
-          Tarrow(Nolabel,ty_arg,ty_res,_) -> ty_arg, ty_res
-        | _ -> assert false
-      in
       unify_exp ~sexp:sarg env {texp with exp_type = ty_fun} ty_expected;
-      if args = [] then texp else
-      (* eta-expand to avoid side effects *)
-      let var_pair name ty =
-        let id = Ident.create_local name in
-        let desc =
-          { val_type = ty; val_kind = Val_reg;
-            val_attributes = [];
-            val_loc = Location.none;
-            val_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-          }
-        in
-        let exp_env = Env.add_value id desc env in
-        {pat_desc =
-          Tpat_var (id, mknoloc name, desc.val_uid);
-         pat_type = ty;
-         pat_extra=[];
-         pat_attributes = [];
-         pat_loc = Location.none; pat_env = env},
-        {exp_type = ty; exp_loc = Location.none; exp_env = exp_env;
-         exp_extra = []; exp_attributes = [];
-         exp_desc =
-         Texp_ident(Path.Pident id, mknoloc (Longident.Lident name), desc)}
-      in
-      let eta_pat, eta_var = var_pair "eta" ty_arg in
-      let func texp =
-        let e =
-          {texp with exp_type = ty_res; exp_desc =
-           Texp_apply
-             (texp,
-              args @ [Nolabel, Arg eta_var])}
-        in
-        let cases = [ case eta_pat e ] in
-        let cases_loc = { texp.exp_loc with loc_ghost = true } in
-        let param = name_cases "param" cases in
-        { texp with exp_type = ty_fun; exp_desc =
-          Texp_function ([],
-            Tfunction_cases
-              { cases; partial = Total; param; loc = cases_loc;
-                exp_extra = None; attributes = [];
-              })
-        }
-      in
+      if n_options = 0 then texp else begin
       Location.prerr_warning texp.exp_loc
         (Warnings.Eliminated_optional_arguments
-           (List.map (fun (l, _) -> Asttypes.string_of_label l) args));
+           (List.map Asttypes.string_of_label lbls));
       if warn then Location.prerr_warning texp.exp_loc
           (Warnings.Non_principal_labels "eliminated optional argument");
       (* let-expand to have side effects *)
-      let let_pat, let_var = var_pair "arg" texp.exp_type in
-      re { texp with exp_type = ty_fun; exp_desc =
-           Texp_let (Nonrecursive,
-                     [{vb_pat=let_pat; vb_expr=texp; vb_attributes=[];
-                       vb_loc=Location.none; vb_rec_kind = Dynamic;
-                      }],
-                     func let_var) }
+      let exp_desc = Texp_elide_opt_thunk { f = texp; n_options } in
+      re { texp with exp_type = ty_fun; exp_desc }
+      end
       end
   | None ->
       let texp = type_expect ?recarg env sarg

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -149,6 +149,10 @@ and expression_desc =
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
   | Texp_struct_item of structure_item * expression
+  | Texp_elide_opt_thunk of {
+      f:expression;
+      n_options:int;
+    }
 
 and meth =
   | Tmeth_name of string

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -298,6 +298,9 @@ and expression_desc =
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
   | Texp_struct_item of structure_item * expression
+  | Texp_elide_opt_thunk of { f :expression; n_options:int }
+    (** [Texp_elide_opt_eta_expand {f=exp;n_options}] can be extended to
+         [let f = exp in fun x -> f ?_:None ?_:None .... x ]*)
 
 and meth =
     Tmeth_name of string

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -190,6 +190,19 @@ let value_kind env ty =
         Pgenval
   end
 
+let function_kinds env f =
+  match scrape_ty env f with
+  | None -> Pgenval, Pgenval
+  | Some ty ->
+      match get_desc ty with
+      | Tarrow (_,x,y,_) -> value_kind env x, value_kind env y
+      | Tfunctor(_,id,arg,res) ->
+          Pgenval,
+          let loc = Location.none in
+          let env, ty = Ctype.open_tfunctor env ~loc id arg res in
+          value_kind env ty
+      | _ -> assert false
+
 (** The compilation of the expression [lazy e] depends on the form of e:
     in some cases we optimize it into [let x = e in lazy x], evaluating
     [e] right now (if it is equivalent) and avoiding creating a thunk.
@@ -252,7 +265,7 @@ let classify_lazy_argument e =
     | Texp_struct_item _ (* [let <structure item> in c] would be ok *)
       -> false
     (* (typically) not commutative *)
-    | Texp_apply _
+    | Texp_apply _ | Texp_elide_opt_thunk _
     | Texp_match _
     | Texp_try _
     | Texp_setfield _

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -17,6 +17,7 @@
 
 val is_function_type :
       Env.t -> Types.type_expr -> (Types.type_expr * Types.type_expr) option
+
 val is_base_type : Env.t -> Types.type_expr -> Path.t -> bool
 
 val maybe_pointer_type : Env.t -> Types.type_expr
@@ -29,6 +30,9 @@ val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
+
+val function_kinds:
+  Env.t -> Types.type_expr -> Lambda.value_kind * Lambda.value_kind
 
 (** [lazy_summary] describes how the expression [lazy e] must be compiled. *)
 type lazy_summary =

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -458,6 +458,7 @@ let expression sub exp =
               | Omitted () -> list
               | Arg exp -> (label, sub.expr sub exp) :: list
           ) list [])
+    | Texp_elide_opt_thunk r -> (sub.expr sub r.f).pexp_desc
     | Texp_match (exp, cases, eff_cases, _) ->
       let merged_cases = List.map (sub.case sub) cases
         @ List.map

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -201,6 +201,7 @@ let classify_expression : Typedtree.expression -> sd =
         classify_module_expression env mexp
     | Texp_function _ ->
         Static
+    | Texp_elide_opt_thunk _ -> Static
     | Texp_lazy e ->
       begin match Typeopt.classify_lazy_argument e with
       | Eager Shortcut ->
@@ -649,6 +650,7 @@ let rec expression : Typedtree.expression -> term_judg =
         join [expression e << function_mode;
               list expression applied << Dereference;
               list expression delayed << Guard]
+    | Texp_elide_opt_thunk { f=e; _ } -> expression e << Dereference
     | Texp_tuple exprs ->
       list expression (List.map snd exprs) << Guard
     | Texp_atomic_loc (expr, _, _) ->


### PR DESCRIPTION
It is possible to apply a higher-order function  to a function whose type match the expected only after eliding optional arguments. For instance, the following is a valid program
```ocaml
let apply f = f ()
let f x ?y () = ()
let () = apply (f 0) 
```
Currently, this is implemented by generating typedtree nodes in the typechecker that elaborate
```ocaml
apply (f 0)
```
into
```ocaml
apply (let v = f 0 in (fun x -> v ?y:None x))
```
Unfortunately, this elaboration becomes very verbose when trying to support the same feature for modular explicit:
```ocaml
module type T = sig type x type 'a t val x: x t end
let apply (f: (module M:T with type x = int) -> M.(x t) ) (module M: T with type x = int) =
  f (module M)
let f x ?y (module M: T with type x = int) = M.x
let l = apply (f 0) (module struct type x = int type 'a t = 'a list let x = [0] end)
```
because it would require to either generate well-typed typedtree nodes for
```ocaml
let v = f 0 in (fun (module M:T with type t = int) -> v ?y:None (module M:T with type t = int)
```
from the types, which is very verbose (see https://github.com/Octachron/ocaml/blob/coercion_for_tfunctor/typing/typecore.ml#L6304 for a *partial* support), or generate approximately typed typedtree nodes which just enough information for the translation to the lambda IR.

This PR proposes to go in another direction and add a new typedtree node `Texp_elide_opt_thunk { f=exp; n_options}` which is elaborated during the translation to lambda to `let f = exp in (fun x -> f ?_:None ... ?_:None x)`. 
With this changes, supporting module-dependent functions only require a small amount of work (this is done in this PR too). 

This has the obvious disadvantage of adding a very specialized typedtree node that has no equivalent in the surface language. Nevertheless, the generation at the lambda level is substantially simpler, and this adds one more case where `Untypeast` is accurate.