### PR TITLE
Give C string constants the type `const char[N]` instead of `char[N]` (`-Wwrite-strings`)

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,10 @@ Working version
 - #14482: Add DWARF CFI support to POWER backend.
   (Tim McGilchrist, review by Xavier Leroy)
 
+- #14666: Give C string constants the type `const char[N]` instead of `char[N]`
+  with the C compiler `-Wwrite-strings` flag.
+  (Antonin Décimo, review by Xavier Leroy and Olivier Nicole)
+
 - #14717: assign 'unique_id' early during domain creation to help debugging
   (Gabriel Scherer, review by Olivier Nicole)
 

--- a/configure
+++ b/configure
@@ -15506,48 +15506,6 @@ fi
      ;;
 esac
 
-# Use -Wold-style-declaration if supported
-as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-Wold-style-declaration" | $as_tr_sh`
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -Wold-style-declaration" >&5
-printf %s "checking whether the C compiler accepts -Wold-style-declaration... " >&6; }
-if eval test \${$as_CACHEVAR+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-
-  ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS $warn_error_flag -Wold-style-declaration"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  eval "$as_CACHEVAR=yes"
-else $as_nop
-  eval "$as_CACHEVAR=no"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  CFLAGS=$ax_check_save_flags
-fi
-eval ac_res=\$$as_CACHEVAR
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
-if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
-then :
-  cc_warnings="$cc_warnings -Wold-style-declaration"
-else $as_nop
-  :
-fi
-
-
 # Use -Wimplicit-fallthrough if supported
 for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
   as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_$flag" | $as_tr_sh`
@@ -15586,6 +15544,53 @@ printf "%s\n" "$ac_res" >&6; }
 if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
 then :
   cc_warnings="$cc_warnings $flag"; break
+else $as_nop
+  :
+fi
+
+done
+
+# Additional warnings
+for flag in \
+  '-Wold-style-declaration' \
+  '-Wwrite-strings' \
+; do
+    as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_$flag" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts $flag" >&5
+printf %s "checking whether the C compiler accepts $flag... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag $flag"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  cc_warnings="$cc_warnings $flag"
 else $as_nop
   :
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1066,15 +1066,19 @@ AS_CASE([$ocaml_cc_vendor],
       [cc_warnings="$cc_warnings -Wno-cast-function-type-mismatch"], [],
       [$warn_error_flag])])
 
-# Use -Wold-style-declaration if supported
-AX_CHECK_COMPILE_FLAG([-Wold-style-declaration],
-  [cc_warnings="$cc_warnings -Wold-style-declaration"], [],
-  [$warn_error_flag])
-
 # Use -Wimplicit-fallthrough if supported
 for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
   AX_CHECK_COMPILE_FLAG([$flag],
     [cc_warnings="$cc_warnings $flag"; break], [], [$warn_error_flag])
+done
+
+# Additional warnings
+for flag in \
+  '-Wold-style-declaration' \
+  '-Wwrite-strings' \
+; do
+    AX_CHECK_COMPILE_FLAG([$flag],
+      [cc_warnings="$cc_warnings $flag"], [], [$warn_error_flag])
 done
 
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -257,7 +257,7 @@ if ( (condition) ) \
   goto cleanup; \
 } else { }
 
-static WCHAR *translate_finename(WCHAR *filename)
+static const WCHAR *translate_finename(const WCHAR *filename)
 {
   if (wcscmp(filename, L"/dev/null") == 0) return L"NUL"; else return filename;
 }
@@ -304,7 +304,7 @@ int run_command(const command_settings *settings)
 
   if (is_defined(settings->stdin_filename))
   {
-    WCHAR *stdin_filename = translate_finename(settings->stdin_filename);
+    const WCHAR *stdin_filename = translate_finename(settings->stdin_filename);
     startup_info.hStdInput = create_input_handle(stdin_filename);
     checkerr( (startup_info.hStdInput == INVALID_HANDLE_VALUE),
       "Could not redirect standard input",
@@ -314,7 +314,8 @@ int run_command(const command_settings *settings)
 
   if (is_defined(settings->stdout_filename))
   {
-    WCHAR *stdout_filename = translate_finename(settings->stdout_filename);
+    const WCHAR *stdout_filename =
+      translate_finename(settings->stdout_filename);
     startup_info.hStdOutput = create_output_handle(
       stdout_filename, settings->append
     );
@@ -338,7 +339,8 @@ int run_command(const command_settings *settings)
 
     if (! stderr_redirected)
     {
-      WCHAR *stderr_filename = translate_finename(settings->stderr_filename);
+      const WCHAR *stderr_filename =
+        translate_finename(settings->stderr_filename);
       startup_info.hStdError = create_output_handle
       (
         stderr_filename, settings->append

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -85,7 +85,7 @@ static int caml_unix_execve_script(const char * path,
             {"/bin/sh", path, argv[1], ..., argv[argc-1], NULL} */
   new_argv = calloc(argc + 3, sizeof (char *));
   if (new_argv == NULL) return ENOMEM;
-  new_argv[0] = "/bin/sh";
+  new_argv[0] = (char *) "/bin/sh";
   new_argv[1] = (char *) path;
   for (size_t i = 1; i < argc; i++) new_argv[i + 1] = argv[i];
   new_argv[argc + 1] = NULL;

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -35,8 +35,8 @@
 struct caml_loc_info {
   int loc_valid;
   int loc_is_raise;
-  char * loc_filename;
-  char * loc_defname;
+  const char * loc_filename;
+  const char * loc_defname;
   int loc_start_lnum;
   int loc_start_chr;
   int loc_end_lnum;
@@ -110,8 +110,8 @@ value caml_remove_debug_info(code_t start);
    for quick lookup */
 struct ev_info {
   code_t ev_pc;
-  char *ev_filename;
-  char *ev_defname;
+  const char *ev_filename;
+  const char *ev_defname;
   int ev_start_lnum;
   int ev_start_chr;  /* Relative to ev_start_lnum */
   int ev_end_lnum;

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -72,7 +72,7 @@ extern void * caml_dlsym(void * handle, const char * name);
 extern void * caml_globalsym(const char * name);
 
 /* Return an error message describing the most recent dynlink failure. */
-extern char * caml_dlerror(void);
+extern const char * caml_dlerror(void);
 
 /* Recover executable name if possible (/proc/sef/exe under Linux,
    GetModuleFileName under Windows).  Return NULL on error,

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -398,7 +398,7 @@ CAMLprim value caml_runtime_parameters (value unit)
 
   CAMLassert (unit == Val_unit);
   char *tweaks = format_gc_tweaks();
-  char *no_tweaks = "";
+  const char *no_tweaks = "";
   value res = caml_alloc_sprintf
       ("b=%d,c=%"F_Z",e=%"F_Z",l=%"F_Z",M=%"F_Z",m=%"F_Z",n=%"F_Z","
        "o=%"F_Z",p=%d,R=%u,s=%"F_S",t=%"F_Z",v=%"F_Z",V=%"F_Z",W=%"F_Z"%s",

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -34,7 +34,7 @@
 #include "caml/backtrace_prim.h"
 
 #define OPCODE_NAME(name) #name,
-static char * names_of_instructions [] = {
+static char const * const names_of_instructions [] = {
   CAML_ZINC_OPCODES(OPCODE_NAME)
   "FIRST_UNIMPLEMENTED_OP"
 };

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -256,7 +256,7 @@ void * caml_globalsym(const char * name)
   return flexdll_dlsym(flexdll_dlopen(NULL,0), name);
 }
 
-char * caml_dlerror(void)
+const char * caml_dlerror(void)
 {
   return flexdll_dlerror();
 }
@@ -295,9 +295,9 @@ void * caml_globalsym(const char * name)
 #endif
 }
 
-char * caml_dlerror(void)
+const char * caml_dlerror(void)
 {
-  return (char*) dlerror();
+  return dlerror();
 }
 
 #endif /* __CYGWIN__ */
@@ -322,7 +322,7 @@ void * caml_globalsym(const char * name)
   return NULL;
 }
 
-char * caml_dlerror(void)
+const char * caml_dlerror(void)
 {
   return "dynamic loading not supported on this platform";
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -277,7 +277,7 @@ void * caml_globalsym(const char * name)
 
 char * caml_dlerror(void)
 {
-  return "dynamic loading not supported on this platform";
+  return (char *) "dynamic loading not supported on this platform";
 }
 
 #endif /* WITH_DYNAMIC_LINKING */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -249,7 +249,7 @@ void * caml_globalsym(const char * name)
   return flexdll_dlsym(flexdll_wdlopen(NULL,0), name);
 }
 
-char * caml_dlerror(void)
+const char * caml_dlerror(void)
 {
   return flexdll_dlerror();
 }
@@ -275,9 +275,9 @@ void * caml_globalsym(const char * name)
   return NULL;
 }
 
-char * caml_dlerror(void)
+const char * caml_dlerror(void)
 {
-  return (char *) "dynamic loading not supported on this platform";
+  return "dynamic loading not supported on this platform";
 }
 
 #endif /* WITH_DYNAMIC_LINKING */

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -182,7 +182,7 @@ void getargs(int argc, char_os **argv)
         {
         case '\0':
             input_file = stdin;
-            file_prefix = T("stdin");
+            file_prefix = (char_os *) T("stdin");
             if (i + 1 < argc) usage();
             return;
 

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1528,7 +1528,7 @@ pack_symbols(void)
     symbol_value[0] = 0;
     symbol_prec[0] = 0;
     symbol_assoc[0] = TOKEN;
-    symbol_tag[0] = "";
+    symbol_tag[0] = (char *) "";
     symbol_true_token[0] = 0;
     for (i = 1; i < ntokens; ++i)
     {
@@ -1543,7 +1543,7 @@ pack_symbols(void)
     symbol_value[start_symbol] = -1;
     symbol_prec[start_symbol] = 0;
     symbol_assoc[start_symbol] = TOKEN;
-    symbol_tag[start_symbol] = "";
+    symbol_tag[start_symbol] = (char *) "";
     symbol_true_token[start_symbol] = 0;
     for (++i; i < nsyms; ++i)
     {


### PR DESCRIPTION
This PR enables the use of the `-Wwrite-strings` flag of GCC and Clang for a bit of added type safety. Some background on character string literals and this flag:

> The type of the [character string] literal is `char[N]`, where `N` is the size of the string in code units of the execution narrow encoding, including the null terminator.

> String literals are not modifiable (and in fact may be placed in read-only memory such as `.rodata`). If a program attempts to modify the static array formed by a string literal, the behavior is undefined.
>
> ```c
> char* p = "Hello";
> p[1] = 'M'; // Undefined behavior
> char a[] = "Hello";
> a[1] = 'M'; // OK: a is not a string literal
> ```

https://en.cppreference.com/w/c/language/string_literal.html

In C++ ordinary string literals have type `const char[N]` which prevents the undefined behavior. GCC and Clang allow changing the type of character literals for just a bit more of type safety with the `-Wwrite-strings` flag.

> When compiling C, give string constants the type `const char[length]` so that copying the address of one into a non-`const char *` pointer produces a warning. These warnings help you find at compile time code that can try to write into a string constant, but only if you have been very careful about using `const` in declarations and prototypes.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wwrite-strings

There are interfaces such as [`dlerror`][1] which return a `char *` that is missing the `const` qualifier, but whose documentation forbids modifying the string returned. Other functions such as [`execve`][2] expect constant parameters, but for historical reasons or other limitations, the `const` qualifier cannot be used.

[1]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/dlerror.html
[2]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/execve.html#tag_17_129_08