### PR TITLE
[4.14] Specify pthread libraries when linking dllthreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,13 +1,6 @@
 OCaml 4.14 maintenance version
 ------------------------------
 
-### Bug fixes:
-
-- #14599, #14606: on ARM64 platforms, ocamlopt was under-estimating
-  the sizes of some instructions.  This could lead to overflows in
-  relative branch offsets, reported as errors by the assembler.
-  (Xavier Leroy, review by Vincent Laviron, report by Raphaël Proust)
-
 ### Build system:
 
 - #12372, #14572: Pass option -no-execute-only to the linker for OpenBSD >= 7.3
@@ -23,6 +16,18 @@ OCaml 4.14 maintenance version
 - #14607: Fix linking with libasmrun_shared.so on Risc-V (undefined symbol
   declared riscv.o)
   (David Allsopp, review by Nicolás Ojeda Bär)
+
+- #14599, #14606: on ARM64 platforms, ocamlopt was under-estimating
+  the sizes of some instructions.  This could lead to overflows in
+  relative branch offsets, reported as errors by the assembler.
+  (Xavier Leroy, review by Vincent Laviron, report by Raphaël Proust)
+
+- #14661: Build dllthreads.so with pthreads flags (removed in #13018). For
+  normal programs there's no semantic difference, because ocamlrun and
+  ocamlc.opt are always linked with pthreads, but it was a regression to require
+  programs wishing to dlopen dllthreads.so to have already linked with pthreads
+  themselves.
+  (David Allsopp, review by ???)
 
 OCaml 4.14.3 (17 February 2026)
 ------------------------------

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -65,8 +65,10 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
+# Bytecode programs always link with pthread libraries, but the dependency
+# should still be recorded in the DLL.
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS)
+	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LIBS)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
 	$(MKLIB_CMD) -o $(LIBNAME)nat $^


### PR DESCRIPTION
#13018 fixed duplicate libraries being passed to the linker, dealing with newer versions of `lld` reporting warnings. Technically speaking, it went slightly too far with the removal of the linking flags, as it means that the bytecode shared stubs library `dllthreads.so`,  was no longer linked against pthreads.

This is not a critical problem firstly because `ocamlrun` and `ocamlc.opt` already link with pthreads, and secondly because glibc 2.34+ has pthreads available by default in libc anyway.

However, this PR morally restores the missing link flags when building dllthreads.so (the recipe looks confusing because dllthreads.so is produced as a side-effect of producing dllthreads.a by `ocamlmklib`).

(for context, this came up as part of a mistake while testing on a Jenkins worker which is still running a pre-glibc 2.34 version of Ubuntu)