### PR TITLE
Always emit the `prefetchw` instruction on x86 and x86_64

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,10 +23,9 @@ Working version
   symbols from the runtime. The declarations were removed in 5.0.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 
-- #14570, #14616: Distinguish between prefetching for read and write access in
-  the runtime. Significant performance benefit for some multi-domain
-  programs. For maximum benefit on AMD64, pass `-mprfchw` or `-march=native` to
-  the C compiler.
+- #14570, #14616, #14665: Distinguish between prefetching for read and write
+  access in the runtime. Significant performance benefit for some multi-domain
+  programs.
   (Nick Barnes, review by Gabriel Scherer, Damien Doligez, and Antonin Décimo)
 
 - #14651: Remove S390x TSan (Thread Sanitizer) support.

--- a/configure
+++ b/configure
@@ -15705,6 +15705,53 @@ fi
     common_cflags="-O" ;;
 esac
 
+# Enable the prefetchw instruction on x86 and x86_64.
+case $target in #(
+  i686*|x86_64*) :
+    as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-mprfchw" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -mprfchw" >&5
+printf %s "checking whether the C compiler accepts -mprfchw... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag -mprfchw"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  internal_cflags="$internal_cflags -mprfchw"
+else $as_nop
+  :
+fi
+ ;; #(
+  *) :
+     ;;
+esac
+
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 # Enable 64-bit time_t in time.h
 case $target in #(

--- a/configure.ac
+++ b/configure.ac
@@ -1145,6 +1145,12 @@ AS_CASE([$ocaml_cc_vendor],
     internal_cflags="$cc_warnings"],
   [common_cflags="-O"])
 
+# Enable the prefetchw instruction on x86 and x86_64.
+AS_CASE([$target],
+  [i686*|x86_64*],
+    [AX_CHECK_COMPILE_FLAG([-mprfchw],
+      [internal_cflags="$internal_cflags -mprfchw"], [], [$warn_error_flag])])
+
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 # Enable 64-bit time_t in time.h
 AS_CASE([$target],


### PR DESCRIPTION
In #14570, @stedolan [wrote](https://github.com/ocaml/ocaml/pull/14570#issuecomment-3932997030):

> it's a reasonable option to just pass `-mprfchw` by default and accept that it won't perform well on 2008-2014-era Intel processors.

The `-mprfchw` flag is needed by GCC (and MinGW-w64), Clang (and clang-cl), and presumably other LLVM-based compilers to emit the `prefetchw` instruction on x86 and x86_64.

MSVC unconditionally emits `prefetchw`. Support in the CPU for this instruction is required since Windows 10.

With GCC and LLVM-based compilers, the option can be reverted by setting `./configure CFLAGS=-mno-prfchw`.

cc @NickBarnes 