### PR TITLE
Semantic highlighting in type error messages

### DIFF
--- a/.depend
+++ b/.depend
@@ -846,6 +846,7 @@ typing/errortrace.cmi : \
     parsing/asttypes.cmi
 typing/errortrace_report.cmo : \
     typing/types.cmi \
+    typing/syntactic_highlighting.cmi \
     typing/printtyp.cmi \
     typing/predef.cmi \
     typing/path.cmi \
@@ -862,6 +863,7 @@ typing/errortrace_report.cmo : \
     typing/errortrace_report.cmi
 typing/errortrace_report.cmx : \
     typing/types.cmx \
+    typing/syntactic_highlighting.cmx \
     typing/printtyp.cmx \
     typing/predef.cmx \
     typing/path.cmx \
@@ -1611,6 +1613,14 @@ typing/subst.cmi : \
     parsing/parsetree.cmi \
     parsing/location.cmi \
     typing/ident.cmi
+typing/syntactic_highlighting.cmo : \
+    typing/outcometree.cmi \
+    typing/syntactic_highlighting.cmi
+typing/syntactic_highlighting.cmx : \
+    typing/outcometree.cmi \
+    typing/syntactic_highlighting.cmi
+typing/syntactic_highlighting.cmi : \
+    typing/outcometree.cmi
 typing/tast_iterator.cmo : \
     typing/typedtree.cmi \
     parsing/parsetree.cmi \

--- a/.gitattributes
+++ b/.gitattributes
@@ -145,6 +145,8 @@ testsuite/tests/lib-uchar/test.ml                       typo.non-ascii
 testsuite/tests/lexing/reject_bad_encoding.ml           typo.prune
 testsuite/tests/asmgen/immediates.cmm                   typo.very-long-line
 testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line
+testsuite/tests/let-syntax/let_syntax.ml                typo.non-ascii
+testsuite/tests/tool-expect-test/clean_typer.ml         typo.non-ascii
 testsuite/tools/*.S                                     typo.missing-header
 testsuite/tools/*.asm                                   typo.missing-header
 testsuite/tests/messages/highlight_tabs.ml              typo.tab

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ typing_SOURCES = \
   typing/gprinttyp.mli typing/gprinttyp.ml \
   typing/btype.mli typing/btype.ml \
   typing/oprint.mli typing/oprint.ml \
+  typing/syntactic_highlighting.mli typing/syntactic_highlighting.ml \
   typing/subst.mli typing/subst.ml \
   typing/predef.mli typing/predef.ml \
   typing/datarepr.mli typing/datarepr.ml \

--- a/testsuite/tests/effect-syntax/error_messages.ml
+++ b/testsuite/tests/effect-syntax/error_messages.ml
@@ -24,8 +24,8 @@ let () = match () with
 Line 3, characters 21-22:
 3 |   | effect A _, k -> k
                          ^
-Error: The value "k" has type "(%eff, unit) continuation"
-       but an expression was expected of type "unit"
+Error: The value "k" has type "(%eff, unit) (|continuation|)"
+       but an expression was expected of type "(|unit|)"
 |}]
 
 let () = match () with

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -360,7 +360,7 @@ let x = let open struct type t = T end in T
 Line 1, characters 42-43:
 1 | let x = let open struct type t = T end in T
                                               ^
-Error: The constructor "T" has type "t" but an expression was expected of type "'a"
+Error: The constructor "T" has type "(|t|)" but an expression was expected of type "'a"
        The type constructor "t" would escape its scope
 |}]
 

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -187,8 +187,8 @@ let ill_typed_1 =
 Line 3, characters 13-14:
 3 |     let+ x = 1 in
                  ^
-Error: The constant "1" has type "int" but an expression was expected of type
-         "bool"
+Error: The constant "1" has type "(|int|)" but an expression was expected of type
+         "(|bool|)"
 |}];;
 
 module Ill_typed_2 = struct
@@ -215,8 +215,8 @@ let ill_typed_2 =
 Line 3, characters 13-14:
 3 |     let+ x = 1
                  ^
-Error: The constant "1" has type "int" but an expression was expected of type
-         "float"
+Error: The constant "1" has type "(|int|)" but an expression was expected of type
+         "(|float|)"
 Hint: Did you mean "1."?
 |}];;
 
@@ -238,8 +238,8 @@ let ill_typed_3 =
 Line 3, characters 4-8:
 3 |     let+ x = 1 in
         ^^^^
-Error: The operator "let+" has type "int" but it was expected to have type
-         "'a -> ('b -> 'c) -> 'd"
+Error: The operator "let+" has type "(|int|)" but it was expected to have type
+         "'a (|->|) ('b -> 'c) -> 'd"
 |}];;
 
 module Ill_typed_4 = struct
@@ -265,7 +265,7 @@ Line 4, characters 4-8:
         ^^^^
 Error: The operator "and+" has type "bool -> (|bool|)"
        but it was expected to have type "bool -> 'a (|->|) 'b"
-       Type "bool" is not compatible with type "'a -> 'b"
+       Type "(|bool|)" is not compatible with type "'a (|->|) 'b"
 |}];;
 
 module Ill_typed_5 = struct
@@ -294,8 +294,8 @@ Lines 3-5, characters 9-14:
 3 | .........x = 1
 4 |     and+ y = 2
 5 |     and+ z = 3...
-Error: These bindings have type "(int * int) * int"
-       but bindings were expected of type "bool"
+Error: These bindings have type "(int * int) (|*|) int"
+       but bindings were expected of type "(|bool|)"
 |}];;
 
 module Ill_typed_6 = struct
@@ -323,8 +323,8 @@ let ill_typed_6 =
 Lines 3-4, characters 9-14:
 3 | .........x = 1
 4 |     and+ y = 2
-Error: These bindings have type "int * int" but bindings were expected of type
-         "int"
+Error: These bindings have type "int (|*|) int" but bindings were expected of type
+         "(|int|)"
 |}];;
 
 
@@ -354,7 +354,7 @@ Line 3, characters 4-8:
         ^^^^
 Error: The operator "let+" has type "(int -> 'a) -> (|int|) -> 'a"
        but it was expected to have type "(int -> 'a) -> ('b * 'c (|->|) 'd) -> 'e"
-       Type "int" is not compatible with type "'b * 'c -> 'd"
+       Type "(|int|)" is not compatible with type "'b * 'c (|->|) 'd"
 |}];;
 
 module Indexed_monad = struct
@@ -499,8 +499,8 @@ Error: This expression has type
          "((|Indexed_monad.closed|), Indexed_monad.opened, unit) Indexed_monad.t"
        but an expression was expected of type
          "((|Indexed_monad.opened|), 'a, 'b) Indexed_monad.t"
-       Type "Indexed_monad.closed" is not compatible with type
-         "Indexed_monad.opened"
+       Type "(|Indexed_monad.closed|)" is not compatible with type
+         "(|Indexed_monad.opened|)"
 |}];;
 
 let indexed_monad4 =
@@ -519,8 +519,8 @@ Error: This expression has type
          "((|Indexed_monad.opened|), Indexed_monad.opened, string) Indexed_monad.t"
        but an expression was expected of type
          "((|Indexed_monad.closed|), 'a, 'b) Indexed_monad.t"
-       Type "Indexed_monad.opened" is not compatible with type
-         "Indexed_monad.closed"
+       Type "(|Indexed_monad.opened|)" is not compatible with type
+         "(|Indexed_monad.closed|)"
 |}];;
 
 (* Test principality using constructor disambiguation *)
@@ -731,7 +731,7 @@ Line 5, characters 11-19:
                ^^^^^^^^
 Error: This pattern matches values of type "GADT_ordering.point"
        but a pattern was expected which matches values of type
-         "a" = "GADT_ordering.point"
+         "a" = "(|GADT_ordering.point|)"
        This instance of "GADT_ordering.point" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -263,8 +263,8 @@ let ill_typed_4 =
 Line 4, characters 4-8:
 4 |     and+ y = 2 in
         ^^^^
-Error: The operator "and+" has type "bool -> bool"
-       but it was expected to have type "bool -> 'a -> 'b"
+Error: The operator "and+" has type "bool -> (|bool|)"
+       but it was expected to have type "bool -> 'a (|->|) 'b"
        Type "bool" is not compatible with type "'a -> 'b"
 |}];;
 
@@ -352,8 +352,8 @@ let ill_typed_7 =
 Line 3, characters 4-8:
 3 |     let+ x = 1
         ^^^^
-Error: The operator "let+" has type "(int -> 'a) -> int -> 'a"
-       but it was expected to have type "(int -> 'a) -> ('b * 'c -> 'd) -> 'e"
+Error: The operator "let+" has type "(int -> 'a) -> (|int|) -> 'a"
+       but it was expected to have type "(int -> 'a) -> ('b * 'c (|->|) 'd) -> 'e"
        Type "int" is not compatible with type "'b * 'c -> 'd"
 |}];;
 
@@ -496,9 +496,9 @@ Line 4, characters 14-25:
 4 |     and+ () = open_ "foo"
                   ^^^^^^^^^^^
 Error: This expression has type
-         "(Indexed_monad.closed, Indexed_monad.opened, unit) Indexed_monad.t"
+         "((|Indexed_monad.closed|), Indexed_monad.opened, unit) Indexed_monad.t"
        but an expression was expected of type
-         "(Indexed_monad.opened, 'a, 'b) Indexed_monad.t"
+         "((|Indexed_monad.opened|), 'a, 'b) Indexed_monad.t"
        Type "Indexed_monad.closed" is not compatible with type
          "Indexed_monad.opened"
 |}];;
@@ -516,9 +516,9 @@ Lines 6-7, characters 4-29:
 6 | ....let* second = read in
 7 |       return (first ^ second)
 Error: This expression has type
-         "(Indexed_monad.opened, Indexed_monad.opened, string) Indexed_monad.t"
+         "((|Indexed_monad.opened|), Indexed_monad.opened, string) Indexed_monad.t"
        but an expression was expected of type
-         "(Indexed_monad.closed, 'a, 'b) Indexed_monad.t"
+         "((|Indexed_monad.closed|), 'a, 'b) Indexed_monad.t"
        Type "Indexed_monad.opened" is not compatible with type
          "Indexed_monad.closed"
 |}];;

--- a/testsuite/tests/parse-errors/bigarray_index_labels.compilers.reference
+++ b/testsuite/tests/parse-errors/bigarray_index_labels.compilers.reference
@@ -2,5 +2,7 @@ File "bigarray_index_labels.ml", line 13, characters 0-12:
 13 | my_big_array.{(1, ~y:2)} <- 1.5;;
      ^^^^^^^^^^^^
 Error: The value my_big_array has type
-         (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array2.t
-       but an expression was expected of type ('a, 'b, 'c) Bigarray.Array1.t
+         (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array2.t =
+           (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array2.t
+       but an expression was expected of type
+         ('a, 'b, 'c) Bigarray.Array1.t = ('a, 'b, 'c) Bigarray.Array1.t

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -49,7 +49,7 @@ Error: Signature mismatch:
          type \#and = string
        is not included in
          type \#and = int
-       The type "string" is not equal to the type "int"
+       The type "(|string|)" is not equal to the type "(|int|)"
 |}]
 
 let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -178,8 +178,8 @@ let f { \#false; \#true } = 0;;
 Line 4, characters 17-23:
 4 | let f { \#false; \#true } = 0
                      ^^^^^^
-Error: The record field "\#true" belongs to the type "u"
-       but is mixed here with fields of type "t"
+Error: The record field "\#true" belongs to the type "(|u|)"
+       but is mixed here with fields of type "(|t|)"
 |}]
 
 

--- a/testsuite/tests/prim-revapply/revapply.ml
+++ b/testsuite/tests/prim-revapply/revapply.ml
@@ -99,7 +99,7 @@ val f : ?x:'a -> y:'b -> unit -> unit = <fun>
 Line 3, characters 34-40:
 3 | let () = () |> (let type u = A in f ~y:0)
                                       ^^^^^^
-Error: This expression has type "?x:'a -> unit -> unit"
+Error: This expression has type "?(|x|):'a -> unit -> unit"
        but an expression was expected of type "unit -> 'b"
        The first argument is labeled "?x",
        but an unlabeled argument was expected

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -10,7 +10,7 @@ Error: Type declarations do not match:
        is not included in
          type 'a x
        Their parameters differ
-       The type "'b x as 'b" is not equal to the type "'a"
+       The type "(|(|'b|) x as 'b|)" is not equal to the type "(|'a|)"
 |}, Principal{|
 Line 1:
 Error: Type declarations do not match:
@@ -18,7 +18,7 @@ Error: Type declarations do not match:
        is not included in
          type 'a x
        Their parameters differ
-       The type "[> `x ]" is not equal to the type "'a"
+       The type "[> `x ]" is not equal to the type "(|'a|)"
 |}];;
 
 

--- a/testsuite/tests/printing-types/existentials.ml
+++ b/testsuite/tests/printing-types/existentials.ml
@@ -15,8 +15,8 @@ type foo1 = Foo : ('a * 'b * 'c * 'd * 'e * 'f) -> foo1
 Line 6, characters 13-14:
 6 |   | Foo a -> a + 1
                  ^
-Error: The value "a" has type "$a * $b * $c * $d * $e * $f"
-       but an expression was expected of type "int"
+Error: The value "a" has type "$a (|*|) $b (|*|) $c (|*|) $d (|*|) $e (|*|) $f"
+       but an expression was expected of type "(|int|)"
        Hint: "$a", "$b", "$c", "$d", "$e" and "$f" are existential types
          bound by the constructor "Foo".
 |}]
@@ -48,8 +48,8 @@ type foo2 =
 Line 13, characters 46-47:
 13 |       let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
                                                    ^
-Error: The value "x" has type "$a * $a1 * $a2 * $a3 * $a4 * $a5 * $a6"
-       but an expression was expected of type "int"
+Error: The value "x" has type "$a (|*|) $a1 (|*|) $a2 (|*|) $a3 (|*|) $a4 (|*|) $a5 (|*|) $a6"
+       but an expression was expected of type "(|int|)"
        Hint: "$a" is an existential type bound by the constructor "Foo1".
        Hint: "$a1" is an existential type bound by the constructor "Foo2".
        Hint: "$a2" is an existential type bound by the constructor "Foo3".
@@ -87,14 +87,14 @@ Line 13, characters 46-47:
 13 |       let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
                                                    ^
 Error: The value "x" has type
-         "($a * $b * $c * $d * $e * $f) *
-         ($a1 * $b1 * $c1 * $d1 * $e1 * $f1) *
-         ($a2 * $b2 * $c2 * $d2 * $e2 * $f2) *
-         ($a3 * $b3 * $c3 * $d3 * $e3 * $f3) *
-         ($a4 * $b4 * $c4 * $d4 * $e4 * $f4) *
-         ($a5 * $b5 * $c5 * $d5 * $e5 * $f5) *
+         "($a * $b * $c * $d * $e * $f) (|*|)
+         ($a1 * $b1 * $c1 * $d1 * $e1 * $f1) (|*|)
+         ($a2 * $b2 * $c2 * $d2 * $e2 * $f2) (|*|)
+         ($a3 * $b3 * $c3 * $d3 * $e3 * $f3) (|*|)
+         ($a4 * $b4 * $c4 * $d4 * $e4 * $f4) (|*|)
+         ($a5 * $b5 * $c5 * $d5 * $e5 * $f5) (|*|)
          ($a6 * $b6 * $c6 * $d6 * $e6 * $f6)"
-       but an expression was expected of type "int"
+       but an expression was expected of type "(|int|)"
        Hint: "$a", "$b", "$c", "$d", "$e" and "$f" are existential types
          bound by the constructor "Foo1".
        Hint: "$a1", "$b1", "$c1", "$d1", "$e1" and "$f1" are existential types

--- a/testsuite/tests/syntactic-arity/warnings.ml
+++ b/testsuite/tests/syntactic-arity/warnings.ml
@@ -16,7 +16,7 @@ module type S = sig type t type _ u = t -> t end
 Line 6, characters 34-56:
 6 | let f ((module M) : (module S)) = ((fun z -> z) : _ M.u);;
                                       ^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -26,7 +26,7 @@ let f ((module M) : (module S)) y = ((fun z -> z) : _ M.u);;
 Line 1, characters 36-58:
 1 | let f ((module M) : (module S)) y = ((fun z -> z) : _ M.u);;
                                         ^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -36,7 +36,7 @@ let f ((module M) : (module S)) y : _ = ((fun z -> z) : _ M.u);;
 Line 1, characters 40-62:
 1 | let f ((module M) : (module S)) y : _ = ((fun z -> z) : _ M.u);;
                                             ^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -46,7 +46,7 @@ let f ((module M) : (module S)) (type a) = ((fun z -> z) : a M.u);;
 Line 1, characters 32-65:
 1 | let f ((module M) : (module S)) (type a) = ((fun z -> z) : a M.u);;
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -56,7 +56,7 @@ let f ((module M) : (module S)) (type a) x = ((fun z -> z) : a M.u);;
 Line 1, characters 32-67:
 1 | let f ((module M) : (module S)) (type a) x = ((fun z -> z) : a M.u);;
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "'a -> M.t -> M.t"
+Error: This expression has type "'a -> (|M.t|) -> (|M.t|)"
        but an expression was expected of type "'b"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -66,7 +66,7 @@ let f ((module M) : (module S)) x (type a) = ((fun z -> z) : a M.u);;
 Line 1, characters 34-67:
 1 | let f ((module M) : (module S)) x (type a) = ((fun z -> z) : a M.u);;
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -76,7 +76,7 @@ let f ((module M) : (module S)) x (type a) :> a M.u = function z -> z
 Line 1, characters 34-69:
 1 | let f ((module M) : (module S)) x (type a) :> a M.u = function z -> z
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -86,7 +86,7 @@ let f ((module M) : (module S)) x (type a) : a M.u = function z -> z
 Line 1, characters 34-68:
 1 | let f ((module M) : (module S)) x (type a) : a M.u = function z -> z
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "M.t -> M.t"
+Error: This expression has type "(|M.t|) -> (|M.t|)"
        but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}];;

--- a/testsuite/tests/tool-expect-test/clean_typer.ml
+++ b/testsuite/tests/tool-expect-test/clean_typer.ml
@@ -64,8 +64,8 @@ let f2 = ffoo bar;;
 Line 1, characters 14-17:
 1 | let f2 = ffoo bar;;
                   ^^^
-Error: The value "bar" has type "Variants.bar M.t"
-       but an expression was expected of type "Variants.foo M.t"
+Error: The value "bar" has type "(|Variants.bar|) M.t"
+       but an expression was expected of type "(|Variants.foo|) M.t"
        Type "Variants.bar" = "[ `Bar ]" is not compatible with type "Variants.foo"
        The first variant type does not allow tag(s) "`Foo"
 |}]
@@ -75,8 +75,8 @@ let f3 = fbar foo;;
 Line 1, characters 14-17:
 1 | let f3 = fbar foo;;
                   ^^^
-Error: The value "foo" has type "Variants.foo M.t"
-       but an expression was expected of type "Variants.bar M.t"
+Error: The value "foo" has type "(|Variants.foo|) M.t"
+       but an expression was expected of type "(|Variants.bar|) M.t"
        Type "Variants.foo" is not compatible with type "Variants.bar" = "[ `Bar ]"
        The second variant type does not allow tag(s) "`Foo"
 |}]

--- a/testsuite/tests/tool-toplevel/use_command.ml
+++ b/testsuite/tests/tool-toplevel/use_command.ml
@@ -20,6 +20,6 @@ Command exited with code 1.
 File "(command-output)", line 1, characters 5-6:
 1 | 1 :: x
          ^
-Error: The value "x" has type "int" but an expression was expected of type
-         "int list"
+Error: The value "x" has type "(|int|)" but an expression was expected of type
+         "int (|list|)"
 |}];;

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -7,8 +7,8 @@ let _ = Int32.(add 1 2l);;
 Line 1, characters 19-20:
 1 | let _ = Int32.(add 1 2l);;
                        ^
-Error: The constant "1" has type "int" but an expression was expected of type
-         "int32"
+Error: The constant "1" has type "(|int|)" but an expression was expected of type
+         "(|int32|)"
 Hint: Did you mean "1l"?
 |}]
 
@@ -17,8 +17,8 @@ let _ : int32 * int32 = 42l, 43;;
 Line 1, characters 29-31:
 1 | let _ : int32 * int32 = 42l, 43;;
                                  ^^
-Error: The constant "43" has type "int" but an expression was expected of type
-         "int32"
+Error: The constant "43" has type "(|int|)" but an expression was expected of type
+         "(|int32|)"
 Hint: Did you mean "43l"?
 |}]
 
@@ -27,8 +27,8 @@ let _ : int32 * nativeint = 42l, 43;;
 Line 1, characters 33-35:
 1 | let _ : int32 * nativeint = 42l, 43;;
                                      ^^
-Error: The constant "43" has type "int" but an expression was expected of type
-         "nativeint"
+Error: The constant "43" has type "(|int|)" but an expression was expected of type
+         "(|nativeint|)"
 Hint: Did you mean "43n"?
 |}]
 
@@ -37,8 +37,8 @@ let _ = min 6L 7;;
 Line 1, characters 15-16:
 1 | let _ = min 6L 7;;
                    ^
-Error: The constant "7" has type "int" but an expression was expected of type
-         "int64"
+Error: The constant "7" has type "(|int|)" but an expression was expected of type
+         "(|int64|)"
 Hint: Did you mean "7L"?
 |}]
 
@@ -47,8 +47,8 @@ let _ : float = 123;;
 Line 1, characters 16-19:
 1 | let _ : float = 123;;
                     ^^^
-Error: The constant "123" has type "int" but an expression was expected of type
-         "float"
+Error: The constant "123" has type "(|int|)" but an expression was expected of type
+         "(|float|)"
 Hint: Did you mean "123."?
 |}]
 
@@ -60,7 +60,7 @@ val x : int = 0
 Line 2, characters 19-20:
 2 | let _ = Int32.(add x 2l);;
                        ^
-Error: The value "x" has type "int" but an expression was expected of type "int32"
+Error: The value "x" has type "(|int|)" but an expression was expected of type "(|int32|)"
 |}]
 
 (* pattern *)
@@ -71,8 +71,8 @@ let _ : int32 -> int32 = function
 Line 2, characters 4-5:
 2 |   | 0 -> 0l
         ^
-Error: This pattern matches values of type "int"
-       but a pattern was expected which matches values of type "int32"
+Error: This pattern matches values of type "(|int|)"
+       but a pattern was expected which matches values of type "(|int32|)"
 Hint: Did you mean "0l"?
 |}]
 
@@ -83,8 +83,8 @@ let _ : int64 -> int64 = function
 Line 2, characters 9-10:
 2 |   | 1L | 2 -> 3L
              ^
-Error: This pattern matches values of type "int"
-       but a pattern was expected which matches values of type "int64"
+Error: This pattern matches values of type "(|int|)"
+       but a pattern was expected which matches values of type "(|int64|)"
 Hint: Did you mean "2L"?
 |}]
 
@@ -94,8 +94,8 @@ let _ : int32 = 1L;;
 Line 1, characters 16-18:
 1 | let _ : int32 = 1L;;
                     ^^
-Error: The constant "1L" has type "int64" but an expression was expected of type
-         "int32"
+Error: The constant "1L" has type "(|int64|)" but an expression was expected of type
+         "(|int32|)"
 Hint: Did you mean "1l"?
 |}]
 let _ : float = 1L;;
@@ -103,8 +103,8 @@ let _ : float = 1L;;
 Line 1, characters 16-18:
 1 | let _ : float = 1L;;
                     ^^
-Error: The constant "1L" has type "int64" but an expression was expected of type
-         "float"
+Error: The constant "1L" has type "(|int64|)" but an expression was expected of type
+         "(|float|)"
 Hint: Did you mean "1."?
 |}]
 let _ : int64 = 1n;;
@@ -112,8 +112,8 @@ let _ : int64 = 1n;;
 Line 1, characters 16-18:
 1 | let _ : int64 = 1n;;
                     ^^
-Error: The constant "1n" has type "nativeint"
-       but an expression was expected of type "int64"
+Error: The constant "1n" has type "(|nativeint|)"
+       but an expression was expected of type "(|int64|)"
 Hint: Did you mean "1L"?
 |}]
 let _ : nativeint = 1l;;
@@ -121,8 +121,8 @@ let _ : nativeint = 1l;;
 Line 1, characters 20-22:
 1 | let _ : nativeint = 1l;;
                         ^^
-Error: The constant "1l" has type "int32" but an expression was expected of type
-         "nativeint"
+Error: The constant "1l" has type "(|int32|)" but an expression was expected of type
+         "(|nativeint|)"
 Hint: Did you mean "1n"?
 |}]
 
@@ -132,16 +132,16 @@ let _ : int64 = 0.;;
 Line 1, characters 16-18:
 1 | let _ : int64 = 0.;;
                     ^^
-Error: The constant "0." has type "float" but an expression was expected of type
-         "int64"
+Error: The constant "0." has type "(|float|)" but an expression was expected of type
+         "(|int64|)"
 |}]
 let _ : int = 1L;;
 [%%expect{|
 Line 1, characters 14-16:
 1 | let _ : int = 1L;;
                   ^^
-Error: The constant "1L" has type "int64" but an expression was expected of type
-         "int"
+Error: The constant "1L" has type "(|int64|)" but an expression was expected of type
+         "(|int|)"
 |}]
 
 (* Check that the hint preserves formatting of int, int32, int64 and nativeint
@@ -151,8 +151,8 @@ let _ : int64 = min 0L 1_000;;
 Line 1, characters 23-28:
 1 | let _ : int64 = min 0L 1_000;;
                            ^^^^^
-Error: The constant "1_000" has type "int" but an expression was expected of type
-         "int64"
+Error: The constant "1_000" has type "(|int|)" but an expression was expected of type
+         "(|int64|)"
 Hint: Did you mean "1_000L"?
 |}]
 let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
@@ -160,8 +160,8 @@ let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
 Line 1, characters 36-44:
 1 | let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
                                         ^^^^^^^^
-Error: The constant "0xAA_BBL" has type "int64"
-       but an expression was expected of type "nativeint"
+Error: The constant "0xAA_BBL" has type "(|int64|)"
+       but an expression was expected of type "(|nativeint|)"
 Hint: Did you mean "0xAA_BBn"?
 |}]
 let _ : int32 -> int32 = function
@@ -171,8 +171,8 @@ let _ : int32 -> int32 = function
 Line 2, characters 9-16:
 2 |   | 1l | 0o2_345 -> 3l
              ^^^^^^^
-Error: This pattern matches values of type "int"
-       but a pattern was expected which matches values of type "int32"
+Error: This pattern matches values of type "(|int|)"
+       but a pattern was expected which matches values of type "(|int32|)"
 Hint: Did you mean "0o2_345l"?
 |}]
 let _ : int32 -> int32 = fun x -> match x with
@@ -182,8 +182,8 @@ let _ : int32 -> int32 = fun x -> match x with
 Line 2, characters 9-20:
 2 |   | 1l | 0b1000_1101 -> 3l
              ^^^^^^^^^^^
-Error: This pattern matches values of type "int"
-       but a pattern was expected which matches values of type "int32"
+Error: This pattern matches values of type "(|int|)"
+       but a pattern was expected which matches values of type "(|int32|)"
 Hint: Did you mean "0b1000_1101l"?
 |}]
 type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
@@ -192,7 +192,7 @@ type t1 = { f1 : int32; }
 Line 1, characters 49-55:
 1 | type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
                                                      ^^^^^^
-Error: The constant "1_000n" has type "nativeint"
-       but an expression was expected of type "int32"
+Error: The constant "1_000n" has type "(|nativeint|)"
+       but an expression was expected of type "(|int32|)"
 Hint: Did you mean "1_000l"?
 |}]

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -9,8 +9,8 @@ if 3 then ();;
 Line 1, characters 3-4:
 1 | if 3 then ();;
        ^
-Error: The constant "3" has type "int" but an expression was expected of type
-         "bool"
+Error: The constant "3" has type "(|int|)" but an expression was expected of type
+         "(|bool|)"
        because it is in the condition of an if-statement
 |}];;
 
@@ -20,8 +20,8 @@ fun b -> if true then (print_int b) else (if b then ());;
 Line 1, characters 45-46:
 1 | fun b -> if true then (print_int b) else (if b then ());;
                                                  ^
-Error: The value "b" has type "int" but an expression was expected of type "
-       bool" because it is in the condition of an if-statement
+Error: The value "b" has type "(|int|)" but an expression was expected of type "
+       (|bool|)" because it is in the condition of an if-statement
 |}];;
 
 (* Left-to-right bias is still there: if we swap the branches, the new error
@@ -32,7 +32,7 @@ fun b -> if true then (if b then ()) else (print_int b);;
 Line 1, characters 53-54:
 1 | fun b -> if true then (if b then ()) else (print_int b);;
                                                          ^
-Error: The value "b" has type "bool" but an expression was expected of type "int"
+Error: The value "b" has type "(|bool|)" but an expression was expected of type "(|int|)"
 |}];;
 
 if (let x = 3 in x) then ();;
@@ -41,8 +41,8 @@ if (let x = 3 in x) then ();;
 Line 1, characters 17-18:
 1 | if (let x = 3 in x) then ();;
                      ^
-Error: The value "x" has type "int" but an expression was expected of type "
-       bool" because it is in the condition of an if-statement
+Error: The value "x" has type "(|int|)" but an expression was expected of type "
+       (|bool|)" because it is in the condition of an if-statement
 |}];;
 
 if (if true then 3 else 4) then ();;
@@ -51,8 +51,8 @@ if (if true then 3 else 4) then ();;
 Line 1, characters 17-18:
 1 | if (if true then 3 else 4) then ();;
                      ^
-Error: The constant "3" has type "int" but an expression was expected of type
-         "bool"
+Error: The constant "3" has type "(|int|)" but an expression was expected of type
+         "(|bool|)"
        because it is in the condition of an if-statement
 |}];;
 
@@ -62,8 +62,8 @@ if true then 3;;
 Line 1, characters 13-14:
 1 | if true then 3;;
                  ^
-Error: The constant "3" has type "int" but an expression was expected of type
-         "unit"
+Error: The constant "3" has type "(|int|)" but an expression was expected of type
+         "(|unit|)"
        because it is in the result of a conditional with no else branch
 |}];;
 
@@ -83,8 +83,8 @@ while 42 do () done;;
 Line 1, characters 6-8:
 1 | while 42 do () done;;
           ^^
-Error: The constant "42" has type "int" but an expression was expected of type
-         "bool"
+Error: The constant "42" has type "(|int|)" but an expression was expected of type
+         "(|bool|)"
        because it is in the condition of a while-loop
 |}];;
 
@@ -96,8 +96,8 @@ while true do (if true then 3 else 4) done;;
 Line 1, characters 14-37:
 1 | while true do (if true then 3 else 4) done;;
                   ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This "if-then-else" expression has type "int"
-       but an expression was expected of type "unit"
+Error: This "if-then-else" expression has type "(|int|)"
+       but an expression was expected of type "(|unit|)"
        because it is in the body of a while-loop
 |}];;
 
@@ -107,8 +107,8 @@ for i = 3. to 4 do () done;;
 Line 1, characters 8-10:
 1 | for i = 3. to 4 do () done;;
             ^^
-Error: The constant "3." has type "float" but an expression was expected of type
-         "int"
+Error: The constant "3." has type "(|float|)" but an expression was expected of type
+         "(|int|)"
        because it is in a for-loop start index
 |}];;
 
@@ -118,8 +118,8 @@ for i = 3 to 4. do () done;;
 Line 1, characters 13-15:
 1 | for i = 3 to 4. do () done;;
                  ^^
-Error: The constant "4." has type "float" but an expression was expected of type
-         "int"
+Error: The constant "4." has type "(|float|)" but an expression was expected of type
+         "(|int|)"
        because it is in a for-loop stop index
 |}];;
 
@@ -131,8 +131,8 @@ for i = 0 to 0 do (if true then 3 else 4) done;;
 Line 1, characters 18-41:
 1 | for i = 0 to 0 do (if true then 3 else 4) done;;
                       ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This "if-then-else" expression has type "int"
-       but an expression was expected of type "unit"
+Error: This "if-then-else" expression has type "(|int|)"
+       but an expression was expected of type "(|unit|)"
        because it is in the body of a for-loop
 |}];;
 
@@ -142,8 +142,8 @@ assert 12;;
 Line 1, characters 7-9:
 1 | assert 12;;
            ^^
-Error: The constant "12" has type "int" but an expression was expected of type
-         "bool"
+Error: The constant "12" has type "(|int|)" but an expression was expected of type
+         "(|bool|)"
        because it is in the condition of an assertion
 |}];;
 
@@ -154,8 +154,8 @@ Error: The constant "12" has type "int" but an expression was expected of type
 Line 1, characters 0-18:
 1 | (let x = 3 in x+1); ();;
     ^^^^^^^^^^^^^^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "unit"
+Error: This expression has type "(|int|)" but an expression was expected of type
+         "(|unit|)"
        because it is in the left-hand side of a sequence
 |}];;
 
@@ -180,8 +180,8 @@ Error: This variant expression is expected to have type "unit"
 Line 2, characters 11-16:
 2 |   | y when y + 1 -> ()
                ^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "bool"
+Error: This expression has type "(|int|)" but an expression was expected of type
+         "(|bool|)"
        because it is in a when-guard
 |}];;
 

--- a/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
+++ b/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
@@ -11,8 +11,8 @@ val g : (unit -> 'a) -> 'a = <fun>
 Line 2, characters 10-11:
 2 | let _ = g 3;;       (* missing `fun () ->' *)
               ^
-Error: The constant "3" has type "int" but an expression was expected of type
-         "unit -> 'a"
+Error: The constant "3" has type "(|int|)" but an expression was expected of type
+         "unit (|->|) 'a"
        Hint: Did you forget to wrap the expression using "fun () ->"?
 |}];;
 
@@ -28,8 +28,8 @@ let _ =
 Line 3, characters 3-16:
 3 |    print_newline;    (* missing unit argument *)
        ^^^^^^^^^^^^^
-Error: The value "print_newline" has type "unit -> unit"
-       but an expression was expected of type "unit"
+Error: The value "print_newline" has type "unit (|->|) unit"
+       but an expression was expected of type "(|unit|)"
        because it is in the left-hand side of a sequence
        Hint: Did you forget to provide "()" as argument?
 |}];;
@@ -41,8 +41,8 @@ print_int x;;
 Line 2, characters 10-11:
 2 | print_int x;;
               ^
-Error: The value "x" has type "unit -> int"
-       but an expression was expected of type "int"
+Error: The value "x" has type "unit (|->|) int"
+       but an expression was expected of type "(|int|)"
        Hint: Did you forget to provide "()" as argument?
 |}];;
 
@@ -54,8 +54,8 @@ let g f =
 Line 3, characters 6-7:
 3 |   f = 3;;
           ^
-Error: The constant "3" has type "int" but an expression was expected of type
-         "unit -> 'a"
+Error: The constant "3" has type "(|int|)" but an expression was expected of type
+         "unit (|->|) 'a"
        Hint: Did you forget to wrap the expression using "fun () ->"?
 |}];;
 
@@ -67,7 +67,7 @@ let g f =
 Line 3, characters 6-7:
 3 |   3 = f;;
           ^
-Error: The value "f" has type "unit -> 'a" but an expression was expected of type
-         "int"
+Error: The value "f" has type "unit (|->|) 'a" but an expression was expected of type
+         "(|int|)"
        Hint: Did you forget to provide "()" as argument?
 |}]

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -324,7 +324,7 @@ Error: Signature mismatch:
          "A of float"
        is not the same as:
          "A of int"
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -350,7 +350,7 @@ Error: Signature mismatch:
          "A of 'b"
        is not the same as:
          "A of 'a"
-       The type "'b" is not equal to the type "'a"
+       The type "(|'b|)" is not equal to the type "(|'a|)"
 |}]
 
 module M : sig
@@ -376,7 +376,7 @@ Error: Signature mismatch:
          "A of 'a"
        is not the same as:
          "A of 'a"
-       The type "'a" is not equal to the type "'b"
+       The type "(|'a|)" is not equal to the type "(|'b|)"
 |}];;
 
 
@@ -403,7 +403,7 @@ Error: Signature mismatch:
          "A : 'd -> ('c, 'd) bar"
        is not the same as:
          "A : 'c -> ('c, 'd) bar"
-       The type "'d" is not equal to the type "'c"
+       The type "(|'d|)" is not equal to the type "(|'c|)"
 |}]
 
 (* Extensions can be rebound *)

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -231,7 +231,7 @@ let a = A 9
 Line 1, characters 10-11:
 1 | let a = A 9
               ^
-Error: The constant "9" has type "int" but an expression was expected of type
+Error: The constant "9" has type "(|int|)" but an expression was expected of type
          "[> `Var ]"
 |}]
 
@@ -241,7 +241,7 @@ type 'a foo += B : int foo
 Line 1, characters 19-22:
 1 | type 'a foo += B : int foo
                        ^^^
-Error: This type "int" should be an instance of type "[> `Var ]"
+Error: This type "(|int|)" should be an instance of type "[> `Var ]"
 |}]
 
 (* Signatures can make an extension private *)
@@ -438,7 +438,7 @@ type bar += A3 = M.A1
 Line 1, characters 17-21:
 1 | type bar += A3 = M.A1
                      ^^^^
-Error: The constructor "M.A1" has type "foo" but was expected to be of type "bar"
+Error: The constructor "M.A1" has type "(|foo|)" but was expected to be of type "(|bar|)"
 |}]
 
 module M = struct type foo += private B1 of int end

--- a/testsuite/tests/typing-extensions/floatarray.ml
+++ b/testsuite/tests/typing-extensions/floatarray.ml
@@ -40,8 +40,8 @@ let f a = match a with [|_|] -> Float.Array.length a | _ -> assert false
 Line 1, characters 51-52:
 1 | let f a = match a with [|_|] -> Float.Array.length a | _ -> assert false
                                                        ^
-Error: The value "a" has type "'a array" but an expression was expected of type
-         "Float.Array.t" = "floatarray"
+Error: The value "a" has type "'a (|array|)" but an expression was expected of type
+         "Float.Array.t" = "(|floatarray|)"
 |}]
 
 type s = floatarray

--- a/testsuite/tests/typing-extensions/iarray.ml
+++ b/testsuite/tests/typing-extensions/iarray.ml
@@ -56,8 +56,8 @@ match ifarray with
 Line 3, characters 4-5:
 3 | | [|1;2;3;4;5|] -> "1--5"
         ^
-Error: This pattern matches values of type "int"
-       but a pattern was expected which matches values of type "float"
+Error: This pattern matches values of type "(|int|)"
+       but a pattern was expected which matches values of type "(|float|)"
 Hint: Did you mean "1."?
 |}];;
 
@@ -70,8 +70,8 @@ match marray with
 Line 2, characters 2-19:
 2 | | ([||] : _ iarray) -> "empty"
       ^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type "'a iarray"
-       but a pattern was expected which matches values of type "int array"
+Error: This pattern matches values of type "'a (|iarray|)"
+       but a pattern was expected which matches values of type "int (|array|)"
 |}];;
 
 match iarray with
@@ -83,6 +83,6 @@ match iarray with
 Line 2, characters 2-18:
 2 | | ([||] : _ array) -> "empty"
       ^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type "'a array"
-       but a pattern was expected which matches values of type "int iarray"
+Error: This pattern matches values of type "'a (|array|)"
+       but a pattern was expected which matches values of type "int (|iarray|)"
 |}];;

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -118,7 +118,7 @@ Line 1, characters 0-37:
 Error: This variant or record definition does not match that of type
          "('a, 'a) foo"
        Their parameters differ
-       The type "'a" is not equal to the type "'b"
+       The type "(|'a|)" is not equal to the type "(|'b|)"
 |}]
 
 (* Check that signatures can hide exstensibility *)

--- a/testsuite/tests/typing-external/pr11392.ml
+++ b/testsuite/tests/typing-external/pr11392.ml
@@ -19,7 +19,7 @@ external cast : int -> 'self nat as 'self = "%identity"
 Line 1, characters 36-41:
 1 | external cast : int -> 'self nat as 'self = "%identity"
                                         ^^^^^
-Error: This alias is bound to type "int -> 'a nat"
+Error: This alias is bound to type "int -> (|'a|) nat"
        but is used as an instance of type "'a"
        The type variable "'a" occurs inside "int -> 'a nat"
 |}]

--- a/testsuite/tests/typing-external/pr11392.ml
+++ b/testsuite/tests/typing-external/pr11392.ml
@@ -20,7 +20,7 @@ Line 1, characters 36-41:
 1 | external cast : int -> 'self nat as 'self = "%identity"
                                         ^^^^^
 Error: This alias is bound to type "int -> (|'a|) nat"
-       but is used as an instance of type "'a"
+       but is used as an instance of type "(|'a|)"
        The type variable "'a" occurs inside "int -> 'a nat"
 |}]
 

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -22,7 +22,7 @@ Lines 7-10, characters 2-22:
  8 |     type t = M.t
  9 |   end : S
 10 |     with type t = M.t)
-Error: This expression has type "(module S with type t = M.t)"
+Error: This expression has type "(module S with type t = (|M.t|))"
        but an expression was expected of type "(module S)"
        The type constructor "M.t" would escape its scope
 |}, Principal{|
@@ -56,7 +56,7 @@ Line 3, characters 41-42:
 3 |   let (module K : S with type t = A.t) = k in
                                              ^
 Error: The value "k" has type "'a" but an expression was expected of type
-         "(module S with type t = A.t)"
+         "(module S with type t = (|A.t|))"
        The type constructor "A.t" would escape its scope
 |}];;
 
@@ -112,6 +112,6 @@ module type S = sig type t val x : t end
 Line 15, characters 8-10:
 15 |   unify ()
              ^^
-Error: The constructor "()" has type "unit"
-       but an expression was expected of type "M.t"
+Error: The constructor "()" has type "(|unit|)"
+       but an expression was expected of type "(|M.t|)"
 |}];;

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -18,7 +18,7 @@ let ret_e1 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else y
                                  ^
-Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -32,7 +32,7 @@ let ret_e2 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else y
                                  ^
-Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -50,6 +50,14 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 3, characters 29-30:
+3 |   | Refl -> if b then x else 0
+                                 ^
+Error: The constant "0" has type "int" but an expression was expected of type
+         "a" = "(|int|)"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 let ret_ei2 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
@@ -65,6 +73,14 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 3, characters 29-30:
+3 |   | Refl -> if b then x else 0
+                                 ^
+Error: The constant "0" has type "int" but an expression was expected of type
+         "a" = "(|int|)"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 
@@ -77,7 +93,7 @@ let ret_f (type a b) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 16-17:
 3 |   | Refl -> [x; y]
                     ^
-Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -91,7 +107,7 @@ let ret_g1 (type a b) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 16-17:
 3 |   | Refl -> [x; y]
                     ^
-Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -231,7 +247,7 @@ Error: Signature mismatch:
          val r : '_weak1 list ref
        is not included in
          val r : T.t list ref
-       The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
+       The type "'_weak1 list ref" is not compatible with the type "(|T.t|) list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -267,7 +267,7 @@ Error: Signature mismatch:
          val r : '_weak2 list ref
        is not included in
          val r : T.t list ref
-       The type "'_weak2 list ref" is not compatible with the type "T.t list ref"
+       The type "(|'_weak2|) list ref" is not compatible with the type "(|T.t|) list ref"
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -29,7 +29,7 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
 Line 2, characters 37-40:
 2 |    let Refl = w2 in let Refl = w1 in g 3;;
                                          ^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: This expression has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -53,7 +53,7 @@ Line 4, characters 12-13:
 4 |   | Bool -> x
                 ^
 Error: The value "x" has type "t" = "bool" but an expression was expected of type
-         "bool"
+         "(|bool|)"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -69,14 +69,14 @@ let g (type t) (x : t) (tag : t ty) =
 Line 4, characters 11-16:
 4 |   | Int -> x > 0
                ^^^^^
-Error: This expression has type "bool" but an expression was expected of type
-         "t" = "int"
+Error: This expression has type "(|bool|)" but an expression was expected of type
+         "t" = "(|int|)"
 |}, Principal{|
 Line 4, characters 11-16:
 4 |   | Int -> x > 0
                ^^^^^
 Error: This expression has type "bool" but an expression was expected of type
-         "t" = "int"
+         "t" = "(|int|)"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-gadts/dynamic_frisch.ml
+++ b/testsuite/tests/typing-gadts/dynamic_frisch.ml
@@ -610,6 +610,16 @@ Error: This pattern matches values of type "a * a vlist"
        Hint: "$a" is an existential type bound by the constructor "Tdyn".
        Hint: "$0" and "$1" are type variables introduced in the equation
          "$a" = "$0 * $1"
+|}, Principal{|
+Line 7, characters 41-58:
+7 |     | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p)))
+                                             ^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type "(|a|) * a vlist"
+       but a pattern was expected which matches values of type "$a" = "(|$0|) * $1"
+       Type "a" is not compatible with type "$0"
+       Hint: "$a" is an existential type bound by the constructor "Tdyn".
+       Hint: "$0" and "$1" are type variables introduced in the equation
+         "$a" = "$0 * $1"
 |}];;
 
 (* Define Sum using object instead of record for first-class polymorphism *)

--- a/testsuite/tests/typing-gadts/dynamic_frisch.ml
+++ b/testsuite/tests/typing-gadts/dynamic_frisch.ml
@@ -606,7 +606,7 @@ Line 7, characters 41-58:
                                              ^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type "a * a vlist"
        but a pattern was expected which matches values of type "$a" = "$0 * $1"
-       Type "a" is not compatible with type "$0"
+       Type "(|a|)" is not compatible with type "(|$0|)"
        Hint: "$a" is an existential type bound by the constructor "Tdyn".
        Hint: "$0" and "$1" are type variables introduced in the equation
          "$a" = "$0 * $1"
@@ -616,7 +616,7 @@ Line 7, characters 41-58:
                                              ^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type "(|a|) * a vlist"
        but a pattern was expected which matches values of type "$a" = "(|$0|) * $1"
-       Type "a" is not compatible with type "$0"
+       Type "(|a|)" is not compatible with type "(|$0|)"
        Hint: "$a" is an existential type bound by the constructor "Tdyn".
        Hint: "$0" and "$1" are type variables introduced in the equation
          "$a" = "$0 * $1"

--- a/testsuite/tests/typing-gadts/gadthead.ml
+++ b/testsuite/tests/typing-gadts/gadthead.ml
@@ -27,6 +27,6 @@ end
 Line 3, characters 17-18:
 3 |     match x with I -> M.print I
                      ^
-Error: This pattern matches values of type "'a g"
-       but a pattern was expected which matches values of type "M.t"
+Error: This pattern matches values of type "'a (|g|)"
+       but a pattern was expected which matches values of type "(|M.t|)"
 |}]

--- a/testsuite/tests/typing-gadts/introduced_variables.ml
+++ b/testsuite/tests/typing-gadts/introduced_variables.ml
@@ -128,7 +128,7 @@ let rec annotate_presence
 Line 18, characters 12-13:
 18 |     Entry.E e
                  ^
-Error: The value "e" has type "($s, $2, $1, $0) Entry.t.E"
+Error: The value "e" has type "($s, (|$2|), $1, $0) Entry.t.E"
        but an expression was expected of type "($s, 'a, 'b, 'c) Entry.t.E"
        The type constructor "$2" would escape its scope
        Hint: "$s" is an existential type bound by the constructor "E".

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -148,8 +148,8 @@ let rec example : type a . a ty -> a = function
 Line 3, characters 54-72:
 3 | | Pair (type b c) (x, y : b ty * c ty) -> (example x, example (*error*)x)
                                                           ^^^^^^^^^^^^^^^^^^
-Error: This expression has type "b" = "$0" but an expression was expected of type
-         "$1"
+Error: This expression has type "b" = "(|$0|)" but an expression was expected of type
+         "(|$1|)"
        Hint: "$0" and "$1" are type variables introduced in the equation
          "a" = "$0 * $1"
 |}]
@@ -180,7 +180,7 @@ Line 2, characters 29-48:
                                  ^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type "b * (b -> c (|option|))"
        but a pattern was expected which matches values of type "b * (b -> (|a|))"
-       Type "c option" is not compatible with type "a"
+       Type "c (|option|)" is not compatible with type "(|a|)"
 |}]
 (* Can only name fresh existentials *)
 let ko2 = function

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -178,8 +178,8 @@ let ko1 (type a) : a th -> a = function
 Line 2, characters 29-48:
 2 |   | Thunk (type b c) (x, f : b * (b -> c option)) -> f x
                                  ^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type "b * (b -> c option)"
-       but a pattern was expected which matches values of type "b * (b -> a)"
+Error: This pattern matches values of type "b * (b -> c (|option|))"
+       but a pattern was expected which matches values of type "b * (b -> (|a|))"
        Type "c option" is not compatible with type "a"
 |}]
 (* Can only name fresh existentials *)

--- a/testsuite/tests/typing-gadts/nested_equations.ml
+++ b/testsuite/tests/typing-gadts/nested_equations.ml
@@ -21,7 +21,7 @@ Line 2, characters 34-37:
                                       ^^^
 Error: This pattern matches values of type "(|int|) t"
        but a pattern was expected which matches values of type "(|bool|) t"
-       Type "int" is not compatible with type "bool"
+       Type "(|int|)" is not compatible with type "(|bool|)"
 |}];;
 
 let w_buffer : Buffer.t t = Obj.magic 0;;
@@ -40,7 +40,7 @@ Line 2, characters 38-41:
                                           ^^^
 Error: This pattern matches values of type "(|int|) t"
        but a pattern was expected which matches values of type "(|Arg.spec|) t"
-       Type "int" is not compatible with type "Arg.spec"
+       Type "(|int|)" is not compatible with type "Arg.spec" = "(|Arg.spec|)"
 |}];;
 
 module M : sig type u val w : u t val x : u end =

--- a/testsuite/tests/typing-gadts/nested_equations.ml
+++ b/testsuite/tests/typing-gadts/nested_equations.ml
@@ -19,8 +19,8 @@ val w_bool : bool t = Int
 Line 2, characters 34-37:
 2 | let f_bool (x : bool) : int = let Int = w_bool in x;; (* fail *)
                                       ^^^
-Error: This pattern matches values of type "int t"
-       but a pattern was expected which matches values of type "bool t"
+Error: This pattern matches values of type "(|int|) t"
+       but a pattern was expected which matches values of type "(|bool|) t"
        Type "int" is not compatible with type "bool"
 |}];;
 
@@ -38,8 +38,8 @@ val w_spec : Arg.spec t = Int
 Line 2, characters 38-41:
 2 | let f_spec (x : Arg.spec) : int = let Int = w_spec in x;; (* fail *)
                                           ^^^
-Error: This pattern matches values of type "int t"
-       but a pattern was expected which matches values of type "Arg.spec t"
+Error: This pattern matches values of type "(|int|) t"
+       but a pattern was expected which matches values of type "(|Arg.spec|) t"
        Type "int" is not compatible with type "Arg.spec"
 |}];;
 

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -21,8 +21,8 @@ let trivial t =
 Line 4, characters 4-11:
 4 |   | BoolLit -> ()
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -46,8 +46,8 @@ let trivial_merged t =
 Line 4, characters 4-11:
 4 |   | BoolLit -> ()
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -81,8 +81,8 @@ let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
 Line 3, characters 22-29:
 3 |   | IntLit, (IntLit | BoolLit) -> ()
                           ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "a t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|a|) t"
        Type "bool" is not compatible with type "a" = "int"
 |}]
 
@@ -121,8 +121,8 @@ let simple t a =
 Line 4, characters 4-11:
 4 |   | BoolLit, true -> ()
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -148,8 +148,8 @@ let simple_merged t a =
 Line 4, characters 4-11:
 4 |   | BoolLit, true -> ()
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -377,8 +377,8 @@ let noop t a =
 Line 4, characters 4-11:
 4 |   | BoolLit, x -> x
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -402,8 +402,8 @@ let noop_merged t a =
 Line 4, characters 4-11:
 4 |   | BoolLit, x -> x
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -437,8 +437,8 @@ let trivial2 t2 =
 Line 4, characters 4-10:
 4 |   | Bool _ -> ()
         ^^^^^^
-Error: This pattern matches values of type "bool t2"
-       but a pattern was expected which matches values of type "int t2"
+Error: This pattern matches values of type "(|bool|) t2"
+       but a pattern was expected which matches values of type "(|int|) t2"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -462,8 +462,8 @@ let trivial2_merged t2 =
 Line 4, characters 4-10:
 4 |   | Bool _ -> ()
         ^^^^^^
-Error: This pattern matches values of type "bool t2"
-       but a pattern was expected which matches values of type "int t2"
+Error: This pattern matches values of type "(|bool|) t2"
+       but a pattern was expected which matches values of type "(|int|) t2"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -488,8 +488,8 @@ let extract t2 =
 Line 4, characters 4-10:
 4 |   | Bool _ -> x
         ^^^^^^
-Error: This pattern matches values of type "bool t2"
-       but a pattern was expected which matches values of type "int t2"
+Error: This pattern matches values of type "(|bool|) t2"
+       but a pattern was expected which matches values of type "(|int|) t2"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -513,8 +513,8 @@ let extract_merged t2 =
 Line 4, characters 4-10:
 4 |   | Bool x -> x
         ^^^^^^
-Error: This pattern matches values of type "bool t2"
-       but a pattern was expected which matches values of type "int t2"
+Error: This pattern matches values of type "(|bool|) t2"
+       but a pattern was expected which matches values of type "(|int|) t2"
        Type "bool" is not compatible with type "int"
 |}]
 
@@ -704,8 +704,8 @@ Lines 3-4, characters 4-42:
 3 | ....IntLit,  ({ contents = true } as x), _
 4 |   | BoolLit,  _, ({ contents = true} as x)............
 Error: The variable "x" on the left-hand side of this or-pattern has type
-         "bool ref"
-       but on the right-hand side it has type "a ref"
+         "(|bool|) ref"
+       but on the right-hand side it has type "(|a|) ref"
        Type "bool" is not compatible with type "a"
 |}]
 

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -23,7 +23,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let trivial_annotated (type a) (t : a t) =
@@ -48,7 +48,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let trivial_merged_annotated (type a) (t : a t) =
@@ -83,7 +83,7 @@ Line 3, characters 22-29:
                           ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|a|) t"
-       Type "bool" is not compatible with type "a" = "int"
+       Type "(|bool|)" is not compatible with type "a" = "(|int|)"
 |}]
 
 let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
@@ -123,7 +123,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let simple_annotated (type a) (t : a t) (a : a) =
@@ -150,7 +150,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let simple_merged_ambi (type a) (t : a t) a =
@@ -166,6 +166,14 @@ Line 4, characters 13-17:
                  ^^^^
 Error: This pattern matches values of type "bool"
        but a pattern was expected which matches values of type "a" = "bool"
+       This instance of "bool" is ambiguous:
+       it would escape the scope of its equation
+|}, Principal{|
+Line 4, characters 13-17:
+4 |   | BoolLit, true -> ()
+                 ^^^^
+Error: This pattern matches values of type "bool"
+       but a pattern was expected which matches values of type "a" = "(|bool|)"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -379,7 +387,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let noop_annotated (type a) (t : a t) (a : a) : a =
@@ -404,7 +412,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let noop_merged_annotated (type a) (t : a t) (a : a) : a =
@@ -439,7 +447,7 @@ Line 4, characters 4-10:
         ^^^^^^
 Error: This pattern matches values of type "(|bool|) t2"
        but a pattern was expected which matches values of type "(|int|) t2"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let trivial2_annotated (type a) (t2 : a t2) =
@@ -464,7 +472,7 @@ Line 4, characters 4-10:
         ^^^^^^
 Error: This pattern matches values of type "(|bool|) t2"
        but a pattern was expected which matches values of type "(|int|) t2"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let trivial2_merged_annotated (type a) (t2 : a t2) =
@@ -490,7 +498,7 @@ Line 4, characters 4-10:
         ^^^^^^
 Error: This pattern matches values of type "(|bool|) t2"
        but a pattern was expected which matches values of type "(|int|) t2"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let extract_annotated (type a) (t2 : a t2) : a =
@@ -515,7 +523,7 @@ Line 4, characters 4-10:
         ^^^^^^
 Error: This pattern matches values of type "(|bool|) t2"
        but a pattern was expected which matches values of type "(|int|) t2"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let extract_merged_annotated (type a) (t2 : a t2) : a =
@@ -530,7 +538,7 @@ Lines 3-4, characters 4-10:
 3 | ....Int x
 4 |   | Bool x.....
 Error: The variable "x" on the left-hand side of this or-pattern has type "
-       int" but on the right-hand side it has type "bool"
+       (|int|)" but on the right-hand side it has type "(|bool|)"
 |}]
 
 let extract_merged_super_annotated (type a) (t2 : a t2) : a =
@@ -554,7 +562,7 @@ Lines 3-4, characters 4-10:
 3 | ....Int (x : a)
 4 |   | Bool x.....
 Error: The variable "x" on the left-hand side of this or-pattern has type "
-       a" but on the right-hand side it has type "bool"
+       (|a|)" but on the right-hand side it has type "(|bool|)"
 |}]
 
 let extract_merged_super_lightly_annotated (type a) (t2 : a t2) =
@@ -588,7 +596,7 @@ Lines 3-4, characters 4-23:
 3 | ....Int (_ as x)
 4 |   | Bool ((_ : a) as x).....
 Error: The variable "x" on the left-hand side of this or-pattern has type "
-       int" but on the right-hand side it has type "a"
+       (|int|)" but on the right-hand side it has type "(|a|)"
 |}]
 
 
@@ -631,7 +639,7 @@ let return_a (type a) (x : a t3) : a =
 Line 3, characters 13-14:
 3 |   | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of
                  ^
-Error: The constant "3" has type "int" but an expression was expected of type "a"
+Error: The constant "3" has type "(|int|)" but an expression was expected of type "(|a|)"
 |}]
 
 (* Making sure we don't break a frequent pattern of GADTs indexed by polymorphic
@@ -706,7 +714,7 @@ Lines 3-4, characters 4-42:
 Error: The variable "x" on the left-hand side of this or-pattern has type
          "(|bool|) ref"
        but on the right-hand side it has type "(|a|) ref"
-       Type "bool" is not compatible with type "a"
+       Type "(|bool|)" is not compatible with type "(|a|)"
 |}]
 
 let f_disamb (type a) (t : a t) (a : bool ref) (b : a ref) =

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -425,7 +425,7 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
 Line 3, characters 37-42:
 3 |    let Refl = w2 in let Refl = w1 in M.g 3;;
                                          ^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: This expression has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -465,7 +465,7 @@ val f :
 Line 3, characters 36-41:
 3 |   let Refl = w2 in let Refl = w1 in M.g 3
                                         ^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: This expression has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -497,7 +497,7 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
 Line 4, characters 3-8:
 4 |    M.res;;
        ^^^^^
-Error: The value "M.res" has type "int" but an expression was expected of type "'a"
+Error: The value "M.res" has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -202,5 +202,5 @@ Error: Signature mismatch:
          "< x : (|'a. 'a -> x|) >"
        The method "x" has type "'a. 'a -> (|'a|)", but the expected method type was
        "'a. 'a -> (|x|)"
-       Type "'a" is not equal to type "x" = "M.x"
+       Type "(|'a|)" is not equal to type "x" = "(|M.x|)"
 |}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -200,7 +200,7 @@ Error: Signature mismatch:
        Their parameters differ
        The type "< x : 'a. 'a -> 'a >" is not equal to the type
          "< x : 'a. 'a -> x >"
-       Type "'a" is not equal to type "x" = "M.x"
        The method "x" has type "'a. 'a -> 'a", but the expected method type was
        "'a. 'a -> x"
+       Type "'a" is not equal to type "x" = "M.x"
 |}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -17,10 +17,10 @@ let f (type a b) (y : (a, b) j t) : a -> b =
 Line 2, characters 6-7:
 2 |   let A = y in fun x -> x;;
           ^
-Error: This pattern matches values of type "i t"
-       but a pattern was expected which matches values of type "(a, b) j t"
-       Type "i" = "< m : 'c. 'c -> 'c >" is not compatible with type
-         "(a, b) j" = "< m : a -> b >"
+Error: This pattern matches values of type "(|i|) t"
+       but a pattern was expected which matches values of type "(a, b) (|j|) t"
+       Type "i" = "< m : (|'c. 'c -> 'c|) >" is not compatible with type
+         "(a, b) j" = "< m : a (|->|) b >"
        The method "m" has type "'c. 'c -> 'c", but the expected method type was
        "a -> b"
        The universal variable "'c" would escape its scope
@@ -198,9 +198,9 @@ Error: Signature mismatch:
        is not included in
          type 'b t = A constraint 'b = < x : 'a. 'a -> x >
        Their parameters differ
-       The type "< x : 'a. 'a -> 'a >" is not equal to the type
-         "< x : 'a. 'a -> x >"
-       The method "x" has type "'a. 'a -> 'a", but the expected method type was
-       "'a. 'a -> x"
+       The type "< x : (|'a. 'a -> 'a|) >" is not equal to the type
+         "< x : (|'a. 'a -> x|) >"
+       The method "x" has type "'a. 'a -> (|'a|)", but the expected method type was
+       "'a. 'a -> (|x|)"
        Type "'a" is not equal to type "x" = "M.x"
 |}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -21,7 +21,7 @@ Error: This pattern matches values of type "(|i|) t"
        but a pattern was expected which matches values of type "(a, b) (|j|) t"
        Type "i" = "< m : (|'c. 'c -> 'c|) >" is not compatible with type
          "(a, b) j" = "< m : a (|->|) b >"
-       The method "m" has type "'c. 'c -> 'c", but the expected method type was
+       The method "m" has type "'c. (|'c|) -> (|'c|)", but the expected method type was
        "a -> b"
        The universal variable "'c" would escape its scope
 |}]

--- a/testsuite/tests/typing-gadts/pr10907.ml
+++ b/testsuite/tests/typing-gadts/pr10907.ml
@@ -48,7 +48,7 @@ let unsound_cast : 'a 'b. 'a -> 'b = fun x ->
 Lines 1-2, characters 37-36:
 1 | .....................................fun x ->
 2 |   match t with Iso (g, h) -> h (g x)
-Error: This definition has type "'b. 'b -> 'b" which is less general than
+Error: This definition has type "'b. (|'b|) -> (|'b|)" which is less general than
          "'a 'b. 'a -> 'b"
        The universal type variable "'b" in the first type matches multiple
        distinct variables in the second type.

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -16,8 +16,8 @@ end
 Line 6, characters 5-10:
 6 |      Equal
          ^^^^^
-Error: The constructor "Equal" has type "(m1, m1) Type.eq"
-       but an expression was expected of type "(m1, m2) Type.eq"
+Error: The constructor "Equal" has type "((|m1|), (|m1|)) Type.eq"
+       but an expression was expected of type "(m1, (|m2|)) Type.eq"
        Type "m1" is not compatible with type "m2"
 |}]
 
@@ -127,7 +127,7 @@ end;;
 Line 2, characters 52-53:
 2 |   let f : type a b. a M.t u -> b M.t = fun (U x) -> x
                                                         ^
-Error: The value "x" has type "$0 M.t" but an expression was expected of type
-         "b M.t"
+Error: The value "x" has type "(|$0|) M.t" but an expression was expected of type
+         "(|b|) M.t"
        Type "$0" is not compatible with type "b"
 |}]

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -18,7 +18,7 @@ Line 6, characters 5-10:
          ^^^^^
 Error: The constructor "Equal" has type "((|m1|), (|m1|)) Type.eq"
        but an expression was expected of type "(m1, (|m2|)) Type.eq"
-       Type "m1" is not compatible with type "m2"
+       Type "(|m1|)" is not compatible with type "(|m2|)"
 |}]
 
 (* could cause unsoundness
@@ -88,9 +88,9 @@ let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
 Line 1, characters 16-21:
 1 | let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
                     ^^^^^
-Error: This pattern matches values of type "($'a M.p * a, $'a M.p * a) Type.eq"
+Error: This pattern matches values of type "((|$'a|) M.p * a, (|$'a|) M.p * a) Type.eq"
        but a pattern was expected which matches values of type
-         "($'a M.p * a, 'b M.p * int) Type.eq"
+         "((|$'a|) M.p * a, 'b M.p * int) Type.eq"
        The type constructor "$'a" would escape its scope
 |}]
 
@@ -129,5 +129,5 @@ Line 2, characters 52-53:
                                                         ^
 Error: The value "x" has type "(|$0|) M.t" but an expression was expected of type
          "(|b|) M.t"
-       Type "$0" is not compatible with type "b"
+       Type "(|$0|)" is not compatible with type "(|b|)"
 |}]

--- a/testsuite/tests/typing-gadts/pr5689.ml
+++ b/testsuite/tests/typing-gadts/pr5689.ml
@@ -104,7 +104,7 @@ Line 7, characters 35-43:
 7 |     | (Kind _, Ast_Text txt)    -> Text txt
                                        ^^^^^^^^
 Error: This constructor has type "[< inkind > `Nonlink ] inline_t"
-       but an expression was expected of type "a inline_t"
+       but an expression was expected of type "(|a|) inline_t"
        Type "[< inkind > `Nonlink ]" = "[< `Link | `Nonlink > `Nonlink ]"
        is not compatible with type "a" = "[< `Link | `Nonlink ]"
        The second variant type is bound to "$'a",

--- a/testsuite/tests/typing-gadts/pr6158.ml
+++ b/testsuite/tests/typing-gadts/pr6158.ml
@@ -15,9 +15,9 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 6, characters 45-49:
 6 | let f : (int s, int t) eq -> unit = function Refl -> ();;
                                                  ^^^^
-Error: This pattern matches values of type "(int s, int s) eq"
+Error: This pattern matches values of type "(int (|s|), int (|s|)) eq"
        but a pattern was expected which matches values of type
-         "(int s, int t) eq"
+         "(int s, int (|t|)) eq"
        Type "int s" is not compatible with type "int t"
 |}];;
 

--- a/testsuite/tests/typing-gadts/pr6158.ml
+++ b/testsuite/tests/typing-gadts/pr6158.ml
@@ -18,7 +18,7 @@ Line 6, characters 45-49:
 Error: This pattern matches values of type "(int (|s|), int (|s|)) eq"
        but a pattern was expected which matches values of type
          "(int s, int (|t|)) eq"
-       Type "int s" is not compatible with type "int t"
+       Type "int (|s|)" is not compatible with type "int (|t|)"
 |}];;
 
 module M (S : sig type 'a t = T of 'a type 'a s = T of 'a end) =
@@ -27,9 +27,9 @@ struct let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> () end;;
 Line 2, characters 54-58:
 2 | struct let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> () end;;
                                                           ^^^^
-Error: This pattern matches values of type "($'a S.s, $'a S.s) eq"
+Error: This pattern matches values of type "((|$'a|) S.s, (|$'a|) S.s) eq"
        but a pattern was expected which matches values of type
-         "($'a S.s, $'a S.t) eq"
+         "((|$'a|) S.s, (|$'a|) S.t) eq"
        The type constructor "$'a" would escape its scope
        Hint: "$'a" is a type variable introduced in the equation
          "$'a S.s" = "$'a S.t"

--- a/testsuite/tests/typing-gadts/pr6174.ml
+++ b/testsuite/tests/typing-gadts/pr6174.ml
@@ -10,7 +10,7 @@ type _ t = C : ((('a -> 'o) -> 'o) -> ('b -> 'o) -> 'o) t
 Line 3, characters 24-25:
 3 |  fun C k -> k (fun x -> x);;
                             ^
-Error: The value "x" has type "$0" but an expression was expected of type "$1" = "o"
+Error: The value "x" has type "(|$0|)" but an expression was expected of type "$1" = "(|o|)"
        Hint: "$0" and "$1" are type variables introduced in the equation
          "a" = "$0 -> $1"
 |}];;

--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -30,9 +30,9 @@ Line 15, characters 4-9:
 15 |   | Local -> fun _ -> raise Exit
          ^^^^^
 Error: This pattern matches values of type
-         "($0, $0 * insert, $0 local_visit_action) context"
+         "((|$0|), (|$0|) * insert, (|$0|) local_visit_action) context"
        but a pattern was expected which matches values of type
-         "($0, $0 * insert, visit_action) context"
+         "((|$0|), (|$0|) * insert, visit_action) context"
        The type constructor "$0" would escape its scope
        Hint: "$0" is a type variable introduced in the equation
          "visit_action" = "$0 local_visit_action"
@@ -49,9 +49,9 @@ Line 4, characters 4-9:
 4 |   | Local -> fun _ -> raise Exit
         ^^^^^
 Error: This pattern matches values of type
-         "($'a, $'a * insert, $'a local_visit_action) context"
+         "((|$'a|), (|$'a|) * insert, (|$'a|) local_visit_action) context"
        but a pattern was expected which matches values of type
-         "($'a, $'a * insert, visit_action) context"
+         "((|$'a|), (|$'a|) * insert, visit_action) context"
        The type constructor "$'a" would escape its scope
        Hint: "$'a" is a type variable introduced in the equation
          "visit_action" = "$'a local_visit_action"

--- a/testsuite/tests/typing-gadts/pr6980.ml
+++ b/testsuite/tests/typing-gadts/pr6980.ml
@@ -25,7 +25,7 @@ Line 11, characters 27-29:
 11 | let g (Aux(Second, f)) = f it;;
                                 ^^
 Error: The value "it" has type "[< `Bar | `Foo > `Bar ]"
-       but an expression was expected of type "[< `Bar | `Foo ]"
+       but an expression was expected of type "(|[< `Bar | `Foo ]|)"
        The second variant type is bound to "$a",
        it may not allow the tag(s) "`Bar"
        Hint: "$a" is an existential type bound by the constructor "Aux".

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -27,8 +27,8 @@ let get1' = function
 Line 3, characters 4-7:
 3 |   | Nil -> assert false ;; (* ok *)
         ^^^
-Error: This pattern matches values of type "('b * 'a, 'b * 'a) t"
+Error: This pattern matches values of type "('b * (|'a|), 'b * (|'a|)) t"
        but a pattern was expected which matches values of type
-         "('b * 'a, 'a) t"
+         "('b (|*|) 'a, 'a) t"
        The type variable "'a" occurs inside "'b * 'a"
 |}];;

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -29,6 +29,6 @@ Line 3, characters 4-7:
         ^^^
 Error: This pattern matches values of type "('b * (|'a|), 'b * (|'a|)) t"
        but a pattern was expected which matches values of type
-         "('b (|*|) 'a, 'a) t"
+         "('b * (|'a|), (|'a|)) t"
        The type variable "'a" occurs inside "'b * 'a"
 |}];;

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -22,6 +22,6 @@ Error: This variant or record definition does not match that of type "'a t"
          "Same : 'l t -> 'l t"
        is not the same as:
          "Same : 'l1 t -> 'l2 t"
-       The type "'l t" is not equal to the type "'l1 t"
+       The type "(|'l|) t" is not equal to the type "(|'l1|) t"
        Type "'l" is not equal to type "'l1"
 |}];;

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -23,5 +23,5 @@ Error: This variant or record definition does not match that of type "'a t"
        is not the same as:
          "Same : 'l1 t -> 'l2 t"
        The type "(|'l|) t" is not equal to the type "(|'l1|) t"
-       Type "'l" is not equal to type "'l1"
+       Type "(|'l|)" is not equal to type "(|'l1|)"
 |}];;

--- a/testsuite/tests/typing-gadts/pr7214.ml
+++ b/testsuite/tests/typing-gadts/pr7214.ml
@@ -15,8 +15,8 @@ type _ t = I : int t
 Line 5, characters 9-10:
 5 |     let (I : a t) = x     (* fail because of toplevel let *)
              ^
-Error: This pattern matches values of type "int t"
-       but a pattern was expected which matches values of type "a t"
+Error: This pattern matches values of type "(|int|) t"
+       but a pattern was expected which matches values of type "(|a|) t"
        Type "int" is not compatible with type "a"
 |}];;
 
@@ -39,7 +39,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 8, characters 10-14:
 8 |      let (Refl : (int, a) eq) = M.e  (* must fail for soundness *)
               ^^^^
-Error: This pattern matches values of type "(int, int) eq"
-       but a pattern was expected which matches values of type "(int, a) eq"
+Error: This pattern matches values of type "((|int|), (|int|)) eq"
+       but a pattern was expected which matches values of type "(int, (|a|)) eq"
        Type "int" is not compatible with type "a"
 |}];;

--- a/testsuite/tests/typing-gadts/pr7214.ml
+++ b/testsuite/tests/typing-gadts/pr7214.ml
@@ -17,7 +17,7 @@ Line 5, characters 9-10:
              ^
 Error: This pattern matches values of type "(|int|) t"
        but a pattern was expected which matches values of type "(|a|) t"
-       Type "int" is not compatible with type "a"
+       Type "(|int|)" is not compatible with type "(|a|)"
 |}];;
 
 (* extra example by Stephen Dolan, using recursive modules *)
@@ -41,5 +41,5 @@ Line 8, characters 10-14:
               ^^^^
 Error: This pattern matches values of type "((|int|), (|int|)) eq"
        but a pattern was expected which matches values of type "(int, (|a|)) eq"
-       Type "int" is not compatible with type "a"
+       Type "(|int|)" is not compatible with type "(|a|)"
 |}];;

--- a/testsuite/tests/typing-gadts/pr7222.ml
+++ b/testsuite/tests/typing-gadts/pr7222.ml
@@ -25,7 +25,7 @@ Line 9, characters 11-18:
                ^^^^^^^
 Error: This pattern matches values of type "($x, 'a -> $x) elt"
        but a pattern was expected which matches values of type
-         "($x, 'a -> $'b -> nil) elt"
+         "($x, 'a -> (|$'b|) -> nil) elt"
        The type constructor "$'b" would escape its scope
        Hint: "$x" is an existential type bound by the constructor "Cons".
        Hint: "$'b" is a type variable introduced in the equation

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -36,8 +36,8 @@ Line 11, characters 16-20:
                      ^^^^
 Error: The constructor "Refl" has type "((|a|), (|a|)) eq"
        but an expression was expected of type "(a, (|t|)) eq"
-       Type "a" is not compatible with type
-         "t" = "([ `Rec of 'a X.t ] as 'a) X/2.t"
+       Type "(|a|)" is not compatible with type
+         "t" = "([ `Rec of 'a X.t ] as 'a) (|X/2.t|)"
        Line 8, characters 2-14:
          Definition of module "X"
        Line 7, characters 12-13:
@@ -91,7 +91,7 @@ Line 4, characters 21-25:
 Error: The constructor "Refl" has type "((|a|), (|a|)) eq"
        but an expression was expected of type "(a, a X.t (|X.t|)) eq"
        Type "a" = "b X.t" is not compatible with type "a (|X.t|) X.t"
-       Type "b" is not compatible with type "a X.t"
+       Type "(|b|)" is not compatible with type "a (|X.t|)"
 |}, Principal{|
 Line 4, characters 21-25:
 4 |     fun Refl Refl -> Refl;;
@@ -99,5 +99,5 @@ Line 4, characters 21-25:
 Error: The constructor "Refl" has type "((|a|), (|a|)) eq"
        but an expression was expected of type "(a, a X.t (|X.t|)) eq"
        Type "a" = "(|b|) X.t" is not compatible with type "a (|X.t|) X.t"
-       Type "b" is not compatible with type "a X.t"
+       Type "(|b|)" is not compatible with type "a (|X.t|)"
 |}]

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -34,8 +34,8 @@ module type Fix =
 Line 11, characters 16-20:
 11 |     fun Refl -> Refl
                      ^^^^
-Error: The constructor "Refl" has type "(a, a) eq"
-       but an expression was expected of type "(a, t) eq"
+Error: The constructor "Refl" has type "((|a|), (|a|)) eq"
+       but an expression was expected of type "(a, (|t|)) eq"
        Type "a" is not compatible with type
          "t" = "([ `Rec of 'a X.t ] as 'a) X/2.t"
        Line 8, characters 2-14:
@@ -88,8 +88,16 @@ end;; (* should fail *)
 Line 4, characters 21-25:
 4 |     fun Refl Refl -> Refl;;
                          ^^^^
-Error: The constructor "Refl" has type "(a, a) eq"
-       but an expression was expected of type "(a, a X.t X.t) eq"
-       Type "a" = "b X.t" is not compatible with type "a X.t X.t"
+Error: The constructor "Refl" has type "((|a|), (|a|)) eq"
+       but an expression was expected of type "(a, a X.t (|X.t|)) eq"
+       Type "a" = "b X.t" is not compatible with type "a (|X.t|) X.t"
+       Type "b" is not compatible with type "a X.t"
+|}, Principal{|
+Line 4, characters 21-25:
+4 |     fun Refl Refl -> Refl;;
+                         ^^^^
+Error: The constructor "Refl" has type "((|a|), (|a|)) eq"
+       but an expression was expected of type "(a, a X.t (|X.t|)) eq"
+       Type "a" = "(|b|) X.t" is not compatible with type "a (|X.t|) X.t"
        Type "b" is not compatible with type "a X.t"
 |}]

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -24,7 +24,7 @@ Error: This variant or record definition does not match that of type "X.t"
        is not the same as:
          "A : 'a * 'b * ('b -> unit) -> X.t"
        The type "(|'a|) -> unit" is not equal to the type "(|'b|) -> unit"
-       Type "'a" is not equal to type "'b"
+       Type "(|'a|)" is not equal to type "(|'b|)"
 |}]
 
 (* would segfault

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -23,7 +23,7 @@ Error: This variant or record definition does not match that of type "X.t"
          "A : 'a * 'b * ('a -> unit) -> X.t"
        is not the same as:
          "A : 'a * 'b * ('b -> unit) -> X.t"
-       The type "'a -> unit" is not equal to the type "'b -> unit"
+       The type "(|'a|) -> unit" is not equal to the type "(|'b|) -> unit"
        Type "'a" is not equal to type "'b"
 |}]
 

--- a/testsuite/tests/typing-gadts/pr7421.ml
+++ b/testsuite/tests/typing-gadts/pr7421.ml
@@ -27,8 +27,8 @@ let f (x : ('a, empty Lazy.t) result) =
 Line 4, characters 16-20:
 4 |   | Error (lazy Refl) -> .;;
                     ^^^^
-Error: This pattern matches values of type "(int, int) eq"
+Error: This pattern matches values of type "((|int|), (|int|)) eq"
        but a pattern was expected which matches values of type
-         "empty" = "(int, unit) eq"
+         "empty" = "(int, (|unit|)) eq"
        Type "int" is not compatible with type "unit"
 |}]

--- a/testsuite/tests/typing-gadts/pr7421.ml
+++ b/testsuite/tests/typing-gadts/pr7421.ml
@@ -30,5 +30,5 @@ Line 4, characters 16-20:
 Error: This pattern matches values of type "((|int|), (|int|)) eq"
        but a pattern was expected which matches values of type
          "empty" = "(int, (|unit|)) eq"
-       Type "int" is not compatible with type "unit"
+       Type "(|int|)" is not compatible with type "(|unit|)"
 |}]

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -46,7 +46,7 @@ let x = match [] with ["1"] -> 1 | [1.0] -> 2 | [1] -> 3 | _ -> 4;;
 Line 1, characters 35-40:
 1 | let x = match [] with ["1"] -> 1 | [1.0] -> 2 | [1] -> 3 | _ -> 4;;
                                        ^^^^^
-Error: This pattern matches values of type "float list"
-       but a pattern was expected which matches values of type "string list"
+Error: This pattern matches values of type "(|float|) list"
+       but a pattern was expected which matches values of type "(|string|) list"
        Type "float" is not compatible with type "string"
 |}]

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -48,5 +48,5 @@ Line 1, characters 35-40:
                                        ^^^^^
 Error: This pattern matches values of type "(|float|) list"
        but a pattern was expected which matches values of type "(|string|) list"
-       Type "float" is not compatible with type "string"
+       Type "(|float|)" is not compatible with type "(|string|)"
 |}]

--- a/testsuite/tests/typing-gadts/pr7902.ml
+++ b/testsuite/tests/typing-gadts/pr7902.ml
@@ -28,6 +28,6 @@ Line 3, characters 12-18:
                 ^^^^^^
 Error: This pattern matches values of type "((|'a|) * (|'a|), (|'a|) * (|'a|)) segment"
        but a pattern was expected which matches values of type
-         "('a (|*|) 'a, 'a) segment"
+         "((|'a|) * (|'a|), (|'a|)) segment"
        The type variable "'a" occurs inside "'a * 'a"
 |}]

--- a/testsuite/tests/typing-gadts/pr7902.ml
+++ b/testsuite/tests/typing-gadts/pr7902.ml
@@ -26,8 +26,8 @@ let color (* : type a b . (a, b) segment -> int *) = function
 Line 3, characters 12-18:
 3 |   | SegCons SegNil -> 0
                 ^^^^^^
-Error: This pattern matches values of type "('a * 'a, 'a * 'a) segment"
+Error: This pattern matches values of type "((|'a|) * (|'a|), (|'a|) * (|'a|)) segment"
        but a pattern was expected which matches values of type
-         "('a * 'a, 'a) segment"
+         "('a (|*|) 'a, 'a) segment"
        The type variable "'a" occurs inside "'a * 'a"
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -91,7 +91,7 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type "(|bool|) t"
        but a pattern was expected which matches values of type "(|int|) t"
-       Type "bool" is not compatible with type "int"
+       Type "(|bool|)" is not compatible with type "(|int|)"
 |}]
 
 let f (type a) t (x : a) =
@@ -105,7 +105,7 @@ let f (type a) t (x : a) =
 Line 3, characters 17-18:
 3 |   | IntLit, n -> n+1
                      ^
-Error: The value "n" has type "a" but an expression was expected of type "int"
+Error: The value "n" has type "(|a|)" but an expression was expected of type "(|int|)"
 |}]
 
 (**********************)
@@ -257,8 +257,8 @@ let () =
 Line 3, characters 27-28:
 3 |   | [ { b = F; _ } ; { a = 3; _ }] -> ()
                                ^
-Error: This pattern matches values of type "int"
-       but a pattern was expected which matches values of type "Foo.t"
+Error: This pattern matches values of type "(|int|)"
+       but a pattern was expected which matches values of type "(|Foo.t|)"
 |}]
 
 type (_, _, _) eq3 = Refl3 : ('a, 'a, 'a) eq3

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -89,8 +89,8 @@ let f (type a) t (x : a) =
 Line 4, characters 4-11:
 4 |   | BoolLit, b -> 1
         ^^^^^^^
-Error: This pattern matches values of type "bool t"
-       but a pattern was expected which matches values of type "int t"
+Error: This pattern matches values of type "(|bool|) t"
+       but a pattern was expected which matches values of type "(|int|) t"
        Type "bool" is not compatible with type "int"
 |}]
 

--- a/testsuite/tests/typing-gadts/syntactic-arity.ml
+++ b/testsuite/tests/typing-gadts/syntactic-arity.ml
@@ -31,8 +31,8 @@ print_endline (ok ());;
 Line 1, characters 14-21:
 1 | print_endline (ok ());;
                   ^^^^^^^
-Error: This expression has type "'a -> 'b"
-       but an expression was expected of type "string"
+Error: This expression has type "'a (|->|) 'b"
+       but an expression was expected of type "(|string|)"
 Hint: This function application is partial, maybe some arguments are missing.
 |}];;
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -546,6 +546,15 @@ Error: This expression has type "(|int|) option"
        Type "int" is not compatible with type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 4, characters 46-48:
+4 |   begin match x with Int -> u := Some 1; r := !u end;
+                                                  ^^
+Error: This expression has type "(|int|) option"
+       but an expression was expected of type "(|a|) option"
+       Type "int" is not compatible with type "a" = "(|int|)"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 let test2 : type a. a t -> a option = fun x ->
@@ -703,6 +712,16 @@ Error: The value "o" has type "< m : (|a|); .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 2, characters 14-15:
+2 |   fun Eq o -> o
+                  ^
+Error: The value "o" has type "< m : (|a|); .. >"
+       but an expression was expected of type "< m : (|b|); .. >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
+       Type "a" is not compatible with type "b" = "(|a|)"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
@@ -715,6 +734,16 @@ Error: The value "o" has type "< m : (|a|); .. >"
        but an expression was expected of type "< m : (|b|); .. >"
        The method "m" has type "(|a|)", but the expected method type was "(|b|)"
        Type "a" is not compatible with type "b" = "a"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
+|}, Principal{|
+Line 2, characters 22-23:
+2 |   match eq with Eq -> o ;; (* should fail *)
+                          ^
+Error: The value "o" has type "< m : (|a|); .. >"
+       but an expression was expected of type "< m : (|b|); .. >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
+       Type "a" is not compatible with type "b" = "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -755,7 +784,7 @@ Line 4, characters 44-45:
 Error: The value "o" has type "< m : (|a|) >" but an expression was expected of type
          "< m : (|b|) >"
        The method "m" has type "(|a|)", but the expected method type was "(|b|)"
-       Type "a" is not compatible with type "b" = "a"
+       Type "a" is not compatible with type "b" = "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -775,6 +804,16 @@ Error: The value "o" has type "< m : (|a|); .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 3, characters 44-45:
+3 |     let r : < m : b > = match eq with Eq -> o in (* fail *)
+                                                ^
+Error: The value "o" has type "< m : (|a|); .. >"
+       but an expression was expected of type "< m : (|b|) >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
+       Type "a" is not compatible with type "b" = "(|a|)"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
@@ -788,6 +827,15 @@ Error: The value "o" has type "[> `A of (|a|) ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 2, characters 14-15:
+2 |   fun Eq o -> o ;; (* fail *)
+                  ^
+Error: The value "o" has type "[> `A of (|a|) ]"
+       but an expression was expected of type "[> `A of (|b|) ]"
+       In tag "`A", type "a" is not compatible with type "b" = "(|a|)"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
@@ -799,6 +847,15 @@ Line 2, characters 22-23:
 Error: The value "v" has type "[> `A of (|a|) ]"
        but an expression was expected of type "[> `A of (|b|) ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
+|}, Principal{|
+Line 2, characters 22-23:
+2 |   match eq with Eq -> v ;; (* should fail *)
+                          ^
+Error: The value "v" has type "[> `A of (|a|) ]"
+       but an expression was expected of type "[> `A of (|b|) ]"
+       In tag "`A", type "a" is not compatible with type "b" = "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -856,7 +913,7 @@ Line 4, characters 49-50:
                                                      ^
 Error: The value "o" has type "[ `A of (|a|) | `B ]"
        but an expression was expected of type "[ `A of (|b|) | `B ]"
-       In tag "`A", type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -873,6 +930,15 @@ Line 3, characters 49-50:
 Error: The value "o" has type "[> `A of (|a|) | `B ]"
        but an expression was expected of type "[ `A of (|b|) | `B ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
+       This instance of "a" is ambiguous:
+       it would escape the scope of its equation
+|}, Principal{|
+Line 3, characters 49-50:
+3 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail *)
+                                                     ^
+Error: The value "o" has type "[> `A of (|a|) | `B ]"
+       but an expression was expected of type "[ `A of (|b|) | `B ]"
+       In tag "`A", type "a" is not compatible with type "b" = "(|a|)"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -288,7 +288,7 @@ module Existential_escape =
 Line 5, characters 21-22:
 5 |     let eval (D x) = x
                          ^
-Error: The value "x" has type "$a t" but an expression was expected of type "'a"
+Error: The value "x" has type "(|$a|) t" but an expression was expected of type "'a"
        The type constructor "$a" would escape its scope
        Hint: "$a" is an existential type bound by the constructor "D".
 |}];;
@@ -372,7 +372,7 @@ Line 13, characters 19-20:
 13 |     | BoolLit b -> b
                         ^
 Error: The value "b" has type "bool" but an expression was expected of type
-         "s" = "bool"
+         "s" = "(|bool|)"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -466,7 +466,7 @@ let test : type a. a t -> a = fun x ->
 Line 2, characters 30-42:
 2 |   let r = match x with Int -> ky 1 (1 : a)  (* fails *)
                                   ^^^^^^^^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: This expression has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -588,7 +588,7 @@ val either : 'a -> 'a -> 'a = <fun>
 Line 3, characters 44-45:
 3 |   match v with Int -> let y = either 1 x in y
                                                 ^
-Error: The value "y" has type "int" but an expression was expected of type "'a"
+Error: The value "y" has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -867,7 +867,7 @@ Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
 Error: This definition has type
-         "'c 'b. ('b, 'b) eq -> ([< `A of 'b | `B ] as 'c) -> 'c"
+         "'c 'b. ('b, 'b) eq -> ((|[< `A of 'b | `B ] as 'c|)) -> (|'c|)"
        which is less general than
          "'d 'e 'a 'b.
            ('a, 'b) eq ->
@@ -1017,8 +1017,8 @@ let f : type a. a ty -> a t -> int = fun x y ->
 Line 6, characters 6-13:
 6 |   | D [|1.0|], TE TC -> 14
           ^^^^^^^
-Error: This pattern matches values of type "'a array"
-       but a pattern was expected which matches values of type "a"
+Error: This pattern matches values of type "'a (|array|)"
+       but a pattern was expected which matches values of type "(|a|)"
 |}];;
 
 type ('a,'b) pair = {right:'a; left:'b}
@@ -1037,8 +1037,8 @@ type ('a, 'b) pair = { right : 'a; left : 'b; }
 Line 8, characters 25-32:
 8 |   | {left=TE TC; right=D [|1.0|]} -> 14
                              ^^^^^^^
-Error: This pattern matches values of type "'a array"
-       but a pattern was expected which matches values of type "a"
+Error: This pattern matches values of type "'a (|array|)"
+       but a pattern was expected which matches values of type "(|a|)"
 |}];;
 
 type ('a,'b) pair = {left:'a; right:'b}
@@ -1085,7 +1085,7 @@ Line 6, characters 17-19:
                      ^^
 Error: The constructor "Eq" has type "((|a|), (|a|)) eq"
        but an expression was expected of type "(a, (|b|)) eq"
-       Type "a" is not compatible with type "b"
+       Type "(|a|)" is not compatible with type "(|b|)"
 |}];;
 
 let f : type a b. (a M.t * a, b M.t * b) eq -> (a, b) eq =
@@ -1203,7 +1203,7 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 Line 3, characters 2-26:
 3 |   (x:<foo:int;bar:int;..>)
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< bar : int; foo : int; .. as $1 >"
+Error: This expression has type "(|< bar : int; foo : int; .. as (|$1|) >|)"
        but an expression was expected of type "'a"
        The type constructor "$1" would escape its scope
        Hint: "$1" is a type variable introduced in the equation
@@ -1212,7 +1212,7 @@ Error: This expression has type "< bar : int; foo : int; .. as $1 >"
 Line 3, characters 2-26:
 3 |   (x:<foo:int;bar:int;..>)
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< bar : int; foo : int; .. as $1 >"
+Error: This expression has type "(|< bar : int; foo : int; .. as (|$1|) >|)"
        but an expression was expected of type "'a"
        This instance of "$1" is ambiguous:
        it would escape the scope of its equation
@@ -1238,7 +1238,7 @@ val g : 't -> 't int_foo -> 't int_bar -> 't * int * int = <fun>
 Line 3, characters 5-10:
 3 |   x, x#foo, x#bar
          ^^^^^
-Error: The method call "x#foo" has type "int"
+Error: The method call "x#foo" has type "(|int|)"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -1311,6 +1311,14 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 5, characters 24-25:
+5 |     if true then a else b
+                            ^
+Error: The value "b" has type "b" = "int" but an expression was expected of type
+         "a" = "(|int|)"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
@@ -1373,7 +1381,7 @@ Line 7, characters 22-36:
 7 |   if true then x else fun x -> x + 1
                           ^^^^^^^^^^^^^^
 Error: This expression has type "'a -> 'b"
-       but an expression was expected of type "M.t" = "int -> int"
+       but an expression was expected of type "M.t" = "int (|->|) int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -1392,7 +1400,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 7, characters 35-36:
 7 |   if true then fun x -> x + 1 else x
                                        ^
-Error: The value "x" has type "M.t" = "int -> int"
+Error: The value "x" has type "M.t" = "int (|->|) int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
@@ -1459,7 +1467,7 @@ module M :
 Line 9, characters 4-5:
 9 |     z#b
         ^
-Error: This expression has type "$a" = "< b : bool >"
+Error: This expression has type "$a" = "(|< b : bool >|)"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
@@ -1487,7 +1495,7 @@ module M :
 Line 9, characters 4-5:
 9 |     z#b
         ^
-Error: This expression has type "$a" = "< b : bool >"
+Error: This expression has type "$a" = "(|< b : bool >|)"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -867,7 +867,7 @@ Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
 Error: This definition has type
-         "'c 'b. ('b, 'b) eq -> ((|[< `A of 'b | `B ] as 'c|)) -> (|'c|)"
+         "'c 'b. ((|'b|), (|'b|)) eq -> ((|[< `A of (|'b|) | `B ] as 'c|)) -> (|'c|)"
        which is less general than
          "'d 'e 'a 'b.
            ('a, 'b) eq ->

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -699,6 +699,7 @@ Line 2, characters 14-15:
                   ^
 Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -712,6 +713,7 @@ Line 2, characters 22-23:
                           ^
 Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -752,6 +754,7 @@ Line 4, characters 44-45:
                                                 ^
 Error: The value "o" has type "< m : a >" but an expression was expected of type
          "< m : b >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -768,6 +771,7 @@ Line 3, characters 44-45:
                                                 ^
 Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b >"
+       The method "m" has type "a", but the expected method type was "b"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -781,7 +781,7 @@ Line 2, characters 14-15:
                   ^
 Error: The value "o" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -794,7 +794,7 @@ Line 2, characters 22-23:
                           ^
 Error: The value "v" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -852,7 +852,7 @@ Line 4, characters 49-50:
                                                      ^
 Error: The value "o" has type "[ `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -868,7 +868,7 @@ Line 3, characters 49-50:
                                                      ^
 Error: The value "o" has type "[> `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
-       Type "a" is not compatible with type "b" = "a"
+       In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -541,8 +541,8 @@ let test2 : type a. a t -> a option = fun x ->
 Line 4, characters 46-48:
 4 |   begin match x with Int -> u := Some 1; r := !u end;
                                                   ^^
-Error: This expression has type "int option"
-       but an expression was expected of type "a option"
+Error: This expression has type "(|int|) option"
+       but an expression was expected of type "(|a|) option"
        Type "int" is not compatible with type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -697,9 +697,9 @@ let f : type a b. (a,b) eq -> <m : a; ..> -> <m : b; ..> =
 Line 2, characters 14-15:
 2 |   fun Eq o -> o
                   ^
-Error: The value "o" has type "< m : a; .. >"
-       but an expression was expected of type "< m : b; .. >"
-       The method "m" has type "a", but the expected method type was "b"
+Error: The value "o" has type "< m : (|a|); .. >"
+       but an expression was expected of type "< m : (|b|); .. >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -711,9 +711,9 @@ let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
 Line 2, characters 22-23:
 2 |   match eq with Eq -> o ;; (* should fail *)
                           ^
-Error: The value "o" has type "< m : a; .. >"
-       but an expression was expected of type "< m : b; .. >"
-       The method "m" has type "a", but the expected method type was "b"
+Error: The value "o" has type "< m : (|a|); .. >"
+       but an expression was expected of type "< m : (|b|); .. >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -752,9 +752,9 @@ val f : ('a, 'b) eq -> < m : 'a > -> < m : 'b > = <fun>
 Line 4, characters 44-45:
 4 |     let r : < m : b > = match eq with Eq -> o in (* fail with principal *)
                                                 ^
-Error: The value "o" has type "< m : a >" but an expression was expected of type
-         "< m : b >"
-       The method "m" has type "a", but the expected method type was "b"
+Error: The value "o" has type "< m : (|a|) >" but an expression was expected of type
+         "< m : (|b|) >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -769,9 +769,9 @@ let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
 Line 3, characters 44-45:
 3 |     let r : < m : b > = match eq with Eq -> o in (* fail *)
                                                 ^
-Error: The value "o" has type "< m : a; .. >"
-       but an expression was expected of type "< m : b >"
-       The method "m" has type "a", but the expected method type was "b"
+Error: The value "o" has type "< m : (|a|); .. >"
+       but an expression was expected of type "< m : (|b|) >"
+       The method "m" has type "(|a|)", but the expected method type was "(|b|)"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -783,8 +783,8 @@ let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
 Line 2, characters 14-15:
 2 |   fun Eq o -> o ;; (* fail *)
                   ^
-Error: The value "o" has type "[> `A of a ]"
-       but an expression was expected of type "[> `A of b ]"
+Error: The value "o" has type "[> `A of (|a|) ]"
+       but an expression was expected of type "[> `A of (|b|) ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -796,8 +796,8 @@ let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
 Line 2, characters 22-23:
 2 |   match eq with Eq -> v ;; (* should fail *)
                           ^
-Error: The value "v" has type "[> `A of a ]"
-       but an expression was expected of type "[> `A of b ]"
+Error: The value "v" has type "[> `A of (|a|) ]"
+       but an expression was expected of type "[> `A of (|b|) ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -854,8 +854,8 @@ Error: This expression has type
 Line 4, characters 49-50:
 4 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail with principal *)
                                                      ^
-Error: The value "o" has type "[ `A of a | `B ]"
-       but an expression was expected of type "[ `A of b | `B ]"
+Error: The value "o" has type "[ `A of (|a|) | `B ]"
+       but an expression was expected of type "[ `A of (|b|) | `B ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -870,8 +870,8 @@ let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
 Line 3, characters 49-50:
 3 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail *)
                                                      ^
-Error: The value "o" has type "[> `A of a | `B ]"
-       but an expression was expected of type "[ `A of b | `B ]"
+Error: The value "o" has type "[> `A of (|a|) | `B ]"
+       but an expression was expected of type "[ `A of (|b|) | `B ]"
        In tag "`A", type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -1017,8 +1017,8 @@ module M : sig type 'a t val eq : ('a t, 'b t) eq end
 Line 6, characters 17-19:
 6 |   function Eq -> Eq (* fail *)
                      ^^
-Error: The constructor "Eq" has type "(a, a) eq"
-       but an expression was expected of type "(a, b) eq"
+Error: The constructor "Eq" has type "((|a|), (|a|)) eq"
+       but an expression was expected of type "(a, (|b|)) eq"
        Type "a" is not compatible with type "b"
 |}];;
 
@@ -1074,7 +1074,21 @@ Line 10, characters 3-4:
 10 |   (x:<foo:int>)
         ^
 Error: The value "x" has type "t" = "< foo : int; .. as $0 >"
-       but an expression was expected of type "< foo : int >"
+       but an expression was expected of type "(|< foo : int >|)"
+       Type "$0" = "< bar : int; .. as $1 >" is not compatible with type "<  >"
+       The second object type has no method "bar"
+       Hint: "$1" is a type variable introduced in the equation
+         "$0" = "< bar : int; .. as $1 >"
+       Hint: "$0" is a type variable introduced in the equation
+         "t" = "< foo : int; .. as $0 >"
+|}, Principal{|
+type _ int_foo = IF_constr : < foo : int; .. > int_foo
+type _ int_bar = IB_constr : < bar : int; .. > int_bar
+Line 10, characters 3-4:
+10 |   (x:<foo:int>)
+        ^
+Error: The value "x" has type "t" = "(|< foo : int; .. as (|$0|) >|)"
+       but an expression was expected of type "(|< foo : int >|)"
        Type "$0" = "< bar : int; .. as $1 >" is not compatible with type "<  >"
        The second object type has no method "bar"
        Hint: "$1" is a type variable introduced in the equation
@@ -1092,6 +1106,19 @@ Line 3, characters 3-4:
 3 |   (x:<foo:int;bar:int>)
        ^
 Error: The value "x" has type "t" = "< foo : int; .. as $0 >"
+       but an expression was expected of type "< bar : int; foo : int >"
+       Type "$0" = "< bar : int; .. as $1 >" is not compatible with type
+         "< bar : int >"
+       The first object type has an abstract row, it cannot be closed
+       Hint: "$1" is a type variable introduced in the equation
+         "$0" = "< bar : int; .. as $1 >"
+       Hint: "$0" is a type variable introduced in the equation
+         "t" = "< foo : int; .. as $0 >"
+|}, Principal{|
+Line 3, characters 3-4:
+3 |   (x:<foo:int;bar:int>)
+       ^
+Error: The value "x" has type "t" = "(|< foo : int; .. as (|$0|) >|)"
        but an expression was expected of type "< bar : int; foo : int >"
        Type "$0" = "< bar : int; .. as $1 >" is not compatible with type
          "< bar : int >"

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
@@ -79,8 +79,8 @@ let f = fun (~foo, ~bar:bar) : (foo:int * bar:int) -> foo * 10 + bar
 Line 1, characters 54-68:
 1 | let f = fun (~foo, ~bar:bar) : (foo:int * bar:int) -> foo * 10 + bar
                                                           ^^^^^^^^^^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "foo:int * bar:int"
+Error: This expression has type "(|int|)" but an expression was expected of type
+         "foo:int (|*|) bar:int"
 |}]
 
 (* Missing label *)
@@ -98,8 +98,8 @@ let f = fun (~foo, ~bar:bar) : (foo:int * int) -> foo * 10 + bar
 Line 1, characters 50-64:
 1 | let f = fun (~foo, ~bar:bar) : (foo:int * int) -> foo * 10 + bar
                                                       ^^^^^^^^^^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "foo:int * int"
+Error: This expression has type "(|int|)" but an expression was expected of type
+         "foo:int (|*|) int"
 |}]
 
 (* Wrong label *)
@@ -169,7 +169,7 @@ let f (~(x:float),y) = x + y
 Line 1, characters 23-24:
 1 | let f (~(x:float),y) = x + y
                            ^
-Error: The value "x" has type "float" but an expression was expected of type "int"
+Error: The value "x" has type "(|float|)" but an expression was expected of type "(|int|)"
 |}]
 (* Reordering in functions *)
 type xy = (x:int * y:int)

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
@@ -224,8 +224,8 @@ let swap : xy -> yx = Fun.id
 Line 1, characters 22-28:
 1 | let swap : xy -> yx = Fun.id
                           ^^^^^^
-Error: The value "Fun.id" has type "xy -> xy"
-       but an expression was expected of type "xy -> yx"
+Error: The value "Fun.id" has type "xy -> (|xy|)"
+       but an expression was expected of type "xy -> (|yx|)"
        Type "xy" = "(|x:|)int * (|y:|)int" is not compatible with type "yx" = "(|y:|)int * (|x:|)int"
        Labels "x" and "y" do not match
 |}]
@@ -235,8 +235,8 @@ let swap : xy -> yx = xy_id
 Line 1, characters 22-27:
 1 | let swap : xy -> yx = xy_id
                           ^^^^^
-Error: The value "xy_id" has type "(y:int * x:int) -> xy"
-       but an expression was expected of type "xy -> yx"
+Error: The value "xy_id" has type "(y:int (|*|) x:int) -> xy"
+       but an expression was expected of type "(|xy|) -> yx"
        Type "(|y:|)int * (|x:|)int" is not compatible with type "xy" = "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]
@@ -246,8 +246,8 @@ let swap : xy -> yx = yx_id
 Line 1, characters 22-27:
 1 | let swap : xy -> yx = yx_id
                           ^^^^^
-Error: The value "yx_id" has type "yx -> yx"
-       but an expression was expected of type "xy -> yx"
+Error: The value "yx_id" has type "(|yx|) -> yx"
+       but an expression was expected of type "(|xy|) -> yx"
        Type "yx" = "(|y:|)int * (|x:|)int" is not compatible with type "xy" = "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuple_patterns.ml
@@ -204,8 +204,8 @@ let swap (~x, ~y) = (~x, ~y : yx)
 Line 1, characters 21-27:
 1 | let swap (~x, ~y) = (~x, ~y : yx)
                          ^^^^^^
-Error: This expression has type "x:'a * y:'b"
-       but an expression was expected of type "yx" = "y:int * x:int"
+Error: This expression has type "(|x:|)'a * (|y:|)'b"
+       but an expression was expected of type "yx" = "(|y:|)int * (|x:|)int"
        Labels "x" and "y" do not match
 |}]
 
@@ -214,8 +214,8 @@ let swap (pt : xy) : yx = pt
 Line 1, characters 26-28:
 1 | let swap (pt : xy) : yx = pt
                               ^^
-Error: The value "pt" has type "xy" = "x:int * y:int"
-       but an expression was expected of type "yx" = "y:int * x:int"
+Error: The value "pt" has type "xy" = "(|x:|)int * (|y:|)int"
+       but an expression was expected of type "yx" = "(|y:|)int * (|x:|)int"
        Labels "x" and "y" do not match
 |}]
 
@@ -226,7 +226,7 @@ Line 1, characters 22-28:
                           ^^^^^^
 Error: The value "Fun.id" has type "xy -> xy"
        but an expression was expected of type "xy -> yx"
-       Type "xy" = "x:int * y:int" is not compatible with type "yx" = "y:int * x:int"
+       Type "xy" = "(|x:|)int * (|y:|)int" is not compatible with type "yx" = "(|y:|)int * (|x:|)int"
        Labels "x" and "y" do not match
 |}]
 
@@ -237,7 +237,7 @@ Line 1, characters 22-27:
                           ^^^^^
 Error: The value "xy_id" has type "(y:int * x:int) -> xy"
        but an expression was expected of type "xy -> yx"
-       Type "y:int * x:int" is not compatible with type "xy" = "x:int * y:int"
+       Type "(|y:|)int * (|x:|)int" is not compatible with type "xy" = "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]
 
@@ -248,7 +248,7 @@ Line 1, characters 22-27:
                           ^^^^^
 Error: The value "yx_id" has type "yx -> yx"
        but an expression was expected of type "xy -> yx"
-       Type "yx" = "y:int * x:int" is not compatible with type "xy" = "x:int * y:int"
+       Type "yx" = "(|y:|)int * (|x:|)int" is not compatible with type "xy" = "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]
 
@@ -539,8 +539,8 @@ val f : (x:int * y:int) -> int = <fun>
 Line 4, characters 21-27:
 4 |   (f z, match z with ~y, ~x -> x + y)
                          ^^^^^^
-Error: This pattern matches values of type "y:'a * x:'b"
-       but a pattern was expected which matches values of type "x:int * y:int"
+Error: This pattern matches values of type "(|y:|)'a * (|x:|)'b"
+       but a pattern was expected which matches values of type "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]
 
@@ -553,8 +553,8 @@ val f : (x:int * y:int) -> int = <fun>
 Line 4, characters 34-35:
 4 |   match z with ~y, ~x -> x + y, f z
                                       ^
-Error: The value "z" has type "y:int * x:int"
-       but an expression was expected of type "x:int * y:int"
+Error: The value "z" has type "(|y:|)int * (|x:|)int"
+       but an expression was expected of type "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]
 

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
@@ -46,8 +46,8 @@ let (x : x:string * int) = ~x:1, 2
 Line 1, characters 30-31:
 1 | let (x : x:string * int) = ~x:1, 2
                                   ^
-Error: The constant "1" has type "int" but an expression was expected of type
-         "string"
+Error: The constant "1" has type "(|int|)" but an expression was expected of type
+         "(|string|)"
 |}]
 
 let (x : int * y:int) = ~x:1, 2
@@ -174,7 +174,7 @@ and b = 2, ~lbl:a
 Line 2, characters 16-17:
 2 | and b = 2, ~lbl:a
                     ^
-Error: The value "a" has type "int * lbl:(int * lbl:'a)"
+Error: The value "a" has type "int * lbl:(int * lbl:(|'a|))"
        but an expression was expected of type "'a"
        The type variable "'a" occurs inside "int * lbl:(int * lbl:'a)"
 |}]
@@ -238,7 +238,7 @@ let z = ~(x:string), ~y:"baz";;
 Line 1, characters 10-11:
 1 | let z = ~(x:string), ~y:"baz";;
               ^
-Error: The value "x" has type "int" but an expression was expected of type "string"
+Error: The value "x" has type "(|int|)" but an expression was expected of type "(|string|)"
 |}];;
 
 (* Take a [a:'a * b:'a] and an int, and returns a

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
@@ -175,7 +175,7 @@ Line 2, characters 16-17:
 2 | and b = 2, ~lbl:a
                     ^
 Error: The value "a" has type "int * lbl:(int * lbl:(|'a|))"
-       but an expression was expected of type "'a"
+       but an expression was expected of type "(|'a|)"
        The type variable "'a" occurs inside "int * lbl:(int * lbl:'a)"
 |}]
 

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples.ml
@@ -35,8 +35,8 @@ let (x : int * int) = ~x:1, 2
 Line 1, characters 22-29:
 1 | let (x : int * int) = ~x:1, 2
                           ^^^^^^^
-Error: This expression has type "x:'a * 'b"
-       but an expression was expected of type "int * int"
+Error: This expression has type "(|x:|)'a * 'b"
+       but an expression was expected of type "(||)int * int"
        The first tuple element is labeled "x",
        but an unlabeled element was expected
 |}]
@@ -55,8 +55,8 @@ let (x : int * y:int) = ~x:1, 2
 Line 1, characters 24-31:
 1 | let (x : int * y:int) = ~x:1, 2
                             ^^^^^^^
-Error: This expression has type "x:'a * 'b"
-       but an expression was expected of type "int * y:int"
+Error: This expression has type "(|x:|)'a * (||)'b"
+       but an expression was expected of type "(||)int * (|y:|)int"
        The first tuple element is labeled "x",
        but an unlabeled element was expected
 |}]
@@ -80,8 +80,8 @@ else
 Line 4, characters 3-24:
 4 |    ~a: "5", 10, ~c: "hi"
        ^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "a:string * int * c:'a"
-       but an expression was expected of type "a:string * int * string"
+Error: This expression has type "a:string * int * (|c:|)'a"
+       but an expression was expected of type "a:string * int * (||)string"
        The first tuple element is labeled "c",
        but an unlabeled element was expected
 |}]
@@ -95,7 +95,7 @@ else
 Line 4, characters 3-24:
 4 |    ~a: "5", 10, ~c: "hi"
        ^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "a:'a * 'b * c:'c"
+Error: This expression has type "a:'a * 'b * (|c:|)'c"
        but an expression was expected of type "a:string * int"
 |}]
 
@@ -108,8 +108,8 @@ else
 Line 4, characters 3-24:
 4 |    ~a: "5", 10, ~c: "hi"
        ^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "a:string * int * c:'a"
-       but an expression was expected of type "a:string * int * b:string"
+Error: This expression has type "a:string * int * (|c:|)'a"
+       but an expression was expected of type "a:string * int * (|b:|)string"
        Labels "c" and "b" do not match
 |}]
 
@@ -162,8 +162,8 @@ let a = choose_pt true (~y: 6, ~x: 5)
 Line 1, characters 23-37:
 1 | let a = choose_pt true (~y: 6, ~x: 5)
                            ^^^^^^^^^^^^^^
-Error: This expression has type "y:'a * x:'b"
-       but an expression was expected of type "x:int * y:int"
+Error: This expression has type "(|y:|)'a * (|x:|)'b"
+       but an expression was expected of type "(|x:|)int * (|y:|)int"
        Labels "y" and "x" do not match
 |}]
 
@@ -275,8 +275,8 @@ let x: string * a:int * int = ~lbl:5, "hi"
 Line 1, characters 30-42:
 1 | let x: string * a:int * int = ~lbl:5, "hi"
                                   ^^^^^^^^^^^^
-Error: This expression has type "lbl:'a * 'b"
-       but an expression was expected of type "string * a:int * int"
+Error: This expression has type "(|lbl:|)'a * (||)'b"
+       but an expression was expected of type "(||)string * (|a:|)int * (|int|)"
 |}]
 
 (* Well-typed *)
@@ -320,8 +320,8 @@ let _ = { x = ~foo:1, ~bar:2}
 Line 1, characters 14-28:
 1 | let _ = { x = ~foo:1, ~bar:2}
                   ^^^^^^^^^^^^^^
-Error: This expression has type "foo:'a * bar:'b"
-       but an expression was expected of type "int * int"
+Error: This expression has type "(|foo:|)'a * (|bar:|)'b"
+       but an expression was expected of type "(||)int * (||)int"
        The first tuple element is labeled "foo",
        but an unlabeled element was expected
 |}]
@@ -336,8 +336,8 @@ let _ : tx = {x = 1, ~bar:2}
 Line 1, characters 18-27:
 1 | let _ : tx = {x = 1, ~bar:2}
                       ^^^^^^^^^
-Error: This expression has type "'a * bar:'b"
-       but an expression was expected of type "foo:int * bar:int"
+Error: This expression has type "(||)'a * bar:'b"
+       but an expression was expected of type "(|foo:|)int * bar:int"
        A label "foo" was expected
 |}]
 
@@ -346,8 +346,8 @@ let _ : tx = { x = ~foo:1, 2}
 Line 1, characters 19-28:
 1 | let _ : tx = { x = ~foo:1, 2}
                        ^^^^^^^^^
-Error: This expression has type "foo:int * 'a"
-       but an expression was expected of type "foo:int * bar:int"
+Error: This expression has type "foo:int * (||)'a"
+       but an expression was expected of type "foo:int * (|bar:|)int"
        A label "bar" was expected
 |}]
 
@@ -356,8 +356,8 @@ let _ : tx = { x = 1, 2}
 Line 1, characters 19-23:
 1 | let _ : tx = { x = 1, 2}
                        ^^^^
-Error: This expression has type "'a * 'b"
-       but an expression was expected of type "foo:int * bar:int"
+Error: This expression has type "(||)'a * (||)'b"
+       but an expression was expected of type "(|foo:|)int * (|bar:|)int"
        A label "foo" was expected
 |}]
 
@@ -491,7 +491,7 @@ Error: Signature mismatch:
          type t = x:int * int
        is not included in
          type t = y:int * int
-       The type "x:int * int" is not equal to the type "y:int * int"
+       The type "(|x:|)int * int" is not equal to the type "(|y:|)int * int"
 |}]
 
 module Int_int : sig
@@ -510,7 +510,7 @@ Error: Signature mismatch:
          type t = x:int * int
        is not included in
          type t = int * int
-       The type "x:int * int" is not equal to the type "int * int"
+       The type "(|x:|)int * int" is not equal to the type "(||)int * int"
 |}]
 
 (* Recursive modules *)

--- a/testsuite/tests/typing-labeled-tuples/labeled_tuples_and_constructors.ml
+++ b/testsuite/tests/typing-labeled-tuples/labeled_tuples_and_constructors.ml
@@ -62,8 +62,8 @@ let _ = f (Foo (5,1))
 Line 1, characters 15-20:
 1 | let _ = f (Foo (5,1))
                    ^^^^^
-Error: This expression has type "'a * 'b"
-       but an expression was expected of type "x:int * int"
+Error: This expression has type "(||)'a * 'b"
+       but an expression was expected of type "(|x:|)int * int"
        A label "x" was expected
 |}]
 
@@ -72,8 +72,8 @@ let _ = f (Foo (5,~x:1))
 Line 1, characters 15-23:
 1 | let _ = f (Foo (5,~x:1))
                    ^^^^^^^^
-Error: This expression has type "'a * x:'b"
-       but an expression was expected of type "x:int * int"
+Error: This expression has type "(||)'a * (|x:|)'b"
+       but an expression was expected of type "(|x:|)int * (||)int"
        A label "x" was expected
 |}]
 
@@ -82,7 +82,7 @@ let _ = f (Foo (5,~y:1))
 Line 1, characters 15-23:
 1 | let _ = f (Foo (5,~y:1))
                    ^^^^^^^^
-Error: This expression has type "'a * y:'b"
-       but an expression was expected of type "x:int * int"
+Error: This expression has type "(||)'a * (|y:|)'b"
+       but an expression was expected of type "(|x:|)int * (||)int"
        A label "x" was expected
 |}]

--- a/testsuite/tests/typing-labels/pr13658.ml
+++ b/testsuite/tests/typing-labels/pr13658.ml
@@ -54,9 +54,9 @@ let f g = g ?x:(g ?x:(Some g)) 0
 Line 1, characters 15-30:
 1 | let f g = g ?x:(g ?x:(Some g)) 0
                    ^^^^^^^^^^^^^^^
-Error: This expression has type "'a -> 'b"
+Error: This expression has type "'a (|->|) 'b"
        but an expression was expected of type
-         "(?x:'c -> 'a -> 'b as 'c) option"
+         "(?x:'c -> 'a -> 'b as 'c) (|option|)"
 Hint: This function application is partial, maybe some arguments are missing.
 |}]
 

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -283,7 +283,7 @@ Line 3, characters 13-23:
 3 |   constraint 'a = float
                  ^^^^^^^^^^
 Error: The type constraints are not consistent.
-       Type "int" is not compatible with type "float"
+       Type "(|int|)" is not compatible with type "(|float|)"
 |}]
 
 type ('a,'b) t = T
@@ -296,7 +296,7 @@ Line 4, characters 13-20:
                  ^^^^^^^
 Error: The type constraints are not consistent.
        Type "(|int|) -> float" is not compatible with type "(|bool|) -> char"
-       Type "int" is not compatible with type "bool"
+       Type "(|int|)" is not compatible with type "(|bool|)"
 |}]
 
 class type ['a, 'b] a = object
@@ -310,7 +310,7 @@ Line 4, characters 2-31:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The class constraints are not consistent.
        Type "(|int|) * int" is not compatible with type "(|float|) * float"
-       Type "int" is not compatible with type "float"
+       Type "(|int|)" is not compatible with type "(|float|)"
 |}]
 
 (* #11101 *)
@@ -434,8 +434,8 @@ and r = [s cstr t | `Bar]
 Line 1, characters 0-12:
 1 | type s = int
     ^^^^^^^^^^^^
-Error: This type constructor expands to type "s" = "int"
-       but is used here with type "float"
+Error: This type constructor expands to type "s" = "(|int|)"
+       but is used here with type "(|float|)"
 |}]
 
 
@@ -448,7 +448,7 @@ Line 1, characters 0-22:
 1 | type 'a t = 'a foo foo
     ^^^^^^^^^^^^^^^^^^^^^^
 Error: Constraints are not satisfied in this type.
-       Type "'a foo" should be an instance of "int"
+       Type "'a (|foo|)" should be an instance of "(|int|)"
        Type "foo" was considered abstract when checking constraints in this
        recursive type definition.
 |}]
@@ -473,7 +473,7 @@ type 'a t3 = < m : 'b. (int -> 'b) as 'a >
 Line 1, characters 23-40:
 1 | type 'a t3 = < m : 'b. (int -> 'b) as 'a >
                            ^^^^^^^^^^^^^^^^^
-Error: This type "'a" should be an instance of type "int -> 'b"
+Error: This type "'a" should be an instance of type "int -> (|'b|)"
        The universal variable "'b" would escape its scope
 |}]
 
@@ -483,7 +483,7 @@ type 'a t4 = < m : 'b. int -> ('b as 'a) > * 'a
 Line 1, characters 31-39:
 1 | type 'a t4 = < m : 'b. int -> ('b as 'a) > * 'a
                                    ^^^^^^^^
-Error: This type "'a" should be an instance of type "'b"
+Error: This type "'a" should be an instance of type "(|'b|)"
        The universal variable "'b" would escape its scope
 |}]
 
@@ -495,6 +495,6 @@ end
 Line 2, characters 17-34:
 2 |   method m : 'b. (int -> 'b) as 'a
                      ^^^^^^^^^^^^^^^^^
-Error: This type "'a" should be an instance of type "int -> 'b"
+Error: This type "'a" should be an instance of type "int -> (|'b|)"
        The universal variable "'b" would escape its scope
 |}]

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -295,7 +295,7 @@ Line 4, characters 13-20:
 4 |   constraint 'a = 'b
                  ^^^^^^^
 Error: The type constraints are not consistent.
-       Type "int -> float" is not compatible with type "bool -> char"
+       Type "(|int|) -> float" is not compatible with type "(|bool|) -> char"
        Type "int" is not compatible with type "bool"
 |}]
 
@@ -309,7 +309,7 @@ Line 4, characters 2-31:
 4 |   constraint 'b = float * float
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The class constraints are not consistent.
-       Type "int * int" is not compatible with type "float * float"
+       Type "(|int|) * int" is not compatible with type "(|float|) * float"
        Type "int" is not compatible with type "float"
 |}]
 

--- a/testsuite/tests/typing-misc/deep.ml
+++ b/testsuite/tests/typing-misc/deep.ml
@@ -21,7 +21,7 @@ Error: Signature mismatch:
          val x : bool * string
        is not included in
          val x : bool * int
-       The type "bool * string" is not compatible with the type "bool * int"
+       The type "bool * (|string|)" is not compatible with the type "bool * (|int|)"
        Type "string" is not compatible with type "int"
 |}]
 
@@ -44,8 +44,8 @@ Error: Signature mismatch:
          val f : int -> int
        is not included in
          val f : int -> (float * string option) list
-       The type "int -> int" is not compatible with the type
-         "int -> (float * string option) list"
+       The type "int -> (|int|)" is not compatible with the type
+         "int -> (float * string option) (|list|)"
        Type "int" is not compatible with type "(float * string option) list"
 |}]
 
@@ -69,8 +69,8 @@ Error: Signature mismatch:
          val f : 'c list * 'd option -> int
        is not included in
          val f : 'a list * 'b list -> int
-       The type "'a list * 'b option -> int" is not compatible with the type
-         "'a list * 'c list -> int"
+       The type "'a list * 'b (|option|) -> int" is not compatible with the type
+         "'a list * 'c (|list|) -> int"
        Type "'b option" is not compatible with type "'c list"
 |}]
 
@@ -93,6 +93,6 @@ Error: Signature mismatch:
          type t = bool * float
        is not included in
          type t = int * float
-       The type "bool * float" is not equal to the type "int * float"
+       The type "(|bool|) * float" is not equal to the type "(|int|) * float"
        Type "bool" is not equal to type "int"
 |}]

--- a/testsuite/tests/typing-misc/deep.ml
+++ b/testsuite/tests/typing-misc/deep.ml
@@ -22,7 +22,7 @@ Error: Signature mismatch:
        is not included in
          val x : bool * int
        The type "bool * (|string|)" is not compatible with the type "bool * (|int|)"
-       Type "string" is not compatible with type "int"
+       Type "(|string|)" is not compatible with type "(|int|)"
 |}]
 
 module T : sig
@@ -46,7 +46,7 @@ Error: Signature mismatch:
          val f : int -> (float * string option) list
        The type "int -> (|int|)" is not compatible with the type
          "int -> (float * string option) (|list|)"
-       Type "int" is not compatible with type "(float * string option) list"
+       Type "(|int|)" is not compatible with type "(float * string option) (|list|)"
 |}]
 
 (* Alpha-equivalence *)
@@ -71,7 +71,7 @@ Error: Signature mismatch:
          val f : 'a list * 'b list -> int
        The type "'a list * 'b (|option|) -> int" is not compatible with the type
          "'a list * 'c (|list|) -> int"
-       Type "'b option" is not compatible with type "'c list"
+       Type "'b (|option|)" is not compatible with type "'c (|list|)"
 |}]
 
 module T : sig
@@ -94,5 +94,5 @@ Error: Signature mismatch:
        is not included in
          type t = int * float
        The type "(|bool|) * float" is not equal to the type "(|int|) * float"
-       Type "bool" is not equal to type "int"
+       Type "(|bool|)" is not equal to type "(|int|)"
 |}]

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -31,7 +31,7 @@ Error: Signature mismatch:
          type t = A.t = A | B
        is not included in
          type t = int * string
-       The type "A.t" is not equal to the type "int * string"
+       The type "(|A.t|)" is not equal to the type "int (|*|) string"
 |}]
 
 module rec B : sig
@@ -63,7 +63,7 @@ Error: Signature mismatch:
          type 'a t = 'a B.t = A of 'a | B
        is not included in
          type 'a t = 'a
-       The type "'a B.t" is not equal to the type "'a"
+       The type "'a (|B.t|)" is not equal to the type "(|'a|)"
 |}];;
 
 module rec C : sig
@@ -128,7 +128,7 @@ Error: Signature mismatch:
          type 'a t = 'a D.t = A of 'a | B
        is not included in
          type 'a t = int
-       The type "'a D.t" is not equal to the type "int"
+       The type "'a (|D.t|)" is not equal to the type "(|int|)"
 |}];;
 
 module rec E : sig
@@ -192,7 +192,7 @@ Error: Signature mismatch:
          type 'a t = 'a E2.t = A of 'a | B
        is not included in
          type 'a t = [ `Foo ]
-       The type "'a E2.t" is not equal to the type "[ `Foo ]"
+       The type "'a (|E2.t|)" is not equal to the type "(|[ `Foo ]|)"
 |}];;
 
 module rec E3 : sig

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -160,7 +160,7 @@ Error: Signature mismatch:
          type 'a t = 'a E.t = A of 'a | B
        is not included in
          type 'a t = 'a constraint 'a = [> `Foo ]
-       The type "'a" is not equal to the type "[> `Foo ]"
+       The type "(|'a|)" is not equal to the type "[> `Foo ]"
 |}];;
 
 module rec E2 : sig
@@ -224,7 +224,7 @@ Error: Signature mismatch:
          type 'a t = 'a E3.t = A of 'a | B
        is not included in
          type 'a t = 'a constraint 'a = [< `Foo ]
-       The type "'a" is not equal to the type "[< `Foo ]"
+       The type "(|'a|)" is not equal to the type "[< `Foo ]"
 |}];;
 
 
@@ -262,5 +262,5 @@ Error: Signature mismatch:
          "Foo of 'b"
        is not the same as:
          "Foo of 'a"
-       The type "'b" is not equal to the type "'a"
+       The type "(|'b|)" is not equal to the type "(|'a|)"
 |}];;

--- a/testsuite/tests/typing-misc/exotic_unifications.ml
+++ b/testsuite/tests/typing-misc/exotic_unifications.ml
@@ -13,7 +13,7 @@ Line 4, characters 8-17:
 4 |         inherit t
             ^^^^^^^^^
 Error: The method "x" has type "(|int|)" but is expected to have type "(|float|)"
-       Type "int" is not compatible with type "float"
+       Type "(|int|)" is not compatible with type "(|float|)"
 |}]
 
 let x =

--- a/testsuite/tests/typing-misc/exotic_unifications.ml
+++ b/testsuite/tests/typing-misc/exotic_unifications.ml
@@ -12,7 +12,7 @@ class virtual t : object method virtual x : float end
 Line 4, characters 8-17:
 4 |         inherit t
             ^^^^^^^^^
-Error: The method "x" has type "int" but is expected to have type "float"
+Error: The method "x" has type "(|int|)" but is expected to have type "(|float|)"
        Type "int" is not compatible with type "float"
 |}]
 

--- a/testsuite/tests/typing-misc/exp_denom.ml
+++ b/testsuite/tests/typing-misc/exp_denom.ml
@@ -10,8 +10,8 @@ let f (x : < m : float >) = print_int x#m
 Line 1, characters 38-41:
 1 | let f (x : < m : float >) = print_int x#m
                                           ^^^
-Error: The method call "x#m" has type "float"
-       but an expression was expected of type "int"
+Error: The method call "x#m" has type "(|float|)"
+       but an expression was expected of type "(|int|)"
 |}]
 
 type r = { f : float }
@@ -23,8 +23,8 @@ type r = { f : float; }
 Line 3, characters 26-29:
 3 | let f (x : r) = print_int x.f
                               ^^^
-Error: The field access "x.f" has type "float"
-       but an expression was expected of type "int"
+Error: The field access "x.f" has type "(|float|)"
+       but an expression was expected of type "(|int|)"
 |}]
 
 type v = Cons
@@ -46,7 +46,7 @@ Line 1, characters 18-23:
 1 | let _ = print_int `Cons
                       ^^^^^
 Error: The constructor "`Cons" has type "[> `Cons ]"
-       but an expression was expected of type "int"
+       but an expression was expected of type "(|int|)"
 |}]
 
 let v = 0.
@@ -57,7 +57,7 @@ val v : float = 0.
 Line 2, characters 18-19:
 2 | let _ = print_int v
                       ^
-Error: The value "v" has type "float" but an expression was expected of type "int"
+Error: The value "v" has type "(|float|)" but an expression was expected of type "(|int|)"
 |}]
 
 let _ = print_int 0.
@@ -66,8 +66,8 @@ let _ = print_int 0.
 Line 1, characters 18-20:
 1 | let _ = print_int 0.
                       ^^
-Error: The constant "0." has type "float" but an expression was expected of type
-         "int"
+Error: The constant "0." has type "(|float|)" but an expression was expected of type
+         "(|int|)"
 |}]
 
 let _ = print_int "foo"
@@ -76,8 +76,8 @@ let _ = print_int "foo"
 Line 1, characters 18-23:
 1 | let _ = print_int "foo"
                       ^^^^^
-Error: This constant has type "string" but an expression was expected of type
-         "int"
+Error: This constant has type "(|string|)" but an expression was expected of type
+         "(|int|)"
 |}]
 
 let _ : int = while false do () done
@@ -86,8 +86,8 @@ let _ : int = while false do () done
 Line 1, characters 14-36:
 1 | let _ : int = while false do () done
                   ^^^^^^^^^^^^^^^^^^^^^^
-Error: This "while" expression has type "unit"
-       but an expression was expected of type "int"
+Error: This "while" expression has type "(|unit|)"
+       but an expression was expected of type "(|int|)"
 |}]
 
 let _ : int = for _ = 1 to 2 do () done
@@ -96,6 +96,6 @@ let _ : int = for _ = 1 to 2 do () done
 Line 1, characters 14-39:
 1 | let _ : int = for _ = 1 to 2 do () done
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This "for" expression has type "unit"
-       but an expression was expected of type "int"
+Error: This "for" expression has type "(|unit|)"
+       but an expression was expected of type "(|int|)"
 |}]

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -111,7 +111,7 @@ Error: Signature mismatch:
            object constraint 'a = int method private id : 'a -> int end
        does not match
          class ['x, 'y] c : object  end
-       The 1st type parameter has type "int" but is expected to have type "'x"
+       The 1st type parameter has type "(|int|)" but is expected to have type "(|'x|)"
 |}]
 
 module M: sig
@@ -134,7 +134,7 @@ Error: Signature mismatch:
          class ['a] c : object  end
        does not match
          class ['a] c : object constraint 'a = int end
-       The 1st type parameter has type "'a" but is expected to have type "int"
+       The 1st type parameter has type "(|'a|)" but is expected to have type "(|int|)"
 |}]
 
 module M: sig
@@ -157,7 +157,7 @@ Error: Signature mismatch:
          class ['a, 'b] c : object  end
        does not match
          class ['a, 'b] c : object constraint 'b = int end
-       The 2nd type parameter has type "'b" but is expected to have type "int"
+       The 2nd type parameter has type "(|'b|)" but is expected to have type "(|int|)"
 |}]
 
 module M: sig
@@ -180,7 +180,7 @@ Error: Signature mismatch:
          class c : float -> object  end
        does not match
          class c : int -> object  end
-       The 1st parameter has type "float" but is expected to have type "int"
+       The 1st parameter has type "(|float|)" but is expected to have type "(|int|)"
 |}]
 
 module M: sig
@@ -203,7 +203,7 @@ Error: Signature mismatch:
          class c : int -> float -> object  end
        does not match
          class c : int -> int -> object  end
-       The 2nd parameter has type "float" but is expected to have type "int"
+       The 2nd parameter has type "(|float|)" but is expected to have type "(|int|)"
 |}]
 
 class virtual foo: foo_t =

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -170,7 +170,7 @@ let () = expect_unlabeled labeled
 Line 1, characters 26-33:
 1 | let () = expect_unlabeled labeled
                               ^^^^^^^
-Error: The value "labeled" has type "x:'a -> unit"
+Error: The value "labeled" has type "(|x|):'a -> unit"
        but an expression was expected of type "unit -> unit"
        The first argument is labeled "x",
        but an unlabeled argument was expected
@@ -182,7 +182,7 @@ Line 1, characters 24-33:
 1 | let () = expect_labeled unlabeled
                             ^^^^^^^^^
 Error: The value "unlabeled" has type "'a -> unit"
-       but an expression was expected of type "x:'b -> unit"
+       but an expression was expected of type "(|x|):'b -> unit"
        A label "x" was expected
 |}]
 
@@ -191,7 +191,7 @@ let () = expect_labeled wrong_label
 Line 1, characters 24-35:
 1 | let () = expect_labeled wrong_label
                             ^^^^^^^^^^^
-Error: The value "wrong_label" has type "y:'a -> unit"
-       but an expression was expected of type "x:'b -> unit"
+Error: The value "wrong_label" has type "(|y|):'a -> unit"
+       but an expression was expected of type "(|x|):'b -> unit"
        Labels "y" and "x" do not match
 |}]

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -17,8 +17,8 @@ and g (x : string) = f ()
 Line 1, characters 17-19:
 1 | let rec f () = g 42
                      ^^
-Error: The constant "42" has type "int" but an expression was expected of type
-         "string"
+Error: The constant "42" has type "(|int|)" but an expression was expected of type
+         "(|string|)"
 |}]
 
 let rec opt_error ?(opt : string) () = f ?opt ()
@@ -26,8 +26,8 @@ let rec opt_error ?(opt : string) () = f ?opt ()
 Line 1, characters 20-32:
 1 | let rec opt_error ?(opt : string) () = f ?opt ()
                         ^^^^^^^^^^^^
-Error: This pattern matches values of type "string"
-       but a pattern was expected which matches values of type "'a option"
+Error: This pattern matches values of type "(|string|)"
+       but a pattern was expected which matches values of type "'a (|option|)"
 |}]
 
 let rec opt_ok_f () = opt_ok_g ~foo:A ~bar:A ()

--- a/testsuite/tests/typing-misc/letitem.ml
+++ b/testsuite/tests/typing-misc/letitem.ml
@@ -9,7 +9,7 @@ let _ =
 Line 3, characters 2-3:
 3 |   A
       ^
-Error: The constructor "A" has type "t" but an expression was expected of type "'a"
+Error: The constructor "A" has type "(|t|)" but an expression was expected of type "'a"
        The type constructor "t" would escape its scope
 |}];;
 
@@ -21,7 +21,7 @@ let _ =
 Line 4, characters 2-3:
 4 |   A
       ^
-Error: The constructor "A" has type "t" but an expression was expected of type "'a"
+Error: The constructor "A" has type "(|t|)" but an expression was expected of type "'a"
        The type constructor "t" would escape its scope
 |}];;
 

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -12,7 +12,7 @@ Line 2, characters 42-43:
 2 | let f (g : 'a list -> 'a t -> 'a) s = g s s;;
                                               ^
 Error: The value "s" has type "(|'a|) list" but an expression was expected of type
-         "'a t" = "'a"
+         "(|'a|) t" = "(|'a|)"
        The type variable "'a" occurs inside "'a list"
 |}];;
 
@@ -22,7 +22,7 @@ Line 1, characters 42-43:
 1 | let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
                                               ^
 Error: The value "s" has type "(|'a|) * 'b" but an expression was expected of type
-         "'a t" = "'a"
+         "(|'a|) t" = "(|'a|)"
        The type variable "'a" occurs inside "'a * 'b"
 |}];;
 
@@ -72,5 +72,5 @@ Line 1, characters 12-48:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "('a Seq.t as 'a) Seq.t (|->|) 'a Seq.t Seq.t list"
        but an expression was expected of type
-         "('a Seq.t as 'a) Seq.t (|->|) 'a Seq.t Seq.t list"
+         "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
 |}];;

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -11,7 +11,7 @@ type 'a t = 'a
 Line 2, characters 42-43:
 2 | let f (g : 'a list -> 'a t -> 'a) s = g s s;;
                                               ^
-Error: The value "s" has type "'a list" but an expression was expected of type
+Error: The value "s" has type "(|'a|) list" but an expression was expected of type
          "'a t" = "'a"
        The type variable "'a" occurs inside "'a list"
 |}];;
@@ -21,7 +21,7 @@ let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
 Line 1, characters 42-43:
 1 | let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
                                               ^
-Error: The value "s" has type "'a * 'b" but an expression was expected of type
+Error: The value "s" has type "(|'a|) * 'b" but an expression was expected of type
          "'a t" = "'a"
        The type variable "'a" occurs inside "'a * 'b"
 |}];;
@@ -70,7 +70,7 @@ let strange x = Seq.[cons x empty; cons empty x];;
 Line 1, characters 12-48:
 1 | let strange x = Seq.[cons x empty; cons empty x];;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
+Error: This expression has type "('a Seq.t as 'a) Seq.t (|->|) 'a Seq.t Seq.t list"
        but an expression was expected of type
-         "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
+         "('a Seq.t as 'a) Seq.t (|->|) 'a Seq.t Seq.t list"
 |}];;

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -247,7 +247,7 @@ Line 5, characters 25-26:
                              ^
 Error: The value "x" has type "[ `X of int ]"
        but an expression was expected of type "[ `X ]"
-       Types for tag "`X" are incompatible
+       Arities for tag "`X" are incompatible.
 |}]
 
 
@@ -258,7 +258,7 @@ Line 1, characters 25-26:
                              ^
 Error: The value "x" has type "[ `X of int ]"
        but an expression was expected of type "[< `X of & int ]"
-       Types for tag "`X" are incompatible
+       Arities for tag "`X" are incompatible.
 |}]
 
 (** Inconsistent type *)
@@ -270,7 +270,7 @@ Line 3, characters 36-37:
                                         ^
 Error: The value "x" has type "[< `X of & int & float ]"
        but an expression was expected of type "[ `X ]"
-       Types for tag "`X" are incompatible
+       Arities for tag "`X" are incompatible.
 |}]
 
 
@@ -302,7 +302,7 @@ Line 4, characters 10-50:
 4 | let f x = (x : [ `Foo of int ] :> [ `Foo | `Bar ])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "[ `Foo of int ]" is not a subtype of "[ `Bar | `Foo ]"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}]
 
 let f x = (x : [ `Foo of int ] list :> [ `Foo | `Bar ] list)
@@ -312,7 +312,7 @@ Line 1, characters 10-60:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "[ `Foo of int ] list" is not a subtype of "[ `Bar | `Foo ] list"
        Type "[ `Foo of int ]" is not a subtype of "[ `Bar | `Foo ]"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}]
 
 (** When typing pattern match containing possibly absent polymorphic variants,
@@ -328,4 +328,29 @@ Error: This pattern matches values of type "[< `A ] * unit * 'a option"
        but a pattern was expected which matches values of type
          "[< `A ] * unit * unit"
        Type "'a option" is not compatible with type "unit"
+|}]
+
+
+(** Present tag arities must be consistent *)
+let f x =
+  let u = match x with
+  | `A 0 -> [x]
+  in
+let v = match x with
+  | `A -> [x]
+  in
+  [ `A; x]
+[%%expect {|
+Lines 2-3, characters 10-15:
+2 | ..........match x with
+3 |   | `A 0 -> [x]
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "`A 1"
+
+Line 8, characters 8-9:
+8 |   [ `A; x]
+            ^
+Error: The value "x" has type "[< `A of & int ]"
+       but an expression was expected of type "[> `A ]"
+       Arities for tag "`A" are incompatible.
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -285,7 +285,7 @@ val f : ([< `A | `B of string | `R of 'a ] as 'a) -> int = <fun>
 Line 4, characters 30-31:
 4 | let g (x:[`A | `R of rt]) = f x
                                   ^
-Error: The value "x" has type "[ `A | `R of rt ]"
+Error: The value "x" has type "[ `A | `R of (|rt|) ]"
        but an expression was expected of type "[< `A | `R of 'a ] as 'a"
        In tag "`R", type "rt" = "[ `A | `B of string | `R of rt ]"
        is not compatible with type "[< `A | `R of 'a ] as 'a"
@@ -310,7 +310,7 @@ let f x = (x : [ `Foo of int ] list :> [ `Foo | `Bar ] list)
 Line 1, characters 10-60:
 1 | let f x = (x : [ `Foo of int ] list :> [ `Foo | `Bar ] list)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "[ `Foo of int ] list" is not a subtype of "[ `Bar | `Foo ] list"
+Error: Type "(|[ `Foo of int ]|) list" is not a subtype of "(|[ `Bar | `Foo ]|) list"
        Type "[ `Foo of int ]" is not a subtype of "[ `Bar | `Foo ]"
        Arities for tag "`Foo" are incompatible.
 |}]
@@ -324,9 +324,9 @@ let f (x: [< `A] * 'a * ' a ) = match x with
 Line 2, characters 4-13:
 2 |   | `A , _, _ -> ()
         ^^^^^^^^^
-Error: This pattern matches values of type "[< `A ] * unit * 'a option"
+Error: This pattern matches values of type "[< `A ] * unit * 'a (|option|)"
        but a pattern was expected which matches values of type
-         "[< `A ] * unit * unit"
+         "[< `A ] * unit * (|unit|)"
        Type "'a option" is not compatible with type "unit"
 |}]
 

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -257,7 +257,7 @@ Line 1, characters 25-26:
 1 | let f (x:[`X of int]) = (x:[<`X of & int])
                              ^
 Error: The value "x" has type "[ `X of int ]"
-       but an expression was expected of type "[< `X of & int ]"
+       but an expression was expected of type "[< `X of (|&|) int ]"
        Arities for tag "`X" are incompatible.
 |}]
 
@@ -268,7 +268,7 @@ let f (x:[<`X of & int & float]) = (x:[`X])
 Line 3, characters 36-37:
 3 | let f (x:[<`X of & int & float]) = (x:[`X])
                                         ^
-Error: The value "x" has type "[< `X of & int & float ]"
+Error: The value "x" has type "[< `X of (|&|) int & float ]"
        but an expression was expected of type "[ `X ]"
        Arities for tag "`X" are incompatible.
 |}]
@@ -350,7 +350,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Line 8, characters 8-9:
 8 |   [ `A; x]
             ^
-Error: The value "x" has type "[< `A of & int ]"
+Error: The value "x" has type "[< `A of (|&|) int ]"
        but an expression was expected of type "[> `A ]"
        Arities for tag "`A" are incompatible.
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -327,7 +327,7 @@ Line 2, characters 4-13:
 Error: This pattern matches values of type "[< `A ] * unit * 'a (|option|)"
        but a pattern was expected which matches values of type
          "[< `A ] * unit * (|unit|)"
-       Type "'a option" is not compatible with type "unit"
+       Type "'a (|option|)" is not compatible with type "(|unit|)"
 |}]
 
 

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -287,8 +287,8 @@ Line 4, characters 30-31:
                                   ^
 Error: The value "x" has type "[ `A | `R of rt ]"
        but an expression was expected of type "[< `A | `R of 'a ] as 'a"
-       Type "rt" = "[ `A | `B of string | `R of rt ]" is not compatible with type
-         "[< `A | `R of 'a ] as 'a"
+       In tag "`R", type "rt" = "[ `A | `B of string | `R of rt ]"
+       is not compatible with type "[< `A | `R of 'a ] as 'a"
        The second variant type does not allow tag(s) "`B"
 |}]
 

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -27,7 +27,7 @@ Error: Signature mismatch:
        is not included in
          val f : t/2 -> unit
        The type "(|t|) -> unit" is not compatible with the type "(|t/2|) -> unit"
-       Type "t" is not compatible with type "t/2"
+       Type "(|t|)" is not compatible with type "(|t/2|)"
        Line 6, characters 4-14:
          Definition of type "t"
        Line 2, characters 2-12:
@@ -56,7 +56,7 @@ Error: Signature mismatch:
          "A of t"
        is not the same as:
          "A of t/2"
-       The type "t" is not equal to the type "t/2"
+       The type "(|t|)" is not equal to the type "(|t/2|)"
        Line 4, characters 9-19:
          Definition of type "t"
        Line 2, characters 2-11:
@@ -122,7 +122,7 @@ Error: Signature mismatch:
          "A of T.t"
        is not the same as:
          "A of T/2.t"
-       The type "T.t" is not equal to the type "T/2.t"
+       The type "(|T.t|)" is not equal to the type "(|T/2.t|)"
        Line 5, characters 6-34:
          Definition of module "T"
        Line 2, characters 2-30:
@@ -184,7 +184,7 @@ Error: Signature mismatch:
          val f : a/2 -> (module a) -> a/2
        The type "a/2 -> (module a) -> (|a|)" is not compatible with the type
          "a/2 -> (module a) -> (|a/2|)"
-       Type "a" is not compatible with type "a/2"
+       Type "(|a|)" is not compatible with type "(|a/2|)"
        Line 5, characters 12-22:
          Definition of type "a"
        Line 3, characters 2-12:
@@ -314,7 +314,7 @@ Error: Signature mismatch:
        does not match
          class type c = object method m : t end
        The method m has type "(|t/2|)" but is expected to have type "(|t|)"
-       Type "t/2" is not equal to type "t" = "K.t"
+       Type "(|t/2|)" is not equal to type "t" = "(|K.t|)"
        Line 12, characters 4-10:
          Definition of type "t"
        Line 9, characters 2-8:
@@ -338,7 +338,7 @@ Error: Signature mismatch:
          type a = M.t
        is not included in
          type a = M/2.t
-       The type "M.t" = "M/2.M.t" is not equal to the type "M/2.t"
+       The type "M.t" = "(|M/2.M.t|)" is not equal to the type "(|M/2.t|)"
        Line 2, characters 14-42:
          Definition of module "M"
        File "_none_", line 1:
@@ -374,7 +374,7 @@ Error: Signature mismatch:
          val f : t -> t -> t -> t
        The type "(|t/4|) -> t/3 -> t/2 -> t" is not compatible with the type
          "(|t|) -> t -> t -> t"
-       Type "t/4" is not compatible with type "t"
+       Type "(|t/4|)" is not compatible with type "(|t|)"
        Line 4, characters 0-10:
          Definition of type "t"
        Line 3, characters 0-10:

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -26,7 +26,7 @@ Error: Signature mismatch:
          val f : t -> unit
        is not included in
          val f : t/2 -> unit
-       The type "t -> unit" is not compatible with the type "t/2 -> unit"
+       The type "(|t|) -> unit" is not compatible with the type "(|t/2|) -> unit"
        Type "t" is not compatible with type "t/2"
        Line 6, characters 4-14:
          Definition of type "t"
@@ -182,8 +182,8 @@ Error: Signature mismatch:
          val f : a/2 -> 'a -> a
        is not included in
          val f : a/2 -> (module a) -> a/2
-       The type "a/2 -> (module a) -> a" is not compatible with the type
-         "a/2 -> (module a) -> a/2"
+       The type "a/2 -> (module a) -> (|a|)" is not compatible with the type
+         "a/2 -> (module a) -> (|a/2|)"
        Type "a" is not compatible with type "a/2"
        Line 5, characters 12-22:
          Definition of type "a"
@@ -313,7 +313,7 @@ Error: Signature mismatch:
          class type c = object method m : t/2 end
        does not match
          class type c = object method m : t end
-       The method m has type "t/2" but is expected to have type "t"
+       The method m has type "(|t/2|)" but is expected to have type "(|t|)"
        Type "t/2" is not equal to type "t" = "K.t"
        Line 12, characters 4-10:
          Definition of type "t"
@@ -372,8 +372,8 @@ Error: Signature mismatch:
          val f : t/4 -> t/3 -> t/2 -> t
        is not included in
          val f : t -> t -> t -> t
-       The type "t/4 -> t/3 -> t/2 -> t" is not compatible with the type
-         "t -> t -> t -> t"
+       The type "(|t/4|) -> t/3 -> t/2 -> t" is not compatible with the type
+         "(|t|) -> t -> t -> t"
        Type "t/4" is not compatible with type "t"
        Line 4, characters 0-10:
          Definition of type "t"

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -24,7 +24,7 @@ Error: Signature mismatch:
        is not included in
          type t = [ `T of t/3 ]
        The type "[ `T of t ]" is not equal to the type "[ `T of t/2 ]"
-       Type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
+       In tag "`T", type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
        Types for tag "`T" are incompatible
        Line 4, characters 2-20:
          Definition of type "t"

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -23,7 +23,7 @@ Error: Signature mismatch:
          type t = [ `T of t ]
        is not included in
          type t = [ `T of t/3 ]
-       The type "[ `T of t ]" is not equal to the type "[ `T of t/2 ]"
+       The type "[ `T of (|t|) ]" is not equal to the type "[ `T of (|t/2|) ]"
        In tag "`T", type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
        Line 4, characters 2-20:
          Definition of type "t"

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -25,7 +25,6 @@ Error: Signature mismatch:
          type t = [ `T of t/3 ]
        The type "[ `T of t ]" is not equal to the type "[ `T of t/2 ]"
        In tag "`T", type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
-       Types for tag "`T" are incompatible
        Line 4, characters 2-20:
          Definition of type "t"
        Line 1, characters 0-12:

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -24,7 +24,7 @@ Error: Signature mismatch:
        is not included in
          type t = [ `T of t/3 ]
        The type "[ `T of (|t|) ]" is not equal to the type "[ `T of (|t/2|) ]"
-       In tag "`T", type "t" = "[ `T of t ]" is not equal to type "t/2" = "int"
+       In tag "`T", type "(|t|)" = "[ `T of (|t|) ]" is not equal to type "t/2" = "(|int|)"
        Line 4, characters 2-20:
          Definition of type "t"
        Line 1, characters 0-12:

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -25,7 +25,7 @@ Line 1, characters 27-28:
                                ^
 Error: The value "x" has type "(|a|) t" but an expression was expected of type
          "< .. > t"
-       Type "a" is not compatible with type "< .. >"
+       Type "(|a|)" is not compatible with type "< .. >"
 |}];;
 
 let _ = fun (x : a t) -> g x;;
@@ -35,7 +35,7 @@ Line 1, characters 27-28:
                                ^
 Error: The value "x" has type "(|a|) t" but an expression was expected of type
          "[< `b ] t"
-       Type "a" is not compatible with type "[< `b ]"
+       Type "(|a|)" is not compatible with type "[< `b ]"
 |}];;
 
 let _ = fun (x : a t) -> h x;;
@@ -45,5 +45,5 @@ Line 1, characters 27-28:
                                ^
 Error: The value "x" has type "(|a|) t" but an expression was expected of type
          "[> `b ] t"
-       Type "a" is not compatible with type "[> `b ]"
+       Type "(|a|)" is not compatible with type "[> `b ]"
 |}];;

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -23,7 +23,7 @@ let _ = fun (x : a t) -> f x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> f x;;
                                ^
-Error: The value "x" has type "a t" but an expression was expected of type
+Error: The value "x" has type "(|a|) t" but an expression was expected of type
          "< .. > t"
        Type "a" is not compatible with type "< .. >"
 |}];;
@@ -33,7 +33,7 @@ let _ = fun (x : a t) -> g x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> g x;;
                                ^
-Error: The value "x" has type "a t" but an expression was expected of type
+Error: The value "x" has type "(|a|) t" but an expression was expected of type
          "[< `b ] t"
        Type "a" is not compatible with type "[< `b ]"
 |}];;
@@ -43,7 +43,7 @@ let _ = fun (x : a t) -> h x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> h x;;
                                ^
-Error: The value "x" has type "a t" but an expression was expected of type
+Error: The value "x" has type "(|a|) t" but an expression was expected of type
          "[> `b ] t"
        Type "a" is not compatible with type "[> `b ]"
 |}];;

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -96,5 +96,6 @@ Error: Signature mismatch:
        Type "[> `B of [> `BA | `BB of int list ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]"
+       In tag "`BB", type "int" is not compatible with type "unit"
        Types for tag "`BB" are incompatible
 |}]

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -96,7 +96,7 @@ Error: Signature mismatch:
        Type "[> `B of [> `BA | `BB of int (|list|) ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]"
-       In tag "`BB", type "int list" is not compatible with type "unit list"
+       In tag "`BB", type "(|int|) list" is not compatible with type "(|unit|) list"
 |}, Principal{|
 Lines 8-27, characters 6-3:
  8 | ......struct
@@ -137,5 +137,5 @@ Error: Signature mismatch:
        Type "[> `B of [> `BA | `BB of int (|list|) ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit (|list|) ] | `C of unit ]"
-       In tag "`BB", type "int list" is not compatible with type "unit list"
+       In tag "`BB", type "(|int|) list" is not compatible with type "(|unit|) list"
 |}]

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -25,7 +25,7 @@ Lines 12-13, characters 35-18:
 13 | else `Right ()) xs
 Error: This expression has type "(|unit|) list * unit list"
        but an expression was expected of type "(|int|) list * int list"
-       Type "unit" is not compatible with type "int"
+       Type "(|unit|)" is not compatible with type "(|int|)"
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -96,6 +96,5 @@ Error: Signature mismatch:
        Type "[> `B of [> `BA | `BB of int list ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]"
-       In tag "`BB", type "int" is not compatible with type "unit"
-       Types for tag "`BB" are incompatible
+       In tag "`BB", type "int list" is not compatible with type "unit list"
 |}]

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -23,8 +23,8 @@ val partition_map :
 Lines 12-13, characters 35-18:
 12 | ...................................partition_map (fun x -> if x then `Left ()
 13 | else `Right ()) xs
-Error: This expression has type "unit list * unit list"
-       but an expression was expected of type "int list * int list"
+Error: This expression has type "(|unit|) list * unit list"
+       but an expression was expected of type "(|int|) list * int list"
        Type "unit" is not compatible with type "int"
 |}]
 
@@ -93,8 +93,49 @@ Error: Signature mismatch:
          "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ] ->
          [> `B of [> `BA | `BB of int list ] | `C of unit ]"
        is not compatible with the type "t -> t"
-       Type "[> `B of [> `BA | `BB of int list ] | `C of unit ]"
+       Type "[> `B of [> `BA | `BB of int (|list|) ] | `C of unit ]"
        is not compatible with type
          "t" = "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]"
+       In tag "`BB", type "int list" is not compatible with type "unit list"
+|}, Principal{|
+Lines 8-27, characters 6-3:
+ 8 | ......struct
+ 9 |   type t = [
+10 |     | `A of int
+11 |     | `B of [ `BA | `BB of unit list ]
+12 |     | `C of unit ]
+...
+24 |         end
+25 |       | _ -> assert false)
+26 |
+27 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t =
+               [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]
+           val a :
+             [> `A of int ] ->
+             [> `B of [> `BA | `BB of int list ] | `C of unit ]
+         end
+       is not included in
+         sig
+           type t =
+               [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]
+           val a : t -> t
+         end
+       Values do not match:
+         val a :
+           [> `A of int ] ->
+           [> `B of [> `BA | `BB of int list ] | `C of unit ]
+       is not included in
+         val a : t -> t
+       The type
+         "[ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ] ->
+         [> `B of [> `BA | `BB of int list ] | `C of unit ]"
+       is not compatible with the type "t -> t"
+       Type "[> `B of [> `BA | `BB of int (|list|) ] | `C of unit ]"
+       is not compatible with type
+         "t" = "[ `A of int | `B of [ `BA | `BB of unit (|list|) ] | `C of unit ]"
        In tag "`BB", type "int list" is not compatible with type "unit list"
 |}]

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -94,9 +94,12 @@ type t2 = < m : 'a. 'a * ('a * 'b) > as 'b
 Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
-Error: The value "x" has type "t1" but an expression was expected of type "t2"
-       The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
-       but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
+Error: The value "x" has type
+         "t1" = "< m : 'a. 'a * ('a * < m : 'c. 'c * 'b > as 'b) >"
+       but an expression was expected of type
+         "t2" = "< m : 'a. 'a * ('a * 'd) > as 'd"
+       The method "m" has type "'c. 'c * ('a * < m : 'c. 'e >) as 'e",
+       but the expected method type was "'a. 'a * ('a * < m : 'a. 'f >) as 'f"
        The universal variable "'a" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -95,8 +95,8 @@ Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
 Error: The value "x" has type "t1" but an expression was expected of type "t2"
-       The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
-       but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
+       The method "m" has type "'c. 'c * ((|'a|) * < m : 'c. 'b >) as 'b",
+       but the expected method type was "'a. (|'a|) * ((|'a|) * < m : 'a. 'd >) as 'd"
        The universal variable "'a" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -94,12 +94,9 @@ type t2 = < m : 'a. 'a * ('a * 'b) > as 'b
 Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
-Error: The value "x" has type
-         "t1" = "< m : 'a. 'a * ('a * < m : 'c. 'c * 'b > as 'b) >"
-       but an expression was expected of type
-         "t2" = "< m : 'a. 'a * ('a * 'd) > as 'd"
-       The method "m" has type "'c. 'c * ('a * < m : 'c. 'e >) as 'e",
-       but the expected method type was "'a. 'a * ('a * < m : 'a. 'f >) as 'f"
+Error: The value "x" has type "t1" but an expression was expected of type "t2"
+       The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
+       but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
        The universal variable "'a" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -26,8 +26,8 @@ Error: Unbound record field "z"
 Line 1, characters 6-14:
 1 | {x=3; contents=2};;
           ^^^^^^^^
-Error: The record field "contents" belongs to the type "'a ref"
-       but is mixed here with fields of type "t"
+Error: The record field "contents" belongs to the type "'a (|ref|)"
+       but is mixed here with fields of type "(|t|)"
 |}];;
 
 (* private types *)
@@ -98,8 +98,8 @@ type bar = { x : int; }
 Line 3, characters 20-21:
 3 | let f (r: bar) = ({ r with z = 3 } : foo)
                         ^
-Error: This expression has type "bar" but an expression was expected of type
-         "foo"
+Error: This expression has type "(|bar|)" but an expression was expected of type
+         "(|foo|)"
 |}];;
 
 type foo = { x: int };;
@@ -159,7 +159,7 @@ Line 3, characters 0-19:
     ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "(|string|) t"
        but an expression was expected of type "(|int|) t"
-       Type "string" is not compatible with type "int"
+       Type "(|string|)" is not compatible with type "(|int|)"
 |}]
 
 (* PR#7696 *)

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -157,8 +157,8 @@ val x : int t = {f = 12; g = 43}
 Line 3, characters 0-19:
 3 | {x with f = "hola"};;
     ^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "string t"
-       but an expression was expected of type "int t"
+Error: This expression has type "(|string|) t"
+       but an expression was expected of type "(|int|) t"
        Type "string" is not compatible with type "int"
 |}]
 

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -197,7 +197,7 @@ Line 1, characters 0-40:
 Error: This variant or record definition does not match that of type
          "(int, [> `A ]) def"
        Their parameters differ
-       The type "int" is not equal to the type "'a"
+       The type "(|int|)" is not equal to the type "(|'a|)"
 |}]
 
 type ('a,'b) kind = ('a, 'b) def = A constraint 'b = [> `A];;
@@ -244,7 +244,7 @@ Error: This variant or record definition does not match that of type "d"
          "x : int;"
        is not the same as:
          "x : float;"
-       The type "int" is not equal to the type "float"
+       The type "(|int|)" is not equal to the type "(|float|)"
        2. An extra field, "y", is provided in the original definition.
 |}]
 

--- a/testsuite/tests/typing-misc/scope_escape.ml
+++ b/testsuite/tests/typing-misc/scope_escape.ml
@@ -10,6 +10,6 @@ Line 2, characters 34-35:
 2 | module M = struct type t let _ = (x : t list ref) end;;
                                       ^
 Error: The value "x" has type "'weak1 list ref"
-       but an expression was expected of type "t list ref"
+       but an expression was expected of type "(|t|) list ref"
        The type constructor "t" would escape its scope
 |}]

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -77,8 +77,8 @@ let rec f x = ( (), () : _ -> _ -> _ )
 Line 3, characters 16-22:
 3 | let rec f x = ( (), () : _ -> _ -> _ )
                     ^^^^^^
-Error: This expression has type "'a * 'b"
-       but an expression was expected of type "'c -> 'd -> 'e"
+Error: This expression has type "'a (|*|) 'b"
+       but an expression was expected of type "'c (|->|) 'd -> 'e"
 |}]
 
 let rec g x = ( ((), ()) : _ -> _ :> _ )
@@ -86,8 +86,8 @@ let rec g x = ( ((), ()) : _ -> _ :> _ )
 Line 1, characters 16-24:
 1 | let rec g x = ( ((), ()) : _ -> _ :> _ )
                     ^^^^^^^^
-Error: This expression has type "'a * 'b"
-       but an expression was expected of type "'c -> 'd"
+Error: This expression has type "'a (|*|) 'b"
+       but an expression was expected of type "'c (|->|) 'd"
 |}]
 
 

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -337,7 +337,7 @@ Line 2, characters 6-15:
 2 | let f (A x|B x) = 0
           ^^^^^^^^^
 Error: The variable "x" on the left-hand side of this or-pattern has type "
-       int" but on the right-hand side it has type "float"
+       (|int|)" but on the right-hand side it has type "(|float|)"
 |}]
 
 (** Orphan pattern variable *)
@@ -386,7 +386,7 @@ Line 3, characters 9-13:
 3 | let x = ([`B]:>[`A])
              ^^^^
 Error: This expression cannot be coerced to type ""[ `A ]""; it has type
-         "[> `B ] list"
+         "[> `B ] (|list|)"
        but is here used with type "[< `A ]"
 |}]
 
@@ -461,8 +461,8 @@ type s = { y : unit; }
 Line 3, characters 21-22:
 3 | let f = function {x; y} -> x
                          ^
-Error: The record field "y" belongs to the type "s"
-       but is mixed here with fields of type "t"
+Error: The record field "y" belongs to the type "(|s|)"
+       but is mixed here with fields of type "(|t|)"
 |}]
 
 

--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -46,7 +46,7 @@ let f (x: int as 'a) (y: float as 'a) = (x,y)
 Line 1, characters 25-36:
 1 | let f (x: int as 'a) (y: float as 'a) = (x,y)
                              ^^^^^^^^^^^
-Error: This type "float" should be an instance of type "int"
+Error: This type "(|float|)" should be an instance of type "(|int|)"
 |}]
 
 type 'a t1 = 'a constraint 'a = 'b list
@@ -59,5 +59,5 @@ type 'a t2 = 'a constraint 'a = 'b option
 Line 4, characters 36-38:
 4 | let f (x : 'a t1) = (assert false : 'a t2)
                                         ^^
-Error: This type "'a option" should be an instance of type "'b list"
+Error: This type "'a (|option|)" should be an instance of type "'b (|list|)"
 |}]

--- a/testsuite/tests/typing-misc/unbound_type_variables.ml
+++ b/testsuite/tests/typing-misc/unbound_type_variables.ml
@@ -134,5 +134,5 @@ Lines 1-5, characters 0-3:
 Error: Some type variables are unbound in this type:
          class ['a, 'b, 'c, 'd, 'e, 'f] c :
            object method m : ('a * 'g * 'c) * ('d * 'h) end
-       The method "m" has type "('a * 'g * 'c) * ('d * 'h)" where "'g" is unbound
+       The method "m" has type "('a * (|'g|) * 'c) * ('d * 'h)" where "(|'g|)" is unbound
 |}]

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -14,7 +14,7 @@ val x : t = A
 Line 5, characters 27-28:
 5 |   let f: t -> t = fun B -> x
                                ^
-Error: The value "x" has type "t/2" but an expression was expected of type "t"
+Error: The value "x" has type "(|t/2|)" but an expression was expected of type "(|t|)"
        Line 4, characters 2-12:
          Definition of type "t"
        Line 1, characters 0-10:
@@ -36,7 +36,7 @@ val y : M.t = M.B
 Line 7, characters 34-35:
 7 |   let f : M.t -> M.t = fun M.C -> y
                                       ^
-Error: The value "y" has type "M/2.t" but an expression was expected of type "M.t"
+Error: The value "y" has type "(|M/2.t|)" but an expression was expected of type "(|M.t|)"
        Lines 4-6, characters 2-5:
          Definition of module "M"
        Line 1, characters 0-32:
@@ -52,7 +52,7 @@ type t = D
 Line 2, characters 25-26:
 2 | let f: t -> t = fun D -> x;;
                              ^
-Error: The value "x" has type "t/2" but an expression was expected of type "t"
+Error: The value "x" has type "(|t/2|)" but an expression was expected of type "(|t|)"
        Line 1, characters 0-10:
          Definition of type "t"
        Line 1, characters 0-10:
@@ -75,7 +75,7 @@ type nonrec ttt = X of ttt
 Line 2, characters 32-33:
 2 | let x: ttt = let rec y = A y in y;;
                                     ^
-Error: The value "y" has type "ttt/2" but an expression was expected of type "ttt"
+Error: The value "y" has type "(|ttt/2|)" but an expression was expected of type "(|ttt|)"
        Line 1, characters 0-26:
          Definition of type "ttt"
        Line 2, characters 0-30:

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -25,7 +25,7 @@ Error: Signature mismatch:
          type t = X.t = A | B
        is not included in
          type t = int * bool
-       The type "X.t" is not equal to the type "int * bool"
+       The type "(|X.t|)" is not equal to the type "int (|*|) bool"
 |}];;
 
 
@@ -67,7 +67,7 @@ Line 1, characters 0-41:
 Error: This variant or record definition does not match that of type
          "(int, [> `A ]) def"
        Their parameters differ
-       The type "int" is not equal to the type "'a"
+       The type "(|int|)" is not equal to the type "(|'a|)"
 |}]
 
 type ('a,'b) kind = ('a, 'b) def = {a:int} constraint 'b = [> `A];;
@@ -102,7 +102,7 @@ Error: This variant or record definition does not match that of type "d"
          "X of int"
        is not the same as:
          "X of float"
-       The type "int" is not equal to the type "float"
+       The type "(|int|)" is not equal to the type "(|float|)"
        2. An extra constructor, "Y", is provided in the original definition.
 |}]
 

--- a/testsuite/tests/typing-modular-explicits/gadt.ml
+++ b/testsuite/tests/typing-modular-explicits/gadt.ml
@@ -65,7 +65,7 @@ val f : 'a -> 'a t2 -> int = <fun>
 Line 3, characters 12-15:
 3 |   | A, f -> f 1
                 ^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: This expression has type "(|int|)" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -119,11 +119,11 @@ Line 13, characters 4-14:
 13 |   | Type.Equal -> ()
          ^^^^^^^^^^
 Error: This pattern matches values of type
-         "((module X : S) -> (int * $'a) R.n,
-          (module X : S) -> (int * $'a) R.n)
+         "((module X : S) -> (int * (|$'a|)) R.n,
+          (module X : S) -> (int * (|$'a|)) R.n)
          Type.eq"
        but a pattern was expected which matches values of type
-         "((module X : S) -> (int * $'a) R.n,
+         "((module X : S) -> (int * (|$'a|)) R.n,
           (module X : S) -> (float * 'b) R.n)
          Type.eq"
        The type constructor "$'a" would escape its scope

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -619,8 +619,8 @@ let failed_subtyping x =
 Line 2, characters 2-63:
 2 |   (x : (module A : Typ) -> A.t list :> (module B : Typ) -> B.t)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "(module A : Typ) -> A.t list" is not a subtype of
-         "(module B : Typ) -> B.t"
+Error: Type "(module A : Typ) -> A.t (|list|)" is not a subtype of
+         "(module B : Typ) -> (|B.t|)"
        Type "A.t list" is not a subtype of "B.t"
 |}]
 
@@ -1332,9 +1332,9 @@ let f (x : (module T : Typ) -> int -> Int.t)
 Line 8, characters 4-5:
 8 |   = x
         ^
-Error: The value "x" has type "(module Int : Typ) -> int -> Stdlib.Int.t"
+Error: The value "x" has type "(module Int : Typ) -> int -> (|Stdlib.Int.t|)"
        but an expression was expected of type
-         "(module Int : Typ) -> int -> Int.t"
+         "(module Int : Typ) -> int -> (|Int.t|)"
        Type "Int.t" = "int" is not compatible with type "Int.t"
 |}]
 

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -92,8 +92,8 @@ let invalid_arg2 = f 3 4 (module Int)
 Line 1, characters 23-24:
 1 | let invalid_arg2 = f 3 4 (module Int)
                            ^
-Error: The constant "4" has type "int" but an expression was expected of type
-         "(module Typ)"
+Error: The constant "4" has type "(|int|)" but an expression was expected of type
+         "((|module|) Typ)"
 |}]
 
 (* Here we cannot extract the type of m *)
@@ -827,7 +827,7 @@ val r : '_weak2 option ref = {contents = None}
 Line 6, characters 12-13:
 6 |   r := Some x
                 ^
-Error: The value "x" has type "T.t" but an expression was expected of type "'weak2"
+Error: The value "x" has type "(|T.t|)" but an expression was expected of type "'weak2"
        The type constructor "T.t" would escape its scope
 |}]
 
@@ -838,7 +838,7 @@ let f x (module A : Add) (y : A.t) = A.add x y
 Line 1, characters 43-44:
 1 | let f x (module A : Add) (y : A.t) = A.add x y
                                                ^
-Error: The value "x" has type "'a" but an expression was expected of type "A.t"
+Error: The value "x" has type "'a" but an expression was expected of type "(|A.t|)"
        The type constructor "A.t" would escape its scope
 |}]
 
@@ -1121,7 +1121,7 @@ module type S = sig type t = private int val f : t end
 Line 6, characters 50-53:
 6 | let check_escape : _ -> _ = fun (module M : S) -> M.f
                                                       ^^^
-Error: The value "M.f" has type "M.t" but an expression was expected of type "'a"
+Error: The value "M.f" has type "(|M.t|)" but an expression was expected of type "'a"
        The type constructor "M.t" would escape its scope
 |}]
 
@@ -1335,7 +1335,7 @@ Line 8, characters 4-5:
 Error: The value "x" has type "(module Int : Typ) -> int -> (|Stdlib.Int.t|)"
        but an expression was expected of type
          "(module Int : Typ) -> int -> (|Int.t|)"
-       Type "Int.t" = "int" is not compatible with type "Int.t"
+       Type "Int.t" = "(|int|)" is not compatible with type "(|Int.t|)"
 |}]
 
 (* At one point the implementation was not robust enough and linking

--- a/testsuite/tests/typing-modular-explicits/typedefs.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs.ml
@@ -290,5 +290,5 @@ Error: This variant or record definition does not match that of type "typ1"
        The type "(module Add with type t = int) -> (|int|) -> int"
        is not equal to the type
          "(module A : Add with type t = int) -> (|float|) -> int"
-       Type "int" is not equal to type "float"
+       Type "(|int|)" is not equal to type "(|float|)"
 |}]

--- a/testsuite/tests/typing-modular-explicits/typedefs.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs.ml
@@ -75,8 +75,8 @@ let t9_fail (x : (module T : T) -> T.t -> int) = C x
 Line 1, characters 51-52:
 1 | let t9_fail (x : (module T : T) -> T.t -> int) = C x
                                                        ^
-Error: The value "x" has type "(module T : T) -> T.t -> int"
-       but an expression was expected of type "(module T : T) -> T.t -> T.t"
+Error: The value "x" has type "(module T : T) -> T.t -> (|int|)"
+       but an expression was expected of type "(module T : T) -> T.t -> (|T.t|)"
        Type "int" is not compatible with type "T.t"
 |}]
 
@@ -287,8 +287,8 @@ Error: This variant or record definition does not match that of type "typ1"
          "A of ((module Add with type t = int) -> int -> int)"
        is not the same as:
          "A of ((module A : Add with type t = int) -> float -> int)"
-       The type "(module Add with type t = int) -> int -> int"
+       The type "(module Add with type t = int) -> (|int|) -> int"
        is not equal to the type
-         "(module A : Add with type t = int) -> float -> int"
+         "(module A : Add with type t = int) -> (|float|) -> int"
        Type "int" is not equal to type "float"
 |}]

--- a/testsuite/tests/typing-modular-explicits/typedefs.ml
+++ b/testsuite/tests/typing-modular-explicits/typedefs.ml
@@ -77,7 +77,7 @@ Line 1, characters 51-52:
                                                        ^
 Error: The value "x" has type "(module T : T) -> T.t -> (|int|)"
        but an expression was expected of type "(module T : T) -> T.t -> (|T.t|)"
-       Type "int" is not compatible with type "T.t"
+       Type "(|int|)" is not compatible with type "(|T.t|)"
 |}]
 
 type 'a t6bis_good = (module M : T with type t = int) -> (M.t as 'a)
@@ -87,7 +87,7 @@ type 'a t6bis_good = (module M : T with type t = int) -> (M.t as 'a)
 Line 1, characters 58-67:
 1 | type 'a t6bis_good = (module M : T with type t = int) -> (M.t as 'a)
                                                               ^^^^^^^^^
-Error: This type "'a" should be an instance of type "M.t"
+Error: This type "'a" should be an instance of type "(|M.t|)"
        The type constructor "M.t" would escape its scope
 |}]
 
@@ -97,7 +97,7 @@ type 'a t6_fail = (module M : T) -> (M.t as 'a)
 Line 1, characters 37-46:
 1 | type 'a t6_fail = (module M : T) -> (M.t as 'a)
                                          ^^^^^^^^^
-Error: This type "'a" should be an instance of type "M.t"
+Error: This type "'a" should be an instance of type "(|M.t|)"
        The type constructor "M.t" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -99,7 +99,7 @@ Error: This variant or record definition does not match that of type "u"
          "X of bool"
        is not the same as:
          "X of int"
-       The type "bool" is not equal to the type "int"
+       The type "(|bool|)" is not equal to the type "(|int|)"
 |}];;
 
 (* PR#5815 *)
@@ -170,7 +170,7 @@ Error: Signature mismatch:
          "E of int"
        is not the same as:
          "E of char"
-       The type "int" is not equal to the type "char"
+       The type "(|int|)" is not equal to the type "(|char|)"
 |}];;
 
 module M : sig type t += C of int end = struct type t += E of int end;;

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -47,7 +47,7 @@ Error: Modules do not match:
        val equal : 'a -> 'a -> bool
      is not included in
        val equal : unit
-     The type "'a -> 'a -> bool" is not compatible with the type "unit"
+     The type "'a (|->|) 'a -> bool" is not compatible with the type "(|unit|)"
 |} ]
 
 

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1956,8 +1956,8 @@ Error: This application of the functor "H" is ill-typed.
             val f : 'a -> 'a
           is not included in
             val f : 'a X.s -> 'a
-          The type "'a X.s -> 'a X.s" is not compatible with the type
-            "'a X.s -> 'a"
+          The type "'a X.s -> 'a (|X.s|)" is not compatible with the type
+            "(|'a|) X.s -> (|'a|)"
           Type "'a X.s" is not compatible with type "'a"
 |}]
 

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1958,7 +1958,7 @@ Error: This application of the functor "H" is ill-typed.
             val f : 'a X.s -> 'a
           The type "'a X.s -> 'a (|X.s|)" is not compatible with the type
             "(|'a|) X.s -> (|'a|)"
-          Type "'a X.s" is not compatible with type "'a"
+          Type "'a (|X.s|)" is not compatible with type "(|'a|)"
 |}]
 
 
@@ -2001,7 +2001,7 @@ Error: Signature mismatch:
             type 'a t = 'a * 'a
           is not included in
             type 'a t = 'a list
-          The type "'a * 'a" is not equal to the type "'a list"
+          The type "'a (|*|) 'a" is not equal to the type "'a (|list|)"
        2. Module types $S2 and $T2 match
 |}]
 
@@ -2196,7 +2196,7 @@ Error: Signature mismatch:
        does not include
          $T1 = sig val f : t val g : Inner.t val h : float end
        Values do not match: val h : float is not included in val h : int
-       The type "float" is not compatible with the type "int"
+       The type "(|float|)" is not compatible with the type "(|int|)"
 |}]
 
 module M: sig

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -527,7 +527,7 @@ Error: Modules do not match:
      is not included in
        val r : Choice.t list ref ref
      The type "'_weak1 list ref ref" is not compatible with the type
-       "Choice.t list ref ref"
+       "(|Choice.t|) list ref ref"
      The type constructor "Choice.t" would escape its scope
 |}];;
 
@@ -683,7 +683,7 @@ Error: Signature mismatch:
          val r : '_weak3 list ref
        is not included in
          val r : t list ref
-       The type "'_weak3 list ref" is not compatible with the type "t list ref"
+       The type "'_weak3 list ref" is not compatible with the type "(|t|) list ref"
        The type constructor "t" would escape its scope
 |}];;
 
@@ -726,7 +726,7 @@ Error: Signature mismatch:
          val r : '_weak4 list ref
        is not included in
          val r : T.t list ref
-       The type "'_weak4 list ref" is not compatible with the type "T.t list ref"
+       The type "'_weak4 list ref" is not compatible with the type "(|T.t|) list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -179,7 +179,7 @@ Error: Signature mismatch:
          "Foo of (int * int) * float"
        is not the same as:
          "Foo of int * float"
-       The type "int * int" is not equal to the type "int"
+       The type "int (|*|) int" is not equal to the type "(|int|)"
 |}];;
 
 module M : sig
@@ -272,8 +272,8 @@ Error: Signature mismatch:
          type t = < m : float * int; n : int >
        The type "< m : (|int|); n : int >" is not equal to the type
          "< m : float (|*|) int; n : int >"
-       The method "m" has type "int", but the expected method type was
-       "float * int"
+       The method "m" has type "(|int|)", but the expected method type was
+       "float (|*|) int"
 |}];;
 
 module M4 : sig
@@ -639,7 +639,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> float
        The type "'a -> (|int|)" is not compatible with the type "'a -> (|float|)"
-       Type "int" is not compatible with type "float"
+       Type "(|int|)" is not compatible with type "(|float|)"
 |}]
 
 module M : sig
@@ -751,7 +751,7 @@ Error: Signature mismatch:
        is not included in
          val f : int -> float
        The type "int -> (|int|)" is not compatible with the type "int -> (|float|)"
-       Type "int" is not compatible with type "float"
+       Type "(|int|)" is not compatible with type "(|float|)"
 |}];;
 
 module M: sig
@@ -1208,7 +1208,7 @@ Error: Signature mismatch:
          type t = [ `A of float ]
        is not included in
          type t = private [> `A of int ]
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
 |}];;
 
 module M : sig
@@ -1322,7 +1322,7 @@ Error: Signature mismatch:
        is not included in
          type t = private < a : float; .. >
        The type "(|int|)" is not equal to the type "(|float|)"
-       Type "int" is not equal to type "float"
+       Type "(|int|)" is not equal to type "(|float|)"
 |}];;
 
 type w = private float
@@ -1351,7 +1351,7 @@ Error: Signature mismatch:
        is not included in
          type t = private int * (int * int)
        The type "int * (|q|)" is not equal to the type "int * (int (|*|) int)"
-       Type "q" is not equal to type "int * int"
+       Type "(|q|)" is not equal to type "int (|*|) int"
 |}];;
 
 type w = float
@@ -1381,7 +1381,7 @@ Error: Signature mismatch:
          type t = private int * (int * int)
        The type "int * (|q|)" is not equal to the type "int * (int (|*|) int)"
        Type "q" = "int * (|w|)" is not equal to type "int * (|int|)"
-       Type "w" = "float" is not equal to type "int"
+       Type "w" = "(|float|)" is not equal to type "(|int|)"
 |}];;
 
 type s = private int
@@ -1406,7 +1406,7 @@ Error: Signature mismatch:
          type t = private s
        is not included in
          type t = private float
-       The type "int" is not equal to the type "float"
+       The type "(|int|)" is not equal to the type "(|float|)"
 |}];;
 
 module M : sig

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -327,7 +327,7 @@ Error: Signature mismatch:
        is not included in
          type t = private [ `C of int ]
        The type "[ `C ]" is not equal to the type "[ `C of int ]"
-       Types for tag "`C" are incompatible
+       Arities for tag "`C" are incompatible.
 |}];;
 
 module M : sig
@@ -350,7 +350,7 @@ Error: Signature mismatch:
        is not included in
          type t = private [ `C ]
        The type "[ `C of int ]" is not equal to the type "[ `C ]"
-       Types for tag "`C" are incompatible
+       Arities for tag "`C" are incompatible.
 |}];;
 
 module M : sig
@@ -946,7 +946,7 @@ Error: Signature mismatch:
          val f : [< `C ] -> unit
        The type "[< `C of & int & float ] -> unit"
        is not compatible with the type "[< `C ] -> unit"
-       Types for tag "`C" are incompatible
+       Arities for tag "`C" are incompatible.
 |}];;
 
 module M : sig
@@ -970,7 +970,7 @@ Error: Signature mismatch:
          val f : [ `Foo ] -> unit
        The type "[ `Foo of int ] -> unit" is not compatible with the type
          "[ `Foo ] -> unit"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}];;
 
 module M : sig
@@ -994,7 +994,7 @@ Error: Signature mismatch:
          val f : [ `Foo of int ] -> unit
        The type "[ `Foo ] -> unit" is not compatible with the type
          "[ `Foo of int ] -> unit"
-       Types for tag "`Foo" are incompatible
+       Arities for tag "`Foo" are incompatible.
 |}];;
 
 module M : sig

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -24,7 +24,7 @@ Error: Signature mismatch:
        is not included in
          type ('a, 'b) t = 'a * 'b
        The type "'a * (|'a|)" is not equal to the type "'a * (|'b|)"
-       Type "'a" is not equal to type "'b"
+       Type "(|'a|)" is not equal to type "(|'b|)"
 |}];;
 
 module M : sig
@@ -47,7 +47,7 @@ Error: Signature mismatch:
        is not included in
          type ('a, 'b) t = 'a * 'a
        The type "'a * (|'b|)" is not equal to the type "'a * (|'a|)"
-       Type "'b" is not equal to type "'a"
+       Type "(|'b|)" is not equal to type "(|'a|)"
 |}];;
 
 type 'a x
@@ -73,7 +73,7 @@ Error: Signature mismatch:
          type ('a, 'b, 'c) t = ('a * 'b * 'c * 'b * 'a) x
        The type "('b * 'c * (|'a|) * 'c * (|'a|)) x" is not equal to the type
          "((|'b|) * 'c * 'a * 'c * (|'b|)) x"
-       Type "'a" is not equal to type "'b"
+       Type "(|'a|)" is not equal to type "(|'b|)"
 |}]
 
 module M : sig
@@ -662,7 +662,7 @@ Error: Signature mismatch:
        is not included in
          val x : 'a list ref
        The type "(|'_weak2|) list ref" is not compatible with the type "(|'a|) list ref"
-       Type "'_weak2" is not compatible with type "'a"
+       Type "(|'_weak2|)" is not compatible with type "(|'a|)"
 |}];;
 
 module M = struct let r = ref [] end;;
@@ -2106,4 +2106,22 @@ Error: Signature mismatch:
        Hint:    "mnox" is a close match.
        The value "vwxy" is required but not provided.
        Hint:     "vwxx" is a close match.
+|}]
+
+module M: sig val x: 'a list end = struct let x = [ 0 ] end
+[%%expect {|
+Line 1, characters 35-59:
+1 | module M: sig val x: 'a list end = struct let x = [ 0 ] end
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val x : int list end
+       is not included in
+         sig val x : 'a list end
+       Values do not match:
+         val x : int list
+       is not included in
+         val x : 'a list
+       The type "(|int|) list" is not compatible with the type "(|'a|) list"
+       Type "(|int|)" is not compatible with type "(|'a|)"
 |}]

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -98,7 +98,7 @@ Error: Signature mismatch:
        The type "< m : 'a. 'a * ('a * 'd) > as 'd" is not equal to the type
          "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'e|) > as 'e) >"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
-       but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
+       but the expected method type was "'c. 'c * ((|'b|) * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
 |}];;
 
@@ -587,7 +587,7 @@ Error: Signature mismatch:
        is not compatible with the type
          "< m : 'b. 'b * < m : (|'c. 'c * 'e|) > as 'e > -> unit"
        The method "m" has type "'a. 'a * (|< m : 'a. 'f >|) as 'f",
-       but the expected method type was "'c. 'c * ('b (|*|) < m : 'c. 'g >) as 'g"
+       but the expected method type was "'c. 'c * ((|'b|) (|*|) < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
 |}];;
 

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -201,7 +201,7 @@ Error: Signature mismatch:
          type t = int * float * int
        is not included in
          type t = int * float
-       The type "int * float * int" is not equal to the type "int * float"
+       The type "int * float * (|int|)" is not equal to the type "int * float"
 |}];;
 
 module M : sig
@@ -586,8 +586,8 @@ Error: Signature mismatch:
        The type "(< m : 'a. 'a * 'd > as 'd) -> unit"
        is not compatible with the type
          "< m : 'b. 'b * < m : 'c. 'c * 'e > as 'e > -> unit"
-       The method "m" has type "'a. 'a * < m : 'a. 'f > as 'f",
-       but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
+       The method "m" has type "'a. 'a * (|< m : 'a. 'f >|) as 'f",
+       but the expected method type was "'c. 'c * ('b (|*|) < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
 |}];;
 
@@ -773,9 +773,9 @@ Error: Signature mismatch:
          val f : int * int -> int * int
        is not included in
          val f : int * float * int -> int -> int
-       The type "int * int -> int * int" is not compatible with the type
-         "int * float * int -> int -> int"
-       Type "int * int" is not compatible with type "int * float * int"
+       The type "int * int -> int (|*|) int" is not compatible with the type
+         "int * float * (|int|) -> int (|->|) int"
+       Type "int * int" is not compatible with type "int * float * (|int|)"
 |}];;
 
 module M: sig
@@ -944,7 +944,7 @@ Error: Signature mismatch:
          val f : [< `C of int & float ] -> unit
        is not included in
          val f : [< `C ] -> unit
-       The type "[< `C of & int & float ] -> unit"
+       The type "[< `C of (|&|) int & float ] -> unit"
        is not compatible with the type "[< `C ] -> unit"
        Arities for tag "`C" are incompatible.
 |}];;
@@ -1746,8 +1746,8 @@ Error: Signature mismatch:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) t"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       The method "x" has type "< x : 'c > * < x : 'c > as 'c",
-       but the expected method type was "< x : 'b > as 'b"
+       The method "x" has type "< x : 'c > (|*|) < x : 'c > as 'c",
+       but the expected method type was "(|< x : 'b >|) as 'b"
 |}]
 module R: sig
   type t = { a: (<x:'a> as 'a) }
@@ -1774,8 +1774,8 @@ Error: Signature mismatch:
          "a : < x : 'a > as 'a;"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       The method "x" has type "< x : 'c > * < x : 'c > as 'c",
-       but the expected method type was "< x : 'b > as 'b"
+       The method "x" has type "< x : 'c > (|*|) < x : 'c > as 'c",
+       but the expected method type was "(|< x : 'b >|) as 'b"
 |}]
 type _ ext = ..
 module Ext: sig
@@ -1809,8 +1809,8 @@ Error: Signature mismatch:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) ext"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       The method "x" has type "< x : 'c > * < x : 'c > as 'c",
-       but the expected method type was "< x : 'b > as 'b"
+       The method "x" has type "< x : 'c > (|*|) < x : 'c > as 'c",
+       but the expected method type was "(|< x : 'b >|) as 'b"
 |}]
 
 (********************************** Nested modules ****************************)
@@ -1873,7 +1873,7 @@ Error: Signature mismatch:
          type t = x:int -> int
        is not included in
          type t = int -> int
-       The type "x:int -> int" is not equal to the type "int -> int"
+       The type "(|x|):int -> int" is not equal to the type "int -> int"
        The first argument is labeled "x",
        but an unlabeled argument was expected
 |}]
@@ -1897,7 +1897,7 @@ Error: Signature mismatch:
          type t = x:int -> int
        is not included in
          type t = y:int -> int
-       The type "x:int -> int" is not equal to the type "y:int -> int"
+       The type "(|x|):int -> int" is not equal to the type "(|y|):int -> int"
        Labels "x" and "y" do not match
 |}]
 
@@ -1920,7 +1920,7 @@ Error: Signature mismatch:
          val f : x:'a -> unit
        is not included in
          val f : int -> unit
-       The type "x:'a -> unit" is not compatible with the type "int -> unit"
+       The type "(|x|):'a -> unit" is not compatible with the type "int -> unit"
        The first argument is labeled "x",
        but an unlabeled argument was expected
 |}]
@@ -1949,7 +1949,7 @@ Error: Signature mismatch:
          val f : ?x:'a -> unit
        is not included in
          val f : int -> unit
-       The type "?x:'a -> unit" is not compatible with the type "int -> unit"
+       The type "?(|x|):'a -> unit" is not compatible with the type "int -> unit"
        The first argument is labeled "?x",
        but an unlabeled argument was expected
 |}]
@@ -1979,7 +1979,7 @@ Error: Signature mismatch:
          val f : ?x:'a -> unit
        is not included in
          val f : x:int -> unit
-       The type "?x:'a -> unit" is not compatible with the type "x:int -> unit"
+       The type "?(|x|):'a -> unit" is not compatible with the type "(|x|):int -> unit"
        The label "?x" was expected to not be optional
 |}]
 
@@ -2008,7 +2008,7 @@ Error: Signature mismatch:
          val f : ?y:'a -> unit
        is not included in
          val f : ?x:int -> unit
-       The type "?y:'a -> unit" is not compatible with the type "?x:int -> unit"
+       The type "?(|y|):'a -> unit" is not compatible with the type "?(|x|):int -> unit"
        Labels "?y" and "?x" do not match
 |}]
 
@@ -2032,7 +2032,7 @@ Error: Signature mismatch:
          val f : 'a -> unit
        is not included in
          val f : ?x:int -> unit
-       The type "'a -> unit" is not compatible with the type "?x:int -> unit"
+       The type "'a -> unit" is not compatible with the type "?(|x|):int -> unit"
        A label "?x" was expected
 |}]
 

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -23,7 +23,7 @@ Error: Signature mismatch:
          type ('a, 'b) t = 'a * 'a
        is not included in
          type ('a, 'b) t = 'a * 'b
-       The type "'a * 'a" is not equal to the type "'a * 'b"
+       The type "'a * (|'a|)" is not equal to the type "'a * (|'b|)"
        Type "'a" is not equal to type "'b"
 |}];;
 
@@ -46,7 +46,7 @@ Error: Signature mismatch:
          type ('a, 'b) t = 'a * 'b
        is not included in
          type ('a, 'b) t = 'a * 'a
-       The type "'a * 'b" is not equal to the type "'a * 'a"
+       The type "'a * (|'b|)" is not equal to the type "'a * (|'a|)"
        Type "'b" is not equal to type "'a"
 |}];;
 
@@ -71,8 +71,8 @@ Error: Signature mismatch:
          type ('b, 'c, 'a) t = ('b * 'c * 'a * 'c * 'a) x
        is not included in
          type ('a, 'b, 'c) t = ('a * 'b * 'c * 'b * 'a) x
-       The type "('b * 'c * 'a * 'c * 'a) x" is not equal to the type
-         "('b * 'c * 'a * 'c * 'b) x"
+       The type "('b * 'c * (|'a|) * 'c * (|'a|)) x" is not equal to the type
+         "((|'b|) * 'c * 'a * 'c * (|'b|)) x"
        Type "'a" is not equal to type "'b"
 |}]
 
@@ -96,7 +96,7 @@ Error: Signature mismatch:
        is not included in
          type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The type "< m : 'a. 'a * ('a * 'd) > as 'd" is not equal to the type
-         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) >"
+         "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'e|) > as 'e) >"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
@@ -270,8 +270,8 @@ Error: Signature mismatch:
          type t = < m : int; n : int >
        is not included in
          type t = < m : float * int; n : int >
-       The type "< m : int; n : int >" is not equal to the type
-         "< m : float * int; n : int >"
+       The type "< m : (|int|); n : int >" is not equal to the type
+         "< m : float (|*|) int; n : int >"
        The method "m" has type "int", but the expected method type was
        "float * int"
 |}];;
@@ -585,7 +585,7 @@ Error: Signature mismatch:
          val f : < m : 'b. 'b * < m : 'c. 'c * 'a > as 'a > -> unit
        The type "(< m : 'a. 'a * 'd > as 'd) -> unit"
        is not compatible with the type
-         "< m : 'b. 'b * < m : 'c. 'c * 'e > as 'e > -> unit"
+         "< m : 'b. 'b * < m : (|'c. 'c * 'e|) > as 'e > -> unit"
        The method "m" has type "'a. 'a * (|< m : 'a. 'f >|) as 'f",
        but the expected method type was "'c. 'c * ('b (|*|) < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
@@ -638,7 +638,7 @@ Error: Signature mismatch:
          val f : 'b -> int
        is not included in
          val f : 'a -> float
-       The type "'a -> int" is not compatible with the type "'a -> float"
+       The type "'a -> (|int|)" is not compatible with the type "'a -> (|float|)"
        Type "int" is not compatible with type "float"
 |}]
 
@@ -661,7 +661,7 @@ Error: Signature mismatch:
          val x : '_weak2 list ref
        is not included in
          val x : 'a list ref
-       The type "'_weak2 list ref" is not compatible with the type "'a list ref"
+       The type "(|'_weak2|) list ref" is not compatible with the type "(|'a|) list ref"
        Type "'_weak2" is not compatible with type "'a"
 |}];;
 
@@ -750,7 +750,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a
        is not included in
          val f : int -> float
-       The type "int -> int" is not compatible with the type "int -> float"
+       The type "int -> (|int|)" is not compatible with the type "int -> (|float|)"
        Type "int" is not compatible with type "float"
 |}];;
 
@@ -773,8 +773,8 @@ Error: Signature mismatch:
          val f : int * int -> int * int
        is not included in
          val f : int * float * int -> int -> int
-       The type "int * int -> int (|*|) int" is not compatible with the type
-         "int * float * (|int|) -> int (|->|) int"
+       The type "int (|*|) int -> int (|*|) int" is not compatible with the type
+         "int (|*|) float (|*|) int -> int (|->|) int"
        Type "int * int" is not compatible with type "int * float * (|int|)"
 |}];;
 
@@ -894,8 +894,8 @@ Error: Signature mismatch:
          val f : < m : 'a. [< `Foo ] as 'a > -> unit
        is not included in
          val f : < m : [< `Foo ] > -> unit
-       The type "< m : 'a. [< `Foo ] as 'a > -> unit"
-       is not compatible with the type "< m : [< `Foo ] > -> unit"
+       The type "< m : (|'a. [< `Foo ] as 'a|) > -> unit"
+       is not compatible with the type "< m : (|[< `Foo ]|) > -> unit"
        The method "m" has type "'b. [< `Foo ] as 'b",
        but the expected method type was "[< `Foo ]"
 |}];;
@@ -919,8 +919,8 @@ Error: Signature mismatch:
          val f : < m : [ `Foo ] > -> unit
        is not included in
          val f : < m : 'a. [< `Foo ] as 'a > -> unit
-       The type "< m : [ `Foo ] > -> unit" is not compatible with the type
-         "< m : 'a. [< `Foo ] as 'a > -> unit"
+       The type "< m : (|[ `Foo ]|) > -> unit" is not compatible with the type
+         "< m : (|'a. [< `Foo ] as 'a|) > -> unit"
        The method "m" has type "[ `Foo ]", but the expected method type was
        "'b. [< `Foo ] as 'b"
 |}];;
@@ -1321,7 +1321,7 @@ Error: Signature mismatch:
          type t = < a : int >
        is not included in
          type t = private < a : float; .. >
-       The type "int" is not equal to the type "float"
+       The type "(|int|)" is not equal to the type "(|float|)"
        Type "int" is not equal to type "float"
 |}];;
 
@@ -1350,7 +1350,7 @@ Error: Signature mismatch:
          type t = private u
        is not included in
          type t = private int * (int * int)
-       The type "int * q" is not equal to the type "int * (int * int)"
+       The type "int * (|q|)" is not equal to the type "int * (int (|*|) int)"
        Type "q" is not equal to type "int * int"
 |}];;
 
@@ -1379,8 +1379,8 @@ Error: Signature mismatch:
          type t = private u
        is not included in
          type t = private int * (int * int)
-       The type "int * q" is not equal to the type "int * (int * int)"
-       Type "q" = "int * w" is not equal to type "int * int"
+       The type "int * (|q|)" is not equal to the type "int * (int (|*|) int)"
+       Type "q" = "int * (|w|)" is not equal to type "int * (|int|)"
        Type "w" = "float" is not equal to type "int"
 |}];;
 
@@ -1744,8 +1744,8 @@ Error: Signature mismatch:
          "A : (< x : 'b * 'b > as 'b) -> (< y : 'a > as 'a) t"
        is not the same as:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) t"
-       The type "< x : 'a * 'a > as 'a" is not equal to the type
-         "< x : 'b > as 'b"
+       The type "< x : 'a (|*|) 'a > as 'a" is not equal to the type
+         "< x : (|'b|) > as 'b"
        The method "x" has type "< x : 'c > (|*|) < x : 'c > as 'c",
        but the expected method type was "(|< x : 'b >|) as 'b"
 |}]
@@ -1772,8 +1772,8 @@ Error: Signature mismatch:
          "a : < x : 'a * 'a > as 'a;"
        is not the same as:
          "a : < x : 'a > as 'a;"
-       The type "< x : 'a * 'a > as 'a" is not equal to the type
-         "< x : 'b > as 'b"
+       The type "< x : 'a (|*|) 'a > as 'a" is not equal to the type
+         "< x : (|'b|) > as 'b"
        The method "x" has type "< x : 'c > (|*|) < x : 'c > as 'c",
        but the expected method type was "(|< x : 'b >|) as 'b"
 |}]
@@ -1807,8 +1807,8 @@ Error: Signature mismatch:
          "A : (< x : 'b * 'b > as 'b) -> (< y : 'a > as 'a) ext"
        is not the same as:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) ext"
-       The type "< x : 'a * 'a > as 'a" is not equal to the type
-         "< x : 'b > as 'b"
+       The type "< x : 'a (|*|) 'a > as 'a" is not equal to the type
+         "< x : (|'b|) > as 'b"
        The method "x" has type "< x : 'c > (|*|) < x : 'c > as 'c",
        but the expected method type was "(|< x : 'b >|) as 'b"
 |}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -345,7 +345,7 @@ Error: In this "with" constraint, the new definition of "M.t"
          type t = s
        is not included in
          type t = private [ `Foo of M.r ]
-       The type "s" = "[ `Foo of s ]" is not equal to the type "[ `Foo of M.r ]"
+       The type "s" is not equal to the type "[ `Foo of M.r ]"
        In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
 |}]
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -346,7 +346,7 @@ Error: In this "with" constraint, the new definition of "M.t"
        is not included in
          type t = private [ `Foo of M.r ]
        The type "s" = "[ `Foo of s ]" is not equal to the type "[ `Foo of M.r ]"
-       Type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
+       In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
        Types for tag "`Foo" are incompatible
 |}]
 
@@ -385,7 +385,7 @@ Error: In this "with" constraint, the new definition of "M.N"
        is not included in
          type t = private [ `Foo of M.r ]
        The type "[ `Foo of t ]" is not equal to the type "[ `Foo of M.r ]"
-       Type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
+       In tag "`Foo", type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
        Types for tag "`Foo" are incompatible
 |}]
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -347,7 +347,6 @@ Error: In this "with" constraint, the new definition of "M.t"
          type t = private [ `Foo of M.r ]
        The type "s" = "[ `Foo of s ]" is not equal to the type "[ `Foo of M.r ]"
        In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
-       Types for tag "`Foo" are incompatible
 |}]
 
 (* Should succeed *)
@@ -386,7 +385,6 @@ Error: In this "with" constraint, the new definition of "M.N"
          type t = private [ `Foo of M.r ]
        The type "[ `Foo of t ]" is not equal to the type "[ `Foo of M.r ]"
        In tag "`Foo", type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
-       Types for tag "`Foo" are incompatible
 |}]
 
 (* Should succeed *)

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -318,7 +318,7 @@ Error: This variant or record definition does not match that of type "s"
          "Foo of s"
        is not the same as:
          "Foo of M.r"
-       The type "s" is not equal to the type "M.r" = "M.t"
+       The type "(|s|)" is not equal to the type "M.r" = "(|M.t|)"
 |}]
 
 (* Should succeed *)
@@ -346,7 +346,7 @@ Error: In this "with" constraint, the new definition of "M.t"
        is not included in
          type t = private [ `Foo of M.r ]
        The type "(|s|)" is not equal to the type "[ `Foo of (|M.r|) ]"
-       In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
+       In tag "`Foo", type "(|s|)" = "[ `Foo of (|s|) ]" is not equal to type "M.r" = "(|M.t|)"
 |}]
 
 (* Should succeed *)
@@ -384,7 +384,7 @@ Error: In this "with" constraint, the new definition of "M.N"
        is not included in
          type t = private [ `Foo of M.r ]
        The type "[ `Foo of (|t|) ]" is not equal to the type "[ `Foo of (|M.r|) ]"
-       In tag "`Foo", type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
+       In tag "`Foo", type "(|t|)" = "[ `Foo of (|t|) ]" is not equal to type "M.r" = "(|M.N.t|)"
 |}]
 
 (* Should succeed *)
@@ -418,7 +418,7 @@ Error: In this "with" constraint, the new definition of "M.N"
          type t = X.t
        is not included in
          type t = M.r
-       The type "X.t" is not equal to the type "M.r" = "M.N.s"
+       The type "(|X.t|)" is not equal to the type "M.r" = "(|M.N.s|)"
 |}]
 
 (* Module constraints with non-aliasable paths

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -345,7 +345,7 @@ Error: In this "with" constraint, the new definition of "M.t"
          type t = s
        is not included in
          type t = private [ `Foo of M.r ]
-       The type "s" is not equal to the type "[ `Foo of M.r ]"
+       The type "(|s|)" is not equal to the type "[ `Foo of (|M.r|) ]"
        In tag "`Foo", type "s" = "[ `Foo of s ]" is not equal to type "M.r" = "M.t"
 |}]
 
@@ -383,7 +383,7 @@ Error: In this "with" constraint, the new definition of "M.N"
          type t = [ `Foo of t ]
        is not included in
          type t = private [ `Foo of M.r ]
-       The type "[ `Foo of t ]" is not equal to the type "[ `Foo of M.r ]"
+       The type "[ `Foo of (|t|) ]" is not equal to the type "[ `Foo of (|M.r|) ]"
        In tag "`Foo", type "t" = "[ `Foo of t ]" is not equal to type "M.r" = "M.N.t"
 |}]
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -664,7 +664,7 @@ Line 6, characters 32-34:
 6 |   module type S2 = S with type ('a, 'b) t = ('a, 'b) t2
                                     ^^
 Error: The type constraints are not consistent.
-       Type "'a * 'b * 'c" is not compatible with type "'d * 'e"
+       Type "'a * 'b * (|'c|)" is not compatible with type "'d * 'e"
 |}]
 
 module type Destructive_with_type_with_constraint = sig
@@ -711,7 +711,7 @@ Line 6, characters 32-34:
 6 |   module type S2 = S with type ('a, 'b) t := ('a, 'b) t2
                                     ^^
 Error: The type constraints are not consistent.
-       Type "'a * 'b * 'c" is not compatible with type "'d * 'e"
+       Type "'a * 'b * (|'c|)" is not compatible with type "'d * 'e"
 |}]
 
 (** Merging and approximation ***)

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -151,12 +151,12 @@ Error: In this "with" constraint, the new definition of "t"
          "X of x"
        is not the same as:
          "X of int"
-       The type "x" is not equal to the type "int"
+       The type "(|x|)" is not equal to the type "(|int|)"
        2. Constructors do not match:
          "Y of y"
        is not the same as:
          "Y of float"
-       The type "y" is not equal to the type "float"
+       The type "(|y|)" is not equal to the type "(|float|)"
 |}]
 
 (** First class module types require an identity *)
@@ -587,5 +587,5 @@ Error: In this "with" constraint, the new definition of "A"
          type t = bool
        is not included in
          type t = int
-       The type "bool" is not equal to the type "int"
+       The type "(|bool|)" is not equal to the type "(|int|)"
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -127,8 +127,8 @@ Error: Signature mismatch:
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
        The type "[ `Bar of int | `Foo of t (|->|) int ]" is not equal to the type
          "[ `Bar of int | `Foo of 'a (|->|) int ] as 'a"
-       In tag "`Foo", type "t -> int" is not equal to type
-         "[ `Bar of int | `Foo of 'b ] -> int as 'b"
+       In tag "`Foo", type "(|t|) -> int" is not equal to type
+         "(|[ `Bar of int | `Foo of 'b ]|) -> int as 'b"
 |}]
 
 (* nondep_type_decl + nondep_type_rec *)

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -127,6 +127,8 @@ Error: Signature mismatch:
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
        The type "[ `Bar of int | `Foo of t -> int ]" is not equal to the type
          "[ `Bar of int | `Foo of 'a -> int ] as 'a"
+       In tag "`Foo", type "t" is not equal to type
+         "[ `Bar of int | `Foo of 'a -> int ] as 'a"
        Types for tag "`Foo" are incompatible
 |}]
 

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -125,8 +125,8 @@ Error: Signature mismatch:
          type s = t
        is not included in
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
-       The type "[ `Bar of int | `Foo of t -> int ]" is not equal to the type
-         "[ `Bar of int | `Foo of 'a -> int ] as 'a"
+       The type "[ `Bar of int | `Foo of t (|->|) int ]" is not equal to the type
+         "[ `Bar of int | `Foo of 'a (|->|) int ] as 'a"
        In tag "`Foo", type "t -> int" is not equal to type
          "[ `Bar of int | `Foo of 'b ] -> int as 'b"
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -127,9 +127,8 @@ Error: Signature mismatch:
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
        The type "[ `Bar of int | `Foo of t -> int ]" is not equal to the type
          "[ `Bar of int | `Foo of 'a -> int ] as 'a"
-       In tag "`Foo", type "t" is not equal to type
-         "[ `Bar of int | `Foo of 'a -> int ] as 'a"
-       Types for tag "`Foo" are incompatible
+       In tag "`Foo", type "t -> int" is not equal to type
+         "[ `Bar of int | `Foo of 'b ] -> int as 'b"
 |}]
 
 (* nondep_type_decl + nondep_type_rec *)

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -24,5 +24,5 @@ Error: Signature mismatch:
          type t = X.t = A | B
        is not included in
          type t = int * bool
-       The type "X.t" is not equal to the type "int * bool"
+       The type "(|X.t|)" is not equal to the type "int (|*|) bool"
 |}];;

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -319,6 +319,6 @@ Error: This variant or record definition does not match that of type "M.t"
          "E of (MkT(Desc).t, MkT(Desc).t) eq"
        The type "((|MkT(M.T).t|), MkT(M.T).t) eq" is not equal to the type
          "((|MkT(Desc).t|), MkT(Desc).t) eq"
-       Type "MkT(M.T).t" = "Set.Make(M.Term0).t" is not equal to type
-         "MkT(Desc).t" = "Set.Make(Desc).t"
+       Type "MkT(M.T).t" = "(|Set.Make(M.Term0).t|)" is not equal to type
+         "MkT(Desc).t" = "(|Set.Make(Desc).t|)"
 |}]

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -317,8 +317,8 @@ Error: This variant or record definition does not match that of type "M.t"
          "E of (MkT(M.T).t, MkT(M.T).t) eq"
        is not the same as:
          "E of (MkT(Desc).t, MkT(Desc).t) eq"
-       The type "(MkT(M.T).t, MkT(M.T).t) eq" is not equal to the type
-         "(MkT(Desc).t, MkT(Desc).t) eq"
+       The type "((|MkT(M.T).t|), MkT(M.T).t) eq" is not equal to the type
+         "((|MkT(Desc).t|), MkT(Desc).t) eq"
        Type "MkT(M.T).t" = "Set.Make(M.Term0).t" is not equal to type
          "MkT(Desc).t" = "Set.Make(Desc).t"
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -39,7 +39,7 @@ Error: This variant or record definition does not match that of type "M1.t"
          "E of M1.x"
        is not the same as:
          "E of M1.y"
-       The type "M1.x" = "int" is not equal to the type "M1.y" = "bool"
+       The type "M1.x" = "(|int|)" is not equal to the type "M1.y" = "(|bool|)"
 |}]
 
 (* Also check the original version *)
@@ -83,5 +83,5 @@ Error: This variant or record definition does not match that of type "M1.t"
        is not the same as:
          "E of (M1.x, M1.y) eq"
        The type "(M1.x, (|M1.x|)) eq" is not equal to the type "(M1.x, (|M1.y|)) eq"
-       Type "M1.x" = "int" is not equal to type "M1.y" = "bool"
+       Type "M1.x" = "(|int|)" is not equal to type "M1.y" = "(|bool|)"
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -82,6 +82,6 @@ Error: This variant or record definition does not match that of type "M1.t"
          "E of (M1.x, M1.x) eq"
        is not the same as:
          "E of (M1.x, M1.y) eq"
-       The type "(M1.x, M1.x) eq" is not equal to the type "(M1.x, M1.y) eq"
+       The type "(M1.x, (|M1.x|)) eq" is not equal to the type "(M1.x, (|M1.y|)) eq"
        Type "M1.x" = "int" is not equal to type "M1.y" = "bool"
 |}]

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -44,15 +44,15 @@ Error: Signature mismatch:
          "f0 : unit * unit * unit * float * unit * unit * unit;"
        is not the same as:
          "f0 : unit * unit * unit * int * unit * unit * unit;"
-       The type "unit * unit * unit * float * unit * unit * unit"
-       is not equal to the type "unit * unit * unit * int * unit * unit * unit"
+       The type "unit * unit * unit * (|float|) * unit * unit * unit"
+       is not equal to the type "unit * unit * unit * (|int|) * unit * unit * unit"
        Type "float" is not equal to type "int"
        2. Fields do not match:
          "f1 : unit * unit * unit * string * unit * unit * unit;"
        is not the same as:
          "f1 : unit * unit * unit * int * unit * unit * unit;"
-       The type "unit * unit * unit * string * unit * unit * unit"
-       is not equal to the type "unit * unit * unit * int * unit * unit * unit"
+       The type "unit * unit * unit * (|string|) * unit * unit * unit"
+       is not equal to the type "unit * unit * unit * (|int|) * unit * unit * unit"
        Type "string" is not equal to type "int"
 |}];;
 
@@ -104,8 +104,8 @@ Error: Signature mismatch:
          "f1 : unit * unit * unit * string * unit * unit * unit;"
        is not the same as:
          "f1 : unit * unit * unit * int * unit * unit * unit;"
-       The type "unit * unit * unit * string * unit * unit * unit"
-       is not equal to the type "unit * unit * unit * int * unit * unit * unit"
+       The type "unit * unit * unit * (|string|) * unit * unit * unit"
+       is not equal to the type "unit * unit * unit * (|int|) * unit * unit * unit"
        Type "string" is not equal to type "int"
 |}];;
 

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -46,14 +46,14 @@ Error: Signature mismatch:
          "f0 : unit * unit * unit * int * unit * unit * unit;"
        The type "unit * unit * unit * (|float|) * unit * unit * unit"
        is not equal to the type "unit * unit * unit * (|int|) * unit * unit * unit"
-       Type "float" is not equal to type "int"
+       Type "(|float|)" is not equal to type "(|int|)"
        2. Fields do not match:
          "f1 : unit * unit * unit * string * unit * unit * unit;"
        is not the same as:
          "f1 : unit * unit * unit * int * unit * unit * unit;"
        The type "unit * unit * unit * (|string|) * unit * unit * unit"
        is not equal to the type "unit * unit * unit * (|int|) * unit * unit * unit"
-       Type "string" is not equal to type "int"
+       Type "(|string|)" is not equal to type "(|int|)"
 |}];;
 
 
@@ -106,7 +106,7 @@ Error: Signature mismatch:
          "f1 : unit * unit * unit * int * unit * unit * unit;"
        The type "unit * unit * unit * (|string|) * unit * unit * unit"
        is not equal to the type "unit * unit * unit * (|int|) * unit * unit * unit"
-       Type "string" is not equal to type "int"
+       Type "(|string|)" is not equal to type "(|int|)"
 |}];;
 
 module M3 : sig
@@ -356,7 +356,7 @@ Error: Signature mismatch:
          "f : int;"
        is not the same as:
          "f : float;"
-       The type "int" is not equal to the type "float"
+       The type "(|int|)" is not equal to the type "(|float|)"
 |}]
 
 (** Existential types introduce equations that must be taken in account
@@ -532,7 +532,7 @@ Error: Signature mismatch:
          "b : float;"
        is not the same as:
          "b : int;"
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
 |}]
 
 

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -391,7 +391,7 @@ Error: Signature mismatch:
          "x : 'x;"
        is not the same as:
          "x : 'a;"
-       The type "'x" is not equal to the type "'a"
+       The type "(|'x|)" is not equal to the type "(|'a|)"
 |}]
 
 

--- a/testsuite/tests/typing-modules/unroll_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/unroll_private_abbrev.ml
@@ -31,7 +31,7 @@ let y =
 Line 2, characters 8-41:
 2 |   match (M.bar :> [ `Bar of M.t | `Foo ]) with
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "M.t" is not a subtype of "[ `Bar of M.t | `Foo ]"
+Error: Type "M.t" is not a subtype of "[ `Bar of (|M.t|) | `Foo ]"
        Type "M.t" = "[ `Bar of M.t | `Foo ]" is not a subtype of "M.t"
 |}]
 
@@ -75,6 +75,6 @@ let y =
 Line 2, characters 8-48:
 2 |   match (N.from M.bar :> [ `Bar of N.s | `Foo ]) with
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "N.s" is not a subtype of "[ `Bar of N.s | `Foo ]"
+Error: Type "N.s" is not a subtype of "[ `Bar of (|N.s|) | `Foo ]"
        Type "N.s" = "[ `Bar of N.s | `Foo ]" is not a subtype of "N.s"
 |}]

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -28,7 +28,7 @@ Error: Signature mismatch:
          "Foo of float * int"
        is not the same as:
          "Foo of int * int"
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
 |}];;
 
 module M2 : sig
@@ -90,7 +90,7 @@ Error: Signature mismatch:
          "x : float;"
        is not the same as:
          "x : int;"
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
 |}];;
 
 module M4 : sig
@@ -407,7 +407,7 @@ Error: Signature mismatch:
          "A of float"
        is not the same as:
          "A of int"
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
        3->6. Constructor "C" has been moved from position 3 to 6.
 |}]
 
@@ -438,7 +438,7 @@ Error: Signature mismatch:
          "B of float"
        is not the same as:
          "B of int"
-       The type "float" is not equal to the type "int"
+       The type "(|float|)" is not equal to the type "(|int|)"
 |}]
 
 module Very_imperfect_match: sig

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -174,7 +174,7 @@ Error: Signature mismatch:
          "A of 'b"
        is not the same as:
          "A of 'a"
-       The type "'b" is not equal to the type "'a"
+       The type "(|'b|)" is not equal to the type "(|'a|)"
 |}];;
 
 module M : sig
@@ -200,7 +200,7 @@ Error: Signature mismatch:
          "A of 'a"
        is not the same as:
          "A of 'a"
-       The type "'a" is not equal to the type "'b"
+       The type "(|'a|)" is not equal to the type "(|'b|)"
 |}];;
 
 

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -38,7 +38,7 @@ Error: The class type
          as 'a
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
-       Type exp = < eval : (string, exp) Hashtbl.t -> expr >
+       In tag `App, type exp = < eval : (string, exp) Hashtbl.t -> expr >
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
        Types for tag `App are incompatible

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -38,7 +38,10 @@ Error: The class type
          as 'a
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
-       In tag `App, type exp = < eval : (string, exp) Hashtbl.t -> expr >
+       In tag `App, type
+         [ `Abs of string * [> `App of 'b ] | `App of expr * expr ] * exp
+         as 'b
+       is not compatible with type expr * expr
+       Type exp = < eval : (string, exp) Hashtbl.t -> expr >
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ]
-       Types for tag `App are incompatible

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -14,12 +14,12 @@ Error: This type entity = < destroy_subject : id subject; entity_id : id >
          < add_observer : < destroy_subject : 'c; .. > entity_container -> 'b;
            .. >
          as 'c
-       Type (id subject, id) observer = < notify : id subject -> id -> unit >
-       is not compatible with type
-         (< destroy_subject : < add_observer : 'd -> 'b; .. >; .. > as 'a)
-         entity_container as 'd =
-           < add_entity : 'a -> 'b; notify : 'a -> id -> unit >
        The method add_observer has type (id subject, id) observer -> unit,
        but the expected method type was
-       < destroy_subject : < add_observer : 'e; .. >; .. > entity_container ->
-       'b as 'e
+       < destroy_subject : < add_observer : 'd; .. >; .. > entity_container ->
+       'b as 'd
+       Type (id subject, id) observer = < notify : id subject -> id -> unit >
+       is not compatible with type
+         (< destroy_subject : < add_observer : 'e -> 'b; .. >; .. > as 'a)
+         entity_container as 'e =
+           < add_entity : 'a -> 'b; notify : 'a -> id -> unit >

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -593,6 +593,8 @@ Error: The value "c3" has type
            "< cmp : int_comparable -> int; setx : int -> unit; x : int >"
        but an expression was expected of type
          "#comparable as 'a" = "< cmp : 'a -> int; .. >"
+       The method "cmp" has type "int_comparable -> int",
+       but the expected method type was "#comparable -> int"
        Type "int_comparable" = "< cmp : int_comparable -> int; x : int >"
        is not compatible with type
          "#comparable as 'a" = "< cmp : 'a -> int; .. >"

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -109,7 +109,7 @@ Error: Some type variables are unbound in this type:
              method get : 'a
              method set : 'a -> unit
            end
-       The method "get" has type "'a" where "'a" is unbound
+       The method "get" has type "(|'a|)" where "(|'a|)" is unbound
 |}];;
 
 class ref (x_init:int) = object
@@ -590,9 +590,9 @@ Line 1, characters 25-27:
                              ^^
 Error: The value "c3" has type
          "int_comparable3" =
-           "< cmp : int_comparable -> int; setx : int -> unit; x : int >"
+           "< cmp : int_comparable (|->|) int; setx : int -> unit; x : int >"
        but an expression was expected of type
-         "#comparable as 'a" = "< cmp : 'a -> int; .. >"
+         "#comparable as 'a" = "< cmp : 'a (|->|) int; .. >"
        The method "cmp" has type "int_comparable -> int",
        but the expected method type was "#comparable -> int"
        Type "int_comparable" = "< cmp : int_comparable -> int; x : int >"

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -716,7 +716,7 @@ Error: Signature mismatch:
        The type "(#c as 'a) -> 'a" is not compatible with the type "#c -> #c"
        Type "(|#c as 'a|)" = "< m : (|'a|); .. >" is not compatible with type
          "(|#c as 'b|)" = "< m : (|'b|); .. >"
-       Type "'a" is not compatible with type "'b"
+       Type "(|'a|)" is not compatible with type "(|'b|)"
 |}];;
 
 module M = struct type t = int class t () = object end end;;
@@ -1075,7 +1075,7 @@ Error: The class type object ('a) method m : < m : 'a; .. > as 'a end
          object method m : < m : 'a > as 'a end
        The method m has type "(|< m : (|'a|); .. > as 'a|)"
        but is expected to have type "(|< m : (|'b|) > as 'b|)"
-       Type "'a" is not compatible with type "<  >"
+       Type "(|'a|)" is not compatible with type "(|<  >|)"
 |}];;
 
 class c :
@@ -1135,7 +1135,7 @@ Error: The class type
        The method m has type "(< m : (|'a|) -> unit; .. > as 'a) -> unit"
        but is expected to have type
          "'b. (< m : 'c; x : int; .. > as 'b) -> unit as 'c"
-       Type "'a" is not compatible with type "< x : int; .. >"
+       Type "(|'a|)" is not compatible with type "(|< x : int; .. >|)"
 |}];;
 
 let is_empty (x : < >) = ()

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -784,7 +784,7 @@ fun (x : 'a t as 'a) -> ();;
 Line 1, characters 17-19:
 1 | fun (x : 'a t as 'a) -> ();;
                      ^^
-Error: This alias is bound to type "'a t" but is used as an instance of type "'a"
+Error: This alias is bound to type "(|'a|) t" but is used as an instance of type "'a"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun (x : 'a t) -> (x : 'a); ();;
@@ -792,7 +792,7 @@ fun (x : 'a t) -> (x : 'a); ();;
 Line 1, characters 19-20:
 1 | fun (x : 'a t) -> (x : 'a); ();;
                        ^
-Error: The value "x" has type "'a t" but an expression was expected of type "'a"
+Error: The value "x" has type "(|'a|) t" but an expression was expected of type "'a"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun ((x : 'a) | (x : 'a t)) -> ();;
@@ -800,7 +800,7 @@ fun ((x : 'a) | (x : 'a t)) -> ();;
 Line 1, characters 10-12:
 1 | fun ((x : 'a) | (x : 'a t)) -> ();;
               ^^
-Error: This type "'a t" should be an instance of type "'a"
+Error: This type "(|'a|) t" should be an instance of type "'a"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun ((x : 'a) | (x : 'a t)) -> ();;
@@ -808,7 +808,7 @@ fun ((x : 'a) | (x : 'a t)) -> ();;
 Line 1, characters 10-12:
 1 | fun ((x : 'a) | (x : 'a t)) -> ();;
               ^^
-Error: This type "'a t" should be an instance of type "'a"
+Error: This type "(|'a|) t" should be an instance of type "'a"
        The type variable "'a" occurs inside "'a t"
 |}];;
 type 'a t = < x : 'a >;;

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -1041,7 +1041,7 @@ Error: The class type object method a : int method b : 'a end
        is not matched by the class type
          object method a : 'a method b : 'a end
        The method a has type "(|int|)" but is expected to have type "(|'a|)"
-       Type "int" is not compatible with type "'a"
+       Type "(|int|)" is not compatible with type "(|'a|)"
 |}];;
 
 class type ['a] ct = object ('a) end

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -37,7 +37,7 @@ Lines 3-5, characters 4-3:
 5 | end..
 Error: Some type variables are unbound in this type:
          class d : unit -> object method f : 'a -> unit end
-       The method "f" has type "'a -> unit" where "'a" is unbound
+       The method "f" has type "(|'a|) -> unit" where "(|'a|)" is unbound
 |}];;
 
 (* Create instance #c *)
@@ -714,8 +714,8 @@ Error: Signature mismatch:
        is not included in
          val f : #c -> #c
        The type "(#c as 'a) -> 'a" is not compatible with the type "#c -> #c"
-       Type "#c as 'a" = "< m : 'a; .. >" is not compatible with type
-         "#c as 'b" = "< m : 'b; .. >"
+       Type "(|#c as 'a|)" = "< m : (|'a|); .. >" is not compatible with type
+         "(|#c as 'b|)" = "< m : (|'b|); .. >"
        Type "'a" is not compatible with type "'b"
 |}];;
 
@@ -741,7 +741,7 @@ fun x -> (x : int -> bool :> 'a -> 'a);;
 Line 1, characters 9-38:
 1 | fun x -> (x : int -> bool :> 'a -> 'a);;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "int -> bool" is not a subtype of "int -> int"
+Error: Type "int -> (|bool|)" is not a subtype of "int -> (|int|)"
        Type "bool" is not a subtype of "int"
 |}];;
 fun x -> (x : int -> bool :> int -> int);;
@@ -749,7 +749,7 @@ fun x -> (x : int -> bool :> int -> int);;
 Line 1, characters 9-40:
 1 | fun x -> (x : int -> bool :> int -> int);;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "int -> bool" is not a subtype of "int -> int"
+Error: Type "int -> (|bool|)" is not a subtype of "int -> (|int|)"
        Type "bool" is not a subtype of "int"
 |}];;
 fun x -> (x : < > :> < .. >);;
@@ -1040,7 +1040,7 @@ Error: The class type object method a : int method b : 'a end
        The class type object method a : int method b : 'a end
        is not matched by the class type
          object method a : 'a method b : 'a end
-       The method a has type "int" but is expected to have type "'a"
+       The method a has type "(|int|)" but is expected to have type "(|'a|)"
        Type "int" is not compatible with type "'a"
 |}];;
 
@@ -1073,8 +1073,8 @@ Lines 3-5, characters 8-3:
 Error: The class type object ('a) method m : < m : 'a; .. > as 'a end
        is not matched by the class type
          object method m : < m : 'a > as 'a end
-       The method m has type "< m : 'a; .. > as 'a"
-       but is expected to have type "< m : 'b > as 'b"
+       The method m has type "(|< m : (|'a|); .. > as 'a|)"
+       but is expected to have type "(|< m : (|'b|) > as 'b|)"
        Type "'a" is not compatible with type "<  >"
 |}];;
 
@@ -1094,9 +1094,9 @@ Error: The class type
          object method foo : (< foo : int; .. > as 'a) -> 'a -> unit end
        is not matched by the class type
          object method foo : < foo : int; .. > -> < foo : int > -> unit end
-       The method foo has type "'a. (< foo : int; .. > as 'a) -> 'a -> unit"
+       The method foo has type "'a. (< foo : int; .. > as 'a) -> (|'a|) -> unit"
        but is expected to have type
-         "'b. (< foo : int; .. > as 'b) -> < foo : int > -> unit"
+         "'b. (< foo : int; .. > as 'b) -> (|< foo : int >|) -> unit"
        Type "'c" is not compatible with type "<  >"
 |}];;
 
@@ -1132,7 +1132,7 @@ Error: The class type
          object ('a) method m : (< m : 'a -> unit; .. > as 'a) -> unit end
        is not matched by the class type
          object method m : < m : 'a; x : int; .. > -> unit as 'a end
-       The method m has type "(< m : 'a -> unit; .. > as 'a) -> unit"
+       The method m has type "(< m : (|'a|) -> unit; .. > as 'a) -> unit"
        but is expected to have type
          "'b. (< m : 'c; x : int; .. > as 'b) -> unit as 'c"
        Type "'a" is not compatible with type "< x : int; .. >"
@@ -1459,6 +1459,6 @@ Line 2, characters 0-16:
 2 | class d = ['a] c
     ^^^^^^^^^^^^^^^^
 Error: Some type variables are unbound in this type: class d : ['a] c
-       The method "m" has type "(< f : 'b; x : 'a > as 'b) -> unit" where "'a"
+       The method "m" has type "(< f : 'b; x : (|'a|) > as 'b) -> unit" where "(|'a|)"
        is unbound
 |}]

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -784,7 +784,7 @@ fun (x : 'a t as 'a) -> ();;
 Line 1, characters 17-19:
 1 | fun (x : 'a t as 'a) -> ();;
                      ^^
-Error: This alias is bound to type "(|'a|) t" but is used as an instance of type "'a"
+Error: This alias is bound to type "(|'a|) t" but is used as an instance of type "(|'a|)"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun (x : 'a t) -> (x : 'a); ();;
@@ -792,7 +792,7 @@ fun (x : 'a t) -> (x : 'a); ();;
 Line 1, characters 19-20:
 1 | fun (x : 'a t) -> (x : 'a); ();;
                        ^
-Error: The value "x" has type "(|'a|) t" but an expression was expected of type "'a"
+Error: The value "x" has type "(|'a|) t" but an expression was expected of type "(|'a|)"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun ((x : 'a) | (x : 'a t)) -> ();;
@@ -800,7 +800,7 @@ fun ((x : 'a) | (x : 'a t)) -> ();;
 Line 1, characters 10-12:
 1 | fun ((x : 'a) | (x : 'a t)) -> ();;
               ^^
-Error: This type "(|'a|) t" should be an instance of type "'a"
+Error: This type "(|'a|) t" should be an instance of type "(|'a|)"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun ((x : 'a) | (x : 'a t)) -> ();;
@@ -808,7 +808,7 @@ fun ((x : 'a) | (x : 'a t)) -> ();;
 Line 1, characters 10-12:
 1 | fun ((x : 'a) | (x : 'a t)) -> ();;
               ^^
-Error: This type "(|'a|) t" should be an instance of type "'a"
+Error: This type "(|'a|) t" should be an instance of type "(|'a|)"
        The type variable "'a" occurs inside "'a t"
 |}];;
 type 'a t = < x : 'a >;;

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -197,6 +197,8 @@ Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+       The method "redrawWidget" has type "parameter_contains_self -> unit",
+       but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
        is not compatible with type "< invalidate : unit; .. >"
        Self type cannot be unified with a closed object type
@@ -213,6 +215,8 @@ Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+       The method "redrawWidget" has type "parameter_contains_self -> unit",
+       but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
        is not compatible with type "< invalidate : unit; .. >"
        Self type cannot be unified with a closed object type
@@ -260,6 +264,8 @@ Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+       The method "redrawWidget" has type "parameter_contains_self -> unit",
+       but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
        is not compatible with type "< invalidate : unit; .. >"
        Self type cannot be unified with a closed object type

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -194,9 +194,9 @@ Line 3, characters 36-41:
 3 |     inherit parameter_contains_self param
                                         ^^^^^
 Error: The value "param" has type
-         "< redrawWidget : parameter_contains_self -> unit; .. >"
+         "< redrawWidget : parameter_contains_self (|->|) unit; .. >"
        but an expression was expected of type
-         "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+         "< redrawWidget : < invalidate : unit; .. > (|->|) unit; .. >"
        The method "redrawWidget" has type "parameter_contains_self -> unit",
        but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
@@ -212,9 +212,9 @@ Line 3, characters 26-31:
 3 |   parameter_contains_self param;;
                               ^^^^^
 Error: The value "param" has type
-         "< redrawWidget : parameter_contains_self -> unit; .. >"
+         "< redrawWidget : parameter_contains_self (|->|) unit; .. >"
        but an expression was expected of type
-         "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+         "< redrawWidget : < invalidate : unit; .. > (|->|) unit; .. >"
        The method "redrawWidget" has type "parameter_contains_self -> unit",
        but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"
@@ -261,9 +261,9 @@ Line 3, characters 36-41:
 3 |     inherit parameter_contains_self param
                                         ^^^^^
 Error: The value "param" has type
-         "< redrawWidget : parameter_contains_self -> unit; .. >"
+         "< redrawWidget : parameter_contains_self (|->|) unit; .. >"
        but an expression was expected of type
-         "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
+         "< redrawWidget : < invalidate : unit; .. > (|->|) unit; .. >"
        The method "redrawWidget" has type "parameter_contains_self -> unit",
        but the expected method type was "< invalidate : unit; .. > -> unit"
        Type "parameter_contains_self" = "< invalidate : unit >"

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -32,7 +32,7 @@ Error: The class type object method x : 'a * float end
        The class type object method x : 'a * float end
        is not matched by the class type object method x : int end
        The method x has type "'a (|*|) float" but is expected to have type "(|int|)"
-       Type "'a * float" is not compatible with type "int"
+       Type "'a (|*|) float" is not compatible with type "(|int|)"
 |}]
 
 let foo = 42#m;;

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -11,7 +11,7 @@ Error: The type of this class,
        "class virtual ['_a] c :
          object constraint '_a = [< `A of int & float ] as '_weak1 end",
        contains non-collapsible conjunctive types in constraints.
-       Type "int" is not compatible with type "float"
+       Type "(|int|)" is not compatible with type "(|float|)"
 |}]
 
 class type ct = object

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -31,7 +31,7 @@ Error: The class type object method x : 'a * float end
        is not matched by the class type ct
        The class type object method x : 'a * float end
        is not matched by the class type object method x : int end
-       The method x has type "'a * float" but is expected to have type "int"
+       The method x has type "'a (|*|) float" but is expected to have type "(|int|)"
        Type "'a * float" is not compatible with type "int"
 |}]
 

--- a/testsuite/tests/typing-objects/pr6907_bad.ml
+++ b/testsuite/tests/typing-objects/pr6907_bad.ml
@@ -18,5 +18,5 @@ Line 2, characters 2-27:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Some type variables are unbound in this type:
          class base : 'e -> ['e] t
-       The method "update" has type "'e -> #base" where "'e" is unbound
+       The method "update" has type "(|'e|) -> #base" where "(|'e|)" is unbound
 |}];;

--- a/testsuite/tests/typing-objects/unbound-type-var.ml
+++ b/testsuite/tests/typing-objects/unbound-type-var.ml
@@ -15,5 +15,5 @@ Lines 1-4, characters 0-3:
 4 | end
 Error: Some type variables are unbound in this type:
          class test : 'a -> 'b -> object method b : 'b end
-       The method "b" has type "'b" where "'b" is unbound
+       The method "b" has type "(|'b|)" where "(|'b|)" is unbound
 |}]

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -58,11 +58,11 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type "< f : 'b -> int >"
-       but an expression was expected of type "t_a" = "< f : 'a. 'a -> int >"
-       The method "f" has type "'b -> int", but the expected method type was
-       "'a. 'a -> int"
-       The universal variable "'a" would escape its scope
+Error: This expression has type "< f : 'a -> int >"
+       but an expression was expected of type "t_a"
+       The method "f" has type "'a -> int", but the expected method type was
+       "'a0. 'a0 -> int"
+       The universal variable "'a0" would escape its scope
 |}
 ]
 
@@ -77,12 +77,11 @@ val f : uv -> int = <fun>
 Line 4, characters 11-49:
 4 | let () = f ( `A (object method f _ = 0 end): _ v);;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "'b v" = "[ `A of < f : 'b -> int > ]"
-       but an expression was expected of type
-         "uv" = "[ `A of < f : 'a. 'a -> int > ]"
-       The method "f" has type "'b -> int", but the expected method type was
-       "'a. 'a -> int"
-       The universal variable "'a" would escape its scope
+Error: This expression has type "'a v" but an expression was expected of type
+         "uv"
+       The method "f" has type "'a -> int", but the expected method type was
+       "'a0. 'a0 -> int"
+       The universal variable "'a0" would escape its scope
 |}]
 
 (* Issue #8702: row types unified with universally quantified types*)

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -38,7 +38,7 @@ Line 4, characters 49-50:
                                                      ^
 Error: The value "y" has type "< a : 'a; b : (|'a|) >"
        but an expression was expected of type "< a : 'a; b : (|'a0. 'a0|) >"
-       The method "b" has type "'a", but the expected method type was "'a0. 'a0"
+       The method "b" has type "'a", but the expected method type was "'a0. (|'a0|)"
        The universal variable "'a0" would escape its scope
 |}]
 
@@ -61,7 +61,7 @@ Lines 5-7, characters 10-5:
 Error: This expression has type "< f : 'a (|->|) int >"
        but an expression was expected of type "t_a"
        The method "f" has type "'a -> int", but the expected method type was
-       "'a0. 'a0 -> int"
+       "'a0. (|'a0|) -> int"
        The universal variable "'a0" would escape its scope
 |}
 ]
@@ -80,7 +80,7 @@ Line 4, characters 11-49:
 Error: This expression has type "'a v" but an expression was expected of type
          "uv"
        The method "f" has type "'a -> int", but the expected method type was
-       "'a0. 'a0 -> int"
+       "'a0. (|'a0|) -> int"
        The universal variable "'a0" would escape its scope
 |}]
 

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -58,11 +58,11 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type "< f : 'a -> int >"
-       but an expression was expected of type "t_a"
-       The method "f" has type "'a -> int", but the expected method type was
-       "'a0. 'a0 -> int"
-       The universal variable "'a0" would escape its scope
+Error: This expression has type "< f : 'b -> int >"
+       but an expression was expected of type "t_a" = "< f : 'a. 'a -> int >"
+       The method "f" has type "'b -> int", but the expected method type was
+       "'a. 'a -> int"
+       The universal variable "'a" would escape its scope
 |}
 ]
 
@@ -77,11 +77,12 @@ val f : uv -> int = <fun>
 Line 4, characters 11-49:
 4 | let () = f ( `A (object method f _ = 0 end): _ v);;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "'a v" but an expression was expected of type
-         "uv"
-       The method "f" has type "'a -> int", but the expected method type was
-       "'a0. 'a0 -> int"
-       The universal variable "'a0" would escape its scope
+Error: This expression has type "'b v" = "[ `A of < f : 'b -> int > ]"
+       but an expression was expected of type
+         "uv" = "[ `A of < f : 'a. 'a -> int > ]"
+       The method "f" has type "'b -> int", but the expected method type was
+       "'a. 'a -> int"
+       The universal variable "'a" would escape its scope
 |}]
 
 (* Issue #8702: row types unified with universally quantified types*)

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -36,8 +36,8 @@ let f (x:<a:'a; b:'a. 'a>) (y:<a:'a;b:'a>) = x = y
 Line 4, characters 49-50:
 4 | let f (x:<a:'a; b:'a. 'a>) (y:<a:'a;b:'a>) = x = y
                                                      ^
-Error: The value "y" has type "< a : 'a; b : 'a >"
-       but an expression was expected of type "< a : 'a; b : 'a0. 'a0 >"
+Error: The value "y" has type "< a : 'a; b : (|'a|) >"
+       but an expression was expected of type "< a : 'a; b : (|'a0. 'a0|) >"
        The method "b" has type "'a", but the expected method type was "'a0. 'a0"
        The universal variable "'a0" would escape its scope
 |}]
@@ -58,7 +58,7 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type "< f : 'a -> int >"
+Error: This expression has type "< f : 'a (|->|) int >"
        but an expression was expected of type "t_a"
        The method "f" has type "'a -> int", but the expected method type was
        "'a0. 'a0 -> int"

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1831,6 +1831,7 @@ Line 2, characters 2-72:
 Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
+       In tag "`Foo", type "'x" is not compatible with type "int"
        Types for tag "`Foo" are incompatible
 |}];;
 (* fail *)
@@ -1843,6 +1844,7 @@ Line 2, characters 2-72:
 Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
+       In tag "`Foo", type "'x" is not compatible with type "int"
        Types for tag "`Foo" are incompatible
 |}];;
 (* ok *)
@@ -1863,6 +1865,7 @@ Line 2, characters 3-4:
 Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >"
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
+       In tag "`Foo", type "'a" is not compatible with type "int"
        Types for tag "`Foo" are incompatible
 |}]
 (* ok (with implicit universal quantification) *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -465,8 +465,8 @@ val f : < m : 'a. 'a -> 'a > -> < m : 'b. 'b -> 'b > = <fun>
 Line 9, characters 41-42:
 9 | let f (x : < m : 'a. 'a -> 'a list >) = (x : < m : 'b. 'b -> 'c >)
                                              ^
-Error: The value "x" has type "< m : 'b. 'b -> 'b list >"
-       but an expression was expected of type "< m : 'b. 'b -> 'c >"
+Error: The value "x" has type "< m : (|'b. 'b -> 'b list|) >"
+       but an expression was expected of type "< m : (|'b. 'b -> 'c|) >"
        The method "m" has type "'b. 'b -> 'b list",
        but the expected method type was "'b. 'b -> 'c"
        The universal variable "'b" would escape its scope
@@ -1033,7 +1033,7 @@ Line 3, characters 13-29:
 3 |   and 'a u = (float,string) t;;
                  ^^^^^^^^^^^^^^^^
 Error: Constraints are not satisfied in this type.
-       Type "(float, string) t" should be an instance of "(int, int) t"
+       Type "((|float|), string) t" should be an instance of "((|int|), (|int|)) t"
        Type "float" is not compatible with type "int"
 |}]
 
@@ -1201,7 +1201,7 @@ Line 2, characters 3-4:
        ^
 Error: The value "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        but an expression was expected of type
-         "< m : 'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd) >"
+         "< m : 'a. 'a * (< m : 'a * < m : (|'c. 'c * 'd|) > > as 'd) >"
        The method "m" has type
        "'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd)",
        but the expected method type was
@@ -1221,9 +1221,9 @@ type bar' = < m : 'a. 'a * 'a bar >
 Line 5, characters 20-21:
 5 | let f (x : foo') = (x : bar');;
                         ^
-Error: The value "x" has type "foo'" = "< m : 'a. 'a * 'a foo >"
-       but an expression was expected of type "bar'" = "< m : 'a. 'a * 'a bar >"
-       Type "'a foo" = "< m : 'a * 'a foo >" is not compatible with type
+Error: The value "x" has type "foo'" = "< m : 'a. 'a * 'a (|foo|) >"
+       but an expression was expected of type "bar'" = "< m : 'a. 'a * 'a (|bar|) >"
+       Type "'a (|foo|)" = "< m : 'a * 'a foo >" is not compatible with type
          "'a bar" = "< m : 'a * < m : 'c. 'c * 'a bar > >"
        Type "'a foo" = "< m : 'a * 'a foo >" is not compatible with type
          "< m : 'c. 'c * 'a bar >"
@@ -1240,9 +1240,9 @@ fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->
 Line 2, characters 3-4:
 2 |   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('c * 'bar)>)> as 'bar);;
        ^
-Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
+Error: The value "x" has type "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'a|) > as 'a) >"
        but an expression was expected of type
-         "< m : 'b. 'b * ('b * < m : 'c. 'c * ('c * 'd) >) > as 'd"
+         "< m : 'b. 'b * ('b * < m : (|'c. 'c * ('c * 'd)|) >) > as 'd"
        The method "m" has type "'c. 'c * ('b * < m : 'c. 'e >) as 'e",
        but the expected method type was
        "'c. 'c * ('c * < m : 'b. 'b * ('b * < m : 'c. 'f >) >) as 'f"
@@ -1273,7 +1273,7 @@ Line 2, characters 3-4:
        ^
 Error: The value "x" has type "< m : 'b. 'b * ('b * 'a) > as 'a"
        but an expression was expected of type
-         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'd > as 'd) >"
+         "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'd|) > as 'd) >"
        The method "m" has type "'b. 'b * ('b * < m : 'c. 'c * 'd > as 'd)",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'e >) as 'e"
        The universal variable "'b" would escape its scope
@@ -1285,7 +1285,7 @@ let f x =
 Lines 2-3, characters 4-46:
 2 | ....(x : <m : 'a. 'a -> ('a * <m:'c. 'c -> 'bar> as 'bar)>
 3 |        :> <m : 'a. 'a -> ('a * 'foo)> as 'foo)..
-Error: Type "< m : 'a. 'a -> ('a * < m : 'c. 'c -> 'b > as 'b) >"
+Error: Type "< m : 'a. 'a -> ('a * < m : (|'c. 'c -> 'b|) > as 'b) >"
        is not a subtype of "< m : 'a. 'a -> 'a * 'd > as 'd"
        Type "'c. 'c -> 'a * < m : 'c. 'e > as 'e" is not a subtype of
          "'a. 'a -> 'a * < m : 'a. 'f > as 'f"
@@ -1298,9 +1298,9 @@ let f (x: <x: 'a 'b 'c. 'a * 'b * 'b * 'c >) =
 Line 2, characters 3-4:
 2 |   (x: <x: 'a 'b 'c. 'c * 'a * 'b * 'b>)
        ^
-Error: The value "x" has type "< x : 'c 'a 'c0. 'c * 'a * 'a * 'c0 >"
+Error: The value "x" has type "< x : (|'c 'a 'c0. 'c * 'a * 'a * 'c0|) >"
        but an expression was expected of type
-         "< x : 'a 'b 'c. 'c * 'a * 'b * 'b >"
+         "< x : (|'a 'b 'c. 'c * 'a * 'b * 'b|) >"
        The method "x" has type "'c 'a 'c0. 'c * 'a * 'a * 'c0",
        but the expected method type was "'a 'b 'c. 'c * 'a * 'b * 'b"
        The universal variables "'a" and "'b" are distinct.
@@ -1312,8 +1312,8 @@ let f (x: <x: 'a. <x: 'b. 'a * 'b > >) =
 Line 2, characters 7-8:
 2 |       (x: <x: 'b. <x: 'a. 'a * 'b > >)
            ^
-Error: The value "x" has type "< x : 'a. < x : 'b. 'a * 'b > >"
-       but an expression was expected of type "< x : 'b. < x : 'a. 'a * 'b > >"
+Error: The value "x" has type "< x : 'a. < x : (|'b. 'a * 'b|) > >"
+       but an expression was expected of type "< x : 'b. < x : (|'a. 'a * 'b|) > >"
        The method "x" has type "'b. 'a * 'b", but the expected method type was
        "'a0. 'a0 * 'b"
        The universal variables "'a" and "'a0" are distinct.
@@ -1327,8 +1327,8 @@ let f (o: <x: 'a 'b. ('a * 'a) * 'b >) =
 Line 2, characters 7-8:
 2 |       (o: <x: 'a 'b. ('a * 'a) * 'a >)
            ^
-Error: The value "o" has type "< x : 'a 'b. ('a * 'a) * 'b >"
-       but an expression was expected of type "< x : 'a. ('a * 'a) * 'a >"
+Error: The value "o" has type "< x : (|'a 'b. ('a * 'a) * 'b|) >"
+       but an expression was expected of type "< x : (|'a. ('a * 'a) * 'a|) >"
        The method "x" has type "'a 'b. ('a * 'a) * 'b",
        but the expected method type was "'a. ('a * 'a) * 'a"
        The universal variables "'b" and "'a" are distinct.
@@ -1354,7 +1354,7 @@ Error: Signature mismatch:
          val f : < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) > -> unit
        The type "(< m : 'a. 'a * ('a * 'd) > as 'd) -> unit"
        is not compatible with the type
-         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) > -> unit"
+         "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'e|) > as 'e) > -> unit"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
@@ -1376,7 +1376,7 @@ Error: Signature mismatch:
        is not included in
          type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The type "< m : 'a. 'a * ('a * 'd) > as 'd" is not equal to the type
-         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) >"
+         "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'e|) > as 'e) >"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
        but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
@@ -1828,9 +1828,9 @@ let (n : < m : 'a. [< `Foo of int] -> 'a >) =
 Line 2, characters 2-72:
 2 |   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
+Error: This expression has type "< m : 'b 'x. ([< `Foo of (|'x|) ] as 'b) -> 'x >"
        but an expression was expected of type
-         "< m : 'a. [< `Foo of int ] -> 'a >"
+         "< m : 'a. [< `Foo of (|int|) ] -> 'a >"
        In tag "`Foo", type "'x" is not compatible with type "int"
 |}];;
 (* fail *)
@@ -1840,9 +1840,9 @@ let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
 Line 2, characters 2-72:
 2 |   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
+Error: This expression has type "< m : 'b 'x. ([< `Foo of (|'x|) ] as 'b) -> 'x >"
        but an expression was expected of type
-         "< m : 'a. [< `Foo of int ] -> 'a >"
+         "< m : 'a. [< `Foo of (|int|) ] -> 'a >"
        In tag "`Foo", type "'x" is not compatible with type "int"
 |}];;
 (* ok *)
@@ -1860,9 +1860,9 @@ let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
 Line 2, characters 3-4:
 2 |   (n : < m : 'b 'r. [< `Foo of int & 'b | `Bar] as 'r >)
        ^
-Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >"
+Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of (|'a|) & int ] as 'c >"
        but an expression was expected of type
-         "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
+         "< m : 'b 'd. [< `Bar | `Foo of (|int|) & 'b ] as 'd >"
        In tag "`Foo", type "'a" is not compatible with type "int"
 |}]
 (* ok (with implicit universal quantification) *)
@@ -2163,7 +2163,7 @@ Lines 1-3, characters 15-3:
 1 | ...............object
 2 |   method x : 'b . 'b s list = [S]
 3 | end
-Error: This expression has type "< x : 'b. 'b s list >"
+Error: This expression has type "< x : (|'b. 'b s list|) >"
        but an expression was expected of type "'a c"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
@@ -2199,7 +2199,7 @@ Lines 1-3, characters 15-3:
 1 | ...............object
 2 |   method x : 'b . 'b s list = []
 3 | end
-Error: This expression has type "< x : 'b. 'b s list >"
+Error: This expression has type "< x : (|'b. 'b s list|) >"
        but an expression was expected of type "'a c"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
@@ -2331,6 +2331,6 @@ Error: Some type variables are unbound in this type:
        The method "m" has type
          "'b.
            < n : 'irr.
-                   ('irr -> unit) * ((< x : 'a; y : 'b; .. > as 'c) -> 'a) >"
-       where "'c" is unbound
+                   ('irr -> unit) * (((|< x : 'a; y : 'b; .. > as 'c|)) -> 'a) >"
+       where "(|'c|)" is unbound
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -519,8 +519,8 @@ end
 Line 3, characters 12-17:
 3 |   method id x = x
                 ^^^^^
-Error: This method has type "'b -> 'b" which is less general than
-         "'b0. 'b0 -> 'b"
+Error: This method has type "(|'b|) -> (|'b|)" which is less general than
+         "'b0. 'b0 -> (|'b|)"
        The type variable "'b" is not generalizable to an universal
        type variable.
 |}];;
@@ -534,8 +534,8 @@ end
 Line 3, characters 12-17:
 3 |   method id x = x
                 ^^^^^
-Error: This method has type "'b -> 'b" which is less general than
-         "'b0. 'b0 -> 'b"
+Error: This method has type "(|'b|) -> (|'b|)" which is less general than
+         "'b0. 'b0 -> (|'b|)"
        The type variable "'b" is not generalizable to an universal
        type variable.
 |}];;
@@ -550,7 +550,7 @@ end
 Line 4, characters 12-17:
 4 |   method id _ = x
                 ^^^^^
-Error: This method has type "'a -> 'a" which is less general than
+Error: This method has type "(|'a|) -> (|'a|)" which is less general than
          "'a0. 'a0 -> 'a0"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -571,7 +571,7 @@ Lines 4-7, characters 12-17:
 5 |     match r with
 6 |       None -> r <- Some x; x
 7 |     | Some y -> y
-Error: This method has type "'a -> 'a" which is less general than
+Error: This method has type "(|'a|) -> (|'a|)" which is less general than
          "'a0. 'a0 -> 'a0"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -857,7 +857,7 @@ type bad = { bad : 'a. 'a option ref; }
 Line 2, characters 17-25:
 2 | let bad = {bad = ref None};;
                      ^^^^^^^^
-Error: This field value has type "'a option ref" which is less general than
+Error: This field value has type "(|'a|) option ref" which is less general than
          "'a0. 'a0 option ref"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -871,7 +871,7 @@ val bad2 : bad2 = {bad2 = None}
 Line 3, characters 13-28:
 3 | bad2.bad2 <- Some (ref None);;
                  ^^^^^^^^^^^^^^^
-Error: This field value has type "'a option ref option"
+Error: This field value has type "(|'a|) option ref option"
        which is less general than "'a0. 'a0 option ref option"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -1034,7 +1034,7 @@ Line 3, characters 13-29:
                  ^^^^^^^^^^^^^^^^
 Error: Constraints are not satisfied in this type.
        Type "((|float|), string) t" should be an instance of "((|int|), (|int|)) t"
-       Type "float" is not compatible with type "int"
+       Type "(|float|)" is not compatible with type "(|int|)"
 |}]
 
 (* Example of wrong expansion *)
@@ -1621,7 +1621,7 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-46:
 2 |   function Leaf x -> x | Node x -> 1 + depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "int t -> int" which is less general than
+Error: This definition has type "(|int|) t -> (|int|)" which is less general than
          "'a. 'a t -> int"
        The type "int" is not a type variable.
 |}];;
@@ -1631,7 +1631,7 @@ let rec depth : 'a. 'a t -> _ =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a t -> 'a" which is less general than
+Error: This definition has type "(|'a|) t -> (|'a|)" which is less general than
          "'a0. 'a0 t -> 'b"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -1642,7 +1642,7 @@ let rec depth : 'a 'b. 'a t -> 'b =
 Line 2, characters 2-42:
 2 |   function Leaf x -> x | Node x -> depth x;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'b. 'b t -> 'b" which is less general than
+Error: This definition has type "'b. (|'b|) t -> (|'b|)" which is less general than
          "'a 'b. 'a t -> 'b"
        The universal type variable "'b" in the first type matches multiple
        distinct variables in the second type.
@@ -1731,7 +1731,7 @@ type t = { f : 'a. 'a -> unit; }
 Line 3, characters 19-20:
 3 | let f ?x y = y in {f};; (* fail *)
                        ^
-Error: This field value has type "unit -> unit" which is less general than
+Error: This field value has type "(|unit|) -> (|unit|)" which is less general than
          "'a. 'a -> unit"
        The type "unit" is not a type variable.
 |}];;
@@ -1831,7 +1831,7 @@ Line 2, characters 2-72:
 Error: This expression has type "< m : 'b 'x. ([< `Foo of (|'x|) ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of (|int|) ] -> 'a >"
-       In tag "`Foo", type "'x" is not compatible with type "int"
+       In tag "`Foo", type "(|'x|)" is not compatible with type "(|int|)"
 |}];;
 (* fail *)
 let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
@@ -1843,7 +1843,7 @@ Line 2, characters 2-72:
 Error: This expression has type "< m : 'b 'x. ([< `Foo of (|'x|) ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of (|int|) ] -> 'a >"
-       In tag "`Foo", type "'x" is not compatible with type "int"
+       In tag "`Foo", type "(|'x|)" is not compatible with type "(|int|)"
 |}];;
 (* ok *)
 let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
@@ -1863,7 +1863,7 @@ Line 2, characters 3-4:
 Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of (|'a|) & int ] as 'c >"
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of (|int|) & 'b ] as 'd >"
-       In tag "`Foo", type "'a" is not compatible with type "int"
+       In tag "`Foo", type "(|'a|)" is not compatible with type "(|int|)"
 |}]
 (* ok (with implicit universal quantification) *)
 let f (n : < m : 'a. [< `Foo of 'a & int | `Bar] >) =
@@ -1882,7 +1882,7 @@ let f b (x: 'x) =
 Line 3, characters 19-22:
 3 |   if b then x else M.A;;
                        ^^^
-Error: The constructor "M.A" has type "M.t"
+Error: The constructor "M.A" has type "(|M.t|)"
        but an expression was expected of type "'x"
        The type constructor "M.t" would escape its scope
 |}];;
@@ -2138,7 +2138,7 @@ let rec foo : 'a . 'a -> 'd = fun x -> x
 Line 1, characters 30-40:
 1 | let rec foo : 'a . 'a -> 'd = fun x -> x
                                   ^^^^^^^^^^
-Error: This definition has type "'a -> 'a" which is less general than
+Error: This definition has type "(|'a|) -> (|'a|)" which is less general than
          "'a0. 'a0 -> 'b"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -2215,7 +2215,7 @@ let f x =
 Line 2, characters 6-44:
 2 |   let ref : type a . a option ref = ref None in
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'a option ref" which is less general than
+Error: This definition has type "(|'a|) option ref" which is less general than
          "'a0. 'a0 option ref"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -2228,7 +2228,7 @@ type pr = { foo : 'a. 'a option ref; }
 Line 2, characters 16-24:
 2 | let x = { foo = ref None }
                     ^^^^^^^^
-Error: This field value has type "'a option ref" which is less general than
+Error: This field value has type "(|'a|) option ref" which is less general than
          "'a0. 'a0 option ref"
        The type variable "'a" is not generalizable to an universal
        type variable.

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1228,7 +1228,7 @@ Error: The value "x" has type "foo'" = "< m : 'a. 'a * 'a (|foo|) >"
        Type "'a foo" = "< m : 'a * 'a foo >" is not compatible with type
          "< m : 'c. 'c * 'a bar >"
        The method "m" has type "(|'a|) * < m : 'c. 'c * (|'a|) bar >",
-       but the expected method type was "'c. 'c * (|'a|) bar"
+       but the expected method type was "'c. (|'c|) * 'a bar"
        The universal variables "'a" and "'c" are distinct.
        The first type variable "'a" was introduced in an earlier universal
        quantification.
@@ -1245,7 +1245,7 @@ Error: The value "x" has type "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'a|) > as '
          "< m : 'b. 'b * ('b * < m : (|'c. 'c * ('c * 'd)|) >) > as 'd"
        The method "m" has type "'c. 'c * ((|'b|) * < m : 'c. 'e >) as 'e",
        but the expected method type was
-       "'c. 'c * ('c * < m : 'b. (|'b|) * ((|'b|) * < m : 'c. 'f >) >) as 'f"
+       "'c. (|'c|) * ((|'c|) * < m : 'b. 'b * ('b * < m : 'c. 'f >) >) as 'f"
        The universal variables "'b" and "'c" are distinct.
        The first type variable "'b" was introduced in an earlier universal
        quantification.
@@ -1302,7 +1302,7 @@ Error: The value "x" has type "< x : (|'c 'a 'c0. 'c * 'a * 'a * 'c0|) >"
        but an expression was expected of type
          "< x : (|'a 'b 'c. 'c * 'a * 'b * 'b|) >"
        The method "x" has type "'c 'a 'c0. 'c * (|'a|) * (|'a|) * 'c0",
-       but the expected method type was "'a 'b 'c. 'c * (|'a|) * 'b * 'b"
+       but the expected method type was "'a 'b 'c. 'c * 'a * (|'b|) * (|'b|)"
        The universal variables "'a" and "'b" are distinct.
 |}]
 
@@ -1315,7 +1315,7 @@ Line 2, characters 7-8:
 Error: The value "x" has type "< x : 'a. < x : (|'b. 'a * 'b|) > >"
        but an expression was expected of type "< x : 'b. < x : (|'a. 'a * 'b|) > >"
        The method "x" has type "'b. (|'a|) * 'b", but the expected method type was
-       "'a0. 'a0 * 'b"
+       "'a0. (|'a0|) * 'b"
        The universal variables "'a" and "'a0" are distinct.
        The first type variable "'a" was introduced in an earlier universal
        quantification.
@@ -1330,7 +1330,7 @@ Line 2, characters 7-8:
 Error: The value "o" has type "< x : (|'a 'b. ('a * 'a) * 'b|) >"
        but an expression was expected of type "< x : (|'a. ('a * 'a) * 'a|) >"
        The method "x" has type "'a 'b. ('a * 'a) * (|'b|)",
-       but the expected method type was "'a. ('a * 'a) * 'a"
+       but the expected method type was "'a. ((|'a|) * (|'a|)) * (|'a|)"
        The universal variables "'b" and "'a" are distinct.
 |}]
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -467,8 +467,8 @@ Line 9, characters 41-42:
                                              ^
 Error: The value "x" has type "< m : (|'b. 'b -> 'b list|) >"
        but an expression was expected of type "< m : (|'b. 'b -> 'c|) >"
-       The method "m" has type "'b. 'b -> 'b list",
-       but the expected method type was "'b. 'b -> 'c"
+       The method "m" has type "'b. (|'b|) -> (|'b|) list",
+       but the expected method type was "'b. (|'b|) -> 'c"
        The universal variable "'b" would escape its scope
 |}];;
 
@@ -1203,9 +1203,9 @@ Error: The value "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        but an expression was expected of type
          "< m : 'a. 'a * (< m : 'a * < m : (|'c. 'c * 'd|) > > as 'd) >"
        The method "m" has type
-       "'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd)",
+       "'a. (|'a|) * (< m : (|'a|) * < m : 'c. 'c * 'd > > as 'd)",
        but the expected method type was
-       "'c. 'c * < m : 'a * < m : 'c. 'e > > as 'e"
+       "'c. 'c * < m : (|'a|) * < m : 'c. 'e > > as 'e"
        The universal variable "'a" would escape its scope
 |}];;
 type 'a foo = <m: 'b. 'a * 'a foo>
@@ -1227,8 +1227,8 @@ Error: The value "x" has type "foo'" = "< m : 'a. 'a * 'a (|foo|) >"
          "'a bar" = "< m : 'a * < m : 'c. 'c * 'a bar > >"
        Type "'a foo" = "< m : 'a * 'a foo >" is not compatible with type
          "< m : 'c. 'c * 'a bar >"
-       The method "m" has type "'a * < m : 'c. 'c * 'a bar >",
-       but the expected method type was "'c. 'c * 'a bar"
+       The method "m" has type "(|'a|) * < m : 'c. 'c * (|'a|) bar >",
+       but the expected method type was "'c. 'c * (|'a|) bar"
        The universal variables "'a" and "'c" are distinct.
        The first type variable "'a" was introduced in an earlier universal
        quantification.
@@ -1243,9 +1243,9 @@ Line 2, characters 3-4:
 Error: The value "x" has type "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'a|) > as 'a) >"
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : (|'c. 'c * ('c * 'd)|) >) > as 'd"
-       The method "m" has type "'c. 'c * ('b * < m : 'c. 'e >) as 'e",
+       The method "m" has type "'c. 'c * ((|'b|) * < m : 'c. 'e >) as 'e",
        but the expected method type was
-       "'c. 'c * ('c * < m : 'b. 'b * ('b * < m : 'c. 'f >) >) as 'f"
+       "'c. 'c * ('c * < m : 'b. (|'b|) * ((|'b|) * < m : 'c. 'f >) >) as 'f"
        The universal variables "'b" and "'c" are distinct.
        The first type variable "'b" was introduced in an earlier universal
        quantification.
@@ -1260,9 +1260,9 @@ Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * ('b * 'd) >) > as 'd"
        The method "m" has type
-       "'c. 'c * ('b * < m : 'b. 'b * ('b * < m : 'c. 'e >) >) as 'e",
+       "'c. 'c * ((|'b|) * < m : 'b. (|'b|) * ((|'b|) * < m : 'c. 'e >) >) as 'e",
        but the expected method type was
-       "'b. 'b * ('b * < m : 'c. 'c * ('b * < m : 'b. 'f >) >) as 'f"
+       "'b. (|'b|) * ((|'b|) * < m : 'c. 'c * ((|'b|) * < m : 'b. 'f >) >) as 'f"
        The universal variable "'b" would escape its scope
 |}];;
 fun (x : <m : 'a. 'a * ('a * 'foo)> as 'foo) ->
@@ -1274,8 +1274,8 @@ Line 2, characters 3-4:
 Error: The value "x" has type "< m : 'b. 'b * ('b * 'a) > as 'a"
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'd|) > as 'd) >"
-       The method "m" has type "'b. 'b * ('b * < m : 'c. 'c * 'd > as 'd)",
-       but the expected method type was "'c. 'c * ('b * < m : 'c. 'e >) as 'e"
+       The method "m" has type "'b. (|'b|) * ((|'b|) * < m : 'c. 'c * 'd > as 'd)",
+       but the expected method type was "'c. 'c * ((|'b|) * < m : 'c. 'e >) as 'e"
        The universal variable "'b" would escape its scope
 |}];;
 let f x =
@@ -1301,8 +1301,8 @@ Line 2, characters 3-4:
 Error: The value "x" has type "< x : (|'c 'a 'c0. 'c * 'a * 'a * 'c0|) >"
        but an expression was expected of type
          "< x : (|'a 'b 'c. 'c * 'a * 'b * 'b|) >"
-       The method "x" has type "'c 'a 'c0. 'c * 'a * 'a * 'c0",
-       but the expected method type was "'a 'b 'c. 'c * 'a * 'b * 'b"
+       The method "x" has type "'c 'a 'c0. 'c * (|'a|) * (|'a|) * 'c0",
+       but the expected method type was "'a 'b 'c. 'c * (|'a|) * 'b * 'b"
        The universal variables "'a" and "'b" are distinct.
 |}]
 
@@ -1314,7 +1314,7 @@ Line 2, characters 7-8:
            ^
 Error: The value "x" has type "< x : 'a. < x : (|'b. 'a * 'b|) > >"
        but an expression was expected of type "< x : 'b. < x : (|'a. 'a * 'b|) > >"
-       The method "x" has type "'b. 'a * 'b", but the expected method type was
+       The method "x" has type "'b. (|'a|) * 'b", but the expected method type was
        "'a0. 'a0 * 'b"
        The universal variables "'a" and "'a0" are distinct.
        The first type variable "'a" was introduced in an earlier universal
@@ -1329,7 +1329,7 @@ Line 2, characters 7-8:
            ^
 Error: The value "o" has type "< x : (|'a 'b. ('a * 'a) * 'b|) >"
        but an expression was expected of type "< x : (|'a. ('a * 'a) * 'a|) >"
-       The method "x" has type "'a 'b. ('a * 'a) * 'b",
+       The method "x" has type "'a 'b. ('a * 'a) * (|'b|)",
        but the expected method type was "'a. ('a * 'a) * 'a"
        The universal variables "'b" and "'a" are distinct.
 |}]
@@ -1356,7 +1356,7 @@ Error: Signature mismatch:
        is not compatible with the type
          "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'e|) > as 'e) > -> unit"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
-       but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
+       but the expected method type was "'c. 'c * ((|'b|) * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
 |}];;
 module M
@@ -1378,7 +1378,7 @@ Error: Signature mismatch:
        The type "< m : 'a. 'a * ('a * 'd) > as 'd" is not equal to the type
          "< m : 'b. 'b * ('b * < m : (|'c. 'c * 'e|) > as 'e) >"
        The method "m" has type "'a. 'a * ('a * < m : 'a. 'f >) as 'f",
-       but the expected method type was "'c. 'c * ('b * < m : 'c. 'g >) as 'g"
+       but the expected method type was "'c. 'c * ((|'b|) * < m : 'c. 'g >) as 'g"
        The universal variable "'b" would escape its scope
 |}];;
 
@@ -2165,7 +2165,7 @@ Lines 1-3, characters 15-3:
 3 | end
 Error: This expression has type "< x : (|'b. 'b s list|) >"
        but an expression was expected of type "'a c"
-       The method "x" has type "'b. 'b s list", but the expected method type was
+       The method "x" has type "'b. (|'b|) s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope
 |}]
@@ -2182,8 +2182,8 @@ Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
 Error: The value "x" has type "u" but an expression was expected of type "v"
-       The method "m" has type "'a s list * < m : 'b > as 'b",
-       but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
+       The method "m" has type "(|'a|) s list * < m : 'b > as 'b",
+       but the expected method type was "'a. (|'a|) s list * < m : 'a. 'c > as 'c"
        The universal variable "'a" would escape its scope
 |}]
 
@@ -2201,7 +2201,7 @@ Lines 1-3, characters 15-3:
 3 | end
 Error: This expression has type "< x : (|'b. 'b s list|) >"
        but an expression was expected of type "'a c"
-       The method "x" has type "'b. 'b s list", but the expected method type was
+       The method "x" has type "'b. (|'b|) s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1832,7 +1832,6 @@ Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
        In tag "`Foo", type "'x" is not compatible with type "int"
-       Types for tag "`Foo" are incompatible
 |}];;
 (* fail *)
 let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
@@ -1845,7 +1844,6 @@ Error: This expression has type "< m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >"
        but an expression was expected of type
          "< m : 'a. [< `Foo of int ] -> 'a >"
        In tag "`Foo", type "'x" is not compatible with type "int"
-       Types for tag "`Foo" are incompatible
 |}];;
 (* ok *)
 let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
@@ -1866,7 +1864,6 @@ Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
        In tag "`Foo", type "'a" is not compatible with type "int"
-       Types for tag "`Foo" are incompatible
 |}]
 (* ok (with implicit universal quantification) *)
 let f (n : < m : 'a. [< `Foo of 'a & int | `Bar] >) =
@@ -2167,7 +2164,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = [S]
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c"
+       but an expression was expected of type "'a c" = "< x : 'a list >"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope
@@ -2184,9 +2181,12 @@ let f (x : u) = (x : v)
 Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
-Error: The value "x" has type "u" but an expression was expected of type "v"
-       The method "m" has type "'a s list * < m : 'b > as 'b",
-       but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
+Error: The value "x" has type
+         "u" = "< m : 'a. 'a s list * (< m : 'a s list * 'b > as 'b) >"
+       but an expression was expected of type
+         "v" = "< m : 'a. 'a s list * 'c > as 'c"
+       The method "m" has type "'a s list * < m : 'd > as 'd",
+       but the expected method type was "'a. 'a s list * < m : 'a. 'e > as 'e"
        The universal variable "'a" would escape its scope
 |}]
 
@@ -2203,7 +2203,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = []
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c"
+       but an expression was expected of type "'a c" = "< x : 'a list >"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -2164,7 +2164,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = [S]
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c" = "< x : 'a list >"
+       but an expression was expected of type "'a c"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope
@@ -2181,12 +2181,9 @@ let f (x : u) = (x : v)
 Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
-Error: The value "x" has type
-         "u" = "< m : 'a. 'a s list * (< m : 'a s list * 'b > as 'b) >"
-       but an expression was expected of type
-         "v" = "< m : 'a. 'a s list * 'c > as 'c"
-       The method "m" has type "'a s list * < m : 'd > as 'd",
-       but the expected method type was "'a. 'a s list * < m : 'a. 'e > as 'e"
+Error: The value "x" has type "u" but an expression was expected of type "v"
+       The method "m" has type "'a s list * < m : 'b > as 'b",
+       but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
        The universal variable "'a" would escape its scope
 |}]
 
@@ -2203,7 +2200,7 @@ Lines 1-3, characters 15-3:
 2 |   method x : 'b . 'b s list = []
 3 | end
 Error: This expression has type "< x : 'b. 'b s list >"
-       but an expression was expected of type "'a c" = "< x : 'a list >"
+       but an expression was expected of type "'a c"
        The method "x" has type "'b. 'b s list", but the expected method type was
        "'a list"
        The universal variable "'b" would escape its scope

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -380,7 +380,7 @@ Error: Signature mismatch:
        Values do not match: val f : p1 is not included in val f : p2
        The type "p1" = "(bool -> bool) -> int" is not compatible with the type
          "p2" = "('a. 'a -> 'a) -> int"
-       Type "bool" is not compatible with type "'a"
+       Type "(|bool|)" is not compatible with type "(|'a|)"
 |}, Principal{|
 Line 1, characters 59-60:
 1 | module Foo (X : sig val f : p1 end) : sig val f : p2 end = X
@@ -393,7 +393,7 @@ Error: Signature mismatch:
        Values do not match: val f : p1 is not included in val f : p2
        The type "p1" = "((|bool|) -> bool) -> int" is not compatible with the type
          "p2" = "('a. (|'a|) -> 'a) -> int"
-       Type "bool" is not compatible with type "'a"
+       Type "(|bool|)" is not compatible with type "(|'a|)"
 |}];;
 
 let foo (f : p1) : p2 = (fun id -> f id)

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -296,7 +296,7 @@ Line 1, characters 24-25:
 1 | let foo (f : p1) : p2 = f
                             ^
 Error: The value "f" has type "p1" = "('a. (|'a|) -> (|'a|)) -> int"
-       but an expression was expected of type "p2" = "('a 'b. (|'a|) -> 'b) -> int"
+       but an expression was expected of type "p2" = "('a 'b. 'a -> (|'b|)) -> int"
        The universal variables "'a" and "'b" are distinct.
 |}];;
 
@@ -335,7 +335,7 @@ Error: Signature mismatch:
          sig val f : p2 end
        Values do not match: val f : p1 is not included in val f : p2
        The type "p1" = "('a. (|'a|) -> (|'a|)) -> int" is not compatible with the type
-         "p2" = "('a 'b. 'a -> 'b) -> int"
+         "p2" = "('a 'b. 'a -> (|'b|)) -> int"
        The universal variables "'a" and "'b" are distinct.
 |}];;
 

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -344,8 +344,8 @@ type p2 = ('a. 'a -> 'a) -> int
 Line 4, characters 24-25:
 4 | let foo (x : p1) : p2 = x
                             ^
-Error: The value "x" has type "p1" = "(bool -> bool) -> int"
-       but an expression was expected of type "p2" = "('a. 'a -> 'a) -> int"
+Error: The value "x" has type "p1" = "((|bool|) -> bool) -> int"
+       but an expression was expected of type "p2" = "('a. (|'a|) -> 'a) -> int"
        Type "bool" is not compatible with type "'a"
 |}];;
 
@@ -367,6 +367,19 @@ Error: Signature mismatch:
        Values do not match: val f : p1 is not included in val f : p2
        The type "p1" = "(bool -> bool) -> int" is not compatible with the type
          "p2" = "('a. 'a -> 'a) -> int"
+       Type "bool" is not compatible with type "'a"
+|}, Principal{|
+Line 1, characters 59-60:
+1 | module Foo (X : sig val f : p1 end) : sig val f : p2 end = X
+                                                               ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : p1 end
+       is not included in
+         sig val f : p2 end
+       Values do not match: val f : p1 is not included in val f : p2
+       The type "p1" = "((|bool|) -> bool) -> int" is not compatible with the type
+         "p2" = "('a. (|'a|) -> 'a) -> int"
        Type "bool" is not compatible with type "'a"
 |}];;
 

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -34,7 +34,7 @@ let _ = poly1 (id (fun x -> x))
 Line 1, characters 14-31:
 1 | let _ = poly1 (id (fun x -> x))
                   ^^^^^^^^^^^^^^^^^
-Error: This argument has type "'a -> 'a" which is less general than
+Error: This argument has type "(|'a|) -> (|'a|)" which is less general than
          "'a0. 'a0 -> 'a0"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -45,7 +45,7 @@ let _ = poly1 (let r = ref None in fun x -> r := Some x; x)
 Line 1, characters 14-59:
 1 | let _ = poly1 (let r = ref None in fun x -> r := Some x; x)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This argument has type "'a -> 'a" which is less general than
+Error: This argument has type "(|'a|) -> (|'a|)" which is less general than
          "'a0. 'a0 -> 'a0"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -56,7 +56,7 @@ let escape f = poly1 (fun x -> f x; x)
 Line 1, characters 21-38:
 1 | let escape f = poly1 (fun x -> f x; x)
                          ^^^^^^^^^^^^^^^^^
-Error: This argument has type "'a -> 'a" which is less general than
+Error: This argument has type "(|'a|) -> (|'a|)" which is less general than
          "'a0. 'a0 -> 'a0"
        The type variable "'a" is not generalizable to an universal
        type variable.
@@ -177,7 +177,7 @@ val needs_magic : ('a 'b. 'a -> 'b) -> string = <fun>
 Line 2, characters 20-32:
 2 | let _ = needs_magic (fun x -> x)
                         ^^^^^^^^^^^^
-Error: This argument has type "'b. 'b -> 'b" which is less general than
+Error: This argument has type "'b. (|'b|) -> (|'b|)" which is less general than
          "'a 'b. 'a -> 'b"
        The universal type variable "'b" in the first type matches multiple
        distinct variables in the second type.
@@ -216,7 +216,7 @@ Line 3, characters 15-16:
 3 |   else with_id f
                    ^
 Error: The value "f" has type "('b -> 'b) -> 'c"
-       but an expression was expected of type "('a. 'a -> 'a) -> 'd"
+       but an expression was expected of type "('a. (|'a|) -> (|'a|)) -> 'd"
        The universal variable "'a" would escape its scope
 |}];;
 
@@ -264,8 +264,8 @@ let non_principal4 =
 Line 2, characters 26-35:
 2 |   [ Some (fun y -> y 6, y "goodbye");
                               ^^^^^^^^^
-Error: This constant has type "string" but an expression was expected of type
-         "int"
+Error: This constant has type "(|string|)" but an expression was expected of type
+         "(|int|)"
 |}];;
 
 (* Functions with polymorphic parameters are separate from other functions *)
@@ -277,7 +277,7 @@ type 'a arg = 'b constraint 'a = 'b -> 'c
 Line 3, characters 20-44:
 3 | type really_poly = (('a. 'a -> 'a) -> string) arg
                         ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type "('a. 'a -> 'a) -> string" should be an instance of type
+Error: This type "('a. (|'a|) -> (|'a|)) -> string" should be an instance of type
          "'b -> 'c"
        The universal variable "'a" would escape its scope
 |}];;
@@ -295,8 +295,8 @@ let foo (f : p1) : p2 = f
 Line 1, characters 24-25:
 1 | let foo (f : p1) : p2 = f
                             ^
-Error: The value "f" has type "p1" = "('a. 'a -> 'a) -> int"
-       but an expression was expected of type "p2" = "('a 'b. 'a -> 'b) -> int"
+Error: The value "f" has type "p1" = "('a. (|'a|) -> (|'a|)) -> int"
+       but an expression was expected of type "p2" = "('a 'b. (|'a|) -> 'b) -> int"
        The universal variables "'a" and "'b" are distinct.
 |}];;
 
@@ -324,6 +324,19 @@ Error: Signature mismatch:
        The type "p1" = "('a. 'a -> 'a) -> int" is not compatible with the type
          "p2" = "('a 'b. 'a -> 'b) -> int"
        The universal variables "'a" and "'b" are distinct.
+|}, Principal{|
+Line 1, characters 59-60:
+1 | module Foo (X : sig val f : p1 end) : sig val f : p2 end = X
+                                                               ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : p1 end
+       is not included in
+         sig val f : p2 end
+       Values do not match: val f : p1 is not included in val f : p2
+       The type "p1" = "('a. (|'a|) -> (|'a|)) -> int" is not compatible with the type
+         "p2" = "('a 'b. 'a -> 'b) -> int"
+       The universal variables "'a" and "'b" are distinct.
 |}];;
 
 let foo (f : p1) : p2 = (fun id -> f id)
@@ -346,7 +359,7 @@ Line 4, characters 24-25:
                             ^
 Error: The value "x" has type "p1" = "((|bool|) -> bool) -> int"
        but an expression was expected of type "p2" = "('a. (|'a|) -> 'a) -> int"
-       Type "bool" is not compatible with type "'a"
+       Type "(|bool|)" is not compatible with type "(|'a|)"
 |}];;
 
 let foo x = (x : p1 :> p2)
@@ -548,7 +561,7 @@ Line 2, characters 2-6:
 2 |   let* x = 3. in
       ^^^^
 Error: The operator "let*" has type
-         "('a. 'a option) -> ('a. 'a -> 'a) -> 'b option * int"
+         "('a. (|'a|) option) -> ('a. 'a -> 'a) -> 'b option * int"
        but it was expected to have type "'c -> ('d -> 'e) -> 'f"
        The universal variable "'a" would escape its scope
 |}]

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -26,9 +26,9 @@ Line 4, characters 11-12:
 4 | = fun x -> x
                ^
 Error: The value "x" has type
-         "< m : 'left 'right. < left : 'left; right : 'right > pair >"
+         "< m : (|'left 'right. < left : 'left; right : 'right > pair|) >"
        but an expression was expected of type
-         "< m : 'left 'right. < left : 'left; right : 'right > pair >"
+         "< m : (|'left 'right. < left : 'left; right : 'right > pair|) >"
        The method "m" has type
        "'left 'right. < left : 'left; right : 'right > pair",
        but the expected method type was

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -31,6 +31,6 @@ Error: Signature mismatch:
          val write : [< `A of string | `B of int ] -> unit
        The type "([< `A of '_weak3 | `B of '_weak4 ] as '_weak2) -> unit"
        is not compatible with the type "[< `A of string | `B of int ] -> unit"
-       Type "[< `A of '_weak3 | `B of '_weak4 ] as '_weak2"
+       Type "(|[< `A of '_weak3 | `B of '_weak4 ] as '_weak2|)"
        is not compatible with type "[< `A of string | `B of int ]"
 |}]

--- a/testsuite/tests/typing-recmod/inconsistent_constraints.ml
+++ b/testsuite/tests/typing-recmod/inconsistent_constraints.ml
@@ -14,7 +14,7 @@ Line 3, characters 15-23:
 3 |     constraint 'b = int
                    ^^^^^^^^
 Error: The type constraints are not consistent.
-       Type "'a X.s" is not compatible with type "int"
+       Type "'a (|X.s|)" is not compatible with type "(|int|)"
        Type "X.s" was considered abstract when checking constraints in this
        recursive module definition.
 |}]

--- a/testsuite/tests/typing-recmod/pr13514.ml
+++ b/testsuite/tests/typing-recmod/pr13514.ml
@@ -13,5 +13,5 @@ end
 Line 6, characters 29-30:
 6 |   let f: t -> M.t = fun x -> x
                                  ^
-Error: The value "x" has type "t" but an expression was expected of type "M.t"
+Error: The value "x" has type "(|t|)" but an expression was expected of type "(|M.t|)"
 |}]

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -51,7 +51,7 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 9, characters 22-23:
 9 |   | Pair (Char, x) -> x + 1
                           ^
-Error: The value "x" has type "$a" but an expression was expected of type "int"
+Error: The value "x" has type "$a" but an expression was expected of type "(|int|)"
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
 
@@ -68,7 +68,7 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 7, characters 35-36:
 7 |   | Pair (Char, x) -> if true then x else 'd'
                                        ^
-Error: The value "x" has type "$a" but an expression was expected of type "'a"
+Error: The value "x" has type "(|$a|)" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
        Hint: "$a" is an existential type bound by the constructor "Pair".

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -620,7 +620,7 @@ Error: Signature mismatch:
          external f : int -> int -> int = "f" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
-       The type "int -> int -> int" is not compatible with the type "int -> int"
+       The type "int -> int (|->|) int" is not compatible with the type "int -> (|int|)"
        Type "int -> int" is not compatible with type "int"
 |}]
 

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -621,7 +621,7 @@ Error: Signature mismatch:
        is not included in
          external f : int -> int = "f" "f_nat"
        The type "int -> int (|->|) int" is not compatible with the type "int -> (|int|)"
-       Type "int -> int" is not compatible with type "int"
+       Type "int (|->|) int" is not compatible with type "(|int|)"
 |}]
 
 (* Bad: unboxed or untagged with the wrong type *)

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -146,7 +146,7 @@ val g : int -> int = <fun>
 Line 2, characters 10-15:
 2 | let _ = g (f 1);;
               ^^^^^
-Error: This expression has type "int -> int"
-       but an expression was expected of type "int"
+Error: This expression has type "int (|->|) int"
+       but an expression was expected of type "(|int|)"
 Hint: This function application is partial, maybe some arguments are missing.
 |}]

--- a/testsuite/tests/typing-warnings/coercions.ml
+++ b/testsuite/tests/typing-warnings/coercions.ml
@@ -25,8 +25,8 @@ Line 1, characters 28-48:
                                 ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type
          "('a, 'b, 'c, 'd, 'd, 'a) format6" =
-           "('a, 'b, 'c, 'd, 'd, 'a) CamlinternalFormatBasics.format6"
-       but an expression was expected of type "string"
+           "('a, 'b, 'c, 'd, 'd, 'a) (|CamlinternalFormatBasics.format6|)"
+       but an expression was expected of type "(|string|)"
 |}]
 ;;
 

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -38,5 +38,5 @@ Error: Signature mismatch:
          val f : fpclass -> fpclass
        The type "fpclass -> (|Stdlib.fpclass|)" is not compatible with the type
          "fpclass -> (|fpclass|)"
-       Type "Stdlib.fpclass" is not compatible with type "fpclass"
+       Type "(|Stdlib.fpclass|)" is not compatible with type "(|fpclass|)"
 |}]

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -36,7 +36,7 @@ Error: Signature mismatch:
          val f : fpclass -> Stdlib.fpclass
        is not included in
          val f : fpclass -> fpclass
-       The type "fpclass -> Stdlib.fpclass" is not compatible with the type
-         "fpclass -> fpclass"
+       The type "fpclass -> (|Stdlib.fpclass|)" is not compatible with the type
+         "fpclass -> (|fpclass|)"
        Type "Stdlib.fpclass" is not compatible with type "fpclass"
 |}]

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -108,7 +108,7 @@ Warning 41 [ambiguous-name]: these field labels belong to several types:
 Line 3, characters 35-36:
 3 |   let f r = match r with {x; y} -> y + y
                                        ^
-Error: The value "y" has type "bool" but an expression was expected of type "int"
+Error: The value "y" has type "(|bool|)" but an expression was expected of type "(|int|)"
 |}]
 
 module F2 = struct
@@ -373,8 +373,8 @@ let r = { M.x = 3; N.y = 4; };; (* error: different definitions *)
 Line 1, characters 19-22:
 1 | let r = { M.x = 3; N.y = 4; };; (* error: different definitions *)
                        ^^^
-Error: The record field "N.y" belongs to the type "N.bar"
-       but is mixed here with fields of type "M.foo"
+Error: The record field "N.y" belongs to the type "(|N.bar|)"
+       but is mixed here with fields of type "(|M.foo|)"
 |}]
 
 module MN = struct include M include N end
@@ -408,8 +408,8 @@ Warning 41 [ambiguous-name]: "y" belongs to several types: "NM.foo" "NM.bar".
 Line 1, characters 19-23:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
                        ^^^^
-Error: The record field "NM.y" belongs to the type "NM.foo" = "M.foo"
-       but is mixed here with fields of type "MN.bar" = "N.bar"
+Error: The record field "NM.y" belongs to the type "NM.foo" = "(|M.foo|)"
+       but is mixed here with fields of type "MN.bar" = "(|N.bar|)"
 |}]
 
 (* Lpw25 *)

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -117,8 +117,8 @@ Warning 16 [unerasable-optional-argument]: this optional argument cannot be eras
 Line 3, characters 2-9:
 3 |   warn_me + 0
       ^^^^^^^
-Error: The value "warn_me" has type "?arg:'a -> unit"
-       but an expression was expected of type "int"
+Error: The value "warn_me" has type "?arg:'a (|->|) unit"
+       but an expression was expected of type "(|int|)"
 |}]
 
 (* https://github.com/ocaml/ocaml/issues/14622 *)

--- a/testsuite/tools/expect.ml
+++ b/testsuite/tools/expect.ml
@@ -217,11 +217,14 @@ function
   | Ptop_def (st :: _) :: _ -> Some st.pstr_loc.loc_start.pos_lnum
 
 
-let visible_inline_code () =
+let visible_inline_code_and_diff () =
   let open Misc.Style in
   let default = get_styles () in
   let inline_code = { ansi = []; text_open = {|"|}; text_close={|"|} } in
-  set_styles { default with inline_code }
+  let difference_highlight =
+    { ansi = []; text_open ="(|"; text_close = "|)" }
+  in
+  set_styles { default with inline_code; difference_highlight }
 
 let eval_expect_file _fname ~file_contents =
   Warnings.reset_fatal ();
@@ -231,7 +234,7 @@ let eval_expect_file _fname ~file_contents =
   let buf = Buffer.create 1024 in
   let ppf = Format.formatter_of_buffer buf in
   let () =
-    visible_inline_code ();
+    visible_inline_code_and_diff ();
     Misc.Style.set_tag_handling ppf in
   let exec_phrases phrases =
     let phrases =

--- a/testsuite/tools/test_in_prefix.ml
+++ b/testsuite/tools/test_in_prefix.ml
@@ -184,6 +184,7 @@ let () =
   Misc.Style.(set_styles {
     warning = no_markup [Bold; FG Yellow];
     error = no_markup [Bold; FG Red];
+    difference_highlight = no_markup [Bold; FG Red];
     loc = no_markup [Bold; FG Blue];
     hint = no_markup [Bold; FG Green];
     inline_code = no_markup [FG Blue]});

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -142,7 +142,7 @@ let execute_phrase print_outcome ppf phr =
                         let outv = outval_of_value newenv v exp.exp_type in
                         let ty =
                           Out_type.prepare_for_printing [exp.exp_type];
-                          Out_type.tree_of_typexp Type_scheme exp.exp_type
+                          Out_type.tree_of_typexp None Type_scheme exp.exp_type
                         in
                         Ophr_eval (outv, ty)
                       | None -> Ophr_signature (pr_item oldenv sg'))

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -142,7 +142,7 @@ let execute_phrase print_outcome ppf phr =
                         let outv = outval_of_value newenv v exp.exp_type in
                         let ty =
                           Out_type.prepare_for_printing [exp.exp_type];
-                          Out_type.tree_of_typexp None Type_scheme exp.exp_type
+                          Out_type.tree_of_typexp [] Type_scheme exp.exp_type
                         in
                         Ophr_eval (outv, ty)
                       | None -> Ophr_signature (pr_item oldenv sg'))

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -225,7 +225,7 @@ let execute_phrase print_outcome ppf phr =
                           in
                           let ty =
                             Out_type.prepare_for_printing [vd.val_type];
-                            Out_type.tree_of_typexp Type_scheme vd.val_type
+                            Out_type.tree_of_typexp None Type_scheme vd.val_type
                           in
                           Ophr_eval (outv, ty)
                       | _ -> assert false

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -225,7 +225,7 @@ let execute_phrase print_outcome ppf phr =
                           in
                           let ty =
                             Out_type.prepare_for_printing [vd.val_type];
-                            Out_type.tree_of_typexp None Type_scheme vd.val_type
+                            Out_type.tree_of_typexp [] Type_scheme vd.val_type
                           in
                           Ophr_eval (outv, ty)
                       | _ -> assert false

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4554,6 +4554,8 @@ let rec moregen type_pairs env t1 t2 =
                 (get_level t2') pack2
           | (Tnil,  Tconstr _ ) -> raise_for Moregen (Obj (Abstract_row Second))
           | (Tconstr _,  Tnil ) -> raise_for Moregen (Obj (Abstract_row First))
+          | Tconstr _ as d1, d2 | d1, (Tconstr _ as d2) ->
+             highlight_for Moregen ~got:(d1,t1) ~expected:(d2,t2)
           | (Tvariant row1, Tvariant row2) ->
               moregen_row type_pairs env row1 row2
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
@@ -4959,6 +4961,8 @@ let rec eqtype rename type_pairs subst env t1 t2 =
               raise_for Equality (Obj (Abstract_row Second))
           | (Tconstr _,  Tnil ) ->
               raise_for Equality (Obj (Abstract_row First))
+          | Tconstr _ as d1, d2 | d1, (Tconstr _ as d2) ->
+             highlight_for Equality ~got:(d1,t1) ~expected:(d2,t2)
           | (Tvariant row1, Tvariant row2) ->
               eqtype_row rename type_pairs subst env row1 row2
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3148,8 +3148,8 @@ let compare_package env unify_list lv1 pack1 lv2 pack2 =
 
 let highlight_for k ~got ~expected =
   let h (d,t) = match d with
-    | Tconstr (p,_,_) -> Some (Errortrace.Type_constructor p)
-    | _ -> Some (Errortrace.Type (Paired,t))
+    | Tconstr (p,_,_) -> [Errortrace.Type_constructor p]
+    | _ -> [Errortrace.Type (Paired,t)]
   in
   let d = { Errortrace.got = h got; expected = h expected } in
   raise_for k (Highlight_hint d)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2659,13 +2659,15 @@ let expand_to_moregen_error env trace =
 
 (* Equivalent to [expand_trace env [Diff {got; expected}]] for a single
    element *)
+let mk_diff ~got ~expected = { d = {got; expected}; ctx = None }
+
 let expanded_diff env ~got ~expected =
-  Diff (map_diff (expand_type env) {got; expected})
+  Diff (map_ctx (expand_type env) (mk_diff ~got ~expected))
 
 (* Diff while transforming a [type_expr] into an [expanded_type] without
    expanding *)
 let unexpanded_diff ~got ~expected =
-  Diff (map_diff trivial_expansion {got; expected})
+  Diff (map_ctx trivial_expansion (mk_diff ~got ~expected))
 
 (**** Unification ****)
 
@@ -3243,7 +3245,7 @@ let rec unify uenv t1 t2 =
     reset_trace_gadt_instances reset_tracing;
   with Unify_trace trace ->
     reset_trace_gadt_instances reset_tracing;
-    raise_trace_for Unify (Diff {got = t1; expected = t2} :: trace)
+    raise_trace_for Unify (diff ~got:t1 ~expected:t2 trace)
 
 and unify2 uenv t1 t2 = unify2_expand uenv t1 t1 t2 t2
 
@@ -3341,8 +3343,10 @@ and unify3 uenv t1 t1' t2 t2' =
               unify_package uenv (get_level t1) pack1 (get_level t2) pack2
             with Unify_trace trace ->
               raise_trace_for Unify
-                (Diff {got = newty (Tpackage pack1);
-                       expected = newty (Tpackage pack2)} :: trace)
+                (diff
+                   ~got:(newty (Tpackage pack1))
+                   ~expected:(newty (Tpackage pack2))
+                  trace)
             end;
             let env = get_env uenv in
             let mty2 = modtype_of_package env Location.none pack2 in
@@ -3565,7 +3569,7 @@ and unify_fields uenv ty1 ty2 =          (* Optimization *)
           unify uenv t1 t2
         with Unify_trace trace ->
           raise_trace_for Unify
-            (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
+            (incompatible_fields ~name ~got:t1 ~expected:t2 trace)
       )
       pairs
   with exn ->
@@ -3675,7 +3679,7 @@ and unify_row uenv row1 row2 =
       (fun (l,f1,f2) ->
         try unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2
         with Unify_trace trace ->
-          raise_trace_for Unify (Variant (Incompatible_types_for l) :: trace)
+          raise_trace_for Unify (in_tag ~l trace)
       )
       pairs;
     if static_row row1 then begin
@@ -3718,7 +3722,7 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
          !rigid_variants && (List.length tl1 = 1 || List.length tl2 = 1)) &&
         begin match tl1 @ tl2 with [] -> false
         | t1 :: tl ->
-            if no_arg then raise_unexplained_for Unify;
+            if no_arg then raise_for Unify (variant_arity_mismatch ~l);
             Types.changed_row_field_exts [f1;f2] (fun () ->
                 List.iter (unify uenv t1) tl
               )
@@ -3788,11 +3792,11 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
   | (Rpresent None | Reither(true,_,_)),
     (Rpresent (Some _) | Reither(false,_,_)) ->
       (* constructor arity mismatch: 0 <> 1 *)
-      raise_unexplained_for Unify
+      raise_for Unify (variant_arity_mismatch ~l)
   | Reither(true, _ :: _, _ ), Rpresent _
   | Rpresent _ , Reither(true, _ :: _, _ ) ->
       (* inconsistent conjunction on a non-absent field *)
-      raise_unexplained_for Unify
+      raise_for Unify (inconsistent_conjunction ~l)
 
 let unify uenv ty1 ty2 =
   let snap = Btype.snapshot () in
@@ -3846,7 +3850,7 @@ let unify_var uenv t1 t2 =
         reset_trace_gadt_instances reset_tracing;
         raise (Unify (expand_to_unification_error
                         env
-                        (Diff { got = t1; expected = t2 } :: trace)))
+                        (diff ~got:t1 ~expected:t2 trace)))
       end
   | _ ->
       unify uenv t1 t2
@@ -3897,7 +3901,7 @@ let instance_funct_nondep env l (tfun : Types.tfunctor) mty =
     let expected =
       newty (Tarrow (l, newmono_package tfun.pack, newvar (), commu_ok))
     in
-    let trace = Diff {got; expected} :: trace in
+    let trace = diff ~got ~expected trace in
     raise (Unify (expand_to_unification_error env trace))
 
 (*
@@ -3971,14 +3975,13 @@ let filter_arrow env ~in_apply t l ~param_hole =
             let t' =
               newty (Tarrow (l, newmono_package pack, newvar (), commu_ok))
             in
-            let diff =
+            let trace =
               if in_apply then
-                Diff { got = t; expected = t' }
+                diff ~got:t ~expected:t' trace
               else
-                Diff { got = t'; expected = t }
+                diff ~got:t' ~expected:t trace
             in
-            Error (Unification_error
-                    (expand_to_unification_error env (diff :: trace)))
+            Error (Unification_error (expand_to_unification_error env trace))
           | () ->
             let ty_param = newmono_package ~level:(get_level t) pack in
             let t' = newty2 ~level:(get_level t)
@@ -3992,16 +3995,13 @@ let filter_arrow env ~in_apply t l ~param_hole =
     end
   | exception Unify_trace trace ->
       let t', _, _ = function_type l ~param_hole (get_level t) in
-      let diff =
+      let trace =
         if in_apply then
-          Diff { got = t; expected = t' }
+          diff ~got:t ~expected:t' trace
         else
-          Diff { got = t'; expected = t }
+          diff ~got:t' ~expected:t trace
       in
-      Error (Unification_error
-              (expand_to_unification_error
-                  env
-                  (diff :: trace)))
+      Error (Unification_error (expand_to_unification_error env trace))
 
 let filter_functor env t l =
   match expand_head_trace env t with
@@ -4021,7 +4021,7 @@ let filter_functor env t l =
       Error (Unification_error
               (expand_to_unification_error
                   env
-                  (Diff { got = t'; expected = t } :: trace)))
+                  (diff ~got:t' ~expected:t trace)))
 
 let is_really_poly env ty =
   let snap = Btype.snapshot () in
@@ -4057,7 +4057,7 @@ let rec filter_method_field env name ty =
                (Unification_error
                   (expand_to_unification_error
                      env
-                     (Diff { got = ty; expected = ty' } :: trace))))
+                     (diff ~got:ty ~expected:ty' trace))))
   in
   match get_desc ty with
   | Tvar _ ->
@@ -4092,7 +4092,7 @@ let filter_method env name ty =
                (Unification_error
                   (expand_to_unification_error
                      env
-                     (Diff { got = ty; expected = ty' } :: trace))))
+                     (diff ~got:ty ~expected:ty' trace))))
   in
   match get_desc ty with
   | Tvar _ ->
@@ -4276,7 +4276,8 @@ let unify_self_types env sign1 sign2 =
   | () -> ()
   | exception Unify err -> begin
       match err.trace with
-      | Errortrace.Diff _ :: Errortrace.Incompatible_fields {name; _} :: rem ->
+      | Errortrace.Diff { ctx=None; _ }
+        :: Errortrace.Diff { ctx = Some (In_method name); _ } :: rem ->
           let err = Errortrace.unification_error ~trace:rem in
           let failure = Method (name, Type_mismatch err) in
           raise (Inherit_class_signature_failed failure)
@@ -4560,7 +4561,7 @@ let rec moregen type_pairs env t1 t2 =
               raise_unexplained_for Moregen
         end
   with Moregen_trace trace ->
-    raise_trace_for Moregen (Diff {got = t1; expected = t2} :: trace)
+    raise_trace_for Moregen (diff ~got:t1 ~expected:t2 trace)
 
 
 and moregen_list type_pairs env tl1 tl2 =
@@ -4605,7 +4606,7 @@ and moregen_fields type_pairs env ty1 ty2 =
        moregen_kind k1 k2;
        try moregen type_pairs env t1 t2 with Moregen_trace trace ->
          raise_trace_for Moregen
-           (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
+           (incompatible_fields ~name ~got:t1 ~expected:t2 trace)
     )
     pairs
 
@@ -4670,15 +4671,15 @@ and moregen_row type_pairs env row1 row2 =
              try
                moregen type_pairs env t1 t2
              with Moregen_trace trace ->
-               raise_trace_for Moregen
-                 (Variant (Incompatible_types_for l) :: trace)
+               raise_trace_for Moregen (in_tag ~l trace)
            end
          | Rpresent None, Rpresent None -> ()
          (* Both [Reither] *)
          | Reither(c1, tl1, _), Reither(c2, tl2, m2) -> begin
              try
                if not (eq_row_field_ext f1 f2) then begin
-                 if c1 && not c2 then raise_unexplained_for Moregen;
+                 if c1 && not c2 then
+                   raise_for Moregen (variant_arity_mismatch ~l);
                  let f2' =
                    rf_either [] ~use_ext_of:f2 ~no_arg:c2 ~matched:m2 in
                  link_row_field_ext ~inside:f1 f2';
@@ -4689,11 +4690,12 @@ and moregen_row type_pairs env row1 row2 =
                      List.iter
                        (fun t1 -> moregen type_pairs env t1 t2)
                        tl1
-                   | [] -> if tl1 <> [] then raise_unexplained_for Moregen
+                   | [] ->
+                      if tl1 <> [] then
+                        raise_for Moregen (variant_arity_mismatch ~l)
                end
              with Moregen_trace trace ->
-               raise_trace_for Moregen
-                 (Variant (Incompatible_types_for l) :: trace)
+               raise_trace_for Moregen (in_tag ~l trace)
            end
          (* Generalizing [Reither] *)
          | Reither(false, tl1, _), Rpresent(Some t2) when may_inst -> begin
@@ -4704,7 +4706,7 @@ and moregen_row type_pairs env row1 row2 =
                  tl1
              with Moregen_trace trace ->
                raise_trace_for Moregen
-                 (Variant (Incompatible_types_for l) :: trace)
+                 (in_tag ~l trace)
            end
          | Reither(true, [], _), Rpresent None when may_inst ->
              link_row_field_ext ~inside:f1 f2
@@ -4715,7 +4717,7 @@ and moregen_row type_pairs env row1 row2 =
          (* Mismatched constructor arguments *)
          | Rpresent (Some _), Rpresent None
          | Rpresent None, Rpresent (Some _) ->
-             raise_for Moregen (Variant (Incompatible_types_for l))
+             raise_for Moregen (variant_arity_mismatch ~l)
          (* Mismatched presence *)
          | Reither _, Rpresent _ ->
              raise_for Moregen
@@ -4965,7 +4967,7 @@ let rec eqtype rename type_pairs subst env t1 t2 =
               raise_unexplained_for Equality
         end
   with Equality_trace trace ->
-    raise_trace_for Equality (Diff {got = t1; expected = t2} :: trace)
+    raise_trace_for Equality (diff ~got:t1 ~expected:t2 trace)
 
 and eqtype_list_same_length rename type_pairs subst env tl1 tl2 =
   List.iter2 (eqtype rename type_pairs subst env) tl1 tl2
@@ -5021,7 +5023,7 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
              eqtype rename type_pairs subst env t1 t2;
            with Equality_trace trace ->
              raise_trace_for Equality
-               (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace))
+               (incompatible_fields ~name ~got:t1 ~expected:t2 trace))
         pairs
 
 and eqtype_kind k1 k2 =
@@ -5071,8 +5073,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
            try
              eqtype rename type_pairs subst env t1 t2
            with Equality_trace trace ->
-             raise_trace_for Equality
-               (Variant (Incompatible_types_for l) :: trace)
+             raise_trace_for Equality (in_tag ~l trace)
          end
        | Rpresent None, Rpresent None -> ()
        (* Both matching [Reither]s *)
@@ -5091,8 +5092,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
                  (fun t1 -> eqtype rename type_pairs subst env t1 t2) tl1
              end
            with Equality_trace trace ->
-             raise_trace_for Equality
-               (Variant (Incompatible_types_for l) :: trace)
+             raise_trace_for Equality (in_tag ~l trace)
          end
        (* Both [Rabsent]s *)
        | Rabsent, Rabsent -> ()
@@ -5100,7 +5100,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
        | Rpresent (Some _), Rpresent None
        | Rpresent None, Rpresent (Some _)
        | Reither _, Reither _ ->
-           raise_for Equality (Variant (Incompatible_types_for l))
+           raise_for Equality (variant_arity_mismatch ~l)
        (* Mismatched presence *)
        | Reither _, Rpresent _ ->
            raise_for Equality
@@ -5955,7 +5955,7 @@ and subtype_row env trace row1 row2 constraints =
           | Rpresent None, Rpresent (Some _)
           | Rpresent (Some _), Rpresent None ->
               subtype_error ~env ~trace
-                ~unification_trace:[Variant (Incompatible_types_for l)]
+                ~unification_trace:[variant_arity_mismatch ~l]
           | _ ->
               raise Exit)
         constraints pairs

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3146,6 +3146,14 @@ let compare_package env unify_list lv1 pack1 lv2 pack2 =
       (!package_subtype env pack1 pack2)
       (fun () -> !package_subtype env pack2 pack1)
 
+let highlight_for k ~got ~expected =
+  let h (d,t) = match d with
+    | Tconstr (p,_,_) -> Some (Errortrace.Type_constructor p)
+    | _ -> Some (Errortrace.Type (Paired,t))
+  in
+  let d = { Errortrace.got = h got; expected = h expected } in
+  raise_for k (Highlight_hint d)
+
 (* force unification in Reither when one side has a non-conjunctive type *)
 (* Code smell: this could also be put in unification_environment.
    Only modified by expand_head_rigid, but the corresponding unification
@@ -3421,8 +3429,11 @@ and unify3 uenv t1 t1' t2 t2' =
       | (Tconstr (_,_,_), _) | (_, Tconstr (_,_,_)) when in_pattern_mode uenv ->
           reify ~eqn:(t1',t2') uenv t1';
           reify ~eqn:(t1',t2') uenv t2';
-          mcomp_for Unify (get_env uenv) t1' t2';
-          record_equation uenv t1' t2'
+          begin match mcomp (get_env uenv) t1' t2' with
+          | () -> record_equation uenv t1' t2'
+          | exception Incompatible ->
+             highlight_for Unify ~got:(d1,t1) ~expected:(d2,t2)
+          end
       | (Tobject (fi1, nm1), Tobject (fi2, _)) ->
           unify_fields uenv fi1 fi2;
           (* Type [t2'] may have been instantiated by [unify_fields] *)
@@ -3474,6 +3485,8 @@ and unify3 uenv t1 t1' t2 t2' =
           raise_for Unify (Obj (Abstract_row Second))
       | (Tconstr _,  Tnil ) ->
           raise_for Unify (Obj (Abstract_row First))
+      | Tconstr _, _ | _, Tconstr _ ->
+         highlight_for Unify ~got:(d1,t1) ~expected:(d2,t2)
       | (_, _) -> raise_unexplained_for Unify
       end;
       (* XXX Commentaires + changer "create_recursion"

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -108,10 +108,10 @@ let raise_trace_for
    trace information; sometimes it makes sense, however, since we're maintaining
    the trace at an outer exception handler. *)
 let raise_unexplained_for tr_exn =
-  raise_trace_for tr_exn []
+  raise_trace_for tr_exn empty_root
 
 let raise_for tr_exn e =
-  raise_trace_for tr_exn [e]
+  raise_trace_for tr_exn (root e)
 
 (* Thrown from [moregen_kind] *)
 exception Public_method_to_private_method
@@ -2659,15 +2659,14 @@ let expand_to_moregen_error env trace =
 
 (* Equivalent to [expand_trace env [Diff {got; expected}]] for a single
    element *)
-let mk_diff ~got ~expected = { d = {got; expected}; ctx = None }
-
-let expanded_diff env ~got ~expected =
-  Diff (map_ctx (expand_type env) (mk_diff ~got ~expected))
+let with_diff f ~got ~expected t = diff ~got:(f got) ~expected:(f expected) t
+let expanded_diff env ~got ~expected t =
+  with_diff (expand_type env) ~got ~expected t
 
 (* Diff while transforming a [type_expr] into an [expanded_type] without
    expanding *)
-let unexpanded_diff ~got ~expected =
-  Diff (map_ctx trivial_expansion (mk_diff ~got ~expected))
+let unexpanded_diff ~got ~expected t =
+  with_diff trivial_expansion ~got ~expected t
 
 (**** Unification ****)
 
@@ -3697,8 +3696,8 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
     match fixed with
     | None -> f ()
     | Some fix ->
-        let tr = [Variant(Fixed_row(pos,Cannot_add_tags [l],fix))] in
-        raise_trace_for Unify tr in
+        let tr = Errortrace.Variant(Fixed_row(pos,Cannot_add_tags [l],fix)) in
+        raise_for Unify tr in
   let first = First, fixed1 and second = Second, fixed2 in
   let either_fixed = match fixed1, fixed2 with
     | None, None -> false
@@ -3784,9 +3783,9 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
   | Rpresent None, Reither(true, [], _) ->
       if_not_fixed second (fun () -> link_row_field_ext ~inside:f2 f1)
   | Rabsent, (Rpresent _ | Reither(_,_,true)) ->
-      raise_trace_for Unify [Variant(No_tags(First, [l,f1]))]
+      raise_for Unify (Variant(No_tags(First, [l,f1])))
   | (Rpresent _ | Reither (_,_,true)), Rabsent ->
-      raise_trace_for Unify [Variant(No_tags(Second, [l,f2]))]
+      raise_for Unify (Variant(No_tags(Second, [l,f2])))
   | (Rpresent (Some _) | Reither(false,_,_)),
     (Rpresent None | Reither(true,_,_))
   | (Rpresent None | Reither(true,_,_)),
@@ -4275,10 +4274,10 @@ let unify_self_types env sign1 sign2 =
   match unify env self_type1 self_type2 with
   | () -> ()
   | exception Unify err -> begin
-      match err.trace with
-      | Errortrace.Diff { ctx=None; _ }
-        :: Errortrace.Diff { ctx = Some (In_method name); _ } :: rem ->
-          let err = Errortrace.unification_error ~trace:rem in
+      match err.trace.path with
+      | { ctx=None; _ } :: { ctx = Some (In_method name); _ } :: rem ->
+          let trace = { err.trace with path = rem } in
+          let err = Errortrace.unification_error ~trace in
           let failure = Method (name, Type_mismatch err) in
           raise (Inherit_class_signature_failed failure)
       | _ ->
@@ -4834,12 +4833,12 @@ let matches ~expand_error_trace env ty ty' =
   | () ->
       if not (all_distinct_vars env vars) then begin
         backtrack snap;
-        let diff =
+        let trace =
           if expand_error_trace
-          then expanded_diff env ~got:ty ~expected:ty'
-          else unexpanded_diff ~got:ty ~expected:ty'
+          then expanded_diff env ~got:ty ~expected:ty' empty_root
+          else unexpanded_diff ~got:ty ~expected:ty' empty_root
         in
-        raise (Matches_failure (env, unification_error ~trace:[diff]))
+        raise (Matches_failure (env, unification_error ~trace))
       end;
       backtrack snap
   | exception Unify err ->
@@ -5704,7 +5703,7 @@ let rec subtype_rec env trace t1 t2 constraints =
         let constraints = subtype_rec env trace t2 t1 constraints in
         subtype_rec
           env
-          (Subtype.Diff {got = u1; expected = u2} :: trace)
+          (Subtype.diff ~got:u1 ~expected:u2 trace)
           u1 u2
           constraints
     | (Tfunctor (l1, id1, pack1, u1), Tfunctor (l2, id2, pack2, u2))
@@ -5713,7 +5712,7 @@ let rec subtype_rec env trace t1 t2 constraints =
         let fcm2 = newty (Tpackage pack2) in
         let constraints =
           subtype_package env
-            (Subtype.Diff {got = fcm2; expected = fcm1} :: trace)
+            (Subtype.diff ~got:fcm2 ~expected:fcm1 trace)
             (get_level t2) pack2 (get_level t1) pack1 constraints
         in
         begin
@@ -5773,7 +5772,7 @@ let rec subtype_rec env trace t1 t2 constraints =
                 else
                   subtype_rec
                     env
-                    (Subtype.Diff {got = t1; expected = t2} :: trace)
+                    (Subtype.diff ~got:t1 ~expected:t2 trace)
                     t1 t2
                     constraints
               else
@@ -5781,7 +5780,7 @@ let rec subtype_rec env trace t1 t2 constraints =
                 then
                   subtype_rec
                     env
-                    (Subtype.Diff {got = t2; expected = t1} :: trace)
+                    (Subtype.diff ~got:t2 ~expected:t1 trace)
                     t2 t1
                     constraints
                 else constraints)
@@ -5807,14 +5806,14 @@ let rec subtype_rec env trace t1 t2 constraints =
           (env, trace, t1, t2, !univar_pairs)::constraints
         end
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
-        let trace = Subtype.Diff {got = u1; expected = u2} :: trace in
+        let trace = Subtype.diff ~got:u1 ~expected:u2 trace in
         subtype_rec env trace u1 u2 constraints
     | (Tpoly (u1, tl1), Tpoly (u2, [])) ->
-        let trace = Subtype.Diff {got = t1; expected = u2} :: trace in
+        let trace = Subtype.diff ~got:t1 ~expected:u2 trace in
         let u1' = instance_poly tl1 u1 in
         subtype_rec env trace u1' u2 constraints
     | (Tpoly (u1, tl1), Tpoly (u2,tl2)) ->
-        let trace = Subtype.Diff {got = t1; expected = t2} :: trace in
+        let trace = Subtype.diff ~got:t1 ~expected:t2 trace in
         begin try
           enter_poly env u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 constraints)
@@ -5830,14 +5829,14 @@ let rec subtype_rec env trace t1 t2 constraints =
 
 and subtype_labeled_list env trace labeled_tl1 labeled_tl2 constraints =
   if 0 <> List.compare_lengths labeled_tl1 labeled_tl2 then
-    subtype_error ~env ~trace ~unification_trace:[];
+    subtype_error ~env ~trace ~unification_trace:empty_root;
   List.fold_left2
     (fun constraints (label1, ty1) (label2, ty2) ->
       if not (Option.equal String.equal label1 label2) then
-        subtype_error ~env ~trace ~unification_trace:[];
+        subtype_error ~env ~trace ~unification_trace:empty_root;
       subtype_rec
         env
-        (Subtype.Diff { got = ty1; expected = ty2 } :: trace)
+        (Subtype.diff ~got:ty1 ~expected:ty2 trace)
         ty1 ty2
         constraints)
     constraints labeled_tl1 labeled_tl2
@@ -5878,7 +5877,7 @@ and subtype_functor env trace ?id1 id pack u1 u2 constraints =
   let env = Env.add_module (Ident.of_unscoped id) Mp_present mty env in
   subtype_rec
     env
-    (Subtype.Diff {got = u1; expected = u2} :: trace)
+    (Subtype.diff ~got:u1 ~expected:u2 trace)
     u1 u2
     constraints
 
@@ -5892,7 +5891,7 @@ and subtype_fields env trace ty1 ty2 constraints =
     if miss1 = [] then
       subtype_rec
         env
-        (Subtype.Diff {got = rest1; expected = rest2} :: trace)
+        (Subtype.diff ~got:rest1 ~expected:rest2 trace)
         rest1 rest2
         constraints
     else
@@ -5911,7 +5910,7 @@ and subtype_fields env trace ty1 ty2 constraints =
        (* These fields are always present *)
        subtype_rec
          env
-         (Subtype.Diff {got = t1; expected = t2} :: trace)
+         (Subtype.diff ~got:t1 ~expected:t2 trace)
          t1 t2
          constraints)
     constraints pairs
@@ -5929,7 +5928,7 @@ and subtype_row env trace row1 row2 constraints =
     Tconstr(p1,_,_), Tconstr(p2,_,_) when Env_unscoped.path_equiv env p1 p2 ->
       subtype_rec
         env
-        (Subtype.Diff {got = more1; expected = more2} :: trace)
+        (Subtype.diff ~got:more1 ~expected:more2 trace)
         more1 more2
         constraints
   | (Tvar _|Tconstr _|Tnil), (Tvar _|Tconstr _|Tnil)
@@ -5942,20 +5941,20 @@ and subtype_row env trace row1 row2 constraints =
           | Rpresent(Some t1), Rpresent(Some t2) ->
               subtype_rec
                 env
-                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                (Subtype.diff ~got:t1 ~expected:t2 trace)
                 t1 t2
                 constraints
           | Reither(false, t1::_, _), Rpresent(Some t2) ->
               subtype_rec
                 env
-                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                (Subtype.diff ~got:t1 ~expected:t2 trace)
                 t1 t2
                 constraints
           | Rabsent, _ -> constraints
           | Rpresent None, Rpresent (Some _)
           | Rpresent (Some _), Rpresent None ->
               subtype_error ~env ~trace
-                ~unification_trace:[variant_arity_mismatch l]
+                ~unification_trace:(root (variant_arity_mismatch l))
           | _ ->
               raise Exit)
         constraints pairs
@@ -5964,7 +5963,7 @@ and subtype_row env trace row1 row2 constraints =
       let constraints =
         subtype_rec
           env
-          (Subtype.Diff {got = more1; expected = more2} :: trace)
+          (Subtype.diff ~got:more1 ~expected:more2 trace)
           more1 more2
           constraints
       in
@@ -5979,7 +5978,7 @@ and subtype_row env trace row1 row2 constraints =
           | Reither(false,[t1],_), Reither(false,[t2],_) ->
               subtype_rec
                 env
-                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                (Subtype.diff ~got:t1 ~expected:t2 trace)
                 t1 t2
                 constraints
           | _ -> raise Exit)
@@ -5992,7 +5991,7 @@ let subtype env ty1 ty2 =
   with_univar_pairs [] (fun () ->
     (* Build constraint set. *)
     let constraints =
-      subtype_rec env [Subtype.Diff {got = ty1; expected = ty2}] ty1 ty2 []
+      subtype_rec env (Subtype.diff ~got:ty1 ~expected:ty2 []) ty1 ty2 []
     in
     TypePairs.clear subtypes;
     (* Enforce constraints. *)
@@ -6003,7 +6002,7 @@ let subtype env ty1 ty2 =
            subtype_error
              ~env
              ~trace:trace0
-             ~unification_trace:(List.tl trace))
+             ~unification_trace:({ trace with path = List.tl trace.path}))
         (List.rev constraints))
 
                               (*******************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3722,7 +3722,7 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
          !rigid_variants && (List.length tl1 = 1 || List.length tl2 = 1)) &&
         begin match tl1 @ tl2 with [] -> false
         | t1 :: tl ->
-            if no_arg then raise_for Unify (variant_arity_mismatch ~l);
+            if no_arg then raise_for Unify (variant_arity_mismatch l);
             Types.changed_row_field_exts [f1;f2] (fun () ->
                 List.iter (unify uenv t1) tl
               )
@@ -3792,11 +3792,11 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
   | (Rpresent None | Reither(true,_,_)),
     (Rpresent (Some _) | Reither(false,_,_)) ->
       (* constructor arity mismatch: 0 <> 1 *)
-      raise_for Unify (variant_arity_mismatch ~l)
-  | Reither(true, _ :: _, _ ), Rpresent _
-  | Rpresent _ , Reither(true, _ :: _, _ ) ->
-      (* inconsistent conjunction on a non-absent field *)
-      raise_for Unify (inconsistent_conjunction ~l)
+      raise_for Unify (variant_arity_mismatch l)
+  | Reither(true, _ :: _, _ ), Rpresent None
+  | Rpresent None , Reither(true, _ :: _, _ ) ->
+      (* inconsistent arity on a non-absent field *)
+      raise_for Unify (variant_arity_mismatch l)
 
 let unify uenv ty1 ty2 =
   let snap = Btype.snapshot () in
@@ -4679,7 +4679,7 @@ and moregen_row type_pairs env row1 row2 =
              try
                if not (eq_row_field_ext f1 f2) then begin
                  if c1 && not c2 then
-                   raise_for Moregen (variant_arity_mismatch ~l);
+                   raise_for Moregen (variant_arity_mismatch l);
                  let f2' =
                    rf_either [] ~use_ext_of:f2 ~no_arg:c2 ~matched:m2 in
                  link_row_field_ext ~inside:f1 f2';
@@ -4692,7 +4692,7 @@ and moregen_row type_pairs env row1 row2 =
                        tl1
                    | [] ->
                       if tl1 <> [] then
-                        raise_for Moregen (variant_arity_mismatch ~l)
+                        raise_for Moregen (variant_arity_mismatch l)
                end
              with Moregen_trace trace ->
                raise_trace_for Moregen (in_tag ~l trace)
@@ -4717,7 +4717,7 @@ and moregen_row type_pairs env row1 row2 =
          (* Mismatched constructor arguments *)
          | Rpresent (Some _), Rpresent None
          | Rpresent None, Rpresent (Some _) ->
-             raise_for Moregen (variant_arity_mismatch ~l)
+             raise_for Moregen (variant_arity_mismatch l)
          (* Mismatched presence *)
          | Reither _, Rpresent _ ->
              raise_for Moregen
@@ -5100,7 +5100,7 @@ and eqtype_row rename type_pairs subst env row1 row2 =
        | Rpresent (Some _), Rpresent None
        | Rpresent None, Rpresent (Some _)
        | Reither _, Reither _ ->
-           raise_for Equality (variant_arity_mismatch ~l)
+           raise_for Equality (variant_arity_mismatch l)
        (* Mismatched presence *)
        | Reither _, Rpresent _ ->
            raise_for Equality
@@ -5955,7 +5955,7 @@ and subtype_row env trace row1 row2 constraints =
           | Rpresent None, Rpresent (Some _)
           | Rpresent (Some _), Rpresent None ->
               subtype_error ~env ~trace
-                ~unification_trace:[variant_arity_mismatch ~l]
+                ~unification_trace:[variant_arity_mismatch l]
           | _ ->
               raise Exit)
         constraints pairs

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4470,7 +4470,7 @@ let subject_level = generic_level - 1
    Update the level of [ty]. First check that the levels of generic
    variables from the subject are not lowered.
 *)
-let moregen_occur env level ty =
+let moregen_occur env ty0 level ty =
   with_type_mark begin fun mark ->
     let rec occur ty =
       let lv = get_level ty in
@@ -4481,7 +4481,7 @@ let moregen_occur env level ty =
     try
       occur ty
     with Occur ->
-      raise_unexplained_for Moregen
+      highlight_for Moregen ~got:(get_desc ty0,ty0) ~expected:(get_desc ty, ty)
   end;
   (* also check for free univars *)
   occur_univar_or_unscoped_for Moregen env ty;
@@ -4495,7 +4495,7 @@ let rec moregen type_pairs env t1 t2 =
   try
     match (get_desc t1, get_desc t2) with
       (Tvar _, _) when may_instantiate t1 ->
-        moregen_occur env (get_level t1) t2;
+        moregen_occur env t1 (get_level t1) t2;
         update_scope_for Moregen (get_scope t1) t2;
         occur_for Moregen (Expression {env; in_subst = false}) t1 t2;
         link_type t1 t2
@@ -4511,9 +4511,11 @@ let rec moregen type_pairs env t1 t2 =
           TypePairs.add type_pairs (t1', t2');
           match (get_desc t1', get_desc t2') with
             (Tvar _, _) when may_instantiate t1' ->
-              moregen_occur env (get_level t1') t2;
+              moregen_occur env t1' (get_level t1') t2;
               update_scope_for Moregen (get_scope t1') t2;
               link_type t1' t2
+          | Tvar _ as d1, d2 | d1, (Tvar _ as d2) ->
+             highlight_for Moregen ~got:(d1,t1) ~expected:(d2,t2)
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) ->
               eq_labels Moregen ~in_pattern_mode:false l1 l2;
               moregen type_pairs env t1 t2;
@@ -4667,7 +4669,7 @@ and moregen_row type_pairs env row1 row2 =
                     (create_row ~fields:r2 ~more:rm2 ~name:None
                        ~fixed:row2_fixed ~closed:row2_closed))
       in
-      moregen_occur env (get_level rm1) ext;
+      moregen_occur env rm1 (get_level rm1) ext;
       update_scope_for Moregen (get_scope rm1) ext;
       (* This [link_type] has to be undone if the rest of the function fails *)
       link_type rm1 ext
@@ -4875,13 +4877,21 @@ let expand_head_rigid env ty =
   let ty' = expand_head env ty in
   rigid_variants := old; ty'
 
+let eq_highlight l =
+  let typ t = Errortrace.Type (Independent, t) in
+  let l = List.map typ l in
+  raise_for Equality (Highlight_hint {got=l; expected=l})
+
 let eqtype_subst type_pairs subst t1 t2 =
   if List.exists
       (fun (t,t') ->
         let found1 = eq_type t1 t in
         let found2 = eq_type t2 t' in
-        if found1 && found2 then true else
-        if found1 || found2 then raise_unexplained_for Equality else false)
+        if found1 && found2 then true
+        else if found1 then eq_highlight [t1;t;t2]
+        else if found2 then eq_highlight [t1;t';t2]
+        else false
+      )
       !subst
   then ()
   else begin
@@ -4919,6 +4929,8 @@ let rec eqtype rename type_pairs subst env t1 t2 =
           match (get_desc t1', get_desc t2') with
             (Tvar _, Tvar _) when rename ->
               eqtype_subst type_pairs subst t1' t2'
+          | Tvar _ as d1, d2 | d1, (Tvar _ as d2) ->
+             highlight_for Equality ~got:(d1,t1) ~expected:(d2,t2)
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) ->
               eq_labels Equality ~in_pattern_mode:false l1 l2;
               eqtype rename type_pairs subst env t1 t2;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -297,14 +297,16 @@ val expand_head_opt: Env.t -> type_expr -> type_expr
 val expanded_diff :
   Env.t ->
   got:type_expr -> expected:type_expr ->
-  (Errortrace.expanded_type, 'variant) Errortrace.elt
+  (Errortrace.expanded_type, 'v) Errortrace.t ->
+  (Errortrace.expanded_type, 'v) Errortrace.t
 
 (** Create an [Errortrace.Diff] by *duplicating* the two types, so that each
     one's expansion is identical to itself.  Despite the name, does create
     [Errortrace.expanded_type]s. *)
 val unexpanded_diff :
   got:type_expr -> expected:type_expr ->
-  (Errortrace.expanded_type, 'variant) Errortrace.elt
+  (Errortrace.expanded_type, 'v) Errortrace.t ->
+  (Errortrace.expanded_type, 'v) Errortrace.t
 
 val full_expand: may_forget_scope:bool -> Env.t -> type_expr -> type_expr
 

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -231,7 +231,11 @@ module Subtype = struct
 end
 
 module Structured = struct
+(** This module contains helper functions to parse the error trace into the more
+    structured type {!Stuctured.t} *)
 
+(** We extend the core explanation type with promoted explanation generated from
+    the main trace *)
 type 'a extended_explanation =
   | Promoted of Format_doc.t
   | Standard of 'a
@@ -241,28 +245,28 @@ type ('a,'b) s = {
   tr: 'a ctx_diff list;
   expl: ('a,'b) root extended_explanation option;
 }
-(**
-This module contains helper functions to split the error trace into three parts:
+(** The structured version of the trace is split in three parts:
 - {!top} the first element of the trace
 - {!tr} a list of meaningful context difference element
 - {!expl} a root explanation for a type error
 *)
 
-(** The first intermediary representation splits the trace into four parts:
+(**  The first intermediary representation splits the trace into four parts:
 - the {!head} element of the trace
-- the {!top_to_ctx} trace elements in reverse order situated before the last
-  method or tag difference
+- {!before}: trace elements appearing before the last method or tag
+  difference, in reverse order.
 - {!last_ctx}: the last method or tag context, and the list of elements after it
-- {!optional}: the last element that might be printed if we don't discover a
-  better element to print later on.
-*)
+  in reverse order.
+- {!optional}: the last element that might be useful to print, if we do not
+  discover a better element to print later on.
+Contrarily to the {!t} format this form can be built element by element. *)
 type ('a,'b) segments =
   {
     head: 'a;
     before:'a list;
     last_ctx:('a * 'a list) option;
     optional: 'a option;
-    expl:  'b option;
+    expl: 'b option;
   }
 
 let head_segment hd expl =

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -240,10 +240,10 @@ type 'a extended_explanation =
   | Promoted of Format_doc.t
   | Standard of 'a
 
-type ('a,'b) s = {
+type ('a,'b,'c) s = {
   top: ('a ctx_diff * bool) option;
   tr: 'a ctx_diff list;
-  expl: ('a,'b) root extended_explanation option;
+  expl: ('b,'c) root extended_explanation option;
 }
 (** The structured version of the trace is split in three parts:
 - {!top} the first element of the trace

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -300,7 +300,7 @@ type printing_status =
       type error.
   *)
 
-(** Construct a segment from an unstructured trace *)
+(** Construct a segmented trace from an unstructured trace *)
 let segment status path expl = match path with
   | [] -> assert false
   | hd :: tr ->
@@ -314,29 +314,33 @@ let segment status path expl = match path with
 
 let promoted x = Option.map (fun p -> Promoted p) x
 let merge promote s =
-  (* First, we commit the last contextualized segment of the trace to the
-     trace *)
-  let rtr, opt, maybe_compact = match s.last_ctx with
-    | None -> s.before, s.optional, false
-    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
+  (* First, we commit the last contextualized segment of the trace to the trace
+     if there one. We also discard the optional last element in this
+     case. *)
+  let rtr, opt = match s.last_ctx with
+    | None -> s.before, s.optional
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None
   in
-  let head, rtr, expl = match s.expl, rtr with
-    | Some expl, _ -> Some s.head, rtr, Some (Standard expl)
-    | None, [] -> Some s.head, [], promoted (promote s.head.d)
-    | None, d :: _ ->
-        match promote d.d with
-        | Some p -> Some s.head, rtr, Some (Promoted p)
-        | None -> Some s.head, rtr, None
+  let rtr, expl =
+    (* If there are no root explanation, we try to promote one from the last
+       element*)
+    match s.expl, rtr, s.head with
+    | Some expl, _, _ -> rtr, Some (Standard expl)
+    | None, [], last | None, last :: _, _ -> rtr, promoted (promote last.d)
   in
+  (* Finally, we keep the last optional element only if there were no
+     explanation at all.*)
   let tr = match expl, opt with
     | None, Some opt -> List.rev (opt :: rtr)
-    | Some _, _ | None, _  -> List.rev rtr
+    | Some _, _ | None, None  -> List.rev rtr
   in
-  let compact head = match tr, maybe_compact with
-    | [], _ | [_], true -> head, true
-    | _ -> head, false
+  (* We use a compact presentation for the top element only if the trace is
+     empty, or is a singleton contextual element (?). *)
+  let compact_head = match tr with
+    | [] | [{ ctx = Some _; _}] -> s.head, true
+    | _ -> s.head, false
   in
-  { top=Option.map compact head; tr; expl }
+  { top = Some compact_head; tr; expl }
 
   let parse ~promote ~status s =
     match s.path with
@@ -345,6 +349,8 @@ let merge promote s =
         { top = None; tr = []; expl}
     | path -> merge promote (segment status path s.root)
 
+  (* In the simple case, we are handling a partial trace with no explanation at
+     all.*)
   let parse_simple status tr =
     match tr with
     | [] -> { top = None; tr = []; expl = None}

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -39,14 +39,24 @@ type expanded_type = { ty: type_expr; expanded: type_expr }
 let trivial_expansion ty = { ty; expanded = ty }
 
 type 'a diff = { got: 'a; expected: 'a }
+type ctx =
+  | In_method of string
+  | In_tag of string
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 
 let map_diff f r =
   (* ordering is often meaningful when dealing with type_expr *)
   let got = f r.got in
   let expected = f r.expected in
   { got; expected }
-
 let swap_diff x = { got = x.expected; expected = x.got }
+
+let map_cdiff f x = { x with d = map_diff f x.d }
+let swap_cdiff x = { x with d = swap_diff x.d }
+
+
+
+
 
 type 'a escape_kind =
   | Constructor of Path.t
@@ -115,13 +125,6 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
-type ctx =
-  | In_method of string
-  | In_tag of string
-type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
-let map_ctx f x = { x with d = map_diff f x.d }
-let swap_ctx x = { x with d = swap_diff x.d }
-
 type ('a, 'variety) root  =
   (* Common *)
   | Variant : 'variety variant -> ('a, 'variety) root
@@ -156,8 +159,10 @@ let map_root (type variety) f : ('a, variety) root -> ('b, variety) root =
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
 
-let map f t =
-  { path = List.map (map_ctx f) t.path; root = Option.map (map_root f) t.root }
+let map f t ={
+  path = List.map (map_cdiff f) t.path;
+  root = Option.map (map_root f) t.root
+}
 let diff ?ctx ~got ~expected trace =
   { trace with path = { ctx; d = {got;expected} } :: trace.path }
 
@@ -187,7 +192,7 @@ let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =
 
 let swap_trace t = {
   root = Option.map swap_root t.root;
-  path = List.map swap_ctx t.path
+  path = List.map swap_cdiff t.path
 }
 
 type unification_error = { trace : unification error } [@@unboxed]
@@ -236,7 +241,7 @@ module Subtype = struct
   assert (trace <> []);
   { trace; unification_trace }
 
-  let map f t = List.map (map_ctx f) t
+  let map f t = List.map (map_cdiff f) t
 end
 
 module Structured = struct

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -356,7 +356,7 @@ let merge promote s =
 
   let parse_simple status tr =
     match tr with
-    | [] -> None
+    | [] -> { top = None; tr = []; expl = None}
     | _ ->
         let s = segment status tr None in
         let rtr = match s.last_ctx with
@@ -367,6 +367,6 @@ let merge promote s =
           | Some x -> x :: rtr
           | None -> rtr
         in
-        Some (s.head, List.rev rtr)
+        { top = Some (s.head,false); tr = List.rev rtr; expl = None }
 
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -89,7 +89,8 @@ type fixed_row_case =
 
 type 'variety variant =
   (* Common *)
-  | Incompatible_types_for : string -> _ variant
+  | Arity_mismatch : string -> _ variant
+  | Inconsistent_conjunction: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -115,16 +116,21 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
+type ctx =
+  | In_method of string
+  | In_tag of string
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
+let map_ctx f x = { x with d = map_diff f x.d }
+let swap_ctx x = { x with d = swap_diff x.d }
+
 type ('a, 'variety) elt =
   (* Common *)
-  | Diff : 'a diff -> ('a, _) elt
+  | Diff : 'a ctx_diff -> ('a, _) elt
   | Variant : 'variety variant -> ('a, 'variety) elt
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
-      (* Could move [Incompatible_fields] into [obj] *)
   | First_class_module: first_class_module -> ('a,_) elt
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
@@ -136,26 +142,29 @@ type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
 let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
-  | Diff x -> Diff (map_diff f x)
+  | Diff x -> Diff (map_ctx f x)
   | Escape {kind = Equation x; context} ->
       Escape { kind = Equation (f x); context }
   | Escape {kind = (Univ _ | Self | Constructor _
       | Module_type _ | Module _ | Constraint);
             _}
   | Variant _ | Obj _ | Function_label_mismatch _ | Tuple_label_mismatch _
-  | Incompatible_fields _
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
 
 let map f t = List.map (map_elt f) t
+let diff ?ctx ~got ~expected trace = Diff { ctx; d = {got;expected} } :: trace
 
-let incompatible_fields ~name ~got ~expected =
-  Incompatible_fields { name; diff={got; expected} }
+let incompatible_fields ~name ~got ~expected  t =
+  Diff { ctx = Some (In_method name); d = { got; expected} } :: t
+let in_tag ~l = function
+  | Diff { ctx = None; d} :: rem -> Diff { ctx = Some(In_tag l); d} :: rem
+  | trace -> trace
+let variant_arity_mismatch ~l = Variant (Arity_mismatch l)
+let inconsistent_conjunction ~l = Variant (Inconsistent_conjunction l)
 
 let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
-  | Diff x -> Diff (swap_diff x)
-  | Incompatible_fields { name; diff } ->
-    Incompatible_fields { name; diff = swap_diff diff}
+  | Diff x -> Diff (swap_ctx x)
   | Obj (Missing_field(pos,s)) -> Obj (Missing_field(swap_position pos,s))
   | Obj (Abstract_row pos) -> Obj (Abstract_row (swap_position pos))
   | Variant (Fixed_row(pos,k,f)) ->

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -54,10 +54,6 @@ let swap_diff x = { got = x.expected; expected = x.got }
 let map_cdiff f x = { x with d = map_diff f x.d }
 let swap_cdiff x = { x with d = swap_diff x.d }
 
-
-
-
-
 type 'a escape_kind =
   | Constructor of Path.t
   | Univ of type_expr
@@ -78,16 +74,6 @@ let map_escape f esc =
      | Equation eq -> Equation (f eq)
      | (Constructor _ | Univ _ | Self | Module_type _
         | Module _ | Constraint) as c -> c}
-
-let explain trace f =
-  let rec explain = function
-    | [] -> None
-    | [h] -> f ~prev:None h
-    | h :: (prev :: _ as rem) ->
-      match f ~prev:(Some prev) h with
-      | Some _ as m -> m
-      | None -> explain rem in
-  explain (List.rev trace)
 
 (* Type indices *)
 type unification = private Unification

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -90,7 +90,6 @@ type fixed_row_case =
 type 'variety variant =
   (* Common *)
   | Arity_mismatch : string -> _ variant
-  | Inconsistent_conjunction: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -160,8 +159,7 @@ let incompatible_fields ~name ~got ~expected  t =
 let in_tag ~l = function
   | Diff { ctx = None; d} :: rem -> Diff { ctx = Some(In_tag l); d} :: rem
   | trace -> trace
-let variant_arity_mismatch ~l = Variant (Arity_mismatch l)
-let inconsistent_conjunction ~l = Variant (Inconsistent_conjunction l)
+let variant_arity_mismatch l = Variant (Arity_mismatch l)
 
 let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
   | Diff x -> Diff (swap_ctx x)

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -122,26 +122,31 @@ type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 let map_ctx f x = { x with d = map_diff f x.d }
 let swap_ctx x = { x with d = swap_diff x.d }
 
-type ('a, 'variety) elt =
+type ('a, 'variety) root  =
   (* Common *)
-  | Diff : 'a ctx_diff -> ('a, _) elt
-  | Variant : 'variety variant -> ('a, 'variety) elt
-  | Obj : 'variety obj -> ('a, 'variety) elt
-  | Escape : 'a escape -> ('a, _) elt
+  | Variant : 'variety variant -> ('a, 'variety) root
+  | Obj : 'variety obj -> ('a, 'variety) root
+  | Escape : 'a escape -> ('a, _) root
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | First_class_module: first_class_module -> ('a,_) elt
+  | First_class_module: first_class_module -> ('a,_) root
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
-  | Rec_occur : type_expr * type_expr -> ('a, _) elt
+  | Rec_occur : type_expr * type_expr -> ('a, _) root
 
-type ('a, 'variety) t = ('a, 'variety) elt list
+type ('a, 'variety) t = {
+  path: 'a ctx_diff list;
+  root: ('a, 'variety) root option
+}
+
+let root root = { root= Some root; path = [] }
+let empty_root = { root = None; path = [] }
 
 type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
-let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
-  | Diff x -> Diff (map_ctx f x)
+let map_root (type variety) f : ('a, variety) root -> ('b, variety) root =
+  function
   | Escape {kind = Equation x; context} ->
       Escape { kind = Equation (f x); context }
   | Escape {kind = (Univ _ | Self | Constructor _
@@ -151,18 +156,21 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
 
-let map f t = List.map (map_elt f) t
-let diff ?ctx ~got ~expected trace = Diff { ctx; d = {got;expected} } :: trace
+let map f t =
+  { path = List.map (map_ctx f) t.path; root = Option.map (map_root f) t.root }
+let diff ?ctx ~got ~expected trace =
+  { trace with path = { ctx; d = {got;expected} } :: trace.path }
 
 let incompatible_fields ~name ~got ~expected  t =
-  Diff { ctx = Some (In_method name); d = { got; expected} } :: t
-let in_tag ~l = function
-  | Diff { ctx = None; d} :: rem -> Diff { ctx = Some(In_tag l); d} :: rem
-  | trace -> trace
+  diff ~ctx:(In_method name) ~got ~expected t
+let in_tag ~l t = match t.path with
+  | { ctx = None; d} :: rem ->
+      { t with path = { ctx = Some(In_tag l); d } :: rem }
+  | _ -> t
 let variant_arity_mismatch l = Variant (Arity_mismatch l)
 
-let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
-  | Diff x -> Diff (swap_ctx x)
+let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =
+  function
   | Obj (Missing_field(pos,s)) -> Obj (Missing_field(swap_position pos,s))
   | Obj (Abstract_row pos) -> Obj (Abstract_row (swap_position pos))
   | Variant (Fixed_row(pos,k,f)) ->
@@ -177,7 +185,10 @@ let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
   | Univar (Quantification_mismatch _) as x -> x
   | x -> x
 
-let swap_trace e = List.map swap_elt e
+let swap_trace t = {
+  root = Option.map swap_root t.root;
+  path = List.map swap_ctx t.path
+}
 
 type unification_error = { trace : unification error } [@@unboxed]
 
@@ -187,16 +198,17 @@ type equality_error =
 
 type moregen_error = { trace : comparison error } [@@unboxed]
 
+let non_empty trace = trace.root <> None || trace.path <> []
 let unification_error ~trace : unification_error =
-  assert (trace <> []);
+  assert (non_empty trace);
   { trace }
 
 let equality_error ~trace ~subst : equality_error =
-    assert (trace <> []);
+    assert (non_empty trace);
     { trace; subst }
 
 let moregen_error ~trace : moregen_error =
-  assert (trace <> []);
+  assert (non_empty trace);
   { trace }
 
 type comparison_error =
@@ -207,10 +219,8 @@ let swap_unification_error ({trace} : unification_error) =
   ({trace = swap_trace trace} : unification_error)
 
 module Subtype = struct
-  type 'a elt =
-    | Diff of 'a diff
 
-  type 'a t = 'a elt list
+  type 'a t = 'a ctx_diff list
 
   type trace       = type_expr t
   type error_trace = expanded_type t
@@ -221,14 +231,12 @@ module Subtype = struct
     { trace             : error_trace
     ; unification_trace : unification error }
 
+  let diff ?ctx ~got ~expected t = { ctx; d = { got; expected }} :: t
   let error ~trace ~unification_trace =
   assert (trace <> []);
   { trace; unification_trace }
 
-  let map_elt f = function
-    | Diff x -> Diff (map_diff f x)
-
-  let map f t = List.map (map_elt f) t
+  let map f t = List.map (map_ctx f) t
 end
 
 module Structured = struct
@@ -237,10 +245,10 @@ type 'a extended_explanation =
   | Promoted of Format_doc.t
   | Standard of 'a
 
-type 'a t = {
-  top: ('a * bool) option;
-  tr: 'a list;
-  expl: 'a extended_explanation option;
+type ('a,'b) s = {
+  top: ('a ctx_diff * bool) option;
+  tr: 'a ctx_diff list;
+  expl: ('a,'b) root extended_explanation option;
 }
 (**
 This module contains helper functions to split the error trace into three parts:
@@ -257,16 +265,17 @@ This module contains helper functions to split the error trace into three parts:
 - {!optional}: the last element that might be printed if we don't discover a
   better element to print later on.
 *)
-type 'a segments =
+type ('a,'b) segments =
   {
     head: 'a;
     before:'a list;
     last_ctx:('a * 'a list) option;
-    optional: 'a option
+    optional: 'a option;
+    expl:  'b option;
   }
 
-let head_segment hd =
-  { head = hd; before=[]; last_ctx = None; optional = None }
+let head_segment hd expl =
+  { head = hd; before=[]; last_ctx = None; optional = None; expl }
 
 (** Add a non-contextual element to the active context *)
 let add x s = match s.last_ctx with
@@ -281,7 +290,8 @@ let add_ctx c s = match s.last_ctx with
       head = s.head;
       optional = None;
       before = rest @ s.before;
-      last_ctx = Some (c,[])
+      last_ctx = Some (c,[]);
+      expl = s.expl
     }
 
 type printing_status =
@@ -300,7 +310,7 @@ type printing_status =
   *)
 
 (** Construct a segment from an unstructured trace *)
-let segment status = function
+let segment status path expl = match path with
   | [] -> assert false
   | hd :: tr ->
       List.fold_left (fun s x ->
@@ -309,7 +319,7 @@ let segment status = function
       | Keep -> add x s
       | Optional_refinement -> { s with optional = Some x }
       | Context -> add_ctx x s
-    ) (head_segment hd) tr
+    ) (head_segment hd expl) tr
 
 let promoted x = Option.map (fun p -> Promoted p) x
 let merge promote s =
@@ -319,18 +329,13 @@ let merge promote s =
     | None -> s.before, s.optional, false
     | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
   in
-  let head, rtr, expl = match rtr with
-    | Diff d :: _ ->
-        begin match promote d.d with
+  let head, rtr, expl = match s.expl, rtr with
+    | Some expl, _ -> Some s.head, rtr, Some (Standard expl)
+    | None, [] -> Some s.head, [], promoted (promote s.head.d)
+    | None, d :: _ ->
+        match promote d.d with
         | Some p -> Some s.head, rtr, Some (Promoted p)
         | None -> Some s.head, rtr, None
-        end
-    | expl :: rest -> Some s.head, rest, Some (Standard expl)
-    | [] ->
-        begin match s.head with
-        | Diff d -> Some s.head, [], promoted (promote d.d)
-        | expl -> None, [], Some (Standard expl)
-        end
   in
   let tr = match expl, opt with
     | None, Some opt -> List.rev (opt :: rtr)
@@ -342,18 +347,26 @@ let merge promote s =
   in
   { top=Option.map compact head; tr; expl }
 
-  let parse ~promote ~status s = merge promote (segment status s)
+  let parse ~promote ~status s =
+    match s.path with
+    | [] ->
+        let expl = Option.map (fun s -> Standard s) s.root in
+        { top = None; tr = []; expl}
+    | path -> merge promote (segment status path s.root)
 
   let parse_simple status tr =
-    let s = segment status tr in
-    let rtr = match s.last_ctx with
-      | None -> s.before
-      | Some (ctx, rest) -> rest @ ctx :: s.before
-    in
-    let rtr = match s.optional with
-      | Some x -> x :: rtr
-      | None -> rtr
-    in
-    s.head, List.rev rtr
+    match tr with
+    | [] -> None
+    | _ ->
+        let s = segment status tr None in
+        let rtr = match s.last_ctx with
+          | None -> s.before
+          | Some (ctx, rest) -> rest @ ctx :: s.before
+        in
+        let rtr = match s.optional with
+          | Some x -> x :: rtr
+          | None -> rtr
+        in
+        Some (s.head, List.rev rtr)
 
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -111,6 +111,12 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
+type highlight_target =
+  | Type of Outcometree.highlight_kind * type_expr
+  | Type_constructor of Path.t
+
+type highlight_hint = highlight_target option diff
+
 type ('a, 'variety) root  =
   (* Common *)
   | Variant : 'variety variant -> ('a, 'variety) root
@@ -120,6 +126,7 @@ type ('a, 'variety) root  =
   | Tuple_label_mismatch of string option diff
   | First_class_module: first_class_module -> ('a,_) root
   | Univar of univar
+  | Highlight_hint of highlight_hint
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) root
 
@@ -130,7 +137,7 @@ type ('a, 'variety) t = {
 
 let root root = { root= Some root; path = [] }
 let empty_root = { root = None; path = [] }
-
+let no_ctx d = { ctx = None; d }
 type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
@@ -144,6 +151,7 @@ let map_root (type variety) f : ('a, variety) root -> ('b, variety) root =
   | Variant _ | Obj _ | Function_label_mismatch _ | Tuple_label_mismatch _
   | Rec_occur (_, _) | First_class_module _  as x -> x
   | Univar _  as x -> x
+  | Highlight_hint _ as x -> x
 
 let map f t ={
   path = List.map (map_cdiff f) t.path;
@@ -159,6 +167,8 @@ let in_tag ~l t = match t.path with
       { t with path = { ctx = Some(In_tag l); d } :: rem }
   | _ -> t
 let variant_arity_mismatch l = Variant (Arity_mismatch l)
+let highlight_type k ty = Some (Type(k,ty))
+
 
 let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =
   function
@@ -174,6 +184,7 @@ let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =
         diff = swap_diff d.diff
       })
   | Univar (Quantification_mismatch _) as x -> x
+  | Highlight_hint d -> Highlight_hint (swap_diff d)
   | x -> x
 
 let swap_trace t = {
@@ -237,8 +248,9 @@ module Structured = struct
 (** We extend the core explanation type with promoted explanation generated from
     the main trace *)
 type 'a extended_explanation =
-  | Promoted of Format_doc.t
   | Standard of 'a
+  | Promoted of highlight_hint option * Format_doc.t
+  | Hint of highlight_hint
 
 type ('a,'b,'c) s = {
   top: ('a ctx_diff * bool) option;
@@ -316,7 +328,25 @@ let segment status path expl = match path with
       | Context -> add_ctx x s
     ) (head_segment hd expl) tr
 
-let promoted x = Option.map (fun p -> Promoted p) x
+let promoted ?hint x = match x, hint with
+  | None, None -> None
+  | Some x, _ -> Some (Promoted (hint,x))
+  | None, Some h -> Some (Hint h)
+
+type 'a visibility =
+  | Visible of 'a
+  | Info of highlight_hint
+  | Invisible
+
+let explanation_visibility = function
+  | None -> Invisible
+  | Some (Highlight_hint h) -> Info h
+  | Some e -> Visible e
+
+let split_hint = function
+  | Highlight_hint h -> Hint h
+  | e -> Standard e
+
 let merge promote s =
   (* First, we commit the last contextualized segment of the trace to the trace
      if there one. We also discard the optional last element in this
@@ -328,14 +358,17 @@ let merge promote s =
   let rtr, expl =
     (* If there are no root explanation, we try to promote one from the last
        element*)
-    match s.expl, rtr, s.head with
-    | Some expl, _, _ -> rtr, Some (Standard expl)
-    | None, [], last | None, last :: _, _ -> rtr, promoted (promote last.d)
+    match explanation_visibility s.expl, rtr, s.head with
+    | Visible expl, _, _ -> rtr, Some (Standard expl)
+    | Invisible, [], last | Invisible, last :: _, _ ->
+        rtr, promoted (promote last.d)
+    | Info hint, [], last | Info hint, last :: _, _ ->
+        rtr, promoted ~hint (promote last.d)
   in
   (* Finally, we keep the last optional element only if there were no
      explanation at all.*)
   let tr = match expl, opt with
-    | None, Some opt -> List.rev (opt :: rtr)
+    | (None | Some (Hint _)), Some opt -> List.rev (opt :: rtr)
     | Some _, _ | None, None  -> List.rev rtr
   in
   (* We use a compact presentation for the top element only if the trace is
@@ -349,8 +382,8 @@ let merge promote s =
   let parse ~promote ~status s =
     match s.path with
     | [] ->
-        let expl = Option.map (fun s -> Standard s) s.root in
-        { top = None; tr = []; expl}
+        let expl = Option.map split_hint s.root in
+        { top = None; tr = []; expl }
     | path -> merge promote (segment status path s.root)
 
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -349,21 +349,4 @@ let merge promote s =
         { top = None; tr = []; expl}
     | path -> merge promote (segment status path s.root)
 
-  (* In the simple case, we are handling a partial trace with no explanation at
-     all.*)
-  let parse_simple status tr =
-    match tr with
-    | [] -> { top = None; tr = []; expl = None}
-    | _ ->
-        let s = segment status tr None in
-        let rtr = match s.last_ctx with
-          | None -> s.before
-          | Some (ctx, rest) -> rest @ ctx :: s.before
-        in
-        let rtr = match s.optional with
-          | Some x -> x :: rtr
-          | None -> rtr
-        in
-        { top = Some (s.head,false); tr = List.rev rtr; expl = None }
-
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -115,7 +115,7 @@ type highlight_target =
   | Type of Outcometree.highlight_kind * type_expr
   | Type_constructor of Path.t
 
-type highlight_hint = highlight_target option diff
+type highlight_hint = highlight_target list diff
 
 type ('a, 'variety) root  =
   (* Common *)
@@ -167,7 +167,7 @@ let in_tag ~l t = match t.path with
       { t with path = { ctx = Some(In_tag l); d } :: rem }
   | _ -> t
 let variant_arity_mismatch l = Variant (Arity_mismatch l)
-let highlight_type k ty = Some (Type(k,ty))
+let highlight_type k ty = [Type(k,ty)]
 
 
 let swap_root (type variety) : ('a, variety) root -> ('a, variety) root =

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -230,3 +230,130 @@ module Subtype = struct
 
   let map f t = List.map (map_elt f) t
 end
+
+module Structured = struct
+
+type 'a extended_explanation =
+  | Promoted of Format_doc.t
+  | Standard of 'a
+
+type 'a t = {
+  top: ('a * bool) option;
+  tr: 'a list;
+  expl: 'a extended_explanation option;
+}
+(**
+This module contains helper functions to split the error trace into three parts:
+- {!top} the first element of the trace
+- {!tr} a list of meaningful context difference element
+- {!expl} a root explanation for a type error
+*)
+
+(** The first intermediary representation splits the trace into four parts:
+- the {!head} element of the trace
+- the {!top_to_ctx} trace elements in reverse order situated before the last
+  method or tag difference
+- {!last_ctx}: the last method or tag context, and the list of elements after it
+- {!optional}: the last element that might be printed if we don't discover a
+  better element to print later on.
+*)
+type 'a segments =
+  {
+    head: 'a;
+    before:'a list;
+    last_ctx:('a * 'a list) option;
+    optional: 'a option
+  }
+
+let head_segment hd =
+  { head = hd; before=[]; last_ctx = None; optional = None }
+
+(** Add a non-contextual element to the active context *)
+let add x s = match s.last_ctx with
+  | None ->  { s with optional = None; before = x :: s.before }
+  | Some (ctx, rest)->
+      { s with optional = None; last_ctx = Some (ctx, x :: rest)}
+
+(** Add a new context, add the last context contents to the {!before} trace *)
+let add_ctx c s = match s.last_ctx with
+  | None -> { s with optional = None; last_ctx = Some (c,[]) }
+  | Some (_ctx, rest) -> {
+      head = s.head;
+      optional = None;
+      before = rest @ s.before;
+      last_ctx = Some (c,[])
+    }
+
+type printing_status =
+  | Discard
+  | Keep
+  | Context
+    (** A {!Context} element marks the entry inside a method or a polymorphic
+        variant tag *)
+  | Optional_refinement
+  (** An [Optional_refinement] printing status is attributed to trace
+      elements that are focusing on a new subpart of a structural type.
+      Since the whole type should have been printed earlier in the trace,
+      we only print those elements if they are the last printed element
+      of a trace, and there is no explicit explanation for the
+      type error.
+  *)
+
+(** Construct a segment from an unstructured trace *)
+let segment status = function
+  | [] -> assert false
+  | hd :: tr ->
+      List.fold_left (fun s x ->
+      match status x with
+      | Discard -> s
+      | Keep -> add x s
+      | Optional_refinement -> { s with optional = Some x }
+      | Context -> add_ctx x s
+    ) (head_segment hd) tr
+
+let promoted x = Option.map (fun p -> Promoted p) x
+let merge promote s =
+  (* First, we commit the last contextualized segment of the trace to the
+     trace *)
+  let rtr, opt, maybe_compact = match s.last_ctx with
+    | None -> s.before, s.optional, false
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
+  in
+  let head, rtr, expl = match rtr with
+    | Diff d :: _ ->
+        begin match promote d.d with
+        | Some p -> Some s.head, rtr, Some (Promoted p)
+        | None -> Some s.head, rtr, None
+        end
+    | expl :: rest -> Some s.head, rest, Some (Standard expl)
+    | [] ->
+        begin match s.head with
+        | Diff d -> Some s.head, [], promoted (promote d.d)
+        | expl -> None, [], Some (Standard expl)
+        end
+  in
+  let tr = match expl, opt with
+    | None, Some opt -> List.rev (opt :: rtr)
+    | Some _, _ | None, _  -> List.rev rtr
+  in
+  let compact head = match tr, maybe_compact with
+    | [], _ | [_], true -> head, true
+    | _ -> head, false
+  in
+  { top=Option.map compact head; tr; expl }
+
+  let parse ~promote ~status s = merge promote (segment status s)
+
+  let parse_simple status tr =
+    let s = segment status tr in
+    let rtr = match s.last_ctx with
+      | None -> s.before
+      | Some (ctx, rest) -> rest @ ctx :: s.before
+    in
+    let rtr = match s.optional with
+      | Some x -> x :: rtr
+      | None -> rtr
+    in
+    s.head, List.rev rtr
+
+end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -102,7 +102,7 @@ type highlight_target =
   | Type of Outcometree.highlight_kind * type_expr
   | Type_constructor of Path.t
 
-type highlight_hint = highlight_target option diff
+type highlight_hint = highlight_target list diff
 
 type ('a, 'variety) root =
   (* Common *)
@@ -144,7 +144,7 @@ val in_tag:
 val variant_arity_mismatch: string -> ('any, 'f) root
 
 val highlight_type:
-  Outcometree.highlight_kind -> Types.type_expr -> highlight_target option
+  Outcometree.highlight_kind -> Types.type_expr -> highlight_target list
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -104,27 +104,33 @@ type ctx =
 type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 val map_ctx: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
 
-type ('a, 'variety) elt =
+type ('a, 'variety) root =
   (* Common *)
-  | Diff : 'a ctx_diff -> ('a, _) elt
-  | Variant : 'variety variant -> ('a, 'variety) elt
-  | Obj : 'variety obj -> ('a, 'variety) elt
-  | Escape : 'a escape -> ('a, _) elt
+  | Variant : 'variety variant -> ('a, 'variety) root
+  | Obj : 'variety obj -> ('a, 'variety) root
+  | Escape : 'a escape -> ('a, _) root
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | First_class_module: first_class_module -> ('a,_) elt
+  | First_class_module: first_class_module -> ('a,_) root
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
-  | Rec_occur : type_expr * type_expr -> ('a, _) elt
+  | Rec_occur : type_expr * type_expr -> ('a, _) root
 
-type ('a, 'variety) t = ('a, 'variety) elt list
+type ('a, 'variety) t = {
+  path: 'a ctx_diff list;
+  root: ('a, 'variety) root option
+}
 
 type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
 val map : ('a -> 'b) -> ('a, 'variety) t -> ('b, 'variety) t
+
 val diff:
   ?ctx:ctx -> got:'a -> expected:'a -> ('a,'variety) t -> ('a,'variety) t
+val root: ('a,'variety) root -> ('a,'variety) t
+val empty_root: ('a,'variety) t
+
 
 val incompatible_fields:
   name:string -> got:type_expr -> expected:type_expr ->
@@ -133,7 +139,7 @@ val incompatible_fields:
 val in_tag:
   l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
 
-val variant_arity_mismatch: string -> ('any, 'f) elt
+val variant_arity_mismatch: string -> ('any, 'f) root
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 
@@ -171,10 +177,9 @@ type comparison_error =
 val swap_unification_error : unification_error -> unification_error
 
 module Subtype : sig
-  type 'a elt =
-    | Diff of 'a diff
 
-  type 'a t = 'a elt list
+  type 'a t = 'a ctx_diff list
+  val diff: ?ctx:ctx -> got:'a -> expected:'a -> 'a t -> 'a t
 
   (** Just as outside [Subtype], we split traces, completed traces, and complete
       errors.  However, in a minor asymmetry, the name [Subtype.error_trace]
@@ -204,10 +209,10 @@ module Structured: sig
     | Promoted of Format_doc.t
     | Standard of 'a
 
-  type 'a t = {
-    top: ('a * bool) option;
-    tr: 'a list;
-    expl: 'a extended_explanation option
+  type ('a,'b) s = {
+    top: ('a ctx_diff * bool) option;
+    tr: 'a ctx_diff list;
+    expl: ('a, 'b) root extended_explanation option
   }
   (**
      This module contains helper functions to split the error trace into three
@@ -235,10 +240,10 @@ module Structured: sig
 
 val parse:
     promote:('a diff -> Format_doc.t option) ->
-    status:(('a, 'b) elt -> printing_status) ->
-    ('a, 'b) elt list ->
-    ('a, 'b) elt t
+    status:('a ctx_diff -> printing_status) ->
+    ('a, 'b) t -> ('a, 'b) s
 
-  val parse_simple: ('a -> printing_status) -> 'a list -> 'a * 'a list
+  val parse_simple:
+    ('a  -> printing_status) -> 'a list -> ('a  * 'a  list) option
 
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -71,7 +71,8 @@ type fixed_row_case =
 
 type 'variety variant =
   (* Common *)
-  | Incompatible_types_for : string -> _ variant
+  | Arity_mismatch : string -> _ variant
+  | Inconsistent_conjunction: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -97,15 +98,21 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
+type ctx =
+  | In_method of string
+  | In_tag of string
+
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
+val map_ctx: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
+
 type ('a, 'variety) elt =
   (* Common *)
-  | Diff : 'a diff -> ('a, _) elt
+  | Diff : 'a ctx_diff -> ('a, _) elt
   | Variant : 'variety variant -> ('a, 'variety) elt
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Function_label_mismatch of Asttypes.arg_label diff
   | Tuple_label_mismatch of string option diff
-  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   | First_class_module: first_class_module -> ('a,_) elt
   | Univar of univar
   (* Unification & Moregen; included in Equality for simplicity *)
@@ -117,9 +124,19 @@ type 'variety trace = (type_expr,     'variety) t
 type 'variety error = (expanded_type, 'variety) t
 
 val map : ('a -> 'b) -> ('a, 'variety) t -> ('b, 'variety) t
+val diff:
+  ?ctx:ctx -> got:'a -> expected:'a -> ('a,'variety) t -> ('a,'variety) t
 
-val incompatible_fields :
-  name:string -> got:type_expr -> expected:type_expr -> (type_expr, _) elt
+val incompatible_fields:
+  name:string -> got:type_expr -> expected:type_expr ->
+  (type_expr, 'v) t -> (type_expr, 'v) t
+
+val in_tag:
+  l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
+
+val variant_arity_mismatch: l:string -> ('any, 'f) elt
+val inconsistent_conjunction: l:string -> ('any, 'f) elt
+
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -98,6 +98,12 @@ type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
 
+type highlight_target =
+  | Type of Outcometree.highlight_kind * type_expr
+  | Type_constructor of Path.t
+
+type highlight_hint = highlight_target option diff
+
 type ('a, 'variety) root =
   (* Common *)
   | Variant : 'variety variant -> ('a, 'variety) root
@@ -107,6 +113,7 @@ type ('a, 'variety) root =
   | Tuple_label_mismatch of string option diff
   | First_class_module: first_class_module -> ('a,_) root
   | Univar of univar
+  | Highlight_hint of highlight_hint
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) root
 
@@ -120,6 +127,7 @@ type 'variety error = (expanded_type, 'variety) t
 
 val map : ('a -> 'b) -> ('a, 'variety) t -> ('b, 'variety) t
 
+val no_ctx: 'a diff -> 'a ctx_diff
 val diff:
   ?ctx:ctx -> got:'a -> expected:'a -> ('a,'variety) t -> ('a,'variety) t
 val root: ('a,'variety) root -> ('a,'variety) t
@@ -134,6 +142,9 @@ val in_tag:
   l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
 
 val variant_arity_mismatch: string -> ('any, 'f) root
+
+val highlight_type:
+  Outcometree.highlight_kind -> Types.type_expr -> highlight_target option
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 
@@ -204,8 +215,9 @@ module Structured: sig
   (** We extend the core explanation type with promoted explanation generated
       from the main trace *)
   type 'a extended_explanation =
-    | Promoted of Format_doc.t
     | Standard of 'a
+    | Promoted of highlight_hint option * Format_doc.t
+    | Hint of highlight_hint
 
   type ('a,'b,'c) s = {
     top: ('a ctx_diff * bool) option; (* top = None => tr = [] *)

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -204,7 +204,7 @@ module Structured: sig
     | Standard of 'a
 
   type ('a,'b) s = {
-    top: ('a ctx_diff * bool) option;
+    top: ('a ctx_diff * bool) option; (* top = None => tr = [] *)
     tr: 'a ctx_diff list;
     expl: ('a, 'b) root extended_explanation option
   }
@@ -235,8 +235,5 @@ val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->
     ('a, 'b) t -> ('a, 'b) s
-
-  val parse_simple:
-    ('a ctx_diff -> printing_status) -> 'a ctx_diff list -> ('a, 'b) s
 
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -35,9 +35,14 @@ type expanded_type = { ty: type_expr; expanded: type_expr }
 val trivial_expansion : type_expr -> expanded_type
 
 type 'a diff = { got: 'a; expected: 'a }
+type ctx =
+  | In_method of string
+  | In_tag of string
+type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
 
 (** [map_diff f {expected;got}] is [{expected=f expected; got=f got}] *)
 val map_diff: ('a -> 'b) -> 'a diff -> 'b diff
+val map_cdiff: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
 
 (** Scope escape related errors *)
 type 'a escape_kind =
@@ -96,13 +101,6 @@ type first_class_module =
 type univar =
   | Var_mismatch of { order:order; diff:type_expr diff }
   | Quantification_mismatch of type_expr list
-
-type ctx =
-  | In_method of string
-  | In_tag of string
-
-type 'a ctx_diff = { ctx: ctx option; d: 'a diff }
-val map_ctx: ('a -> 'b) -> 'a ctx_diff -> 'b ctx_diff
 
 type ('a, 'variety) root =
   (* Common *)

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -207,10 +207,10 @@ module Structured: sig
     | Promoted of Format_doc.t
     | Standard of 'a
 
-  type ('a,'b) s = {
+  type ('a,'b,'c) s = {
     top: ('a ctx_diff * bool) option; (* top = None => tr = [] *)
     tr: 'a ctx_diff list;
-    expl: ('a, 'b) root extended_explanation option
+    expl: ('b, 'c) root extended_explanation option
   }
   (** The structured version of the trace is split in three parts:
       - {!top} the first element of the trace
@@ -241,6 +241,6 @@ module Structured: sig
 val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->
-    ('a, 'b) t -> ('a, 'b) s
+    ('a, 'b) t -> ('a, 'a, 'b) s
 
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -198,7 +198,11 @@ module Subtype : sig
 end
 
 module Structured: sig
+(** This module contains helper functions to parse the error trace into the more
+    structured type {!Stuctured.t} *)
 
+  (** We extend the core explanation type with promoted explanation generated
+      from the main trace *)
   type 'a extended_explanation =
     | Promoted of Format_doc.t
     | Standard of 'a
@@ -208,14 +212,11 @@ module Structured: sig
     tr: 'a ctx_diff list;
     expl: ('a, 'b) root extended_explanation option
   }
-  (**
-     This module contains helper functions to split the error trace into three
-     parts:
-     - {!top} the first element of the trace
-     - {!tr} a list of meaningful context difference element
-     - {!expl} a root explanation for a type error
-  *)
-
+  (** The structured version of the trace is split in three parts:
+      - {!top} the first element of the trace
+      - {!tr} a list of meaningful context difference element
+      - {!expl} a root explanation for a type error
+   *)
 
   type printing_status =
     | Discard
@@ -231,6 +232,12 @@ module Structured: sig
         of a trace, and there is no explicit explanation for the
         type error.
     *)
+
+  (** [parse ~promote ~status] builds a structured trace from an unstructured
+      one. The [status] function is used to classify elements of the trace,
+      whereas the [promote] function describe which kind of trace element might
+      be promoted to an extended explanation in the absence of a standard
+      explanation. *)
 val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -197,3 +197,48 @@ module Subtype : sig
 
   val map : ('a -> 'b) -> 'a t -> 'b t
 end
+
+module Structured: sig
+
+  type 'a extended_explanation =
+    | Promoted of Format_doc.t
+    | Standard of 'a
+
+  type 'a t = {
+    top: ('a * bool) option;
+    tr: 'a list;
+    expl: 'a extended_explanation option
+  }
+  (**
+     This module contains helper functions to split the error trace into three
+     parts:
+     - {!top} the first element of the trace
+     - {!tr} a list of meaningful context difference element
+     - {!expl} a root explanation for a type error
+  *)
+
+
+  type printing_status =
+    | Discard
+    | Keep
+    | Context
+    (** A {!Context} element marks the entry inside a method or a polymorphic
+        variant tag *)
+    | Optional_refinement
+    (** An [Optional_refinement] printing status is attributed to trace
+        elements that are focusing on a new subpart of a structural type.
+        Since the whole type should have been printed earlier in the trace,
+        we only print those elements if they are the last printed element
+        of a trace, and there is no explicit explanation for the
+        type error.
+    *)
+
+val parse:
+    promote:('a diff -> Format_doc.t option) ->
+    status:(('a, 'b) elt -> printing_status) ->
+    ('a, 'b) elt list ->
+    ('a, 'b) elt t
+
+  val parse_simple: ('a -> printing_status) -> 'a list -> 'a * 'a list
+
+end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -71,8 +71,7 @@ type fixed_row_case =
 
 type 'variety variant =
   (* Common *)
-  | Arity_mismatch : string -> _ variant
-  | Inconsistent_conjunction: string -> _ variant
+  | Arity_mismatch: string -> _ variant
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
@@ -134,9 +133,7 @@ val incompatible_fields:
 val in_tag:
   l:string -> (type_expr, 'f) t -> (type_expr, 'f) t
 
-val variant_arity_mismatch: l:string -> ('any, 'f) elt
-val inconsistent_conjunction: l:string -> ('any, 'f) elt
-
+val variant_arity_mismatch: string -> ('any, 'f) elt
 
 val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -62,10 +62,6 @@ type 'a escape =
 
 val map_escape : ('a -> 'b) -> 'a escape -> 'b escape
 
-val explain: 'a list ->
-  (prev:'a option -> 'a -> 'b option) ->
-  'b option
-
 (** Type indices *)
 type unification = private Unification
 type comparison  = private Comparison

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -237,13 +237,12 @@ module Structured: sig
         of a trace, and there is no explicit explanation for the
         type error.
     *)
-
 val parse:
     promote:('a diff -> Format_doc.t option) ->
     status:('a ctx_diff -> printing_status) ->
     ('a, 'b) t -> ('a, 'b) s
 
   val parse_simple:
-    ('a  -> printing_status) -> 'a list -> ('a  * 'a  list) option
+    ('a ctx_diff -> printing_status) -> 'a ctx_diff list -> ('a, 'b) s
 
 end

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -40,8 +40,8 @@ module Structured = Errortrace.Structured
 
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
-let trees_of_trace mode =
-  List.map (Errortrace.map_cdiff (trees_of_type_expansion mode))
+let trees_of_trace mode l =
+  List.map (Errortrace.map_cdiff (trees_of_type_expansion mode)) l
 
 let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
 
@@ -136,11 +136,12 @@ let promote_diff env {Errortrace.got; expected} =
   Btype.backtrack snap;
   res
 
-let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
+let may_prepare_expansion compact (ty_exp, htarget) =
+  let Errortrace.{ty; expanded} = ty_exp in
   match Types.get_desc expanded with
     Tvariant _ | Tobject _ when compact ->
-      Variable_names.reserve ty; Errortrace.{ty; expanded = ty}
-  | _ -> prepare_expansion ty_exp
+      Variable_names.reserve ty; Errortrace.{ty; expanded = ty}, htarget
+  | _ -> prepare_expansion ty_exp, htarget
 
 let print_path p =
   Fmt.dprintf "%a" !Oprint.out_ident (namespaced_tree_of_path Type p)
@@ -450,8 +451,8 @@ let head_error_printer mode txt_got txt_but = function
 
 let warn_on_missing_defs env ppf = function
   | None -> ()
-  | Some Errortrace.{ d = { got      = {ty=te1; expanded=_};
-                            expected = {ty=te2; expanded=_} }; _ } ->
+  | Some Errortrace.{ d = { got      = {ty=te1; expanded=_}, _;
+                            expected = {ty=te2; expanded=_}, _ }; _ } ->
       warn_on_missing_def env ppf te1;
       warn_on_missing_def env ppf te2
 
@@ -490,8 +491,8 @@ let explain_names env ppf =
        let paths = List.map tree_of_path paths in
        match explanation with
        | Internal_names.Equation { lhs; rhs; } ->
-           let rhseq = tree_of_typexp Type_scheme rhs in
-           let lhseq = tree_of_typexp Type_scheme lhs in
+           let rhseq = tree_of_typexp None Type_scheme rhs in
+           let lhseq = tree_of_typexp None Type_scheme lhs in
            fprintf ppf
              "@ @[<2>@{<hint>Hint@}:@ %a@ %a@ \
               introduced in the equation@ %a = %a@]"
@@ -514,8 +515,39 @@ let explain_names env ppf =
 let hide_variant ty_exp =
   Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
 
+let zip_cdiff x y =
+  let open Errortrace in
+  let d = {
+        got = x.d.got, y.d.got;
+        expected = x.d.expected, y.d.expected
+      }
+  in
+  { ctx = x.ctx; d }
+
+let highlight_type ty =
+  let hty x = highlight_type Paired x.Errortrace.ty in
+  Errortrace.map_cdiff hty ty
+let no_highlight = Errortrace.{ ctx = None; d = { got = None; expected = None} }
+
+let associate_htarget { Structured.top; tr; expl} =
+  match top, tr with
+  | None, _ -> { Structured.top = None; tr = []; expl }
+  | Some (h,c), [] ->
+      let h = Errortrace.map_cdiff (fun x -> x, None) h in
+      { Structured.top = Some (h, c); tr = []; expl }
+  | Some (h,c), a :: q ->
+      let top = Some (zip_cdiff h (highlight_type a), c) in
+      let htrace = List.map highlight_type q @ [no_highlight] in
+      let tr = List.map2 zip_cdiff tr htrace in
+      { Structured.top; tr; expl }
+
 let structured_trace env tr =
-  Structured.parse ~promote:(promote_diff env) ~status:printing_status tr
+  associate_htarget
+  @@ Structured.parse ~promote:(promote_diff env) ~status:printing_status tr
+
+let prepare_trace_expansion tr =
+  let expand_elt (x,h) = prepare_expansion x, h in
+  List.map (Errortrace.map_cdiff expand_elt) tr
 
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
@@ -527,7 +559,7 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   with_labels (not !Clflags.classic) (fun () ->
       let head = Option.map prepare_expansion_head str.top in
       let head_error = head_error_printer mode txt1 txt2 head in
-      let tr = List.map (Errortrace.map_cdiff prepare_expansion) str.tr in
+      let tr = prepare_trace_expansion str.tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 str.expl in
       fprintf ppf
@@ -582,7 +614,8 @@ module Subtype = struct
   let parse_sub tr =
     (* The subtype part of the trace does not contain any explanation *)
     let trace = { Errortrace.root = None; path = tr } in
-    Structured.parse ~promote:(Fun.const None) ~status:printing_status trace
+    associate_htarget
+      (Structured.parse ~promote:(Fun.const None) ~status:printing_status trace)
 
   let flatten_trace filter_trace fst (str: _ Structured.s) =
     with_labels (not !Clflags.classic) (fun () ->
@@ -596,9 +629,13 @@ module Subtype = struct
       | None, _ -> []
     )
 
+  let subtyping_printing_status elt =
+    printing_status (Errortrace.map_cdiff fst elt)
+
   let rec filter_trace keep_last = function
     | [] -> []
-    | [elt] when printing_status elt = Structured.Optional_refinement ->
+    | [elt] when
+        subtyping_printing_status elt = Structured.Optional_refinement ->
         if keep_last then [elt] else []
     | d :: rem -> d :: filter_trace keep_last rem
 

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -45,6 +45,22 @@ let trees_of_trace mode =
 
 let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
 
+let syntactic_highlighting l r = match l, r with
+  | Same l, Same r ->
+      let l, r = Syntactic_highlighting.diff l r in
+      Same l, Same r
+  | Same l, Diff (short, expanded) ->
+      let l, expanded = Syntactic_highlighting.diff l expanded in
+      Same l, Diff (short, expanded)
+  | Diff (short, expanded), Same r ->
+      let expanded, r = Syntactic_highlighting.diff expanded r in
+      Diff(short,expanded), Same r
+  | Diff (short, expanded), Diff (short', expanded') ->
+      let short, short' = Syntactic_highlighting.diff short short' in
+      let expanded, expanded' =
+        Syntactic_highlighting.diff expanded expanded' in
+      Diff (short, expanded), Diff (short', expanded')
+
 let rec trace fst txt ppf = function
   | elt :: rem ->
       if not fst then fprintf ppf "@,";
@@ -53,19 +69,23 @@ let rec trace fst txt ppf = function
       (trace false txt) rem
   | [] -> ()
 and trace_elt txt ppf = function
-  | { ctx = None; Errortrace.d = {got; expected} } ->
-      fprintf ppf "Type@;<1 2>%a@ %s@;<1 2>%a"
-       pp_type_expansion got txt pp_type_expansion expected
-  | { ctx = Some (In_tag l); Errortrace.d = {got; expected} } ->
-      fprintf ppf "In tag %a, type@;<1 2>%a@ %s@;<1 2>%a"
-       print_tag l
-       pp_type_expansion got txt pp_type_expansion expected
-  | { ctx = Some (In_method m); Errortrace.d = {got; expected} } ->
-      fprintf ppf "@,@[The method %a has type@ %a,@ \
-                   but the expected method type was@ %a@]"
-        Style.inline_code m
-        pp_type_expansion got
-        pp_type_expansion expected
+  | { ctx; Errortrace.d = {got; expected} } ->
+      let got, expected = syntactic_highlighting got expected in
+      match ctx with
+      | None ->
+          fprintf ppf "Type@;<1 2>%a@ %s@;<1 2>%a"
+            pp_type_expansion got txt pp_type_expansion expected
+      | Some (In_tag l) ->
+          fprintf ppf "In tag %a, type@;<1 2>%a@ %s@;<1 2>%a"
+            print_tag l
+            pp_type_expansion got txt pp_type_expansion expected
+      | Some (In_method m) ->
+          fprintf ppf
+            "@,@[The method %a has type@ %a,@ \
+             but the expected method type was@ %a@]"
+            Style.inline_code m
+            pp_type_expansion got
+            pp_type_expansion expected
 
 
 let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
@@ -423,9 +443,10 @@ let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
   | Some d ->
       let d = Errortrace.(map_diff (trees_of_type_expansion mode) d.d) in
+      let got, expected = syntactic_highlighting d.got d.expected in
       doc_printf "%a@;<1 2>%a@ %a@;<1 2>%a"
-        pp_doc txt_got pp_type_expansion d.got
-        pp_doc txt_but pp_type_expansion d.expected
+        pp_doc txt_got pp_type_expansion got
+        pp_doc txt_but pp_type_expansion expected
 
 let warn_on_missing_defs env ppf = function
   | None -> ()

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -177,9 +177,9 @@ let promote_diff env {Errortrace.got; expected} =
   res
 
 let merge env s =
-  let rtr, opt = match s.last_ctx with
-    | None -> s.before, s.optional
-    | Some (ctx, rest) -> rest @ ctx :: s.before, None
+  let rtr, opt, maybe_compact = match s.last_ctx with
+    | None -> s.before, s.optional, false
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
   in
   let head, rtr, expl = match rtr with
     | Errortrace.Diff d :: _ ->
@@ -199,7 +199,11 @@ let merge env s =
     | None, Some opt -> head @ List.rev (opt :: rtr)
     | Some _, _ | None, _  -> head @ List.rev rtr
   in
-  rtr, expl
+  let compact = match rtr, maybe_compact with
+    | [_], _ | [_;_], true -> true
+    | _ -> false
+  in
+  rtr, expl, compact
 
   let split env status s= merge env (segment status s)
 end
@@ -612,16 +616,16 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
   let tr = Errortrace.map hide_variant tr in
-  let tr, expl = Structured_trace.split env printing_status tr in
+  let tr, expl, compact = Structured_trace.split env printing_status tr in
   let elt, tr = match tr with
     | [] -> None, tr
     | hd :: tr -> Some hd, tr
   in
   with_labels (not !Clflags.classic) (fun () ->
       let tr = simplify_trace tr in
-      let head = Option.bind elt (prepare_expansion_head (List.is_empty tr)) in
-      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
+      let head = Option.bind elt (prepare_expansion_head compact) in
       let head_error = head_error_printer mode txt1 txt2 head in
+      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 expl in
       fprintf ppf
@@ -679,7 +683,9 @@ module Subtype = struct
     let tr = Errortrace.map f tr in
     match tr with
     | [] -> [], None
-    | _ -> Structured_trace.split env printing_status tr
+    | _ ->
+        let tr, expl, _ = Structured_trace.split env printing_status tr in
+        tr, expl
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -36,6 +36,7 @@ open Out_type
 open Format_doc
 module Fmt = Format_doc
 module Style = Misc.Style
+module Structured = Errortrace.Structured
 
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
@@ -71,13 +72,13 @@ let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
                                       expected = {ty = t2; expanded = t2'} } =
   if  Btype.is_constr_row ~allow_ident:true t1'
    || Btype.is_constr_row ~allow_ident:true t2'
-  then Errortrace.Structured.Discard
+  then Structured.Discard
   else if same_path t1 t1' && same_path t2 t2' then
-    Errortrace.Structured.Optional_refinement
-  else Errortrace.Structured.Keep
+    Structured.Optional_refinement
+  else Structured.Keep
 
 let printing_status = function
-  | { Errortrace.ctx = Some _; _} -> Errortrace.Structured.Context
+  | { Errortrace.ctx = Some _; _} -> Structured.Context
   | d -> diff_printing_status d.Errortrace.d
 
 let is_unit_param env ty =
@@ -387,8 +388,8 @@ let explanation (type variety) intro
 let mismatch intro expl =
   match expl with
   | None -> None
-  | Some (Errortrace.Structured.Promoted msg) -> Some msg
-  | Some (Errortrace.Structured.Standard e) -> explanation intro e
+  | Some (Structured.Promoted msg) -> Some msg
+  | Some (Structured.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
   match Types.get_desc t with
@@ -493,8 +494,7 @@ let hide_variant ty_exp =
   Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
 
 let structured_trace env tr =
- Errortrace.Structured.parse ~promote:(promote_diff env) ~status:printing_status
-   tr
+  Structured.parse ~promote:(promote_diff env) ~status:printing_status tr
 
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
@@ -551,73 +551,52 @@ let comparison ppf mode env = function
   | Errortrace.Moregen_error  error -> moregen  ppf mode env error
 
 module Subtype = struct
-  (* There's a frustrating amount of code duplication between this module and
-     the outside code, particularly in [prepare_trace] and [filter_trace].
-     Unfortunately, [Subtype] is *just* similar enough to have code duplication,
-     while being *just* different enough (it's only [Diff]) for the abstraction
-     to be nonobvious.  Someday, perhaps... *)
 
-  let prepare_unification_trace env f tr =
-    let tr = Errortrace.map f tr in
-    match tr.path with
-    | [] -> None, Option.map (fun x -> Errortrace.Structured.Standard x) tr.root
-    | _ ->
-        let str = structured_trace env tr in
-        match str.top with
-        | Some (h,_) -> Some (h,str.tr), str.expl
-        | None -> None, str.expl
+  let prepare_trace { Errortrace.Subtype.trace; unification_trace } =
+    let trace = Errortrace.Subtype.map prepare_expansion trace in
+    let unification_trace =
+      Errortrace.map prepare_expansion unification_trace in
+    Errortrace.Subtype.error ~trace ~unification_trace
 
-  let prepare_trace f tr =
-    let tr = Errortrace.Subtype.map f tr in
-    Errortrace.Structured.parse_simple printing_status tr
-
-  let trace filter_trace fst txt ppf htr =
+  let flatten_trace filter_trace fst (str: _ Structured.s) =
     with_labels (not !Clflags.classic) (fun () ->
-      match htr with
-      | Some (elt,tr) ->
+      match str.top, str.tr with
+      | Some (elt,_), tr ->
         let diffed_elt =
           Errortrace.map_ctx (trees_of_type_expansion Type) elt
         in
-        let tr = filter_trace tr in
-        let tr =
-          trees_of_trace Type
-          @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
-        let tr = if fst then diffed_elt :: tr else tr in
-        trace fst txt ppf tr
-      | None -> ()
+        let tr = trees_of_trace Type (filter_trace tr) in
+        if fst then diffed_elt :: tr else tr
+      | None, _ -> []
     )
 
-  let rec filter_subtype_trace keep_last = function
+  let rec filter_trace keep_last = function
     | [] -> []
-    | [elt]
-      when printing_status elt = Errortrace.Structured.Optional_refinement ->
+    | [elt] when printing_status elt = Structured.Optional_refinement ->
         if keep_last then [elt] else []
-    | d :: rem -> d :: filter_subtype_trace keep_last rem
+    | d :: rem -> d :: filter_trace keep_last rem
 
+  let obj_only_trace (trace: _ Structured.s) =
+    match trace.top, trace.tr, trace.expl with
+    | None, [], Some (Standard (Obj _ | Variant _ | Escape _ ))
+    | None, [], None -> true
+    | _ -> false
 
-  let error
-        ppf
-        env
-        (Errortrace.Subtype.{trace = tr_sub; unification_trace = tr_unif})
-        txt1 =
+  let error ppf env tr txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub = prepare_trace prepare_expansion tr_sub in
-      let tr_unif, expl =
-        prepare_unification_trace env prepare_expansion tr_unif
-      in
-      let keep_first = match tr_unif, expl with
-        | None, Some (Standard (Obj _ | Variant _ | Escape _ ))
-        | None, None -> true
-        | _ -> false in
-      fprintf ppf "@[<v>%a"
-        (trace (filter_subtype_trace keep_first) true txt1) tr_sub;
-      if tr_unif = None && expl = None then fprintf ppf "@]" else
-        let mis = mismatch (doc_printf "Within this type") expl in
-        fprintf ppf "%a%a%t@]"
-          (trace Fun.id false "is not compatible with type") tr_unif
-          (pp_print_option pp_doc) mis
-          Ident_conflicts.err_print
+      let tr = prepare_trace tr in
+      let tr_sub = Structured.parse_simple printing_status tr.trace in
+      let str_unif = structured_trace env tr.unification_trace in
+      let keep_last = obj_only_trace str_unif in
+      let tr_sub = flatten_trace (filter_trace keep_last) true tr_sub in
+      let tr_unif = flatten_trace Fun.id false str_unif in
+      let mis = mismatch (doc_printf "Within this type") str_unif.expl in
+      fprintf ppf "@[<v>%a%a%a%t@]"
+        (trace true txt1) tr_sub
+        (trace false "is not compatible with type") tr_unif
+        (pp_print_option pp_doc) mis
+        Ident_conflicts.err_print
     )
 end
 

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -43,8 +43,6 @@ let trees_of_trace mode =
   List.map (Errortrace.map_ctx (trees_of_type_expansion mode))
 
 let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
-let incompatible_tag_types s =
-  doc_printf "@,Types for tag %a are incompatible" print_tag s
 
 let rec trace fst txt ppf = function
   | elt :: rem ->
@@ -62,14 +60,62 @@ and trace_elt txt ppf = function
        print_tag l
        pp_type_expansion got txt pp_type_expansion expected
   | { ctx = Some (In_method m); Errortrace.d = {got; expected} } ->
-      fprintf ppf "In method %a, type@;<1 2>%a@ %s@;<1 2>%a"
-       Style.inline_code m
-       pp_type_expansion got txt pp_type_expansion expected
+      fprintf ppf "@,@[The method %a has type@ %a,@ \
+                   but the expected method type was@ %a@]"
+        Style.inline_code m
+        pp_type_expansion got
+        pp_type_expansion expected
+
+(**
+This module contains helper functions to split the error trace into two parts:
+- a list of meaningful context difference element
+- a root explanation
+*)
+module Structured_trace = struct
+
+(** Flatten the trace and remove elements that are always discarded
+    during printing *)
+
+(** The first intermediary representation splits the trace into four parts:
+- the head element of the trace
+- the trace elements in reverse order situated before the last method or tag
+  difference
+- the last method or tag context, and the list of elements after it
+- the last element that could be optioannly printed
+*)
+type 'a segments =
+  {
+    head: 'a;
+    before:'a list;
+    last_ctx:('a * 'a list) option;
+    optional: 'a option
+  }
+
+let head_segment hd =
+  { head = hd; before=[]; last_ctx = None; optional = None }
+
+(** Add a non-contextual element to the active context *)
+let add x s = match s.last_ctx with
+  | None ->  { s with optional = None; before = x :: s.before }
+  | Some (ctx, rest)->
+      { s with optional = None; last_ctx = Some (ctx, x :: rest)}
+
+(** Add a new context, add the last context contents to the {!before} trace *)
+let add_ctx c s = match s.last_ctx with
+  | None ->  { s with optional = None; last_ctx = Some (c,[]) }
+  | Some (_ctx, rest) -> {
+      head = s.head;
+      optional = None;
+      before = rest @ s.before;
+      last_ctx = Some (c,[])
+    }
 
 type printing_status =
   | Discard
   | Keep
-  | Contextual_refinement of Errortrace.ctx
+  | Context
+    (** A {!Context} element marks the entry inside a method or a polymorphic
+        variant tag *)
   | Optional_refinement
   (** An [Optional_refinement] printing status is attributed to trace
       elements that are focusing on a new subpart of a structural type.
@@ -79,57 +125,116 @@ type printing_status =
       type error.
   *)
 
+(** Construct a segment from an unstructured trace *)
+let segment status = function
+  | [] -> assert false
+  | hd :: tr ->
+      List.fold_left (fun s x ->
+      match status x with
+      | Discard -> s
+      | Keep -> add x s
+      | Optional_refinement -> { s with optional = Some x }
+      | Context -> add_ctx x s
+    ) (head_segment hd) tr
+
+type 'a extended_explanation =
+  | Promoted of Format_doc.t
+  | Standard of 'a
+
+let is_unit_param env ty =
+  let ty, vars = Btype.tpoly_get_poly ty in
+  if vars <> [] then false
+  else begin
+    match Types.get_desc (Ctype.expand_head env ty) with
+    | Tconstr (p, _, _) -> Path.same p Predef.path_unit
+    | _ -> false
+  end
+
+let unifiable env ty1 ty2 =
+    try Ctype.unify env ty1 ty2; true
+    with Ctype.Unify _ -> false
+
+let promote_diff env {Errortrace.got; expected} =
+  let snap = Btype.snapshot () in
+  let t3, t4 = Errortrace.(got.expanded, expected.expanded) in
+  let res = match Types.get_desc t3, Types.get_desc t4 with
+  | Tarrow (_, ty1, ty2, _), _
+    when is_unit_param env ty1 && unifiable env ty2 t4 ->
+      Some (Promoted (doc_printf
+          "@,@[@{<hint>Hint@}: Did you forget to provide %a as argument?@]"
+          Style.inline_code "()"
+        ))
+  | _, Tarrow (_, ty1, ty2, _)
+    when is_unit_param env ty1 && unifiable env t3 ty2 ->
+      Some (Promoted (doc_printf
+          "@,@[@{<hint>Hint@}: Did you forget to wrap the expression using \
+           %a?@]"
+          Style.inline_code "fun () ->"
+        ))
+  | _ -> None
+  in
+  Btype.backtrack snap;
+  res
+
+let merge env s =
+  let rtr, opt = match s.last_ctx with
+    | None -> s.before, s.optional
+    | Some (ctx, rest) -> rest @ ctx :: s.before, None
+  in
+  let head, rtr, expl = match rtr with
+    | Errortrace.Diff d :: _ ->
+        begin match promote_diff env d.d with
+        | Some p -> [s.head], rtr, Some p
+        | None -> [s.head], rtr, None
+        end
+    | expl :: rest -> [s.head], rest, Some (Standard expl)
+    | [] ->
+        begin match s.head with
+        | Errortrace.Diff d -> [s.head], [], promote_diff env d.d
+        | expl -> [], [], Some (Standard expl)
+        end
+  in
+  let rtr =
+    match expl, opt with
+    | None, Some opt -> head @ List.rev (opt :: rtr)
+    | Some _, _ | None, _  -> head @ List.rev rtr
+  in
+  rtr, expl
+
+  let split env status s= merge env (segment status s)
+end
+
 let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
                                       expected = {ty = t2; expanded = t2'} } =
   if  Btype.is_constr_row ~allow_ident:true t1'
    || Btype.is_constr_row ~allow_ident:true t2'
-  then Discard
-  else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
-  else Keep
+  then Structured_trace.Discard
+  else if same_path t1 t1' && same_path t2 t2' then
+    Structured_trace.Optional_refinement
+  else Structured_trace.Keep
 
 let printing_status = function
-  | Errortrace.Diff { ctx = Some (In_method _); _} -> Keep
-  | Errortrace.Diff d ->
-      begin match diff_printing_status d.d, d.ctx with
-      | Optional_refinement, Some c -> Contextual_refinement c
-      | x, _ -> x
-      end
-  | Errortrace.Escape {kind = Constraint} -> Keep
-  | _ -> Keep
+  | Errortrace.Diff { ctx = Some _; _} -> Structured_trace.Context
+  | Errortrace.Diff d -> diff_printing_status d.d
+  | _ -> Structured_trace.Keep
 
-(** Flatten the trace and remove elements that are always discarded
-    during printing *)
-
-(* Takes [printing_status] to change behavior for [Subtype] *)
-let prepare_any_trace merge printing_status tr =
-  let clean_trace x l = match printing_status x, l with
-    | Keep , _ -> x :: l
-    | (Contextual_refinement _ | Optional_refinement), [] -> [x]
-    | Contextual_refinement ctx, [x] -> [merge ctx x]
-    | (Contextual_refinement _ | Optional_refinement | Discard), _ -> l
-  in
-  match tr with
-  | [] -> []
-  | elt :: rem -> elt :: List.fold_right clean_trace rem []
-
-let merge_ctx ctx = function
-  | Errortrace.Diff ({ ctx = None; _ } as d) ->
-      Errortrace.Diff { d with ctx = Some ctx }
-  | d -> d
-
-let prepare_trace f tr =
-  prepare_any_trace merge_ctx printing_status (Errortrace.map f tr)
 
 (** Keep elements that are [Diff _ ] and split the the last element if it is
     optionally elidable, require a prepared trace *)
-let rec filter_trace = function
-  | [] -> [], None
+let rec filter_trace keep_last = function
+  | [] -> []
   | [Errortrace.Diff d as elt]
-    when printing_status elt = Optional_refinement -> [], Some d
+    when printing_status elt = Structured_trace.Optional_refinement ->
+      if keep_last then [d] else []
   | Errortrace.Diff ({ctx=(None|Some (In_tag _)); _ } as d) :: rem ->
-      let filtered, last = filter_trace rem in
-      d :: filtered, last
-  | _ :: rem -> filter_trace rem
+      d :: filter_trace keep_last rem
+  | _ :: rem -> filter_trace keep_last rem
+
+let simplify_trace tr =
+  List.filter_map (function
+      | Errortrace.Diff d -> Some d
+      | _ -> None)
+    tr
 
 let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
   match Types.get_desc expanded with
@@ -142,42 +247,6 @@ let print_path p =
 
 let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
-
-let is_unit_param env ty =
-  let ty, vars = Btype.tpoly_get_poly ty in
-  if vars <> [] then false
-  else begin
-    match Types.get_desc (Ctype.expand_head env ty) with
-    | Tconstr (p, _, _) -> Path.same p Predef.path_unit
-    | _ -> false
-  end
-
-let unifiable env ty1 ty2 =
-  let snap = Btype.snapshot () in
-  let res =
-    try Ctype.unify env ty1 ty2; true
-    with Ctype.Unify _ -> false
-  in
-  Btype.backtrack snap;
-  res
-
-let explanation_diff env t3 t4 =
-  match Types.get_desc t3, Types.get_desc t4 with
-  | Tarrow (_, ty1, ty2, _), _
-    when is_unit_param env ty1 && unifiable env ty2 t4 ->
-      Some (doc_printf
-          "@,@[@{<hint>Hint@}: Did you forget to provide %a as argument?@]"
-          Style.inline_code "()"
-        )
-  | _, Tarrow (_, ty1, ty2, _)
-    when is_unit_param env ty1 && unifiable env t3 ty2 ->
-      Some (doc_printf
-          "@,@[@{<hint>Hint@}: Did you forget to wrap the expression using \
-           %a?@]"
-          Style.inline_code "fun () ->"
-        )
-  | _ ->
-      None
 
 let explain_fixed_row_case = function
   | Errortrace.Cannot_be_closed -> doc_printf "it cannot be closed"
@@ -296,16 +365,6 @@ let explain_object (type variety) : variety Errortrace.obj -> _ = function
               "@,Self type cannot be unified with a closed object type"
            )
 
-let explain_incompatible_fields name (diff: Types.type_expr Errortrace.diff) =
-  Variable_names.reserve diff.got;
-  Variable_names.reserve diff.expected;
-  doc_printf "@,@[The method %a has type@ %a,@ \
-  but the expected method type was@ %a@]"
-    Style.inline_code name
-    (Style.as_inline_code type_expr_with_reserved_names) diff.got
-    (Style.as_inline_code type_expr_with_reserved_names) diff.expected
-
-
 let explain_label_mismatch ~missing_label_msg  {Errortrace.got;expected} =
   let quoted_label ppf l = Style.inline_code ppf (Asttypes.string_of_label l) in
   match got, expected with
@@ -342,14 +401,8 @@ let explain_first_class_module = function
   | Errortrace.Package_coercion pr ->
       Some(doc_printf "@,@[%a@]" Fmt.pp_doc pr)
 
-let explain_univar prev = function
+let explain_univar = function
   | Errortrace.Var_mismatch { diff; order} ->
-      let prev = match prev with
-        | Some (Errortrace.Diff { ctx=Some (In_method name); d }) ->
-            let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
-            explain_incompatible_fields name d
-        | _ -> Fmt.Doc.empty
-      in
       add_type_to_preparation diff.got;
       add_type_to_preparation diff.expected;
       let more = match order with
@@ -366,8 +419,7 @@ let explain_univar prev = function
               (Style.as_inline_code prepared_type_expr) diff.expected
       in
       doc_printf
-        "%a@,@[The universal variables@ %a and@ %a@ are distinct.%a@]"
-        Fmt.pp_doc prev
+        "@,@[The universal variables@ %a and@ %a@ are distinct.%a@]"
         (Style.as_inline_code prepared_type_expr) diff.got
         (Style.as_inline_code prepared_type_expr) diff.expected
         pp_doc more
@@ -395,25 +447,15 @@ let explain_univar prev = function
       let pp_sep _ () = () in
       doc_printf "%a" (pp_print_list ~pp_sep pp) delta
 
-let explanation (type variety) intro prev env
+let explanation (type variety) intro
   : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
-  | Errortrace.Diff { ctx = None; d = {got; expected} } ->
-    explanation_diff env got.expanded expected.expanded
-  | Errortrace.Diff { ctx = Some (In_method name); d } ->
-    let diff = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
-    Some(explain_incompatible_fields name diff)
-  | Errortrace.Diff { ctx = Some (In_tag name); _ } ->
-    Some(incompatible_tag_types name)
   | Errortrace.Escape {kind; context} ->
     let pre =
-      match context, kind, prev with
-      | Some ctx, _, _ ->
+      match context, kind with
+      | Some ctx, _ ->
         Variable_names.reserve ctx;
         doc_printf "@[%a@;<1 2>%a@]" pp_doc intro
           (Style.as_inline_code type_expr_with_reserved_names) ctx
-      | None, Univ _, Some(Errortrace.Diff { ctx=Some (In_method name); d} ) ->
-          let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
-          explain_incompatible_fields name d
       | _ -> Format_doc.Doc.empty
     in
     explain_escape pre kind
@@ -461,10 +503,14 @@ let explanation (type variety) intro prev env
              {[ The type int occurs inside int list -> 'a |}
         *)
     end
-  | Univar um -> Some (explain_univar prev um)
+  | Univar um -> Some (explain_univar um)
+  | Diff _ -> None
 
-let mismatch intro env trace =
-  Errortrace.explain trace (fun ~prev h -> explanation intro prev env h)
+let mismatch intro expl =
+  match expl with
+  | None -> None
+  | Some (Structured_trace.Promoted msg) -> Some msg
+  | Some (Structured_trace.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
   match Types.get_desc t with
@@ -567,34 +613,27 @@ let explain_names env ppf =
              Style.inline_code constructor
     ) explanations
 
+let hide_variant ty_exp =
+  Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
+
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
-  let tr =
-    prepare_trace
-      (fun ty_exp ->
-         Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded})
-      tr
+  let tr = Errortrace.map hide_variant tr in
+  let tr, expl = Structured_trace.split env printing_status tr in
+  let elt, tr = match tr with
+    | [] -> None, tr
+    | hd :: tr -> Some hd, tr
   in
-  match tr with
-  | [] -> assert false
-  | (elt :: tr) as full_trace ->
-      with_labels (not !Clflags.classic) (fun () ->
-      let tr, last = filter_trace tr in
-      let head = prepare_expansion_head (tr=[] && last=None) elt in
+  with_labels (not !Clflags.classic) (fun () ->
+      let tr = simplify_trace tr in
+      let head = Option.bind elt (prepare_expansion_head (List.is_empty tr)) in
       let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
-      let last = Option.map (Errortrace.map_ctx prepare_expansion) last in
       let head_error = head_error_printer mode txt1 txt2 head in
       let tr = trees_of_trace mode tr in
-      let last =
-        Option.map (Errortrace.map_ctx (trees_of_type_expansion mode)) last in
-      let mis = mismatch txt1 env full_trace in
-      let tr = match mis, last with
-        | None, Some elt -> tr @ [elt]
-        | Some _, _ | _, None -> tr
-      in
+      let mis = mismatch txt1 expl in
       fprintf ppf
         "@[<v>\
          @[%a%a@]%a%a\
@@ -643,25 +682,34 @@ module Subtype = struct
      while being *just* different enough (it's only [Diff]) for the abstraction
      to be nonobvious.  Someday, perhaps... *)
 
-  let printing_status = function
+  let sub_printing_status = function
     | Errortrace.Subtype.Diff d -> diff_printing_status d
 
-  let prepare_unification_trace = prepare_trace
+  let prepare_unification_trace env f tr =
+    let tr = Errortrace.map f tr in
+    match tr with
+    | [] -> [], None
+    | _ -> Structured_trace.split env printing_status tr
 
   let prepare_trace f tr =
-    prepare_any_trace (fun _ d -> d) printing_status
-      (Errortrace.Subtype.map f tr)
+    let tr = Errortrace.Subtype.map f tr in
+    let s = Structured_trace.segment sub_printing_status tr in
+    let rtr = match s.last_ctx with
+    | None -> s.before
+    | Some (ctx, rest) -> rest @ ctx :: s.before
+    in
+    let rtr = match s.optional with
+      | Some x -> x :: rtr
+      | None -> rtr
+    in
+    s.head :: List.rev rtr, None
 
   let trace filter_trace get_diff fst keep_last txt ppf tr =
     with_labels (not !Clflags.classic) (fun () ->
       match tr with
       | elt :: tr' ->
         let diffed_elt = get_diff elt in
-        let tr, last = filter_trace tr' in
-        let tr = match keep_last, last with
-          | true, Some last -> tr @ [last]
-          | _ -> tr
-        in
+        let tr = filter_trace keep_last tr' in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
@@ -675,14 +723,13 @@ module Subtype = struct
     )
 
   let no_ctx d = { Errortrace.d; ctx = None}
-  let rec filter_subtype_trace = function
-    | [] -> [], None
+  let rec filter_subtype_trace keep_last = function
+    | [] -> []
     | [Errortrace.Subtype.Diff d as elt]
-      when printing_status elt = Optional_refinement ->
-        [], Some (no_ctx d)
+      when sub_printing_status elt = Structured_trace.Optional_refinement ->
+        if keep_last then [no_ctx d] else []
     | Errortrace.Subtype.Diff d :: rem ->
-        let ftr, last = filter_subtype_trace rem in
-        no_ctx d :: ftr, last
+        no_ctx d :: filter_subtype_trace keep_last rem
 
   let unification_get_diff = function
     | Errortrace.Diff diff ->
@@ -701,16 +748,18 @@ module Subtype = struct
         txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub = prepare_trace prepare_expansion tr_sub in
-      let tr_unif = prepare_unification_trace prepare_expansion tr_unif in
-      let keep_first = match tr_unif with
-        | [Obj _ | Variant _ | Escape _ ] | [] -> true
+      let tr_sub, _ = prepare_trace prepare_expansion tr_sub in
+      let tr_unif, expl_unif =
+        prepare_unification_trace env prepare_expansion tr_unif
+      in
+      let keep_first = match tr_unif, expl_unif with
+        | [], Some (Standard (Obj _ | Variant _ | Escape _ )) | [], None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
         (trace filter_subtype_trace subtype_get_diff true keep_first txt1)
         tr_sub;
-      if tr_unif = [] then fprintf ppf "@]" else
-        let mis = mismatch (doc_printf "Within this type") env tr_unif in
+      if tr_unif = [] && expl_unif = None then fprintf ppf "@]" else
+        let mis = mismatch (doc_printf "Within this type") expl_unif in
         fprintf ppf "%a%a%t@]"
           (trace filter_trace unification_get_diff false
              (mis = None) "is not compatible with type") tr_unif

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -219,17 +219,7 @@ let printing_status = function
   | _ -> Structured_trace.Keep
 
 
-(** Keep elements that are [Diff _ ] and split the the last element if it is
-    optionally elidable, require a prepared trace *)
-let rec filter_trace keep_last = function
-  | [] -> []
-  | [Errortrace.Diff d as elt]
-    when printing_status elt = Structured_trace.Optional_refinement ->
-      if keep_last then [d] else []
-  | Errortrace.Diff ({ctx=(None|Some (In_tag _)); _ } as d) :: rem ->
-      d :: filter_trace keep_last rem
-  | _ :: rem -> filter_trace keep_last rem
-
+(** Keep elements that are [Diff _ ]  *)
 let simplify_trace tr =
   List.filter_map (function
       | Errortrace.Diff d -> Some d
@@ -704,12 +694,12 @@ module Subtype = struct
     in
     s.head :: List.rev rtr, None
 
-  let trace filter_trace get_diff fst keep_last txt ppf tr =
+  let trace filter_trace get_diff fst txt ppf tr =
     with_labels (not !Clflags.classic) (fun () ->
       match tr with
       | elt :: tr' ->
         let diffed_elt = get_diff elt in
-        let tr = filter_trace keep_last tr' in
+        let tr = filter_trace tr' in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
@@ -756,13 +746,13 @@ module Subtype = struct
         | [], Some (Standard (Obj _ | Variant _ | Escape _ )) | [], None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
-        (trace filter_subtype_trace subtype_get_diff true keep_first txt1)
+        (trace (filter_subtype_trace keep_first) subtype_get_diff true txt1)
         tr_sub;
       if tr_unif = [] && expl_unif = None then fprintf ppf "@]" else
         let mis = mismatch (doc_printf "Within this type") expl_unif in
         fprintf ppf "%a%a%t@]"
-          (trace filter_trace unification_get_diff false
-             (mis = None) "is not compatible with type") tr_unif
+          (trace simplify_trace unification_get_diff false
+             "is not compatible with type") tr_unif
           (pp_print_option pp_doc) mis
           Ident_conflicts.err_print
     )

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -149,6 +149,16 @@ let print_path p =
 let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
 
+let both_side_diff f x =
+  { Errortrace.ctx = None; d = {got = f x; expected = f x} }
+
+let both_side x  = both_side_diff (highlight_type Independent) x
+let both_side_constructor p =
+  both_side_diff (fun p -> Some(Out_type.Type_constructor p) ) p
+
+
+let no_highlight = Errortrace.{ ctx = None; d = { got = None; expected = None} }
+
 let explain_fixed_row_case = function
   | Errortrace.Cannot_be_closed -> doc_printf "it cannot be closed"
   | Errortrace.Cannot_add_tags tags ->
@@ -157,6 +167,7 @@ let explain_fixed_row_case = function
 
 let pp_path ppf p =
   Style.as_inline_code Printtyp.Doc.path ppf p
+
 
 let explain_fixed_row pos expl = match expl with
   | Types.Fixed_private ->
@@ -175,6 +186,12 @@ let explain_fixed_row pos expl = match expl with
            print_path p ppf))
       p
   | Types.Rigid -> Format_doc.Doc.empty
+
+
+let highlight_fixed_row expl = match expl with
+  | Types.Fixed_private | Types.Rigid -> no_highlight
+  | Types.Univar x -> both_side x
+  | Types.Reified p -> both_side_constructor p
 
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
@@ -215,6 +232,16 @@ let explain_variant (type variety) : variety Errortrace.variant -> _ = function
              Errortrace.print_pos pos
              Errortrace.print_pos (Errortrace.swap_position pos))
 
+
+let highlight_variant (type variety) : variety Errortrace.variant -> _ =
+  function
+  | Errortrace.Arity_mismatch _
+  | Errortrace.No_intersection
+  | Errortrace.No_tags(_,_)
+  | Errortrace.Presence_not_guaranteed_for _
+  | Errortrace.Openness _ -> no_highlight
+  | Errortrace.Fixed_row (_, _, e) ->  highlight_fixed_row e
+
 let explain_escape pre = function
   | Errortrace.Univ u ->
       Variable_names.reserve u;
@@ -250,6 +277,15 @@ let explain_escape pre = function
       Some (doc_printf "%a@,Self type cannot escape its class" pp_doc pre)
   | Errortrace.Constraint ->
       None
+
+let highlight_escape = function
+  | Errortrace.Univ u -> both_side u
+  | Errortrace.Constructor p -> both_side_constructor p
+  | Errortrace.Module_type _
+  | Errortrace.Module _ -> no_highlight
+  | Errortrace.Equation Errortrace.{ty = _; expanded = t} -> both_side t
+  | Errortrace.Self
+  | Errortrace.Constraint -> no_highlight
 
 let explain_object (type variety) : variety Errortrace.obj -> _ = function
   | Errortrace.Missing_field (pos,f) -> Some(
@@ -348,6 +384,14 @@ let explain_univar = function
       let pp_sep _ () = () in
       doc_printf "%a" (pp_print_list ~pp_sep pp) delta
 
+let highlight_univar = function
+  | Errortrace.Var_mismatch { diff; order=_} -> both_side diff.got
+  | Errortrace.Quantification_mismatch delta ->
+    begin match delta with
+    | a :: _ -> both_side a
+    | [] -> no_highlight
+    end
+
 let explanation (type variety) intro
   : (Errortrace.expanded_type, variety) Errortrace.root -> _ = function
   | Errortrace.Escape {kind; context} ->
@@ -405,6 +449,22 @@ let explanation (type variety) intro
         *)
     end
   | Univar um -> Some (explain_univar um)
+
+let highlight_explanation (type variety)
+  : (Errortrace.expanded_type, variety) Errortrace.root -> _ = function
+  | Errortrace.Escape {kind; context = _ } -> highlight_escape kind
+  | Errortrace.Function_label_mismatch _
+  | Errortrace.Tuple_label_mismatch _ -> no_highlight
+  | Errortrace.Variant v -> highlight_variant v
+  | Errortrace.Obj _
+  | Errortrace.First_class_module _ -> no_highlight
+  | Errortrace.Rec_occur(x,y) ->
+
+      let got = highlight_type Paired x in
+      let expected = highlight_type Paired y in
+      { Errortrace.ctx = None; d = { got; expected} }
+  | Univar um -> highlight_univar um
+
 
 let mismatch intro expl =
   match expl with
@@ -527,7 +587,6 @@ let zip_cdiff x y =
 let highlight_type ty =
   let hty x = highlight_type Paired x.Errortrace.ty in
   Errortrace.map_cdiff hty ty
-let no_highlight = Errortrace.{ ctx = None; d = { got = None; expected = None} }
 
 let associate_htarget { Structured.top; tr; expl} =
   match top, tr with
@@ -537,7 +596,11 @@ let associate_htarget { Structured.top; tr; expl} =
       { Structured.top = Some (h, c); tr = []; expl }
   | Some (h,c), a :: q ->
       let top = Some (zip_cdiff h (highlight_type a), c) in
-      let htrace = List.map highlight_type q @ [no_highlight] in
+      let hexpl = match expl with
+        | None | Some (Structured.Promoted _) -> no_highlight
+        | Some (Structured.Standard std) -> highlight_explanation std
+      in
+      let htrace = List.map highlight_type q @ [hexpl] in
       let tr = List.map2 zip_cdiff tr htrace in
       { Structured.top; tr; expl }
 

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -558,6 +558,11 @@ module Subtype = struct
       Errortrace.map prepare_expansion unification_trace in
     Errortrace.Subtype.error ~trace ~unification_trace
 
+  let parse_sub tr =
+    (* The subtype part of the trace does not contain any explanation *)
+    let trace = { Errortrace.root = None; path = tr } in
+    Structured.parse ~promote:(Fun.const None) ~status:printing_status trace
+
   let flatten_trace filter_trace fst (str: _ Structured.s) =
     with_labels (not !Clflags.classic) (fun () ->
       match str.top, str.tr with
@@ -586,7 +591,7 @@ module Subtype = struct
     wrap_printing_env ~error:true env (fun () ->
       reset ();
       let tr = prepare_trace tr in
-      let tr_sub = Structured.parse_simple printing_status tr.trace in
+      let tr_sub = parse_sub tr.trace in
       let str_unif = structured_trace env tr.unification_trace in
       let keep_last = obj_only_trace str_unif in
       let tr_sub = flatten_trace (filter_trace keep_last) true tr_sub in

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -458,10 +458,9 @@ let highlight_explanation_core (type variety)
   | Errortrace.Variant v -> highlight_variant v
   | Errortrace.Obj _
   | Errortrace.First_class_module _ -> no_highlight
-  | Errortrace.Rec_occur(x,y) ->
-      let got = Errortrace.highlight_type Paired x in
-      let expected = Errortrace.highlight_type Paired y in
-      Errortrace.no_ctx { got; expected }
+  | Errortrace.Rec_occur(x,_) ->
+      let l = Errortrace.highlight_type Independent x in
+      Errortrace.no_ctx { got=l; expected=l }
   | Errortrace.Univar um -> highlight_univar um
   | Errortrace.Highlight_hint h -> Errortrace.no_ctx h
 

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -40,19 +40,36 @@ module Style = Misc.Style
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
 let trees_of_trace mode =
-  List.map (Errortrace.map_diff (trees_of_type_expansion mode))
+  List.map (Errortrace.map_ctx (trees_of_type_expansion mode))
+
+let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
+let incompatible_tag_types s =
+  doc_printf "@,Types for tag %a are incompatible" print_tag s
 
 let rec trace fst txt ppf = function
-  | {Errortrace.got; expected} :: rem ->
+  | elt :: rem ->
       if not fst then fprintf ppf "@,";
-      fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@]%a"
+      fprintf ppf "@[%a@]%a"
+      (trace_elt txt) elt
+      (trace false txt) rem
+  | [] -> ()
+and trace_elt txt ppf = function
+  | { ctx = None; Errortrace.d = {got; expected} } ->
+      fprintf ppf "Type@;<1 2>%a@ %s@;<1 2>%a"
        pp_type_expansion got txt pp_type_expansion expected
-       (trace false txt) rem
-  | _ -> ()
+  | { ctx = Some (In_tag l); Errortrace.d = {got; expected} } ->
+      fprintf ppf "In tag %a, type@;<1 2>%a@ %s@;<1 2>%a"
+       print_tag l
+       pp_type_expansion got txt pp_type_expansion expected
+  | { ctx = Some (In_method m); Errortrace.d = {got; expected} } ->
+      fprintf ppf "In method %a, type@;<1 2>%a@ %s@;<1 2>%a"
+       Style.inline_code m
+       pp_type_expansion got txt pp_type_expansion expected
 
 type printing_status =
   | Discard
   | Keep
+  | Contextual_refinement of Errortrace.ctx
   | Optional_refinement
   (** An [Optional_refinement] printing status is attributed to trace
       elements that are focusing on a new subpart of a structural type.
@@ -71,7 +88,12 @@ let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
   else Keep
 
 let printing_status = function
-  | Errortrace.Diff d -> diff_printing_status d
+  | Errortrace.Diff { ctx = Some (In_method _); _} -> Keep
+  | Errortrace.Diff d ->
+      begin match diff_printing_status d.d, d.ctx with
+      | Optional_refinement, Some c -> Contextual_refinement c
+      | x, _ -> x
+      end
   | Errortrace.Escape {kind = Constraint} -> Keep
   | _ -> Keep
 
@@ -79,18 +101,24 @@ let printing_status = function
     during printing *)
 
 (* Takes [printing_status] to change behavior for [Subtype] *)
-let prepare_any_trace printing_status tr =
-  let clean_trace x l = match printing_status x with
-    | Keep -> x :: l
-    | Optional_refinement when l = [] -> [x]
-    | Optional_refinement | Discard -> l
+let prepare_any_trace merge printing_status tr =
+  let clean_trace x l = match printing_status x, l with
+    | Keep , _ -> x :: l
+    | (Contextual_refinement _ | Optional_refinement), [] -> [x]
+    | Contextual_refinement ctx, [x] -> [merge ctx x]
+    | (Contextual_refinement _ | Optional_refinement | Discard), _ -> l
   in
   match tr with
   | [] -> []
   | elt :: rem -> elt :: List.fold_right clean_trace rem []
 
+let merge_ctx ctx = function
+  | Errortrace.Diff ({ ctx = None; _ } as d) ->
+      Errortrace.Diff { d with ctx = Some ctx }
+  | d -> d
+
 let prepare_trace f tr =
-  prepare_any_trace printing_status (Errortrace.map f tr)
+  prepare_any_trace merge_ctx printing_status (Errortrace.map f tr)
 
 (** Keep elements that are [Diff _ ] and split the the last element if it is
     optionally elidable, require a prepared trace *)
@@ -98,7 +126,7 @@ let rec filter_trace = function
   | [] -> [], None
   | [Errortrace.Diff d as elt]
     when printing_status elt = Optional_refinement -> [], Some d
-  | Errortrace.Diff d :: rem ->
+  | Errortrace.Diff ({ctx=(None|Some (In_tag _)); _ } as d) :: rem ->
       let filtered, last = filter_trace rem in
       d :: filtered, last
   | _ :: rem -> filter_trace rem
@@ -111,8 +139,6 @@ let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
 
 let print_path p =
   Fmt.dprintf "%a" !Oprint.out_ident (namespaced_tree_of_path Type p)
-
-let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
 
 let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
@@ -180,12 +206,11 @@ let explain_fixed_row pos expl = match expl with
       p
   | Types.Rigid -> Format_doc.Doc.empty
 
+
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
   (* Common *)
-  | Errortrace.Incompatible_types_for s ->
-      Some(doc_printf "@,Types for tag %a are incompatible"
-             print_tag s
-          )
+  | Errortrace.Arity_mismatch s -> Some(incompatible_tag_types s)
+  | Errortrace.Inconsistent_conjunction s -> Some (incompatible_tag_types s)
   (* Unification *)
   | Errortrace.No_intersection ->
       Some(doc_printf "@,These two variant types have no intersection")
@@ -319,8 +344,9 @@ let explain_first_class_module = function
 let explain_univar prev = function
   | Errortrace.Var_mismatch { diff; order} ->
       let prev = match prev with
-        | Some (Errortrace.Incompatible_fields f) ->
-            explain_incompatible_fields f.name f.diff
+        | Some (Errortrace.Diff { ctx=Some (In_method name); d }) ->
+            let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
+            explain_incompatible_fields name d
         | _ -> Fmt.Doc.empty
       in
       add_type_to_preparation diff.got;
@@ -370,8 +396,13 @@ let explain_univar prev = function
 
 let explanation (type variety) intro prev env
   : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
-  | Errortrace.Diff {got; expected} ->
+  | Errortrace.Diff { ctx = None; d = {got; expected} } ->
     explanation_diff env got.expanded expected.expanded
+  | Errortrace.Diff { ctx = Some (In_method name); d } ->
+    let diff = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
+    Some(explain_incompatible_fields name diff)
+  | Errortrace.Diff { ctx = Some (In_tag name); _ } ->
+    Some(incompatible_tag_types name)
   | Errortrace.Escape {kind; context} ->
     let pre =
       match context, kind, prev with
@@ -379,13 +410,12 @@ let explanation (type variety) intro prev env
         Variable_names.reserve ctx;
         doc_printf "@[%a@;<1 2>%a@]" pp_doc intro
           (Style.as_inline_code type_expr_with_reserved_names) ctx
-      | None, Univ _, Some(Errortrace.Incompatible_fields {name; diff}) ->
-        explain_incompatible_fields name diff
+      | None, Univ _, Some(Errortrace.Diff { ctx=Some (In_method name); d} ) ->
+          let d = Errortrace.map_diff (fun t -> t.Errortrace.ty) d in
+          explain_incompatible_fields name d
       | _ -> Format_doc.Doc.empty
     in
     explain_escape pre kind
-  | Errortrace.Incompatible_fields { name; diff} ->
-    Some(explain_incompatible_fields name diff)
   | Errortrace.Function_label_mismatch diff ->
     let missing_label_msg =
       format_of_string
@@ -462,21 +492,21 @@ let warn_on_missing_def env ppf t =
 
 let prepare_expansion_head empty_tr = function
   | Errortrace.Diff d ->
-      Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
+      Some (Errortrace.map_ctx (may_prepare_expansion empty_tr) d)
   | _ -> None
 
 let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
   | Some d ->
-      let d = Errortrace.map_diff (trees_of_type_expansion mode) d in
+      let d = Errortrace.(map_diff (trees_of_type_expansion mode) d.d) in
       doc_printf "%a@;<1 2>%a@ %a@;<1 2>%a"
-        pp_doc txt_got pp_type_expansion d.Errortrace.got
-        pp_doc txt_but pp_type_expansion d.Errortrace.expected
+        pp_doc txt_got pp_type_expansion d.got
+        pp_doc txt_but pp_type_expansion d.expected
 
 let warn_on_missing_defs env ppf = function
   | None -> ()
-  | Some Errortrace.{got      = {ty=te1; expanded=_};
-                     expected = {ty=te2; expanded=_} } ->
+  | Some Errortrace.{ d = { got      = {ty=te1; expanded=_};
+                            expected = {ty=te2; expanded=_} }; _ } ->
       warn_on_missing_def env ppf te1;
       warn_on_missing_def env ppf te2
 
@@ -553,12 +583,12 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
       with_labels (not !Clflags.classic) (fun () ->
       let tr, last = filter_trace tr in
       let head = prepare_expansion_head (tr=[] && last=None) elt in
-      let tr = List.map (Errortrace.map_diff prepare_expansion) tr in
-      let last = Option.map (Errortrace.map_diff prepare_expansion) last in
+      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
+      let last = Option.map (Errortrace.map_ctx prepare_expansion) last in
       let head_error = head_error_printer mode txt1 txt2 head in
       let tr = trees_of_trace mode tr in
       let last =
-        Option.map (Errortrace.map_diff (trees_of_type_expansion mode)) last in
+        Option.map (Errortrace.map_ctx (trees_of_type_expansion mode)) last in
       let mis = mismatch txt1 env full_trace in
       let tr = match mis, last with
         | None, Some elt -> tr @ [elt]
@@ -618,7 +648,8 @@ module Subtype = struct
   let prepare_unification_trace = prepare_trace
 
   let prepare_trace f tr =
-    prepare_any_trace printing_status (Errortrace.Subtype.map f tr)
+    prepare_any_trace (fun _ d -> d) printing_status
+      (Errortrace.Subtype.map f tr)
 
   let trace filter_trace get_diff fst keep_last txt ppf tr =
     with_labels (not !Clflags.classic) (fun () ->
@@ -632,7 +663,7 @@ module Subtype = struct
         in
         let tr =
           trees_of_trace Type
-          @@ List.map (Errortrace.map_diff prepare_expansion) tr in
+          @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
         let tr =
           match fst, diffed_elt with
           | true, Some elt -> elt :: tr
@@ -642,23 +673,25 @@ module Subtype = struct
       | _ -> ()
     )
 
+  let no_ctx d = { Errortrace.d; ctx = None}
   let rec filter_subtype_trace = function
     | [] -> [], None
     | [Errortrace.Subtype.Diff d as elt]
       when printing_status elt = Optional_refinement ->
-        [], Some d
+        [], Some (no_ctx d)
     | Errortrace.Subtype.Diff d :: rem ->
         let ftr, last = filter_subtype_trace rem in
-        d :: ftr, last
+        no_ctx d :: ftr, last
 
   let unification_get_diff = function
     | Errortrace.Diff diff ->
-        Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
+        Some (Errortrace.map_ctx (trees_of_type_expansion Type) diff)
     | _ -> None
 
   let subtype_get_diff = function
     | Errortrace.Subtype.Diff diff ->
-        Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
+        let d = Errortrace.map_diff (trees_of_type_expansion Type) diff in
+        Some { Errortrace.d; ctx = None }
 
   let error
         ppf

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -152,9 +152,9 @@ let print_tags ppf tags  =
 let both_side_diff f x =
   { Errortrace.ctx = None; d = {got = f x; expected = f x} }
 
-let both_side x  = both_side_diff (highlight_type Independent) x
+let both_side x  = both_side_diff (Errortrace.highlight_type Independent) x
 let both_side_constructor p =
-  both_side_diff (fun p -> Some(Out_type.Type_constructor p) ) p
+  both_side_diff (fun p -> Some(Errortrace.Type_constructor p) ) p
 
 
 let no_highlight = Errortrace.{ ctx = None; d = { got = None; expected = None} }
@@ -449,8 +449,9 @@ let explanation (type variety) intro
         *)
     end
   | Univar um -> Some (explain_univar um)
+  | Highlight_hint _ -> None
 
-let highlight_explanation (type variety)
+let highlight_explanation_core (type variety)
   : (Errortrace.expanded_type, variety) Errortrace.root -> _ = function
   | Errortrace.Escape {kind; context = _ } -> highlight_escape kind
   | Errortrace.Function_label_mismatch _
@@ -459,17 +460,22 @@ let highlight_explanation (type variety)
   | Errortrace.Obj _
   | Errortrace.First_class_module _ -> no_highlight
   | Errortrace.Rec_occur(x,y) ->
+      let got = Errortrace.highlight_type Paired x in
+      let expected = Errortrace.highlight_type Paired y in
+      Errortrace.no_ctx { got; expected }
+  | Errortrace.Univar um -> highlight_univar um
+  | Errortrace.Highlight_hint h -> Errortrace.no_ctx h
 
-      let got = highlight_type Paired x in
-      let expected = highlight_type Paired y in
-      { Errortrace.ctx = None; d = { got; expected} }
-  | Univar um -> highlight_univar um
-
+let highlight_explanation = function
+  | None | Some (Structured.Promoted(None,_))-> no_highlight
+  | Some (Structured.Promoted (Some hint,_)) | Some (Structured.Hint hint) ->
+      Errortrace.no_ctx hint
+  | Some (Structured.Standard std) -> highlight_explanation_core std
 
 let mismatch intro expl =
   match expl with
-  | None -> None
-  | Some (Structured.Promoted msg) -> Some msg
+  | None | Some (Structured.Hint _) -> None
+  | Some (Structured.Promoted (_,msg)) -> Some msg
   | Some (Structured.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
@@ -585,21 +591,18 @@ let zip_cdiff x y =
   { ctx = x.ctx; d }
 
 let highlight_type ty =
-  let hty x = highlight_type Paired x.Errortrace.ty in
+  let hty x = Errortrace.highlight_type Paired x.Errortrace.ty in
   Errortrace.map_cdiff hty ty
 
 let associate_htarget { Structured.top; tr; expl} =
   match top, tr with
   | None, _ -> { Structured.top = None; tr = []; expl }
   | Some (h,c), [] ->
-      let h = Errortrace.map_cdiff (fun x -> x, None) h in
+      let h = zip_cdiff h (highlight_explanation expl) in
       { Structured.top = Some (h, c); tr = []; expl }
   | Some (h,c), a :: q ->
       let top = Some (zip_cdiff h (highlight_type a), c) in
-      let hexpl = match expl with
-        | None | Some (Structured.Promoted _) -> no_highlight
-        | Some (Structured.Standard std) -> highlight_explanation std
-      in
+      let hexpl = highlight_explanation expl in
       let htrace = List.map highlight_type q @ [hexpl] in
       let tr = List.map2 zip_cdiff tr htrace in
       { Structured.top; tr; expl }
@@ -705,7 +708,7 @@ module Subtype = struct
   let obj_only_trace (trace: _ Structured.s) =
     match trace.top, trace.tr, trace.expl with
     | None, [], Some (Standard (Obj _ | Variant _ | Escape _ ))
-    | None, [], None -> true
+    | None, [], (None | Some (Hint _)) -> true
     | _ -> false
 
   let error ppf env tr txt1 =

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -41,7 +41,7 @@ module Structured = Errortrace.Structured
 type 'a diff = 'a Out_type.diff = Same of 'a | Diff of 'a * 'a
 
 let trees_of_trace mode =
-  List.map (Errortrace.map_ctx (trees_of_type_expansion mode))
+  List.map (Errortrace.map_cdiff (trees_of_type_expansion mode))
 
 let print_tag ppf s = Style.inline_code ppf ("`" ^ s)
 
@@ -417,7 +417,7 @@ let warn_on_missing_def env ppf t =
   | _ -> ()
 
 let prepare_expansion_head (h,empty_tr)=
-  Errortrace.map_ctx (may_prepare_expansion empty_tr) h
+  Errortrace.map_cdiff (may_prepare_expansion empty_tr) h
 
 let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
@@ -506,7 +506,7 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   with_labels (not !Clflags.classic) (fun () ->
       let head = Option.map prepare_expansion_head str.top in
       let head_error = head_error_printer mode txt1 txt2 head in
-      let tr = List.map (Errortrace.map_ctx prepare_expansion) str.tr in
+      let tr = List.map (Errortrace.map_cdiff prepare_expansion) str.tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 str.expl in
       fprintf ppf
@@ -563,7 +563,7 @@ module Subtype = struct
       match str.top, str.tr with
       | Some (elt,_), tr ->
         let diffed_elt =
-          Errortrace.map_ctx (trees_of_type_expansion Type) elt
+          Errortrace.map_cdiff (trees_of_type_expansion Type) elt
         in
         let tr = trees_of_trace Type (filter_trace tr) in
         if fst then diffed_elt :: tr else tr

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -66,87 +66,28 @@ and trace_elt txt ppf = function
         pp_type_expansion got
         pp_type_expansion expected
 
-module Structured_trace = struct
+
+let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
+                                      expected = {ty = t2; expanded = t2'} } =
+  if  Btype.is_constr_row ~allow_ident:true t1'
+   || Btype.is_constr_row ~allow_ident:true t2'
+  then Errortrace.Structured.Discard
+  else if same_path t1 t1' && same_path t2 t2' then
+    Errortrace.Structured.Optional_refinement
+  else Errortrace.Structured.Keep
+
+let printing_status = function
+  | Errortrace.Diff { ctx = Some _; _} -> Errortrace.Structured.Context
+  | Errortrace.Diff d -> diff_printing_status d.d
+  | _ -> Errortrace.Structured.Keep
 
 
-  type ('a,'b) t = {
-  top: ('a * bool) option;
-  tr: 'a list;
-  expl: 'b
-}
-(**
-This module contains helper functions to split the error trace into three parts:
-- {!top} the first element of the trace
-- {!tr} a list of meaningful context difference element
-- {!expl} a root explanation for a type error
-*)
-
-(** The first intermediary representation splits the trace into four parts:
-- the {!head} element of the trace
-- the {!top_to_ctx} trace elements in reverse order situated before the last
-  method or tag difference
-- {!last_ctx}: the last method or tag context, and the list of elements after it
-- {!optional}: the last element that might be printed if we don't discover a
-  better element to print later on.
-*)
-type 'a segments =
-  {
-    head: 'a;
-    before:'a list;
-    last_ctx:('a * 'a list) option;
-    optional: 'a option
-  }
-
-
-let head_segment hd =
-  { head = hd; before=[]; last_ctx = None; optional = None }
-
-(** Add a non-contextual element to the active context *)
-let add x s = match s.last_ctx with
-  | None ->  { s with optional = None; before = x :: s.before }
-  | Some (ctx, rest)->
-      { s with optional = None; last_ctx = Some (ctx, x :: rest)}
-
-(** Add a new context, add the last context contents to the {!before} trace *)
-let add_ctx c s = match s.last_ctx with
-  | None -> { s with optional = None; last_ctx = Some (c,[]) }
-  | Some (_ctx, rest) -> {
-      head = s.head;
-      optional = None;
-      before = rest @ s.before;
-      last_ctx = Some (c,[])
-    }
-
-type printing_status =
-  | Discard
-  | Keep
-  | Context
-    (** A {!Context} element marks the entry inside a method or a polymorphic
-        variant tag *)
-  | Optional_refinement
-  (** An [Optional_refinement] printing status is attributed to trace
-      elements that are focusing on a new subpart of a structural type.
-      Since the whole type should have been printed earlier in the trace,
-      we only print those elements if they are the last printed element
-      of a trace, and there is no explicit explanation for the
-      type error.
-  *)
-
-(** Construct a segment from an unstructured trace *)
-let segment status = function
-  | [] -> assert false
-  | hd :: tr ->
-      List.fold_left (fun s x ->
-      match status x with
-      | Discard -> s
-      | Keep -> add x s
-      | Optional_refinement -> { s with optional = Some x }
-      | Context -> add_ctx x s
-    ) (head_segment hd) tr
-
-type 'a extended_explanation =
-  | Promoted of Format_doc.t
-  | Standard of 'a
+(** Keep elements that are [Diff _ ]  *)
+let simplify_trace tr =
+  List.filter_map (function
+      | Errortrace.Diff d -> Some d
+      | _ -> None)
+    tr
 
 let is_unit_param env ty =
   let ty, vars = Btype.tpoly_get_poly ty in
@@ -167,76 +108,21 @@ let promote_diff env {Errortrace.got; expected} =
   let res = match Types.get_desc t3, Types.get_desc t4 with
   | Tarrow (_, ty1, ty2, _), _
     when is_unit_param env ty1 && unifiable env ty2 t4 ->
-      Some (Promoted (doc_printf
+      Some (doc_printf
           "@,@[@{<hint>Hint@}: Did you forget to provide %a as argument?@]"
           Style.inline_code "()"
-        ))
+        )
   | _, Tarrow (_, ty1, ty2, _)
     when is_unit_param env ty1 && unifiable env t3 ty2 ->
-      Some (Promoted (doc_printf
+      Some (doc_printf
           "@,@[@{<hint>Hint@}: Did you forget to wrap the expression using \
            %a?@]"
           Style.inline_code "fun () ->"
-        ))
+        )
   | _ -> None
   in
   Btype.backtrack snap;
   res
-
-let merge env s =
-  (* First, we commit the last contextualized segment of the trace to the
-     trace *)
-  let rtr, opt, maybe_compact = match s.last_ctx with
-    | None -> s.before, s.optional, false
-    | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
-  in
-  let head, rtr, expl = match rtr with
-    | Errortrace.Diff d :: _ ->
-        begin match promote_diff env d.d with
-        | Some p -> Some s.head, rtr, Some p
-        | None -> Some s.head, rtr, None
-        end
-    | expl :: rest -> Some s.head, rest, Some (Standard expl)
-    | [] ->
-        begin match s.head with
-        | Errortrace.Diff d -> Some s.head, [], promote_diff env d.d
-        | expl -> None, [], Some (Standard expl)
-        end
-  in
-  let tr = match expl, opt with
-    | None, Some opt -> List.rev (opt :: rtr)
-    | Some _, _ | None, _  -> List.rev rtr
-  in
-  let compact head = match tr, maybe_compact with
-    | [], _ | [_], true -> head, true
-    | _ -> head, false
-  in
-  { top=Option.map compact head; tr; expl }
-
-  let split env status s = merge env (segment status s)
-end
-
-let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
-                                      expected = {ty = t2; expanded = t2'} } =
-  if  Btype.is_constr_row ~allow_ident:true t1'
-   || Btype.is_constr_row ~allow_ident:true t2'
-  then Structured_trace.Discard
-  else if same_path t1 t1' && same_path t2 t2' then
-    Structured_trace.Optional_refinement
-  else Structured_trace.Keep
-
-let printing_status = function
-  | Errortrace.Diff { ctx = Some _; _} -> Structured_trace.Context
-  | Errortrace.Diff d -> diff_printing_status d.d
-  | _ -> Structured_trace.Keep
-
-
-(** Keep elements that are [Diff _ ]  *)
-let simplify_trace tr =
-  List.filter_map (function
-      | Errortrace.Diff d -> Some d
-      | _ -> None)
-    tr
 
 let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
   match Types.get_desc expanded with
@@ -511,8 +397,8 @@ let explanation (type variety) intro
 let mismatch intro expl =
   match expl with
   | None -> None
-  | Some (Structured_trace.Promoted msg) -> Some msg
-  | Some (Structured_trace.Standard e) -> explanation intro e
+  | Some (Errortrace.Structured.Promoted msg) -> Some msg
+  | Some (Errortrace.Structured.Standard e) -> explanation intro e
 
 let warn_on_missing_def env ppf t =
   match Types.get_desc t with
@@ -618,13 +504,17 @@ let explain_names env ppf =
 let hide_variant ty_exp =
   Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded}
 
+let structured_trace env tr =
+ Errortrace.Structured.parse ~promote:(promote_diff env) ~status:printing_status
+   tr
+
 (* [subst] comes out of equality, and is [[]] otherwise *)
 let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
   let tr = Errortrace.map hide_variant tr in
-  let str = Structured_trace.split env printing_status tr in
+  let str = structured_trace env tr in
   with_labels (not !Clflags.classic) (fun () ->
       let tr = simplify_trace str.tr in
       let head = Option.bind str.top prepare_expansion_head in
@@ -680,7 +570,7 @@ module Subtype = struct
      while being *just* different enough (it's only [Diff]) for the abstraction
      to be nonobvious.  Someday, perhaps... *)
 
-  let sub_printing_status = function
+  let printing_status = function
     | Errortrace.Subtype.Diff d -> diff_printing_status d
 
   let prepare_unification_trace env f tr =
@@ -688,23 +578,15 @@ module Subtype = struct
     match tr with
     | [] -> None, None
     | _ ->
-        let str = Structured_trace.split env printing_status tr in
+        let str = structured_trace env tr in
         match str.top with
         | Some (h,_) -> Some (h,str.tr), str.expl
         | None -> None, str.expl
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in
-    let s = Structured_trace.segment sub_printing_status tr in
-    let rtr = match s.last_ctx with
-    | None -> s.before
-    | Some (ctx, rest) -> rest @ ctx :: s.before
-    in
-    let rtr = match s.optional with
-      | Some x -> x :: rtr
-      | None -> rtr
-    in
-    Some (s.head, List.rev rtr), None
+    let htr = Errortrace.Structured.parse_simple printing_status tr in
+    Some htr, None
 
   let trace filter_trace get_diff fst txt ppf htr =
     with_labels (not !Clflags.classic) (fun () ->
@@ -728,7 +610,7 @@ module Subtype = struct
   let rec filter_subtype_trace keep_last = function
     | [] -> []
     | [Errortrace.Subtype.Diff d as elt]
-      when sub_printing_status elt = Structured_trace.Optional_refinement ->
+      when printing_status elt = Errortrace.Structured.Optional_refinement ->
         if keep_last then [no_ctx d] else []
     | Errortrace.Subtype.Diff d :: rem ->
         no_ctx d :: filter_subtype_trace keep_last rem

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -209,8 +209,9 @@ let explain_fixed_row pos expl = match expl with
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
   (* Common *)
-  | Errortrace.Arity_mismatch s -> Some(incompatible_tag_types s)
-  | Errortrace.Inconsistent_conjunction s -> Some (incompatible_tag_types s)
+  | Errortrace.Arity_mismatch s ->
+      Some(doc_printf "@,@[Arities for tag %a are incompatible.@]"
+             print_tag s)
   (* Unification *)
   | Errortrace.No_intersection ->
       Some(doc_printf "@,These two variant types have no intersection")

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -149,15 +149,14 @@ let print_path p =
 let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
 
-let both_side_diff f x =
-  { Errortrace.ctx = None; d = {got = f x; expected = f x} }
+let both_side_diff f x = Errortrace.no_ctx {got = f x; expected = f x}
 
 let both_side x  = both_side_diff (Errortrace.highlight_type Independent) x
 let both_side_constructor p =
-  both_side_diff (fun p -> Some(Errortrace.Type_constructor p) ) p
+  both_side_diff (fun p -> [Errortrace.Type_constructor p] ) p
 
 
-let no_highlight = Errortrace.{ ctx = None; d = { got = None; expected = None} }
+let no_highlight = Errortrace.no_ctx { Errortrace.got = []; expected = []}
 
 let explain_fixed_row_case = function
   | Errortrace.Cannot_be_closed -> doc_printf "it cannot be closed"
@@ -385,12 +384,12 @@ let explain_univar = function
       doc_printf "%a" (pp_print_list ~pp_sep pp) delta
 
 let highlight_univar = function
-  | Errortrace.Var_mismatch { diff; order=_} -> both_side diff.got
+  | Errortrace.Var_mismatch { diff; order=_} ->
+      Errortrace.no_ctx
+      @@ Errortrace.map_diff (Errortrace.highlight_type Independent) diff
   | Errortrace.Quantification_mismatch delta ->
-    begin match delta with
-    | a :: _ -> both_side a
-    | [] -> no_highlight
-    end
+      let delta = List.map (fun t -> Errortrace.Type(Independent,t)) delta in
+      Errortrace.no_ctx {Errortrace.got = delta; expected = delta }
 
 let explanation (type variety) intro
   : (Errortrace.expanded_type, variety) Errortrace.root -> _ = function
@@ -557,8 +556,8 @@ let explain_names env ppf =
        let paths = List.map tree_of_path paths in
        match explanation with
        | Internal_names.Equation { lhs; rhs; } ->
-           let rhseq = tree_of_typexp None Type_scheme rhs in
-           let lhseq = tree_of_typexp None Type_scheme lhs in
+           let rhseq = tree_of_typexp [] Type_scheme rhs in
+           let lhseq = tree_of_typexp [] Type_scheme lhs in
            fprintf ppf
              "@ @[<2>@{<hint>Hint@}:@ %a@ %a@ \
               introduced in the equation@ %a = %a@]"

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -77,17 +77,8 @@ let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
   else Errortrace.Structured.Keep
 
 let printing_status = function
-  | Errortrace.Diff { ctx = Some _; _} -> Errortrace.Structured.Context
-  | Errortrace.Diff d -> diff_printing_status d.d
-  | _ -> Errortrace.Structured.Keep
-
-
-(** Keep elements that are [Diff _ ]  *)
-let simplify_trace tr =
-  List.filter_map (function
-      | Errortrace.Diff d -> Some d
-      | _ -> None)
-    tr
+  | { Errortrace.ctx = Some _; _} -> Errortrace.Structured.Context
+  | d -> diff_printing_status d.Errortrace.d
 
 let is_unit_param env ty =
   let ty, vars = Btype.tpoly_get_poly ty in
@@ -336,7 +327,7 @@ let explain_univar = function
       doc_printf "%a" (pp_print_list ~pp_sep pp) delta
 
 let explanation (type variety) intro
-  : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
+  : (Errortrace.expanded_type, variety) Errortrace.root -> _ = function
   | Errortrace.Escape {kind; context} ->
     let pre =
       match context, kind with
@@ -392,7 +383,6 @@ let explanation (type variety) intro
         *)
     end
   | Univar um -> Some (explain_univar um)
-  | Diff _ -> None
 
 let mismatch intro expl =
   match expl with
@@ -425,10 +415,8 @@ let warn_on_missing_def env ppf t =
       end
   | _ -> ()
 
-let prepare_expansion_head (h,empty_tr)= match h with
-  | Errortrace.Diff d ->
-      Some (Errortrace.map_ctx (may_prepare_expansion empty_tr) d)
-  | _ -> None
+let prepare_expansion_head (h,empty_tr)=
+  Errortrace.map_ctx (may_prepare_expansion empty_tr) h
 
 let head_error_printer mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
@@ -516,10 +504,9 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   let tr = Errortrace.map hide_variant tr in
   let str = structured_trace env tr in
   with_labels (not !Clflags.classic) (fun () ->
-      let tr = simplify_trace str.tr in
-      let head = Option.bind str.top prepare_expansion_head in
+      let head = Option.map prepare_expansion_head str.top in
       let head_error = head_error_printer mode txt1 txt2 head in
-      let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
+      let tr = List.map (Errortrace.map_ctx prepare_expansion) str.tr in
       let tr = trees_of_trace mode tr in
       let mis = mismatch txt1 str.expl in
       fprintf ppf
@@ -570,13 +557,10 @@ module Subtype = struct
      while being *just* different enough (it's only [Diff]) for the abstraction
      to be nonobvious.  Someday, perhaps... *)
 
-  let printing_status = function
-    | Errortrace.Subtype.Diff d -> diff_printing_status d
-
   let prepare_unification_trace env f tr =
     let tr = Errortrace.map f tr in
-    match tr with
-    | [] -> None, None
+    match tr.path with
+    | [] -> None, Option.map (fun x -> Errortrace.Structured.Standard x) tr.root
     | _ ->
         let str = structured_trace env tr in
         match str.top with
@@ -585,45 +569,31 @@ module Subtype = struct
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in
-    let htr = Errortrace.Structured.parse_simple printing_status tr in
-    Some htr, None
+    Errortrace.Structured.parse_simple printing_status tr
 
-  let trace filter_trace get_diff fst txt ppf htr =
+  let trace filter_trace fst txt ppf htr =
     with_labels (not !Clflags.classic) (fun () ->
       match htr with
       | Some (elt,tr) ->
-        let diffed_elt = get_diff elt in
+        let diffed_elt =
+          Errortrace.map_ctx (trees_of_type_expansion Type) elt
+        in
         let tr = filter_trace tr in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
-        let tr =
-          match fst, diffed_elt with
-          | true, Some elt -> elt :: tr
-          | _, _ -> tr
-        in
+        let tr = if fst then diffed_elt :: tr else tr in
         trace fst txt ppf tr
       | None -> ()
     )
 
-  let no_ctx d = { Errortrace.d; ctx = None}
   let rec filter_subtype_trace keep_last = function
     | [] -> []
-    | [Errortrace.Subtype.Diff d as elt]
+    | [elt]
       when printing_status elt = Errortrace.Structured.Optional_refinement ->
-        if keep_last then [no_ctx d] else []
-    | Errortrace.Subtype.Diff d :: rem ->
-        no_ctx d :: filter_subtype_trace keep_last rem
+        if keep_last then [elt] else []
+    | d :: rem -> d :: filter_subtype_trace keep_last rem
 
-  let unification_get_diff = function
-    | Errortrace.Diff diff ->
-        Some (Errortrace.map_ctx (trees_of_type_expansion Type) diff)
-    | _ -> None
-
-  let subtype_get_diff = function
-    | Errortrace.Subtype.Diff diff ->
-        let d = Errortrace.map_diff (trees_of_type_expansion Type) diff in
-        Some { Errortrace.d; ctx = None }
 
   let error
         ppf
@@ -632,22 +602,20 @@ module Subtype = struct
         txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub, _ = prepare_trace prepare_expansion tr_sub in
-      let tr_unif, expl_unif =
+      let tr_sub = prepare_trace prepare_expansion tr_sub in
+      let tr_unif, expl =
         prepare_unification_trace env prepare_expansion tr_unif
       in
-      let keep_first = match tr_unif, expl_unif with
+      let keep_first = match tr_unif, expl with
         | None, Some (Standard (Obj _ | Variant _ | Escape _ ))
         | None, None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
-        (trace (filter_subtype_trace keep_first) subtype_get_diff true txt1)
-        tr_sub;
-      if tr_unif = None && expl_unif = None then fprintf ppf "@]" else
-        let mis = mismatch (doc_printf "Within this type") expl_unif in
+        (trace (filter_subtype_trace keep_first) true txt1) tr_sub;
+      if tr_unif = None && expl = None then fprintf ppf "@]" else
+        let mis = mismatch (doc_printf "Within this type") expl in
         fprintf ppf "%a%a%t@]"
-          (trace simplify_trace unification_get_diff false
-             "is not compatible with type") tr_unif
+          (trace Fun.id false "is not compatible with type") tr_unif
           (pp_print_option pp_doc) mis
           Ident_conflicts.err_print
     )

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -66,22 +66,28 @@ and trace_elt txt ppf = function
         pp_type_expansion got
         pp_type_expansion expected
 
-(**
-This module contains helper functions to split the error trace into two parts:
-- a list of meaningful context difference element
-- a root explanation
-*)
 module Structured_trace = struct
 
-(** Flatten the trace and remove elements that are always discarded
-    during printing *)
+
+  type ('a,'b) t = {
+  top: ('a * bool) option;
+  tr: 'a list;
+  expl: 'b
+}
+(**
+This module contains helper functions to split the error trace into three parts:
+- {!top} the first element of the trace
+- {!tr} a list of meaningful context difference element
+- {!expl} a root explanation for a type error
+*)
 
 (** The first intermediary representation splits the trace into four parts:
-- the head element of the trace
-- the trace elements in reverse order situated before the last method or tag
-  difference
-- the last method or tag context, and the list of elements after it
-- the last element that could be optioannly printed
+- the {!head} element of the trace
+- the {!top_to_ctx} trace elements in reverse order situated before the last
+  method or tag difference
+- {!last_ctx}: the last method or tag context, and the list of elements after it
+- {!optional}: the last element that might be printed if we don't discover a
+  better element to print later on.
 *)
 type 'a segments =
   {
@@ -90,6 +96,7 @@ type 'a segments =
     last_ctx:('a * 'a list) option;
     optional: 'a option
   }
+
 
 let head_segment hd =
   { head = hd; before=[]; last_ctx = None; optional = None }
@@ -102,7 +109,7 @@ let add x s = match s.last_ctx with
 
 (** Add a new context, add the last context contents to the {!before} trace *)
 let add_ctx c s = match s.last_ctx with
-  | None ->  { s with optional = None; last_ctx = Some (c,[]) }
+  | None -> { s with optional = None; last_ctx = Some (c,[]) }
   | Some (_ctx, rest) -> {
       head = s.head;
       optional = None;
@@ -177,6 +184,8 @@ let promote_diff env {Errortrace.got; expected} =
   res
 
 let merge env s =
+  (* First, we commit the last contextualized segment of the trace to the
+     trace *)
   let rtr, opt, maybe_compact = match s.last_ctx with
     | None -> s.before, s.optional, false
     | Some (ctx, rest) -> rest @ ctx :: s.before, None, true
@@ -184,28 +193,27 @@ let merge env s =
   let head, rtr, expl = match rtr with
     | Errortrace.Diff d :: _ ->
         begin match promote_diff env d.d with
-        | Some p -> [s.head], rtr, Some p
-        | None -> [s.head], rtr, None
+        | Some p -> Some s.head, rtr, Some p
+        | None -> Some s.head, rtr, None
         end
-    | expl :: rest -> [s.head], rest, Some (Standard expl)
+    | expl :: rest -> Some s.head, rest, Some (Standard expl)
     | [] ->
         begin match s.head with
-        | Errortrace.Diff d -> [s.head], [], promote_diff env d.d
-        | expl -> [], [], Some (Standard expl)
+        | Errortrace.Diff d -> Some s.head, [], promote_diff env d.d
+        | expl -> None, [], Some (Standard expl)
         end
   in
-  let rtr =
-    match expl, opt with
-    | None, Some opt -> head @ List.rev (opt :: rtr)
-    | Some _, _ | None, _  -> head @ List.rev rtr
+  let tr = match expl, opt with
+    | None, Some opt -> List.rev (opt :: rtr)
+    | Some _, _ | None, _  -> List.rev rtr
   in
-  let compact = match rtr, maybe_compact with
-    | [_], _ | [_;_], true -> true
-    | _ -> false
+  let compact head = match tr, maybe_compact with
+    | [], _ | [_], true -> head, true
+    | _ -> head, false
   in
-  rtr, expl, compact
+  { top=Option.map compact head; tr; expl }
 
-  let split env status s= merge env (segment status s)
+  let split env status s = merge env (segment status s)
 end
 
 let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
@@ -531,7 +539,7 @@ let warn_on_missing_def env ppf t =
       end
   | _ -> ()
 
-let prepare_expansion_head empty_tr = function
+let prepare_expansion_head (h,empty_tr)= match h with
   | Errortrace.Diff d ->
       Some (Errortrace.map_ctx (may_prepare_expansion empty_tr) d)
   | _ -> None
@@ -616,18 +624,14 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   (* We want to substitute in the opposite order from [Eqtype] *)
   Variable_names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
   let tr = Errortrace.map hide_variant tr in
-  let tr, expl, compact = Structured_trace.split env printing_status tr in
-  let elt, tr = match tr with
-    | [] -> None, tr
-    | hd :: tr -> Some hd, tr
-  in
+  let str = Structured_trace.split env printing_status tr in
   with_labels (not !Clflags.classic) (fun () ->
-      let tr = simplify_trace tr in
-      let head = Option.bind elt (prepare_expansion_head compact) in
+      let tr = simplify_trace str.tr in
+      let head = Option.bind str.top prepare_expansion_head in
       let head_error = head_error_printer mode txt1 txt2 head in
       let tr = List.map (Errortrace.map_ctx prepare_expansion) tr in
       let tr = trees_of_trace mode tr in
-      let mis = mismatch txt1 expl in
+      let mis = mismatch txt1 str.expl in
       fprintf ppf
         "@[<v>\
          @[%a%a@]%a%a\
@@ -682,10 +686,12 @@ module Subtype = struct
   let prepare_unification_trace env f tr =
     let tr = Errortrace.map f tr in
     match tr with
-    | [] -> [], None
+    | [] -> None, None
     | _ ->
-        let tr, expl, _ = Structured_trace.split env printing_status tr in
-        tr, expl
+        let str = Structured_trace.split env printing_status tr in
+        match str.top with
+        | Some (h,_) -> Some (h,str.tr), str.expl
+        | None -> None, str.expl
 
   let prepare_trace f tr =
     let tr = Errortrace.Subtype.map f tr in
@@ -698,14 +704,14 @@ module Subtype = struct
       | Some x -> x :: rtr
       | None -> rtr
     in
-    s.head :: List.rev rtr, None
+    Some (s.head, List.rev rtr), None
 
-  let trace filter_trace get_diff fst txt ppf tr =
+  let trace filter_trace get_diff fst txt ppf htr =
     with_labels (not !Clflags.classic) (fun () ->
-      match tr with
-      | elt :: tr' ->
+      match htr with
+      | Some (elt,tr) ->
         let diffed_elt = get_diff elt in
-        let tr = filter_trace tr' in
+        let tr = filter_trace tr in
         let tr =
           trees_of_trace Type
           @@ List.map (Errortrace.map_ctx prepare_expansion) tr in
@@ -715,7 +721,7 @@ module Subtype = struct
           | _, _ -> tr
         in
         trace fst txt ppf tr
-      | _ -> ()
+      | None -> ()
     )
 
   let no_ctx d = { Errortrace.d; ctx = None}
@@ -749,12 +755,13 @@ module Subtype = struct
         prepare_unification_trace env prepare_expansion tr_unif
       in
       let keep_first = match tr_unif, expl_unif with
-        | [], Some (Standard (Obj _ | Variant _ | Escape _ )) | [], None -> true
+        | None, Some (Standard (Obj _ | Variant _ | Escape _ ))
+        | None, None -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
         (trace (filter_subtype_trace keep_first) subtype_get_diff true txt1)
         tr_sub;
-      if tr_unif = [] && expl_unif = None then fprintf ppf "@]" else
+      if tr_unif = None && expl_unif = None then fprintf ppf "@]" else
         let mis = mismatch (doc_printf "Within this type") expl_unif in
         fprintf ppf "%a%a%t@]"
           (trace simplify_trace unification_get_diff false

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -15,12 +15,34 @@
 
 open Format_doc
 open Outcometree
+module Style = Misc.Style
+
+let highlight x = { highlighted=true; item=x }
+
+let plain x = { highlighted=false; item=x }
+
 
 exception Ellipsis
 
 let cautious f ppf arg =
   try f ppf arg with
     Ellipsis -> fprintf ppf "..."
+
+let highlight_if b printer ppf x =
+  if b then Style.highlight printer ppf x
+  else printer ppf x
+
+let highlight_open_if ppf b =
+  if b then fprintf ppf "@{<diff>"
+  else ()
+
+let highlight_close_if ppf b =
+  if b then fprintf ppf "@}"
+  else ()
+
+
+let may_highlight printer ppf x =
+  highlight_if x.highlighted printer ppf x.item
 
 let print_lident ppf = function
   | "::" -> pp_print_string ppf "(::)"
@@ -34,6 +56,7 @@ let rec print_ident ppf =
       print_ident ppf id; pp_print_char ppf '.'; print_lident ppf s
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
+  | Oide_highlight (_,id) -> Style.highlight print_ident ppf id
 
 let out_ident = ref print_ident
 
@@ -271,94 +294,121 @@ let rec print_list pr sep ppf =
   | a :: l -> pr ppf a; sep ppf; print_list pr sep ppf l
 
 let pr_present =
-  print_list (fun ppf s -> fprintf ppf "`%s" s) (fun ppf -> fprintf ppf "@ ")
+  print_list
+    (may_highlight (fun ppf s -> fprintf ppf "`%s" s))
+    (fun ppf -> fprintf ppf "@ ")
 
 let pr_var = Pprintast.Doc.tyvar
 let ty_var ~non_gen ppf s =
-  pr_var ppf (if non_gen then "_" ^ s else s)
+  highlight_if non_gen.highlighted pr_var ppf
+    (if non_gen.item then "_" ^ s else s)
 
 let pr_vars =
   print_list pr_var (fun ppf -> fprintf ppf "@ ")
 
-let print_arg_label ppf (lbl : Asttypes.arg_label) =
+let print_arg_label ~highlight ppf (lbl : Asttypes.arg_label) =
   match lbl with
   | Nolabel -> ()
-  | Labelled s -> fprintf ppf "%a:" print_lident s
-  | Optional s -> fprintf ppf "?%a:" print_lident s
+  | Labelled s -> fprintf ppf "%a:" (highlight_if highlight print_lident) s
+  | Optional s -> fprintf ppf "?%a:" (highlight_if highlight print_lident) s
 
-let rec print_out_type ppf =
+let variant_prefix ~closed ~tags ppf =
+  let str x = highlight_if closed.highlighted pp_print_string ppf x in
+  match closed.item, tags with
+  | true, None -> pp_print_string ppf " "
+  | true, Some _ -> str "< "
+  | false, None -> str "> "
+  | false, Some _ -> str "? "
+
+let comma_sep ppf () = fprintf ppf ","
+let prod_sep ~highlight ppf () =
+  pp_print_string ppf " ";
+  highlight_if highlight pp_print_string ppf "*"
+let and_sep ppf () = fprintf ppf " &"
+
+let rec print_out_type ?(highlight=false) ppf =
   function
   | Otyp_alias {non_gen; aliased; alias } ->
+      highlight_open_if ppf highlight;
       fprintf ppf "@[%a@ as %a@]"
-        print_out_type aliased
-        (ty_var ~non_gen) alias
+        (print_out_type ~highlight:false) aliased
+        (ty_var ~non_gen) alias;
+      highlight_close_if ppf highlight;
   | Otyp_poly (sl, ty) ->
+      highlight_open_if ppf highlight;
       fprintf ppf "@[<hov 2>%a.@ %a@]"
         pr_vars sl
-        print_out_type ty
+        (print_out_type ~highlight:false) ty;
+      highlight_close_if ppf highlight;
+  | Otyp_highlight (_,x) -> print_out_type ~highlight:true ppf x
   | ty ->
-      print_out_type_1 ppf ty
+      print_out_type_1 ~highlight ppf ty
 
-and print_out_type_1 ppf =
+and print_out_type_1 ?(highlight=false) ppf =
   function
     Otyp_arrow (lab, ty1, ty2) ->
       pp_open_box ppf 0;
-      print_arg_label ppf lab;
+      print_arg_label ~highlight:lab.highlighted ppf lab.item;
       print_out_type_2 ~arg:true ppf ty1;
-      pp_print_string ppf " ->";
+      pp_print_string ppf " ";
+      highlight_if highlight pp_print_string ppf "->";
       pp_print_space ppf ();
       print_out_type_1 ppf ty2;
       pp_close_box ppf ()
   | Otyp_functor (lab, id, pack, ty) ->
       pp_open_box ppf 0;
-      print_arg_label ppf lab;
+      print_arg_label ~highlight:lab.highlighted ppf lab.item;
       pp_print_string ppf "(module ";
       print_ident ppf id;
       pp_print_string ppf " : ";
       print_package ppf pack;
-      pp_print_string ppf ") ->";
+      highlight_if highlight pp_print_string ppf ") ->";
       pp_print_space  ppf ();
       print_out_type_1 ppf ty;
       pp_close_box ppf ()
-  | ty -> print_out_type_2 ~arg:false ppf ty
-and print_out_type_2 ~arg ppf =
+  | Otyp_highlight (_,x) -> print_out_type_1 ~highlight:true ppf x
+  | ty -> print_out_type_2 ~arg:false ~highlight ppf ty
+and print_out_type_2 ~arg ?(highlight=false) ppf =
   function
     Otyp_tuple tyl ->
       (* Tuples require parens in argument function argument position (~arg)
          when the first element has a label. *)
       let parens =
         match tyl with
-        | (Some _, _) :: _ -> arg
+        | ({item=Some _; _}, _) :: _ -> arg
         | _ -> false
       in
       if parens then pp_print_char ppf '(';
       let print_elem ppf (label, ty) =
         pp_open_box ppf 0;
-        print_label_type ppf label;
+        may_highlight print_label_type ppf label;
         print_simple_out_type ppf ty;
         pp_close_box ppf ()
       in
-      fprintf ppf "@[<0>%a@]" (print_typlist print_elem " *") tyl;
+      fprintf ppf "@[<0>%a@]"
+        (print_typlist print_elem (prod_sep ~highlight)) tyl;
       if parens then pp_print_char ppf ')'
-  | ty -> print_simple_out_type ppf ty
-and print_simple_out_type ppf =
+  | Otyp_highlight (_,x) -> print_out_type_2 ~arg ~highlight:true ppf x
+  | ty -> print_simple_out_type ~highlight ppf ty
+and print_simple_out_type ?(highlight=false) ppf =
   function
     Otyp_class (id, tyl) ->
-      fprintf ppf "@[%a#%a@]" print_typargs tyl print_ident id
+      fprintf ppf "@[%a#%a@]" print_typargs tyl
+        (highlight_if highlight print_ident) id
   | Otyp_constr (id, tyl) ->
       pp_open_box ppf 0;
       print_typargs ppf tyl;
-      print_ident ppf id;
+      highlight_if highlight print_ident ppf id;
       pp_close_box ppf ()
-  | Otyp_object { fields; row} ->
-      fprintf ppf "@[<2>< %a >@]"
-        (print_object_fields row) fields
-  | Otyp_stuff s -> pp_print_string ppf s
-  | Otyp_var (non_gen, s) -> ty_var ~non_gen ppf s
-  | Otyp_variant (row_fields, closed, tags) ->
-      let print_present ppf =
-        function
-          None | Some [] -> ()
+  | Otyp_object {fields; row} ->
+      highlight_open_if ppf highlight;
+      fprintf ppf "@[<2>< %a >@]" (print_object_fields row) fields;
+      highlight_close_if ppf highlight
+  | Otyp_stuff s -> highlight_if highlight pp_print_string ppf s
+  | Otyp_var (non_gen, s) -> highlight_if highlight (ty_var ~non_gen) ppf s
+  | Otyp_variant { fields=row_fields; closed; presents=tags } ->
+      let print_present ppf = function
+        | None | Some [] -> ()
         | Some l -> fprintf ppf "@;<1 -2>> @[<hov>%a@]" pr_present l
       in
       let print_fields ppf =
@@ -369,32 +419,41 @@ and print_simple_out_type ppf =
         | Ovar_typ typ ->
            print_simple_out_type ppf typ
       in
-      fprintf ppf "@[<hov>[%s@[<hv>@[<hv>%a@]%a@]@ ]@]"
-        (if closed then if tags = None then " " else "< "
-         else if tags = None then "> " else "? ")
+      highlight_open_if ppf highlight;
+      fprintf ppf "@[<hov>[%t@[<hv>@[<hv>%a@]%a@]@ ]@]"
+        (variant_prefix ~closed ~tags)
         print_fields row_fields
-        print_present tags
+        print_present tags;
+      highlight_close_if ppf highlight
   | Otyp_alias _ | Otyp_poly _ | Otyp_arrow _
   | Otyp_functor _ | Otyp_tuple _ as ty ->
       pp_open_box ppf 1;
       pp_print_char ppf '(';
-      print_out_type ppf ty;
+      print_out_type ~highlight ppf ty;
       pp_print_char ppf ')';
       pp_close_box ppf ()
   | Otyp_abstract | Otyp_open | Otyp_external _
   | Otyp_sum _ | Otyp_manifest (_, _) -> ()
   | Otyp_record lbls -> print_record_decl ppf lbls
   | Otyp_module pack ->
-      fprintf ppf "@[<1>(module %a)@]" print_package pack
+      fprintf ppf "@[<1>(%a %a)@]"
+        (highlight_if highlight pp_print_string) "module"
+        print_package pack
+
   | Otyp_attribute (t, attr) ->
-      fprintf ppf "@[<1>(%a [@@%s])@]" print_out_type t attr.oattr_name
+      fprintf ppf "@[<1>(%a [@@%s])@]"
+        (print_out_type ~highlight) t attr.oattr_name
+  | Otyp_highlight (_,x) -> print_simple_out_type ~highlight:true ppf x
 and print_package ppf pack =
   fprintf ppf "%a" print_ident pack.opack_path;
   let first = ref true in
   List.iter
     (fun (s, t) ->
       let sep = if !first then (first := false; "with") else "and" in
-      fprintf ppf " %s type %s = %a" sep s print_out_type t
+      fprintf ppf " %s type %a = %a"
+        sep
+        (may_highlight pp_print_string) s
+        (print_out_type ~highlight:false) t
     )
     pack.opack_constraints
 and print_record_decl ppf lbls =
@@ -403,27 +462,41 @@ and print_record_decl ppf lbls =
 and print_object_fields row ppf =
   function
     [] ->
-      begin match row with
+      begin match row.item with
       | Orow_closed -> ()
-      | Orow_open_anonymous -> fprintf ppf ".."
-      | Orow_open ty -> fprintf ppf ".. as %a" print_out_type ty
+      | Orow_open_anonymous ->
+          highlight_if row.highlighted pp_print_string ppf ".."
+      | Orow_open ty ->
+         highlight_open_if ppf row.highlighted;
+         fprintf ppf ".. as %a"
+           (print_out_type ~highlight:false) ty;
+         highlight_close_if ppf row.highlighted
       end
   | [s, t] ->
-      fprintf ppf "%a : %a" print_lident s print_out_type t;
-      if row <> Orow_closed then fprintf ppf ";@ ";
+      fprintf ppf "%a : %a"
+        (may_highlight print_lident) s
+        (print_out_type ~highlight:false) t;
+      if row.item <> Orow_closed then fprintf ppf ";@ ";
       print_object_fields row ppf []
   | (s, t) :: l ->
-      fprintf ppf "%s : %a;@ %a"
-        s print_out_type t (print_object_fields row) l
-and print_row_field ppf (l, opt_amp, tyl) =
+      fprintf ppf "%a : %a;@ %a"
+        (may_highlight pp_print_string) s
+        (print_out_type ~highlight:false) t
+        (print_object_fields row) l
+and print_row_field ppf hfield =
+  let field = hfield.item in
   let pr_of ppf =
-    if opt_amp then fprintf ppf " of@ &@ "
-    else if tyl <> [] then fprintf ppf " of@ "
+    if field.constant.item then
+      fprintf ppf " of@ %a@ "
+        (highlight_if field.constant.highlighted pp_print_string) "&"
+    else if field.argument_conjunction <> [] then fprintf ppf " of@ "
     else fprintf ppf ""
   in
-  fprintf ppf "@[<hv 2>`%a%t%a@]" print_lident l pr_of
-    (print_typlist print_out_type " &")
-    tyl
+  highlight_open_if ppf hfield.highlighted;
+  fprintf ppf "@[<hv 2>`%a%t%a@]" (may_highlight print_lident) field.name pr_of
+    (print_typlist print_out_type and_sep)
+    field.argument_conjunction;
+  highlight_close_if ppf hfield.highlighted
 and print_typlist : 'a . (_ -> 'a -> _) -> _ -> _ -> 'a list -> _ =
   fun print_elem sep ppf tyl ->
   match tyl with
@@ -431,7 +504,7 @@ and print_typlist : 'a . (_ -> 'a -> _) -> _ -> _ -> 'a list -> _ =
   | [ty] -> print_elem ppf ty
   | ty :: tyl ->
       print_elem ppf ty;
-      pp_print_string ppf sep;
+      sep ppf ();
       pp_print_space ppf ();
       print_typlist print_elem sep ppf tyl
 and print_typargs ppf =
@@ -441,7 +514,7 @@ and print_typargs ppf =
   | tyl ->
       pp_open_box ppf 1;
       pp_print_char ppf '(';
-      print_typlist print_out_type "," ppf tyl;
+      print_typlist print_out_type comma_sep ppf tyl;
       pp_print_char ppf ')';
       pp_close_box ppf ();
       pp_print_space ppf ()
@@ -451,18 +524,18 @@ and print_out_label ppf {olab_name; olab_mut; olab_atomic; olab_type} =
      | Mutable -> "mutable "
      | Immutable -> "")
     print_lident olab_name
-    print_out_type olab_type
+    (print_out_type ~highlight:false) olab_type
     (match olab_atomic with Atomic -> " [@atomic]" | Nonatomic -> "")
 
 let out_label = ref print_out_label
 
-let out_type = ref print_out_type
+let out_type = ref (print_out_type ~highlight:false)
 
 let out_type_args = ref print_typargs
 
 (* Class types *)
 
-let print_type_parameter ?(non_gen=false) ppf s =
+let print_type_parameter ?(non_gen=plain false) ppf s =
   if s = "_" then fprintf ppf "_" else ty_var ~non_gen ppf s
 
 let type_parameter ppf {ot_non_gen=non_gen; ot_name=ty; ot_variance=var,inj} =
@@ -491,12 +564,13 @@ let rec print_out_class_type ppf =
         function
           [] -> ()
         | tyl ->
-            fprintf ppf "@[<1>[%a]@]@ " (print_typlist !out_type ",") tyl
+            fprintf ppf "@[<1>[%a]@]@ " (print_typlist !out_type comma_sep) tyl
       in
       fprintf ppf "@[%a%a@]" pr_tyl tyl print_ident id
   | Octy_arrow (lab, ty, cty) ->
-      fprintf ppf "@[%a%a ->@ %a@]" print_arg_label lab
-        (print_out_type_2 ~arg:true) ty print_out_class_type cty
+      fprintf ppf "@[%a%a ->@ %a@]" (print_arg_label ~highlight:false) lab
+        (print_out_type_2 ~highlight:false ~arg:true) ty
+        print_out_class_type cty
   | Octy_signature (self_ty, csil) ->
       let pr_param ppf =
         function
@@ -802,16 +876,19 @@ and print_out_constr ppf constr =
           pp_print_string ppf name
       | _ ->
           fprintf ppf "@[<2>%s of@ %a@]" name
-            (print_typlist print_simple_out_type " *") tyl
+            (print_typlist print_simple_out_type (prod_sep ~highlight:false))
+            tyl
       end
   | Some ret_type ->
       begin match tyl with
       | [] ->
-          fprintf ppf "@[<2>%s :@ %a@]" name print_simple_out_type  ret_type
+          fprintf ppf "@[<2>%s :@ %a@]" name
+            (print_simple_out_type ~highlight:false) ret_type
       | _ ->
           fprintf ppf "@[<2>%s :@ %a -> %a@]" name
-            (print_typlist print_simple_out_type " *")
-            tyl print_simple_out_type ret_type
+            (print_typlist print_simple_out_type (prod_sep ~highlight:false))
+            tyl
+            (print_simple_out_type ~highlight:false) ret_type
       end
 
 and print_out_extension_constructor ppf ext =
@@ -820,8 +897,7 @@ and print_out_extension_constructor ppf ext =
         [] -> fprintf ppf "%a" print_lident ext.oext_type_name
       | [ty_param] ->
         fprintf ppf "@[%a@ %a@]"
-          type_parameter
-          ty_param
+          type_parameter ty_param
           print_lident ext.oext_type_name
       | _ ->
         fprintf ppf "@[(@[%a)@]@ %a@]"

--- a/typing/oprint.mli
+++ b/typing/oprint.mli
@@ -15,6 +15,9 @@
 
 open Outcometree
 
+val highlight: 'a -> 'a highlightable
+val plain: 'a -> 'a highlightable
+
 type 'a printer = 'a Format_doc.printer ref
 type 'a toplevel_printer = (Format.formatter -> 'a -> unit) ref
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1115,13 +1115,33 @@ let alias_nongen_row mode px ty =
           Aliases.add_proxy px
     | _ -> ()
 
-let rec tree_of_typexp mode ty =
+type highlight_target =
+  | Type of Outcometree.highlight_kind * Types.type_expr
+  | Type_constructor of Path.t
+let highlight_type k ty = Some (Type(k,ty))
+
+let match_target target ty = match target with
+  | None -> None
+  | Some (Type (k,tty)) ->
+      if Types.Transient_expr.(TransientTypeOps.equal ty (repr tty)) then
+        Some k
+      else None
+  | Some (Type_constructor tp) -> match ty.desc with
+    | Tconstr (p,_,_) -> if Path.same p tp then Some Paired else None
+    | _ -> None
+
+let highlight h o = match h  with
+  | None -> o
+  | Some k -> Otyp_highlight (k,o)
+
+let rec tree_of_typexp htarget mode ty =
   let px = proxy ty in
+  let highlight = highlight (match_target htarget px) in
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
    let non_gen = is_non_gen mode (Transient_expr.type_expr px) in
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
-   Otyp_var (plain non_gen, name) else
-
+   highlight (Otyp_var (plain non_gen, name))
+  else
   let pr_typ () =
     let tty = Transient_expr.repr ty in
     match tty.desc with
@@ -1145,11 +1165,11 @@ let rec tree_of_typexp mode ty =
                      loops. *)
                   if Aliases.is_aliased_proxy (proxy mono)
                   then Otyp_stuff "<hidden>"
-                  else tree_of_typexp mode ty
+                  else tree_of_typexp htarget mode ty
               | _ -> Otyp_stuff "<hidden>"
             else Otyp_stuff "<hidden>"
-          else tree_of_typexp mode ty1 in
-        Otyp_arrow (plain lab, t1, tree_of_typexp mode ty2)
+          else tree_of_typexp htarget mode ty1 in
+        Otyp_arrow (plain lab, t1, tree_of_typexp htarget mode ty2)
     | Tfunctor (l, id, pack, ty) ->
         let lab =
           if !print_labels || is_optional l then l else Nolabel
@@ -1160,20 +1180,21 @@ let rec tree_of_typexp mode ty =
           Env.add_module ~noalias:true (Ident.of_unscoped id) Mp_present mty env
         in
         let ty =
-          wrap_env ~keep_short_paths:true fenv (tree_of_typexp mode) ty
+          wrap_env ~keep_short_paths:true fenv (tree_of_typexp htarget mode) ty
         in
         let id = Oide_ident { printed_name = Ident.Unscoped.name id } in
-        Otyp_functor (plain lab, id, tree_of_package mode pack, ty)
+        Otyp_functor (plain lab, id, tree_of_package htarget mode pack, ty)
     | Ttuple tyl ->
-        Otyp_tuple (tree_of_labeled_typlist mode tyl)
+        Otyp_tuple (tree_of_labeled_typlist htarget mode tyl)
     | Tconstr(p, tyl, _abbrev) ->
         let p', s = best_type_path p in
         let tyl' = apply_subst s tyl in
         if is_nth s && not (tyl'=[])
-        then tree_of_typexp mode (List.hd tyl')
+        then tree_of_typexp htarget mode (List.hd tyl')
         else begin
           Internal_names.add p';
-          Otyp_constr (tree_of_best_type_path p p', tree_of_typlist mode tyl')
+          let args = tree_of_typlist htarget mode tyl' in
+          Otyp_constr (tree_of_best_type_path p p', args)
         end
     | Tvariant row ->
         let Row {fields; name; closed; _} = row_repr row in
@@ -1195,7 +1216,7 @@ let rec tree_of_typexp mode ty =
         | Some(p, tyl) when nameable_row row ->
             let (p', s) = best_type_path p in
             let id = tree_of_best_type_path p p' in
-            let args = tree_of_typlist mode (apply_subst s tyl) in
+            let args = tree_of_typlist htarget mode (apply_subst s tyl) in
             let out_variant =
               if is_nth s then List.hd args else Otyp_constr (id, args) in
             if closed && all_present then
@@ -1204,33 +1225,33 @@ let rec tree_of_typexp mode ty =
               let closed = plain closed in
               Otyp_variant { fields=Ovar_typ out_variant; closed; presents}
         | _ ->
-            let fields = List.map (tree_of_row_field mode) fields in
+            let fields = List.map (tree_of_row_field htarget mode) fields in
             let closed = plain closed in
             Otyp_variant {fields=Ovar_fields fields; closed; presents}
         end
     | Tobject (fi, nm) ->
-        tree_of_typobject mode fi !nm
+        tree_of_typobject htarget mode fi !nm
     | Tnil | Tfield _ ->
-        tree_of_typobject mode ty None
+        tree_of_typobject htarget mode ty None
     | Tsubst _ ->
         (* This case should only happen when debugging the compiler *)
         Otyp_stuff "<Tsubst>"
     | Tlink _ ->
         fatal_error "Out_type.tree_of_typexp"
     | Tpoly (ty, []) ->
-        tree_of_typexp mode ty
+        tree_of_typexp htarget mode ty
     | Tpoly (ty, tyl) ->
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
           prerr_string "; " in *)
-        if tyl = [] then tree_of_typexp mode ty else begin
+        if tyl = [] then tree_of_typexp htarget mode ty else begin
           let tyl = List.map Transient_expr.repr tyl in
           let old_delayed = !Aliases.delayed in
           (* Make the names delayed, so that the real type is
              printed once when used as proxy *)
           List.iter Aliases.add_delayed tyl;
           let tl = List.map Variable_names.(name_of_type new_name) tyl in
-          let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
+          let tr = Otyp_poly (tl, tree_of_typexp htarget mode ty) in
           (* Forget names when we leave scope *)
           Variable_names.remove_names tyl;
           Aliases.delayed := old_delayed; tr
@@ -1238,7 +1259,7 @@ let rec tree_of_typexp mode ty =
     | Tunivar _ ->
         Otyp_var (plain false, Variable_names.(name_of_type new_name) tty)
     | Tpackage pack ->
-        let pack = tree_of_package mode pack in
+        let pack = tree_of_package htarget mode pack in
         Otyp_module pack
   in
   Aliases.remove_delay px;
@@ -1249,35 +1270,37 @@ let rec tree_of_typexp mode ty =
     (* add_printed_proxy chose a name, thus the name generator
        doesn't matter.*)
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
-    Otyp_alias {non_gen=plain non_gen;  aliased = pr_typ (); alias } end
-  else pr_typ ()
+    highlight
+      (Otyp_alias {non_gen=plain non_gen;  aliased = pr_typ (); alias })
+  end
+  else highlight (pr_typ ())
 
-and tree_of_row_field mode (l, f) =
+and tree_of_row_field htarget mode (l, f) =
   match row_field_repr f with
   | Rpresent None | Reither(true, [], _) ->
      plain { name = plain l; constant=plain false; argument_conjunction=[]}
   | Rpresent(Some ty) ->
       plain { name = plain l;
         constant=plain false;
-        argument_conjunction=[tree_of_typexp mode ty]
+        argument_conjunction=[tree_of_typexp htarget mode ty]
       }
   | Reither(c, tyl, _) ->
      plain {
        name = plain l;
        constant = plain c (* contradiction if [c=true] *);
-       argument_conjunction = tree_of_typlist mode tyl
+       argument_conjunction = tree_of_typlist htarget mode tyl
      }
   | Rabsent ->
      (* actually, an error *)
       plain { name = plain l; constant=plain false; argument_conjunction=[] }
 
-and tree_of_typlist mode tyl =
-  List.map (tree_of_typexp mode) tyl
+and tree_of_typlist htarget mode tyl =
+  List.map (tree_of_typexp htarget mode) tyl
 
-and tree_of_labeled_typlist mode tyl =
-  List.map (fun (label, ty) -> plain label, tree_of_typexp mode ty) tyl
+and tree_of_labeled_typlist htarget mode tyl =
+  List.map (fun (label, ty) -> plain label, tree_of_typexp htarget mode ty) tyl
 
-and tree_of_typobject mode fi nm =
+and tree_of_typobject htarget mode fi nm =
   begin match nm with
   | None ->
       let pr_fields fi =
@@ -1292,11 +1315,11 @@ and tree_of_typobject mode fi nm =
         let sorted_fields =
           List.sort
             (fun (n, _) (n', _) -> String.compare n n') present_fields in
-        tree_of_typfields mode rest sorted_fields in
+        tree_of_typfields htarget mode rest sorted_fields in
       let (fields, row) = pr_fields fi in
       Otyp_object { fields; row}
   | Some (p, _ty :: tyl) ->
-      let args = tree_of_typlist mode tyl in
+      let args = tree_of_typlist htarget mode tyl in
       let (p', s) = best_type_path p in
       assert (s = Id);
       Otyp_class (tree_of_best_type_path p p', args)
@@ -1304,7 +1327,7 @@ and tree_of_typobject mode fi nm =
       fatal_error "Out_type.tree_of_typobject"
   end
 
-and tree_of_typfields mode rest = function
+and tree_of_typfields htarget mode rest = function
   | [] ->
       let row =
         match get_desc rest with
@@ -1314,37 +1337,37 @@ and tree_of_typfields mode rest = function
         | Tvar _ | Tunivar _ ->
             Orow_open_anonymous
         | Tconstr _ ->
-            Orow_open (tree_of_typexp mode rest)
+            Orow_open (tree_of_typexp htarget mode rest)
         | Tnil -> Orow_closed
         | _ -> fatal_error "typfields (1)"
       in
       ([], plain row)
   | (s, t) :: l ->
-      let field = (plain s, tree_of_typexp mode t) in
-      let (fields, rest) = tree_of_typfields mode rest l in
+      let field = (plain s, tree_of_typexp htarget mode t) in
+      let (fields, rest) = tree_of_typfields htarget mode rest l in
       (field :: fields, rest)
 
-and tree_of_package mode {pack_path; pack_constraints} =
+and tree_of_package htarget mode {pack_path; pack_constraints} =
   let constraints (li,ty) =
-    plain (String.concat "." li), tree_of_typexp mode ty
+    plain (String.concat "." li), tree_of_typexp htarget mode ty
   in
   { opack_path = tree_of_path (Some Module_type) pack_path;
     opack_constraints = List.map constraints pack_constraints }
 
-let typexp mode ppf ty =
-  !Oprint.out_type ppf (tree_of_typexp mode ty)
+let typexp ?htarget mode ppf ty =
+  !Oprint.out_type ppf (tree_of_typexp htarget mode ty)
 
-let prepared_type_expr ppf ty = typexp Type ppf ty
+let prepared_type_expr ?htarget ppf ty = typexp ?htarget Type ppf ty
 
 (* "Half-prepared" type expression: [ty] should have had its names reserved, but
    should not have had its loops marked. *)
-let type_expr_with_reserved_names ppf ty =
+let type_expr_with_reserved_names ?htarget ppf ty =
   Aliases.reset ();
   Aliases.mark_loops ty;
-  prepared_type_expr ppf ty
+  prepared_type_expr ?htarget ppf ty
 
 
-let prepared_type_scheme ppf ty = typexp Type_scheme ppf ty
+let prepared_type_scheme ?htarget ppf ty = typexp ?htarget Type_scheme ppf ty
 
 (* Print one type declaration *)
 
@@ -1353,8 +1376,8 @@ let tree_of_constraints params =
     (fun ty list ->
        let ty' = unalias ty in
        if proxy ty != proxy ty' then
-         let tr = tree_of_typexp Type_scheme ty in
-         (tr, tree_of_typexp Type_scheme ty') :: list
+         let tr = tree_of_typexp None Type_scheme ty in
+         (tr, tree_of_typexp None Type_scheme ty') :: list
        else list)
     params []
 
@@ -1399,16 +1422,16 @@ let tree_of_label l =
     olab_name = Ident.name l.ld_id;
     olab_mut = l.ld_mutable;
     olab_atomic = l.ld_atomic;
-    olab_type = tree_of_typexp Type l.ld_type;
+    olab_type = tree_of_typexp None Type l.ld_type;
   }
 
 let tree_of_constructor_arguments = function
-  | Cstr_tuple l -> tree_of_typlist Type l
+  | Cstr_tuple l -> tree_of_typlist None Type l
   | Cstr_record l -> [ Otyp_record (List.map tree_of_label l) ]
 
 let tree_of_single_constructor cd =
   let name = Ident.name cd.cd_id in
-  let ret = Option.map (tree_of_typexp Type) cd.cd_res in
+  let ret = Option.map (tree_of_typexp None Type) cd.cd_res in
   let args = tree_of_constructor_arguments cd.cd_args in
   {
       ocstr_name = name;
@@ -1527,13 +1550,13 @@ let tree_of_type_decl id decl =
         decl.type_params decl.type_variance
     in
     (Ident.name id,
-     List.map2 (fun ty cocn -> type_param cocn (tree_of_typexp Type ty))
+     List.map2 (fun ty cocn -> type_param cocn (tree_of_typexp None Type ty))
        params vari)
   in
   let tree_of_manifest ty1 =
     match ty_manifest with
     | None -> ty1
-    | Some ty -> Otyp_manifest (tree_of_typexp Type ty, ty1)
+    | Some ty -> Otyp_manifest (tree_of_typexp None Type ty, ty1)
   in
   let (name, args) = type_defined decl in
   let constraints = tree_of_constraints params in
@@ -1543,7 +1566,7 @@ let tree_of_type_decl id decl =
         begin match ty_manifest with
         | None -> (Otyp_abstract, Public, false)
         | Some ty ->
-            tree_of_typexp Type ty, decl.type_private, false
+            tree_of_typexp None Type ty, decl.type_private, false
         end
     | Type_variant (cstrs, rep) ->
         tree_of_manifest
@@ -1628,7 +1651,7 @@ let add_extension_constructor_to_preparation ext =
   Option.iter prepare_type ext.ext_ret_type
 
 let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
-  let ret = Option.map (tree_of_typexp Type) ext_ret_type in
+  let ret = Option.map (tree_of_typexp None Type) ext_ret_type in
   let args = tree_of_constructor_arguments ext_args in
   (args, ret)
 
@@ -1668,7 +1691,7 @@ let prepared_tree_of_extension_constructor id ext es =
     param_scope
       (fun () ->
          List.iter (Aliases.add_printed ~non_gen:false) ty_params;
-         List.map2 (fun v ty -> type_param v (tree_of_typexp Type ty))
+         List.map2 (fun v ty -> type_param v (tree_of_typexp None Type ty))
           ty_variances ty_params
       )
   in
@@ -1709,7 +1732,7 @@ let tree_of_value_description id decl =
   (* Format.eprintf "@[%a@]@." raw_type_expr decl.val_type; *)
   let id = Ident.name id in
   let () = prepare_for_printing [decl.val_type] in
-  let ty = tree_of_typexp Type_scheme decl.val_type in
+  let ty = tree_of_typexp None Type_scheme decl.val_type in
   let vd =
     { oval_name = id;
       oval_type = ty;
@@ -1736,7 +1759,7 @@ let prepare_method _lab (priv, _virt, ty) =
 
 let tree_of_method mode (lab, priv, virt, ty) =
   let (ty, tyl) = method_type priv ty in
-  let tty = tree_of_typexp mode ty in
+  let tty = tree_of_typexp None mode ty in
   Variable_names.remove_names (List.map Transient_expr.repr tyl);
   let priv = priv <> Mpublic in
   let virt = virt = Virtual in
@@ -1771,7 +1794,8 @@ let rec tree_of_class_type mode params =
         tree_of_class_type mode params cty
       else
         let namespace = Namespace.best_class_namespace p' in
-        Octy_constr (tree_of_path namespace p', tree_of_typlist Type_scheme tyl)
+        let args = tree_of_typlist None Type_scheme tyl in
+        Octy_constr (tree_of_path namespace p', args)
   | Cty_signature sign ->
       let px = proxy sign.csig_self_row in
       let self_ty =
@@ -1794,7 +1818,7 @@ let rec tree_of_class_type mode params =
       let csil =
         List.fold_left
           (fun csil (l, m, v, t) ->
-            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp mode t)
+            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp None mode t)
             :: csil)
           csil all_vars
       in
@@ -1818,16 +1842,16 @@ let rec tree_of_class_type mode params =
        if is_optional l then
          match get_desc ty with
          | Tconstr(path, [ty], _) when Path.same path Predef.path_option ->
-             tree_of_typexp mode ty
+             tree_of_typexp None mode ty
          | _ -> Otyp_stuff "<hidden>"
-       else tree_of_typexp mode ty in
+       else tree_of_typexp None mode ty in
       Octy_arrow (lab, tr, tree_of_class_type mode params cty)
 
 
 let tree_of_class_param param variance =
   let ot_variance = syntactic_variance variance
       ~with_variance:(!Clflags.print_variance || not (is_Tvar param)) in
-  match tree_of_typexp Type_scheme param with
+  match tree_of_typexp None Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
   | _ -> {ot_non_gen=plain false; ot_name="?"; ot_variance}
 
@@ -2049,18 +2073,20 @@ let same_path t t' =
 
 type 'a diff = Same of 'a | Diff of 'a * 'a
 
-let trees_of_type_expansion mode Errortrace.{ty = t; expanded = t'} =
+let trees_of_type_expansion mode (Errortrace.{ty = t; expanded = t'}, htarget) =
   Aliases.reset ();
   Aliases.mark_loops t;
   if same_path t t'
-  then begin Aliases.add_delayed (proxy t); Same (tree_of_typexp mode t) end
-  else begin
+  then begin
+    Aliases.add_delayed (proxy t);
+    Same (tree_of_typexp htarget mode t)
+  end else begin
     Aliases.mark_loops t';
     let t' = if proxy t == proxy t' then unalias t' else t' in
     (* beware order matter due to side effect,
        e.g. when printing object types *)
-    let first = tree_of_typexp mode t in
-    let second = tree_of_typexp mode t' in
+    let first = tree_of_typexp htarget mode t in
+    let second = tree_of_typexp htarget mode t' in
     if first = second then Same first
     else Diff(first,second)
   end

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1115,18 +1115,13 @@ let alias_nongen_row mode px ty =
           Aliases.add_proxy px
     | _ -> ()
 
-type highlight_target =
-  | Type of Outcometree.highlight_kind * Types.type_expr
-  | Type_constructor of Path.t
-let highlight_type k ty = Some (Type(k,ty))
-
 let match_target target ty = match target with
   | None -> None
-  | Some (Type (k,tty)) ->
+  | Some (Errortrace.Type (k,tty)) ->
       if Types.Transient_expr.(TransientTypeOps.equal ty (repr tty)) then
         Some k
       else None
-  | Some (Type_constructor tp) -> match ty.desc with
+  | Some (Errortrace.Type_constructor tp) -> match ty.desc with
     | Tconstr (p,_,_) -> if Path.same p tp then Some Paired else None
     | _ -> None
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -27,6 +27,7 @@ open Outcometree
 module String = Misc.Stdlib.String
 module Sig_component_kind = Shape.Sig_component_kind
 module Style = Misc.Style
+let plain = Oprint.plain
 
 (* Print a long identifier *)
 
@@ -1119,7 +1120,7 @@ let rec tree_of_typexp mode ty =
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
    let non_gen = is_non_gen mode (Transient_expr.type_expr px) in
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
-   Otyp_var (non_gen, name) else
+   Otyp_var (plain non_gen, name) else
 
   let pr_typ () =
     let tty = Transient_expr.repr ty in
@@ -1127,7 +1128,7 @@ let rec tree_of_typexp mode ty =
     | Tvar _ ->
         let non_gen = is_non_gen mode ty in
         let name_gen = Variable_names.new_var_name ~non_gen ty in
-        Otyp_var (non_gen, Variable_names.name_of_type name_gen tty)
+        Otyp_var (plain non_gen, Variable_names.name_of_type name_gen tty)
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
           if !print_labels || is_optional l then l else Nolabel
@@ -1148,7 +1149,7 @@ let rec tree_of_typexp mode ty =
               | _ -> Otyp_stuff "<hidden>"
             else Otyp_stuff "<hidden>"
           else tree_of_typexp mode ty1 in
-        Otyp_arrow (lab, t1, tree_of_typexp mode ty2)
+        Otyp_arrow (plain lab, t1, tree_of_typexp mode ty2)
     | Tfunctor (l, id, pack, ty) ->
         let lab =
           if !print_labels || is_optional l then l else Nolabel
@@ -1161,8 +1162,8 @@ let rec tree_of_typexp mode ty =
         let ty =
           wrap_env ~keep_short_paths:true fenv (tree_of_typexp mode) ty
         in
-        Otyp_functor (lab, Oide_ident { printed_name = Ident.Unscoped.name id },
-                      tree_of_package mode pack, ty)
+        let id = Oide_ident { printed_name = Ident.Unscoped.name id } in
+        Otyp_functor (plain lab, id, tree_of_package mode pack, ty)
     | Ttuple tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode tyl)
     | Tconstr(p, tyl, _abbrev) ->
@@ -1181,14 +1182,15 @@ let rec tree_of_typexp mode ty =
             List.filter (fun (_, f) -> row_field_repr f <> Rabsent)
               fields
           else fields in
-        let present =
-          List.filter
-            (fun (_, f) ->
+        let presents =
+          List.filter_map
+            (fun (x, f) ->
                match row_field_repr f with
-               | Rpresent _ -> true
-               | _ -> false)
+               | Rpresent _ -> Some (plain x)
+               | _ -> None)
             fields in
-        let all_present = List.length present = List.length fields in
+        let all_present = List.length presents = List.length fields in
+        let presents = if all_present then None else Some presents in
         begin match name with
         | Some(p, tyl) when nameable_row row ->
             let (p', s) = best_type_path p in
@@ -1199,14 +1201,12 @@ let rec tree_of_typexp mode ty =
             if closed && all_present then
               out_variant
             else
-              let tags =
-                if all_present then None else Some (List.map fst present) in
-              Otyp_variant (Ovar_typ out_variant, closed, tags)
+              let closed = plain closed in
+              Otyp_variant { fields=Ovar_typ out_variant; closed; presents}
         | _ ->
             let fields = List.map (tree_of_row_field mode) fields in
-            let tags =
-              if all_present then None else Some (List.map fst present) in
-            Otyp_variant (Ovar_fields fields, closed, tags)
+            let closed = plain closed in
+            Otyp_variant {fields=Ovar_fields fields; closed; presents}
         end
     | Tobject (fi, nm) ->
         tree_of_typobject mode fi !nm
@@ -1236,7 +1236,7 @@ let rec tree_of_typexp mode ty =
           Aliases.delayed := old_delayed; tr
         end
     | Tunivar _ ->
-        Otyp_var (false, Variable_names.(name_of_type new_name) tty)
+        Otyp_var (plain false, Variable_names.(name_of_type new_name) tty)
     | Tpackage pack ->
         let pack = tree_of_package mode pack in
         Otyp_module pack
@@ -1249,24 +1249,33 @@ let rec tree_of_typexp mode ty =
     (* add_printed_proxy chose a name, thus the name generator
        doesn't matter.*)
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
-    Otyp_alias {non_gen;  aliased = pr_typ (); alias } end
+    Otyp_alias {non_gen=plain non_gen;  aliased = pr_typ (); alias } end
   else pr_typ ()
 
 and tree_of_row_field mode (l, f) =
   match row_field_repr f with
-  | Rpresent None | Reither(true, [], _) -> (l, false, [])
-  | Rpresent(Some ty) -> (l, false, [tree_of_typexp mode ty])
+  | Rpresent None | Reither(true, [], _) ->
+     plain { name = plain l; constant=plain false; argument_conjunction=[]}
+  | Rpresent(Some ty) ->
+      plain { name = plain l;
+        constant=plain false;
+        argument_conjunction=[tree_of_typexp mode ty]
+      }
   | Reither(c, tyl, _) ->
-      if c (* contradiction: constant constructor with an argument *)
-      then (l, true, tree_of_typlist mode tyl)
-      else (l, false, tree_of_typlist mode tyl)
-  | Rabsent -> (l, false, [] (* actually, an error *))
+     plain {
+       name = plain l;
+       constant = plain c (* contradiction if [c=true] *);
+       argument_conjunction = tree_of_typlist mode tyl
+     }
+  | Rabsent ->
+     (* actually, an error *)
+      plain { name = plain l; constant=plain false; argument_conjunction=[] }
 
 and tree_of_typlist mode tyl =
   List.map (tree_of_typexp mode) tyl
 
 and tree_of_labeled_typlist mode tyl =
-  List.map (fun (label, ty) -> label, tree_of_typexp mode ty) tyl
+  List.map (fun (label, ty) -> plain label, tree_of_typexp mode ty) tyl
 
 and tree_of_typobject mode fi nm =
   begin match nm with
@@ -1297,7 +1306,7 @@ and tree_of_typobject mode fi nm =
 
 and tree_of_typfields mode rest = function
   | [] ->
-      let open_row =
+      let row =
         match get_desc rest with
         | Tconstr (Pident p, _, _)
           when Btype.is_row_name (Ident.name p) ->
@@ -1309,18 +1318,18 @@ and tree_of_typfields mode rest = function
         | Tnil -> Orow_closed
         | _ -> fatal_error "typfields (1)"
       in
-      ([], open_row)
+      ([], plain row)
   | (s, t) :: l ->
-      let field = (s, tree_of_typexp mode t) in
+      let field = (plain s, tree_of_typexp mode t) in
       let (fields, rest) = tree_of_typfields mode rest l in
       (field :: fields, rest)
 
 and tree_of_package mode {pack_path; pack_constraints} =
+  let constraints (li,ty) =
+    plain (String.concat "." li), tree_of_typexp mode ty
+  in
   { opack_path = tree_of_path (Some Module_type) pack_path;
-    opack_constraints =
-      List.map
-        (fun (li, ty) -> (String.concat "." li, tree_of_typexp mode ty))
-        pack_constraints }
+    opack_constraints = List.map constraints pack_constraints }
 
 let typexp mode ppf ty =
   !Oprint.out_type ppf (tree_of_typexp mode ty)
@@ -1482,7 +1491,7 @@ let tree_of_type_decl id decl =
   let type_param ot_variance =
     function
     | Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
-    | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}
+    | _ -> {ot_non_gen=plain false; ot_name="?"; ot_variance}
   in
   let type_defined decl =
     let abstr =
@@ -1637,11 +1646,14 @@ let prepared_tree_of_extension_constructor id ext es =
   let type_param ot_variance =
     function
     | Otyp_var (_ot_non_gen, ot_name) ->
-        {ot_non_gen=false; ot_name; ot_variance}
+        {ot_non_gen=plain false; ot_name; ot_variance}
         (* NB(#14315): simply using the given ot_non_gen here
            does not break the testsuite *)
-    | _ ->
-        {ot_non_gen=false; ot_name="?"; ot_variance=NoVariance,NoInjectivity}
+    | _ -> {
+        ot_non_gen = plain false;
+        ot_name = "?";
+        ot_variance= NoVariance, NoInjectivity
+      }
   in
   let param_scope f =
     match ext.ext_ret_type with
@@ -1765,7 +1777,7 @@ let rec tree_of_class_type mode params =
       let self_ty =
         if Aliases.is_aliased_proxy px then
           Some
-            (Otyp_var (false, Variable_names.(name_of_type new_name) px))
+            (Otyp_var (plain false, Variable_names.(name_of_type new_name) px))
         else None
       in
       let csil = [] in
@@ -1817,7 +1829,7 @@ let tree_of_class_param param variance =
       ~with_variance:(!Clflags.print_variance || not (is_Tvar param)) in
   match tree_of_typexp Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
-  | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}
+  | _ -> {ot_non_gen=plain false; ot_name="?"; ot_variance}
 
 let tree_of_class_declaration id cl rs =
   let params = filter_params cl.cty_params in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1115,23 +1115,22 @@ let alias_nongen_row mode px ty =
           Aliases.add_proxy px
     | _ -> ()
 
-let match_target target ty = match target with
-  | None -> None
-  | Some (Errortrace.Type (k,tty)) ->
+let match_target ty target = match target with
+  | Errortrace.Type (k,tty) ->
       if Types.Transient_expr.(TransientTypeOps.equal ty (repr tty)) then
-        Some k
+       Some k
       else None
-  | Some (Errortrace.Type_constructor tp) -> match ty.desc with
+  | Errortrace.Type_constructor tp -> match ty.desc with
     | Tconstr (p,_,_) -> if Path.same p tp then Some Paired else None
     | _ -> None
 
-let highlight h o = match h  with
+let highlight h o = match h with
   | None -> o
   | Some k -> Otyp_highlight (k,o)
 
 let rec tree_of_typexp htarget mode ty =
   let px = proxy ty in
-  let highlight = highlight (match_target htarget px) in
+  let highlight = highlight (List.find_map (match_target px) htarget) in
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
    let non_gen = is_non_gen mode (Transient_expr.type_expr px) in
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
@@ -1349,7 +1348,7 @@ and tree_of_package htarget mode {pack_path; pack_constraints} =
   { opack_path = tree_of_path (Some Module_type) pack_path;
     opack_constraints = List.map constraints pack_constraints }
 
-let typexp ?htarget mode ppf ty =
+let typexp ?(htarget=[]) mode ppf ty =
   !Oprint.out_type ppf (tree_of_typexp htarget mode ty)
 
 let prepared_type_expr ?htarget ppf ty = typexp ?htarget Type ppf ty
@@ -1371,8 +1370,8 @@ let tree_of_constraints params =
     (fun ty list ->
        let ty' = unalias ty in
        if proxy ty != proxy ty' then
-         let tr = tree_of_typexp None Type_scheme ty in
-         (tr, tree_of_typexp None Type_scheme ty') :: list
+         let tr = tree_of_typexp [] Type_scheme ty in
+         (tr, tree_of_typexp [] Type_scheme ty') :: list
        else list)
     params []
 
@@ -1417,16 +1416,16 @@ let tree_of_label l =
     olab_name = Ident.name l.ld_id;
     olab_mut = l.ld_mutable;
     olab_atomic = l.ld_atomic;
-    olab_type = tree_of_typexp None Type l.ld_type;
+    olab_type = tree_of_typexp [] Type l.ld_type;
   }
 
 let tree_of_constructor_arguments = function
-  | Cstr_tuple l -> tree_of_typlist None Type l
+  | Cstr_tuple l -> tree_of_typlist [] Type l
   | Cstr_record l -> [ Otyp_record (List.map tree_of_label l) ]
 
 let tree_of_single_constructor cd =
   let name = Ident.name cd.cd_id in
-  let ret = Option.map (tree_of_typexp None Type) cd.cd_res in
+  let ret = Option.map (tree_of_typexp [] Type) cd.cd_res in
   let args = tree_of_constructor_arguments cd.cd_args in
   {
       ocstr_name = name;
@@ -1545,13 +1544,13 @@ let tree_of_type_decl id decl =
         decl.type_params decl.type_variance
     in
     (Ident.name id,
-     List.map2 (fun ty cocn -> type_param cocn (tree_of_typexp None Type ty))
+     List.map2 (fun ty cocn -> type_param cocn (tree_of_typexp [] Type ty))
        params vari)
   in
   let tree_of_manifest ty1 =
     match ty_manifest with
     | None -> ty1
-    | Some ty -> Otyp_manifest (tree_of_typexp None Type ty, ty1)
+    | Some ty -> Otyp_manifest (tree_of_typexp [] Type ty, ty1)
   in
   let (name, args) = type_defined decl in
   let constraints = tree_of_constraints params in
@@ -1561,7 +1560,7 @@ let tree_of_type_decl id decl =
         begin match ty_manifest with
         | None -> (Otyp_abstract, Public, false)
         | Some ty ->
-            tree_of_typexp None Type ty, decl.type_private, false
+            tree_of_typexp [] Type ty, decl.type_private, false
         end
     | Type_variant (cstrs, rep) ->
         tree_of_manifest
@@ -1646,7 +1645,7 @@ let add_extension_constructor_to_preparation ext =
   Option.iter prepare_type ext.ext_ret_type
 
 let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
-  let ret = Option.map (tree_of_typexp None Type) ext_ret_type in
+  let ret = Option.map (tree_of_typexp [] Type) ext_ret_type in
   let args = tree_of_constructor_arguments ext_args in
   (args, ret)
 
@@ -1686,7 +1685,7 @@ let prepared_tree_of_extension_constructor id ext es =
     param_scope
       (fun () ->
          List.iter (Aliases.add_printed ~non_gen:false) ty_params;
-         List.map2 (fun v ty -> type_param v (tree_of_typexp None Type ty))
+         List.map2 (fun v ty -> type_param v (tree_of_typexp [] Type ty))
           ty_variances ty_params
       )
   in
@@ -1727,7 +1726,7 @@ let tree_of_value_description id decl =
   (* Format.eprintf "@[%a@]@." raw_type_expr decl.val_type; *)
   let id = Ident.name id in
   let () = prepare_for_printing [decl.val_type] in
-  let ty = tree_of_typexp None Type_scheme decl.val_type in
+  let ty = tree_of_typexp [] Type_scheme decl.val_type in
   let vd =
     { oval_name = id;
       oval_type = ty;
@@ -1754,7 +1753,7 @@ let prepare_method _lab (priv, _virt, ty) =
 
 let tree_of_method mode (lab, priv, virt, ty) =
   let (ty, tyl) = method_type priv ty in
-  let tty = tree_of_typexp None mode ty in
+  let tty = tree_of_typexp [] mode ty in
   Variable_names.remove_names (List.map Transient_expr.repr tyl);
   let priv = priv <> Mpublic in
   let virt = virt = Virtual in
@@ -1789,7 +1788,7 @@ let rec tree_of_class_type mode params =
         tree_of_class_type mode params cty
       else
         let namespace = Namespace.best_class_namespace p' in
-        let args = tree_of_typlist None Type_scheme tyl in
+        let args = tree_of_typlist [] Type_scheme tyl in
         Octy_constr (tree_of_path namespace p', args)
   | Cty_signature sign ->
       let px = proxy sign.csig_self_row in
@@ -1813,7 +1812,7 @@ let rec tree_of_class_type mode params =
       let csil =
         List.fold_left
           (fun csil (l, m, v, t) ->
-            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp None mode t)
+            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp [] mode t)
             :: csil)
           csil all_vars
       in
@@ -1837,16 +1836,16 @@ let rec tree_of_class_type mode params =
        if is_optional l then
          match get_desc ty with
          | Tconstr(path, [ty], _) when Path.same path Predef.path_option ->
-             tree_of_typexp None mode ty
+             tree_of_typexp [] mode ty
          | _ -> Otyp_stuff "<hidden>"
-       else tree_of_typexp None mode ty in
+       else tree_of_typexp [] mode ty in
       Octy_arrow (lab, tr, tree_of_class_type mode params cty)
 
 
 let tree_of_class_param param variance =
   let ot_variance = syntactic_variance variance
       ~with_variance:(!Clflags.print_variance || not (is_Tvar param)) in
-  match tree_of_typexp None Type_scheme param with
+  match tree_of_typexp [] Type_scheme param with
     Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
   | _ -> {ot_non_gen=plain false; ot_name="?"; ot_variance}
 

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -95,14 +95,14 @@ val add_type_to_preparation: type_expr -> unit
 type type_or_scheme = Type | Type_scheme
 
 val tree_of_typexp:
-  Errortrace.highlight_target option -> type_or_scheme -> type_expr -> out_type
+  Errortrace.highlight_target list -> type_or_scheme -> type_expr -> out_type
 (** [tree_of_typexp] generate the [outcometree] for a prepared type
     expression.*)
 
 val prepared_type_scheme:
-  ?htarget:Errortrace.highlight_target -> type_expr printer
+  ?htarget:Errortrace.highlight_target list -> type_expr printer
 val prepared_type_expr:
-  ?htarget:Errortrace.highlight_target -> type_expr printer
+  ?htarget:Errortrace.highlight_target list -> type_expr printer
 (** The printers [prepared_type_expr] and [prepared_type_scheme] should only be
     used on prepared types. Types can be prepared by initially calling
     {!prepare_for_printing} or adding them later to the preparation with
@@ -117,12 +117,12 @@ val prepared_type_expr:
     "half-prepared" type expression should have had its names reserved (with
     {!Variable_names.reserve}), but should not have had its cycles marked. *)
 val type_expr_with_reserved_names:
-  ?htarget:Errortrace.highlight_target -> type_expr printer
+  ?htarget:Errortrace.highlight_target list -> type_expr printer
 
 type 'a diff = Same of 'a | Diff of 'a * 'a
 val trees_of_type_expansion:
   type_or_scheme
-  -> Errortrace.expanded_type * Errortrace.highlight_target option
+  -> Errortrace.expanded_type * Errortrace.highlight_target list
   -> out_type diff
 val prepare_expansion: Errortrace.expanded_type -> Errortrace.expanded_type
 val pp_type_expansion: out_type diff printer

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -93,12 +93,18 @@ val add_type_to_preparation: type_expr -> unit
 (** In [Type_scheme] mode, non-generic types variables are printed as weakly
     polymorphic type variables. *)
 type type_or_scheme = Type | Type_scheme
-val tree_of_typexp: type_or_scheme -> type_expr -> out_type
+type highlight_target =
+  | Type of highlight_kind * type_expr
+  | Type_constructor of Path.t
+val highlight_type: highlight_kind -> type_expr -> highlight_target option
+
+val tree_of_typexp:
+  highlight_target option -> type_or_scheme -> type_expr -> out_type
 (** [tree_of_typexp] generate the [outcometree] for a prepared type
     expression.*)
 
-val prepared_type_scheme: type_expr printer
-val prepared_type_expr: type_expr printer
+val prepared_type_scheme: ?htarget:highlight_target -> type_expr printer
+val prepared_type_expr: ?htarget:highlight_target -> type_expr printer
 (** The printers [prepared_type_expr] and [prepared_type_scheme] should only be
     used on prepared types. Types can be prepared by initially calling
     {!prepare_for_printing} or adding them later to the preparation with
@@ -112,11 +118,13 @@ val prepared_type_expr: type_expr printer
 (** [type_expr_with_reserved_names] can print "half-prepared" type expression. A
     "half-prepared" type expression should have had its names reserved (with
     {!Variable_names.reserve}), but should not have had its cycles marked. *)
-val type_expr_with_reserved_names: type_expr printer
+val type_expr_with_reserved_names:
+  ?htarget:highlight_target -> type_expr printer
 
 type 'a diff = Same of 'a | Diff of 'a * 'a
 val trees_of_type_expansion:
-  type_or_scheme -> Errortrace.expanded_type -> out_type diff
+  type_or_scheme -> Errortrace.expanded_type * highlight_target option
+  -> out_type diff
 val prepare_expansion: Errortrace.expanded_type -> Errortrace.expanded_type
 val pp_type_expansion: out_type diff printer
 val hide_variant_name: Types.type_expr -> Types.type_expr

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -93,18 +93,16 @@ val add_type_to_preparation: type_expr -> unit
 (** In [Type_scheme] mode, non-generic types variables are printed as weakly
     polymorphic type variables. *)
 type type_or_scheme = Type | Type_scheme
-type highlight_target =
-  | Type of highlight_kind * type_expr
-  | Type_constructor of Path.t
-val highlight_type: highlight_kind -> type_expr -> highlight_target option
 
 val tree_of_typexp:
-  highlight_target option -> type_or_scheme -> type_expr -> out_type
+  Errortrace.highlight_target option -> type_or_scheme -> type_expr -> out_type
 (** [tree_of_typexp] generate the [outcometree] for a prepared type
     expression.*)
 
-val prepared_type_scheme: ?htarget:highlight_target -> type_expr printer
-val prepared_type_expr: ?htarget:highlight_target -> type_expr printer
+val prepared_type_scheme:
+  ?htarget:Errortrace.highlight_target -> type_expr printer
+val prepared_type_expr:
+  ?htarget:Errortrace.highlight_target -> type_expr printer
 (** The printers [prepared_type_expr] and [prepared_type_scheme] should only be
     used on prepared types. Types can be prepared by initially calling
     {!prepare_for_printing} or adding them later to the preparation with
@@ -119,11 +117,12 @@ val prepared_type_expr: ?htarget:highlight_target -> type_expr printer
     "half-prepared" type expression should have had its names reserved (with
     {!Variable_names.reserve}), but should not have had its cycles marked. *)
 val type_expr_with_reserved_names:
-  ?htarget:highlight_target -> type_expr printer
+  ?htarget:Errortrace.highlight_target -> type_expr printer
 
 type 'a diff = Same of 'a | Diff of 'a * 'a
 val trees_of_type_expansion:
-  type_or_scheme -> Errortrace.expanded_type * highlight_target option
+  type_or_scheme
+  -> Errortrace.expanded_type * Errortrace.highlight_target option
   -> out_type diff
 val prepare_expansion: Errortrace.expanded_type -> Errortrace.expanded_type
 val pp_type_expansion: out_type diff printer

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -26,10 +26,15 @@
     rewritten on the fly to avoid name collisions *)
 type out_name = { mutable printed_name: string }
 
+type highlight_kind =
+  | Paired
+  | Independent
+
 type out_ident =
   | Oide_apply of out_ident * out_ident
   | Oide_dot of out_ident * string
   | Oide_ident of out_name
+  | Oide_highlight of highlight_kind * out_ident
 
 type out_string =
   | Ostr_string
@@ -58,8 +63,13 @@ type out_value =
   | Oval_lazy of out_value
   | Oval_floatarray of floatarray
 
+type 'a highlightable = {
+  highlighted:bool;
+  item:'a
+}
+
 type out_type_param = {
-    ot_non_gen: bool;
+    ot_non_gen: bool highlightable;
     ot_name: string;
     ot_variance: Asttypes.variance * Asttypes.injectivity
 }
@@ -67,28 +77,38 @@ type out_type_param = {
 type out_type =
   | Otyp_abstract
   | Otyp_open
-  | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
-  | Otyp_arrow of Asttypes.arg_label * out_type * out_type
+  | Otyp_alias of {non_gen:bool highlightable; aliased:out_type; alias:string}
+  | Otyp_arrow of Asttypes.arg_label highlightable * out_type * out_type
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
-  | Otyp_object of { fields: (string * out_type) list; row: out_row}
+  | Otyp_object of {
+      fields: (string highlightable * out_type) list;
+      row:out_row highlightable
+    }
   | Otyp_record of out_label list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
-  | Otyp_tuple of (string option * out_type) list
-  | Otyp_var of bool * string
-  | Otyp_variant of out_variant * bool * (string list) option
+  | Otyp_tuple of (string option highlightable * out_type) list
+  | Otyp_var of bool highlightable * string
+  | Otyp_variant of {
+      fields:out_variant;
+      closed:bool highlightable;
+      presents: (string highlightable list) option
+    }
   | Otyp_poly of string list * out_type
   | Otyp_module of out_package
   | Otyp_attribute of out_type * out_attribute
   | Otyp_external of string
-  | Otyp_functor of Asttypes.arg_label * out_ident * out_package * out_type
+  | Otyp_functor of
+      Asttypes.arg_label highlightable * out_ident * out_package * out_type
+  | Otyp_highlight of highlight_kind * out_type
 
 and out_row =
   | Orow_closed
   | Orow_open_anonymous
   | Orow_open of out_type
+
 
 and out_label = {
   olab_name: string;
@@ -105,12 +125,18 @@ and out_constructor = {
 
 and out_package = {
   opack_path: out_ident;
-  opack_constraints: (string * out_type) list;
+  opack_constraints: (string highlightable * out_type) list;
 }
 
 and out_variant =
-  | Ovar_fields of (string * bool * out_type list) list
+  | Ovar_fields of out_field highlightable list
   | Ovar_typ of out_type
+
+and out_field = {
+      name:string highlightable;
+      constant:bool highlightable;
+      argument_conjunction: out_type list
+    }
 
 type out_class_type =
   | Octy_constr of out_ident * out_type list

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -30,10 +30,10 @@ module Doc = struct
 
 
   let typexp mode ppf ty =
-    !Oprint.out_type ppf (tree_of_typexp mode ty)
+    !Oprint.out_type ppf (tree_of_typexp None mode ty)
 
   let type_expansion k ppf e =
-    pp_type_expansion ppf (trees_of_type_expansion k e)
+    pp_type_expansion ppf (trees_of_type_expansion k (e,None))
 
   let type_declaration id ppf decl =
     !Oprint.out_sig_item ppf (tree_of_type_declaration id decl Trec_first)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -84,7 +84,8 @@ module Doc = struct
 
   let constructor_arguments ppf a =
     let tys = tree_of_constructor_arguments a in
-    !Oprint.out_type ppf (Otyp_tuple (List.map (fun t -> None, t) tys))
+    let plain_labels t = Oprint.plain None, t in
+    !Oprint.out_type ppf (Otyp_tuple (List.map plain_labels tys))
 
   let label ppf l =
     prepare_for_printing [l.Types.ld_type];

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -30,10 +30,10 @@ module Doc = struct
 
 
   let typexp mode ppf ty =
-    !Oprint.out_type ppf (tree_of_typexp None mode ty)
+    !Oprint.out_type ppf (tree_of_typexp [] mode ty)
 
   let type_expansion k ppf e =
-    pp_type_expansion ppf (trees_of_type_expansion k (e,None))
+    pp_type_expansion ppf (trees_of_type_expansion k (e,[]))
 
   let type_declaration id ppf decl =
     !Oprint.out_sig_item ppf (tree_of_type_declaration id decl Trec_first)

--- a/typing/syntactic_highlighting.ml
+++ b/typing/syntactic_highlighting.ml
@@ -1,0 +1,181 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Florian Angeletti, projet Cambium, INRIA Paris                        *)
+(*                                                                        *)
+(*   Copyright 2024 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Outcometree
+let plain x = { highlighted=false; item=x }
+
+let highlighting_on x = { x with highlighted=true }
+
+let highlight_diff x y =
+  if x.item = y.item then x, y else
+    highlighting_on x, highlighting_on y
+
+let rec highlight_map_diff ~key ~diff ~mismatch l r = match l, r with
+  | [], r -> [], List.map mismatch r
+  | l, [] -> List.map mismatch l, r
+  | lh :: lq, rh :: rq ->
+      if key lh < key rh then
+        let l, r = highlight_map_diff ~key ~diff ~mismatch lq r in
+        mismatch lh :: l, r
+      else if key lh = key rh then
+        let lh, rh = diff (key lh) lh rh in
+        let lq, rq = highlight_map_diff ~key ~diff ~mismatch lq rq in
+        lh :: lq, rh :: rq
+      else
+        let l, rq = highlight_map_diff ~key ~diff ~mismatch l rq in
+        l, mismatch rh :: rq
+
+let rec highlight_map2 ~mismatch f x y = match x, y with
+  | [], [] -> [], []
+  | [], r -> [], List.map mismatch r
+  | l, [] -> List.map mismatch l, []
+  | lh :: lq, rh :: rq ->
+      let lh, rh = f lh rh in
+      let lq, rq = highlight_map2 ~mismatch f lq rq in
+      lh :: lq, rh :: rq
+
+let hty ty = Otyp_highlight (Independent, ty)
+
+let rec diff l r = match l, r with
+  | Otyp_highlight (Independent, _) as x, y
+  | x, (Otyp_highlight (Independent,_) as y) -> x, y
+  | (Otyp_highlight (Paired, _) as x), (Otyp_highlight (Paired, _) as y) -> x, y
+  | Otyp_highlight (Paired, x), y | x, Otyp_highlight (Paired, y) -> x, y
+  | (Otyp_abstract | Otyp_open | Otyp_stuff _ | Otyp_manifest _
+    | Otyp_record _ | Otyp_sum _ | Otyp_external _ ), _
+  | _ , (Otyp_abstract | Otyp_open | Otyp_stuff _ | Otyp_manifest _
+        | Otyp_record _ | Otyp_sum _ | Otyp_external _ ) -> l, r
+  | (Otyp_var _ | Otyp_constr _ as l), r
+  | l, (Otyp_var _ | Otyp_constr _ as r) -> l, r
+  | Otyp_class _ , _ | _, Otyp_class _ -> l, r
+  | Otyp_poly (b,ty), Otyp_poly (b',ty') ->
+      let ty, ty' = diff ty ty' in
+      Otyp_poly (b,ty), Otyp_poly (b',ty')
+  | Otyp_poly (b,l), r ->
+      let l, r = diff l r in
+      Otyp_poly (b,l), r
+  | l, Otyp_poly (b,r) ->
+      let l, r = diff l r in
+      l, Otyp_poly (b,r)
+  | Otyp_alias l, Otyp_alias r ->
+      let non_gen_l, non_gen_r = highlight_diff l.non_gen r.non_gen in
+      let aliased_l, aliased_r = diff l.aliased r.aliased in
+      Otyp_alias { non_gen=non_gen_l; aliased = aliased_l; alias = l.alias },
+      Otyp_alias { non_gen=non_gen_r; aliased = aliased_r; alias = r.alias }
+  | Otyp_alias l, r ->
+      let aliased, r = diff l.aliased r in
+      Otyp_alias { l with aliased }, r
+  | l, Otyp_alias r ->
+      let l, aliased = diff l r.aliased in
+      l, Otyp_alias { r with aliased }
+
+  | Otyp_arrow (label, arg, ret), Otyp_arrow (label', arg', ret') ->
+     let label, label' = highlight_diff label label' in
+     let arg, arg' = diff arg arg' in
+     let ret, ret' = diff ret ret' in
+     Otyp_arrow (label,arg,ret), Otyp_arrow (label',arg',ret')
+
+  | Otyp_functor (label,name,package,ret),
+    Otyp_functor (label',name',package', ret') ->
+     let label, label' = highlight_diff label label' in
+     let package, package' = package_highlight package package' in
+     let ret, ret' = diff ret ret' in
+     Otyp_functor (label,name,package,ret),
+     Otyp_functor (label',name',package', ret')
+  | Otyp_functor (label,name,package,ret), Otyp_arrow (label',arg', ret') ->
+     let label, label' = highlight_diff label label' in
+     let ret, ret' = diff ret ret' in
+     Otyp_functor (label,name,package,ret), Otyp_arrow (label',arg', ret')
+  | Otyp_arrow (label, arg, ret), Otyp_functor (label',name',package',ret') ->
+     let label, label' = highlight_diff label label' in
+     let ret, ret' = diff ret ret' in
+     Otyp_arrow (label, arg, ret), Otyp_functor (label',name',package',ret')
+
+  | Otyp_functor _, _ | _, Otyp_functor _ -> hty l, hty r
+  | Otyp_arrow _, _ | _, Otyp_arrow _ -> hty l, hty r
+
+  | Otyp_object l, Otyp_object r ->
+      let (fields,row), (fields',row') =
+        object_highlight (l.fields,l.row)  (r.fields, r.row)
+      in
+      Otyp_object { fields; row }, Otyp_object { fields=fields'; row=row' }
+  | Otyp_object _, _ | _, Otyp_object _ -> hty l, hty r
+  | Otyp_tuple l, Otyp_tuple r ->
+      let elt (lbl,ty) (lbl',ty') =
+        let lbl, lbl' = highlight_diff lbl lbl' in
+        let ty, ty' = diff ty ty' in
+        (lbl,ty), (lbl',ty')
+      in
+      let mismatch (lbl,ty) =
+        if lbl.item <> None then (highlighting_on lbl, ty)
+        else (lbl, hty ty)
+      in
+      let l, r = highlight_map2 ~mismatch elt l r in
+      Otyp_tuple l, Otyp_tuple r
+  | Otyp_tuple _, _ | _, Otyp_tuple _ -> hty l, hty r
+
+  | Otyp_attribute (l,att), r ->
+      let l, r = diff l r in
+      Otyp_attribute (l,att), r
+  | l, Otyp_attribute (r,att) ->
+      let l, r = diff l r in
+      l, Otyp_attribute (r,att)
+  | Otyp_variant l, Otyp_variant r ->
+      let fields, fields' = variant_diff l.fields r.fields in
+      Otyp_variant { l with fields },
+      Otyp_variant { r with fields = fields' }
+  | Otyp_variant _, _ | _, Otyp_variant _ -> hty l, hty r
+  | Otyp_module l, Otyp_module r ->
+     let l, r = package_highlight l r in
+     Otyp_module l, Otyp_module r
+
+and variant_diff x y =
+  match x, y with
+  | Ovar_typ x, Ovar_typ y ->
+    let x, y = diff x y in
+    Ovar_typ x, Ovar_typ y
+  | Ovar_typ _, _ | _, Ovar_typ _ -> x, y
+  | Ovar_fields l, Ovar_fields r ->
+      let key (x:out_field highlightable) = x.item.name.item in
+      let mismatch x = x in
+      let diff _name x y =
+        let x = x.item and y = y.item in
+        (* constant vs non constant can be decided syntactically *)
+        let constant, constant' = highlight_diff x.constant y.constant in
+        plain { x with constant }, plain { y with constant=constant' }
+      in
+      let l, r = highlight_map_diff ~key ~diff ~mismatch l r in
+      Ovar_fields l, Ovar_fields r
+
+and package_highlight l r =
+  (* nothing syntactic here *)
+  l, r
+
+and object_highlight (fields,row) (fields',row') =
+  let diff lbl (_,ty) (_,ty') =
+    let ty, ty' = diff ty ty' in
+    (plain lbl,ty), (plain lbl,ty')
+  in
+  (* no syntactic difference for subtyping *)
+  let mismatch x = x in
+  let key (lbl,_) = lbl.item in
+  let fields, fields'=
+    highlight_map_diff ~key ~diff ~mismatch fields fields'
+  in
+  (fields, row), (fields',row')
+
+let diff l r = match l, r with
+  | Otyp_highlight _ as x, y | x, (Otyp_highlight _ as y) -> x, y
+  | x, y -> diff x y

--- a/typing/syntactic_highlighting.mli
+++ b/typing/syntactic_highlighting.mli
@@ -1,0 +1,18 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Florian Angeletti, projet Cambium, INRIA Paris                        *)
+(*                                                                        *)
+(*   Copyright 2026 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val diff:
+  Outcometree.out_type -> Outcometree.out_type ->
+  Outcometree.out_type * Outcometree.out_type

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2017,7 +2017,7 @@ let quoted_type ppf t = Style.as_inline_code Printtyp.type_expr ppf t
 
 let report_error_doc env ppf =
   let pp_args ppf args =
-    let args = List.map (Out_type.tree_of_typexp None Type) args in
+    let args = List.map (Out_type.tree_of_typexp [] Type) args in
     Style.as_inline_code !Oprint.out_type_args ppf args
   in
   function
@@ -2072,9 +2072,9 @@ let report_error_doc env ppf =
       Out_type.prepare_for_printing [abbrev; actual; expected];
       fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
        but is used with type@ %a@]"
-        out_type (Out_type.tree_of_typexp None Type abbrev)
-        out_type (Out_type.tree_of_typexp None Type actual)
-        out_type (Out_type.tree_of_typexp None Type expected)
+        out_type (Out_type.tree_of_typexp [] Type abbrev)
+        out_type (Out_type.tree_of_typexp [] Type actual)
+        out_type (Out_type.tree_of_typexp [] Type expected)
   | Constructor_type_mismatch (c, err) ->
       let msg = Format_doc.doc_printf in
       Errortrace_report.unification ppf env err

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2017,7 +2017,7 @@ let quoted_type ppf t = Style.as_inline_code Printtyp.type_expr ppf t
 
 let report_error_doc env ppf =
   let pp_args ppf args =
-    let args = List.map (Out_type.tree_of_typexp Type) args in
+    let args = List.map (Out_type.tree_of_typexp None Type) args in
     Style.as_inline_code !Oprint.out_type_args ppf args
   in
   function
@@ -2072,9 +2072,9 @@ let report_error_doc env ppf =
       Out_type.prepare_for_printing [abbrev; actual; expected];
       fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
        but is used with type@ %a@]"
-        out_type (Out_type.tree_of_typexp Type abbrev)
-        out_type (Out_type.tree_of_typexp Type actual)
-        out_type (Out_type.tree_of_typexp Type expected)
+        out_type (Out_type.tree_of_typexp None Type abbrev)
+        out_type (Out_type.tree_of_typexp None Type actual)
+        out_type (Out_type.tree_of_typexp None Type expected)
   | Constructor_type_mismatch (c, err) ->
       let msg = Format_doc.doc_printf in
       Errortrace_report.unification ppf env err
@@ -2143,11 +2143,12 @@ let report_error_doc env ppf =
         in
         Out_type.add_type_to_preparation meth_ty;
         Out_type.add_type_to_preparation ty1;
+        let h = Out_type.highlight_type Independent ty0 in
         fprintf ppf
           "The method %a@ has type@;<1 2>%a@ where@ %a@ is unbound"
           Style.inline_code meth
-          out_type (Out_type.tree_of_typexp Type meth_ty)
-          out_type (Out_type.tree_of_typexp Type ty0)
+          out_type (Out_type.tree_of_typexp h Type meth_ty)
+          out_type (Out_type.tree_of_typexp h Type ty0)
       in
       fprintf ppf
         "@[<v>@[Some type variables are unbound in this type:@;<1 2>%a@]@ \

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2143,7 +2143,7 @@ let report_error_doc env ppf =
         in
         Out_type.add_type_to_preparation meth_ty;
         Out_type.add_type_to_preparation ty1;
-        let h = Out_type.highlight_type Independent ty0 in
+        let h = Errortrace.highlight_type Independent ty0 in
         fprintf ppf
           "The method %a@ has type@;<1 2>%a@ where@ %a@ is unbound"
           Style.inline_code meth

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1798,7 +1798,7 @@ let check_scope_escape loc env level ty =
   with Escape esc ->
     (* We don't expand the type here because if we do, we might expand to the
        type that escaped, leading to confusing error messages. *)
-    let trace = Errortrace.[Escape (map_escape trivial_expansion esc)] in
+    let trace = Errortrace.(root (Escape (map_escape trivial_expansion esc))) in
     raise (Error(loc,
                  env,
                  Pattern_type_clash(Errortrace.unification_error ~trace, None)))
@@ -3658,9 +3658,9 @@ let check_univars env kind exp ty_expected vars =
   let ty, errs = polyfy env exp_ty vars in
   if errs <> [] then
     let ty_expected = instance ty_expected in
-    let diff = Ctype.expanded_diff env ~got:ty ~expected:ty_expected in
-    let explanation = Errortrace.Univar (Quantification_mismatch errs) in
-    let err = Errortrace.unification_error ~trace:[diff;explanation] in
+    let root = Errortrace.(root (Univar (Quantification_mismatch errs))) in
+    let trace = Ctype.expanded_diff env ~got:ty ~expected:ty_expected root in
+    let err = Errortrace.unification_error ~trace in
     raise (Error(exp.exp_loc, env, Less_general(kind,err)))
 
 (* [check_statement] implements the [non-unit-statement] check.
@@ -7416,11 +7416,9 @@ let tuple_component ~print_article ppf lbl =
   | None -> fprintf ppf "%sunlabeled component" article
 
 (* Returns the first diff of the trace *)
-let type_clash_of_trace trace =
-  Errortrace.(explain trace (fun ~prev:_ -> function
-    | Diff diff -> Some diff
-    | _ -> None
-  ))
+let type_clash_of_trace trace = match trace.Errortrace.path with
+  | d :: _ -> Some d
+  | _ -> None
 
 (** More precise denomination for type errors. Used by messages:
 
@@ -7668,15 +7666,9 @@ let report_error ~loc env = function
     (* The last diff's expected type will be the locally-abstract type
        that the GADT pattern introduced an equation on.
     *)
-    let type_with_local_equation =
-      let last_diff =
-        List.find_map
-          (function Errortrace.Diff diff -> Some diff | _ -> None)
-          (List.rev trace)
-      in
-      match last_diff with
-      | None -> None
-      | Some diff -> Some diff.d.expected.ty
+    let type_with_local_equation = match List.rev trace.path with
+        | x :: _ -> Some x.d.expected.ty
+        | [] -> None
     in
     (* [syntactic_arity>1] for this error, so "arguments" is always plural. *)
     Location.errorf ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7490,7 +7490,7 @@ let report_literal_type_constraint expected_type const =
 
 let report_literal_type_constraint const = function
   | Some tr ->
-      begin match get_desc Errortrace.(tr.expected.ty) with
+      begin match get_desc Errortrace.(tr.d.expected.ty) with
         Tconstr (typ, [], _) ->
           report_literal_type_constraint typ const
       | _ -> []
@@ -7499,7 +7499,7 @@ let report_literal_type_constraint const = function
 
 let report_partial_application = function
   | Some tr -> begin
-      match get_desc tr.Errortrace.got.Errortrace.expanded with
+      match get_desc Errortrace.(tr.d.got.expanded) with
       | Tarrow _ ->
           [ Location.msg
               "@[@{<hint>Hint@}:@ This function application is partial,@ \
@@ -7676,7 +7676,7 @@ let report_error ~loc env = function
       in
       match last_diff with
       | None -> None
-      | Some diff -> Some diff.expected.ty
+      | Some diff -> Some diff.d.expected.ty
     in
     (* [syntactic_arity>1] for this error, so "arguments" is always plural. *)
     Location.errorf ~loc

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1962,7 +1962,8 @@ let explain_unbound_gen ppf ~params tv tl typ kwd pr =
 let explain_unbound ppf ~params tv tl typ kwd lab =
   explain_unbound_gen ppf ~params tv tl typ kwd
     (fun ppf ti ->
-       fprintf ppf "%s%a" (lab ti) Out_type.prepared_type_expr (typ ti)
+       fprintf ppf "%s%a" (lab ti)
+         (Out_type.prepared_type_expr ?htarget:None) (typ ti)
     )
 
 let explain_unbound_single ppf ~params tv ty =
@@ -2183,8 +2184,8 @@ let report_error ~loc = function
          All uses need to match the definition for the recursive type \
          to be regular.@]"
         Style.inline_code (Path.name definition)
-        quoted_out_type (Out_type.tree_of_typexp Type defined_as)
-        quoted_out_type (Out_type.tree_of_typexp Type used_as)
+        quoted_out_type (Out_type.tree_of_typexp None Type defined_as)
+        quoted_out_type (Out_type.tree_of_typexp None Type used_as)
         (fun pp ->
            let is_expansion = function Expands_to _ -> true | _ -> false in
            if List.exists is_expansion reaching_path then

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -308,9 +308,10 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
                 (* Expansion is not helpful here -- the restriction on GADT
                    return types is purely syntactic.  (In the worst case,
                    expansion produces gibberish.) *)
-                [Ctype.unexpanded_diff
+                Ctype.unexpanded_diff
                    ~got:ret_type
-                   ~expected:(Ctype.newconstr type_path type_params)]
+                   ~expected:(Ctype.newconstr type_path type_params)
+                   Errortrace.empty_root
               in
               raise (Error(sret_type.ptyp_loc,
                            Constraint_failed(

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2184,8 +2184,8 @@ let report_error ~loc = function
          All uses need to match the definition for the recursive type \
          to be regular.@]"
         Style.inline_code (Path.name definition)
-        quoted_out_type (Out_type.tree_of_typexp None Type defined_as)
-        quoted_out_type (Out_type.tree_of_typexp None Type used_as)
+        quoted_out_type (Out_type.tree_of_typexp [] Type defined_as)
+        quoted_out_type (Out_type.tree_of_typexp [] Type used_as)
         (fun pp ->
            let is_expansion = function Expands_to _ -> true | _ -> false in
            if List.exists is_expansion reaching_path then

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1024,8 +1024,8 @@ let report_error_doc loc env = function
         Location.errorf ~loc
           "This variant type contains a constructor %a@ \
            which should be@ %a"
-          pp_out_type (Out_type.tree_of_typexp None Type ty)
-          pp_out_type (Out_type.tree_of_typexp None Type ty')
+          pp_out_type (Out_type.tree_of_typexp [] Type ty)
+          pp_out_type (Out_type.tree_of_typexp [] Type ty')
         )
   | Not_a_variant ty ->
       Location.aligned_error_hint ~loc

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1024,8 +1024,8 @@ let report_error_doc loc env = function
         Location.errorf ~loc
           "This variant type contains a constructor %a@ \
            which should be@ %a"
-          pp_out_type (Out_type.tree_of_typexp Type ty)
-          pp_out_type (Out_type.tree_of_typexp Type ty')
+          pp_out_type (Out_type.tree_of_typexp None Type ty)
+          pp_out_type (Out_type.tree_of_typexp None Type ty')
         )
   | Not_a_variant ty ->
       Location.aligned_error_hint ~loc

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -955,6 +955,7 @@ module Style = struct
     loc: tag_style;
     hint: tag_style;
     inline_code: tag_style;
+    difference_highlight: tag_style;
   }
 
   let no_markup stl = { ansi = stl; text_close = ""; text_open = "" }
@@ -964,6 +965,7 @@ module Style = struct
       error = no_markup [Bold; FG Red];
       loc = no_markup [Bold];
       hint = no_markup [Bold; FG Blue];
+      difference_highlight = no_markup [FG Red];
       inline_code= no_markup [Bold]
     }
 
@@ -979,40 +981,51 @@ module Style = struct
     | Format.String_tag "loc" -> (!cur_styles).loc
     | Format.String_tag "hint" -> (!cur_styles).hint
     | Format.String_tag "inline_code" -> (!cur_styles).inline_code
+    | Format.String_tag "diff" -> (!cur_styles).difference_highlight
     | Format.String_tag "ralign" -> no_markup []
     | Style s -> no_markup s
     | _ -> raise Not_found
 
-
-  let as_inline_code printer ppf x =
+  let with_tag tag printer ppf x =
     let open Format_doc in
-    pp_open_stag ppf (Format.String_tag "inline_code");
+    pp_open_stag ppf (Format.String_tag tag);
     printer ppf x;
     pp_close_stag ppf ()
+
+  let highlight printer ppf x = with_tag "diff" printer ppf x
+  let as_inline_code printer ppf x = with_tag "inline_code" printer ppf x
 
   let inline_code ppf s = as_inline_code Format_doc.pp_print_string ppf s
   let hint ppf = Format_doc.fprintf ppf "@{<hint>Hint@}"
 
   (* either prints the tag of [s] or delegates to [or_else] *)
-  let mark_open_tag ~or_else s =
+  let mark_open_tag stack ~or_else s =
     try
       let style = style_of_tag s in
+      stack := style.ansi :: !stack;
       if !Color.enabled then ansi_of_style_l style.ansi else style.text_open
     with Not_found -> or_else s
 
-  let mark_close_tag ~or_else s =
+  let mark_close_tag stack ~or_else s =
     try
       let style = style_of_tag s in
-      if !Color.enabled then ansi_of_style_l [Reset] else style.text_close
+      let after_reset = match !stack with
+      | [] -> []
+      | [_] -> stack := []; []
+      | _ :: (before :: _ as q) -> stack := q; before
+      in
+      if !Color.enabled then ansi_of_style_l (Reset::after_reset)
+      else style.text_close
     with Not_found -> or_else s
 
   (* add tag handling to formatter [ppf] *)
   let set_tag_handling ppf =
     let open Format in
+    let stack = ref [] in
     let functions = pp_get_formatter_stag_functions ppf () in
     let functions' = {functions with
-      mark_open_stag=(mark_open_tag ~or_else:functions.mark_open_stag);
-      mark_close_stag=(mark_close_tag ~or_else:functions.mark_close_stag);
+      mark_open_stag=(mark_open_tag stack ~or_else:functions.mark_open_stag);
+      mark_close_stag=(mark_close_tag stack ~or_else:functions.mark_close_stag);
     } in
     pp_set_mark_tags ppf true; (* enable tags *)
     pp_set_formatter_stag_functions ppf functions';

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -551,9 +551,11 @@ module Style : sig
     loc: tag_style;
     hint: tag_style;
     inline_code: tag_style;
+    difference_highlight: tag_style;
   }
 
   val hint: Format_doc.formatter -> unit
+  val highlight: 'a Format_doc.printer -> 'a Format_doc.printer
   val as_inline_code: 'a Format_doc.printer -> 'a Format_doc.printer
   val inline_code: string Format_doc.printer
 


### PR DESCRIPTION
This PR is built on top of #14536 and is a precise version of #1481 which avoids any false positive (but without the complex elision strategy implemented in #1481).

This PR proposes to improve all the error messages comparing two type expressions by highlighting the incompatible subexpressions in the compared types.

For instance, in
```ocaml
module M: sig
  type 'a t
  val fold: ('a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
end = struct
  type 'a t = 'a
  let fold ~f x start = f x start
end
```
the error message after this PR highlights that in
>```
>The type «f»:('a -> 'b -> 'c) -> 'a -> 'b -> 'c
>is not compatible with the type ('d -> 'e -> 'e) -> 'd t -> 'e -> 'e
>```

the difference is the label `f` for the argument of fold, whereas the various type variables are not involved in the error [^1].

Similarly, with an error on the expected type of a polymorphic function
```ocaml
module M: sig
  type ('a,'b) t 
  val map2: ('l -> 'l2) -> ('r -> 'r2) -> ('l,'r) t -> ('l2,'r2) t
end = struct
  type ('a,'b) t = 'a * 'b
  let map2 f g (x,y)= (f x, f (g x))
end
```
>```
> The type ('a -> 'b) -> («'a» -> 'a) -> «'a» * 'c -> 'b * 'b
>is not compatible with the type
>  ('a -> 'b) -> («'d» -> 'e) -> ('a, «'d») t -> ('b, 'e) t
>```
the highlighting makes it easier to catch that the incompatible type variables are in the first argument of the second functional argument.

In order to avoid any false positive in the highlighting, the current highlighting algorithm is combining two conservative highlighting passes:

- a syntactic highlighting pass that compares two outcome tree and highlight incompatible types (types which can never be equal like `_ -> _` or `_ * _` at the toplevel). In particular, this syntactic highlight considers that type constructors or variables may always be equal in some contexts.
 
- a trace-guided highlighting that uses the error trace emitted by the typechecker to highlight for the `k`-th element of the trace the subexpressions that will be compared in the `k+1`-th element of the trace. Typically, in a error message like
>```
>Error: The value y has type («char», string) t
>       but an expression was expected of type («int», float) t
>       Type char is not compatible with type int
>```
we can highlight the `char` and `int` subexpression in the first part of the error message because they are the focus in the second (and last) part of the error message.  

A small disadvantage of this approach is that for non-syntactically distinguishable part of type expressions, only the first mismatch is detected since the typechecker stops at this point.
 
Another important point is with this trace-guided approach the quality of the highlighting is dependent on the typechecker providing explanation on all non-syntactic mismatch in type expressions.  Consequently, the second part of this PR is adding highlighting hints to the error trace to make it possible to highlight type constructor or variable mismatch (because previously the typechecker was just raising an unexplained error in those cases).

-----------------------------------------------------------

In term of implementation,

- the first commit, aae083bafcf066ef390542872a1b6b4073653016, makes the `outcometree` highlightable
- the second commit, 1f2c8cae3a14d2db7f9985b589d745ba40b208bf, implements syntactic highlighting
- the third commit, 27eaa14442251379a19be166b5989ef8a6e47875, add text markers for this highlighting in expect tests
- the fourth commit, 954370479e3765daeb6175edbff010dbcd3119b9, implements the core part of the trace-guided highlighting
- the fifth commit f92d3fac24542401614b17311a4523dd833f5eef, sixth commit 81660ebed7dab5f731329a5287ad2baa1369a06d, and seventh commit 37717882286c7c8237436abe015c4cafb539d245 adds more information in the error trace for guiding highlighting when the typechecker detetcs incompatible type constructors or variables
- the eight commit, 96de7121f4cd74053b8b5595cdc73515149cf458, adds support for multiple highlighting targets for error messages where we have a comparison between more than two objects.
- the last two commits are refinements of the highligting.

[^1]: I am using «...» as a text marker for highlighted code, the current implementation uses a red font color in the terminal.