### PR TITLE
Add missing longidents locations to the typed tree iterator/mapper

### DIFF
--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -354,7 +354,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       sub.expr sub exp1;
       sub.expr sub exp2
   | Texp_atomic_loc (exp, lid, _) ->
-      iter_loc sub lid;
+      iter_loc_lid sub lid;
       sub.expr sub exp
   | Texp_array (_, list) -> List.iter (sub.expr sub) list
   | Texp_ifthenelse (exp1, exp2, expo) ->

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -421,7 +421,7 @@ let expr sub x =
           sub.expr sub exp2
         )
     | Texp_atomic_loc (exp, lid, ld) ->
-        Texp_atomic_loc (sub.expr sub exp, map_loc sub lid, ld)
+        Texp_atomic_loc (sub.expr sub exp, map_loc_lid sub lid, ld)
     | Texp_array (mut, list) ->
         Texp_array (mut, List.map (sub.expr sub) list)
     | Texp_ifthenelse (exp1, exp2, expo) ->


### PR DESCRIPTION
If I understand correctly, following #13302, it is expected for `tast_iterator` and `tast_mapper` to iterate over all of the locs in the longidents in typedtree. It seems like the ones in `Texp_atomic_loc` were missed.

(I noticed this while working on the merge of 5.4 into our oxcaml branch. Apologies for the noise if I've misunderstood something and it's unnecessary.)