### PR TITLE
Correct order of compiler flags in ocamltest

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -273,9 +273,9 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
         c_headers_flags;
         Ocaml_flags.stdlib;
         directory_flags env;
-        flags env;
         libraries;
         backend_default_flags env compiler#target;
+        flags env;
         backend_flags env compiler#target;
         compile_flags;
         output;
@@ -315,9 +315,9 @@ let compile_module compiler module_ log env =
     Ocaml_flags.stdlib;
     c_headers_flags;
     directory_flags env;
-    flags env;
     libraries compiler#target env;
     backend_default_flags env compiler#target;
+    flags env;
     backend_flags env compiler#target;
     "-c " ^ module_;
   ] in

--- a/testsuite/tests/asmcomp/staticalloc.ml
+++ b/testsuite/tests/asmcomp/staticalloc.ml
@@ -1,6 +1,6 @@
 (* TEST
  include config;
- flags = "config.cmx";
+ binary_modules = "config";
  native;
 *)
 

--- a/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
+++ b/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
@@ -1,8 +1,8 @@
 (* TEST
  include config;
+ binary_modules = "config";
  flags = "-w -55";
- ocamlc_flags = "config.cmo";
- ocamlopt_flags = "-inline 20 config.cmx";
+ ocamlopt_flags = "-inline 20";
  native;
 *)
 


### PR DESCRIPTION
When compiling files, there are three variables which add flags to the compiler invocation, `ocamlc_default_flags` (internal), `ocamlc_flags` and `flags` (and equivalent `ocamlopt_` versions).

The `_default_flags` variables haven't been used since #10208, but while trying to use them to reduce the diff between OxCaml and OCaml I found that the order in which these variables are put into the command line is incorrect. As with the build system, we should have the defaults and common options to the left - i.e. each more specific variable able to override a more general set of options. As it happens, this was already being correctly done with the toplevel actions.

In particular, it means that warnings, alerts and other options for which there's a `-no` counterpart can be specified in default options and overridden in flags.

In passing, while checking this, I switched two tests which were abusing flags to pass modules to use the `binary_modules` variable instead (which all the other tests with `include config` were already doing - `binary_modules` is newer than `include config`).