### PR TITLE
HashedType.hash: clarify required properties of [hash]

### DIFF
--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -370,8 +370,8 @@ module type HashedType =
           in the table. In particular, if the hash function depends on mutable
           key data, then that data must not be mutated while the key is in the
           table. Similarly, as the hash function may be called while the table
-          itself is being modified, it should avoid accessing the table as part
-          of its computation.
+          itself is being modified, it should avoid accessing the table as
+          part of its computation.
 
           Examples: suitable ([equal], [hash]) pairs for arbitrary key
           types include

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -365,6 +365,14 @@ module type HashedType =
       (** A hashing function on keys. It must be such that if two keys are
           equal according to [equal], then they have identical hash values
           as computed by [hash].
+
+          The hash value of a key should remain constant as long as the key is
+          in the table. In particular, if the hash function depends on mutable
+          key data, then that data must not be mutated while the key is in the
+          table. Similarly, as the hash function may be called while the table
+          itself is being modified, it should avoid accessing the table as part
+          of its computation.
+
           Examples: suitable ([equal], [hash]) pairs for arbitrary key
           types include
 -         ([(=)], {!hash}) for comparing objects by structure

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -387,8 +387,8 @@ module Hashtbl : sig
             in the table. In particular, if the hash function depends on mutable
             key data, then that data must not be mutated while the key is in the
             table. Similarly, as the hash function may be called while the table
-            itself is being modified, it should avoid accessing the table as part
-            of its computation.
+            itself is being modified, it should avoid accessing the table as
+            part of its computation.
 
             Examples: suitable ([equal], [hash]) pairs for arbitrary key
             types include

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -382,6 +382,14 @@ module Hashtbl : sig
         (** A hashing function on keys. It must be such that if two keys are
             equal according to [equal], then they have identical hash values
             as computed by [hash].
+
+            The hash value of a key should remain constant as long as the key is
+            in the table. In particular, if the hash function depends on mutable
+            key data, then that data must not be mutated while the key is in the
+            table. Similarly, as the hash function may be called while the table
+            itself is being modified, it should avoid accessing the table as part
+            of its computation.
+
             Examples: suitable ([equal], [hash]) pairs for arbitrary key
             types include
   -         ([(=)], {!hash}) for comparing objects by structure

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -370,8 +370,8 @@ module type HashedType =
           in the table. In particular, if the hash function depends on mutable
           key data, then that data must not be mutated while the key is in the
           table. Similarly, as the hash function may be called while the table
-          itself is being modified, it should avoid accessing the table as part
-          of its computation.
+          itself is being modified, it should avoid accessing the table as
+          part of its computation.
 
           Examples: suitable ([equal], [hash]) pairs for arbitrary key
           types include

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -365,6 +365,14 @@ module type HashedType =
       (** A hashing function on keys. It must be such that if two keys are
           equal according to [equal], then they have identical hash values
           as computed by [hash].
+
+          The hash value of a key should remain constant as long as the key is
+          in the table. In particular, if the hash function depends on mutable
+          key data, then that data must not be mutated while the key is in the
+          table. Similarly, as the hash function may be called while the table
+          itself is being modified, it should avoid accessing the table as part
+          of its computation.
+
           Examples: suitable ([equal], [hash]) pairs for arbitrary key
           types include
 -         ([(=)], {!hash}) for comparing objects by structure


### PR DESCRIPTION
An attempt to clarify #14660.

Fixes #14660