### PR TITLE
Fix #14512, allowing functions in CPS

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,7 +46,7 @@ Working version
 
 ### Type system:
 
-- #14512, #?: Improve check for warning 16 (unerasable-optional-argument)
+- #14512, #14671: Improve check for warning 16 (unerasable-optional-argument)
   (Alistair O'Brien, Jacques Garrigue, review by Florian Angeletti,
    Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -46,8 +46,9 @@ Working version
 
 ### Type system:
 
-- #14512: Improve check for warning 16 (unerasable-optional-argument)
-  (Alistair O'Brien, review by Florian Angeletti, Gabriel Scherer)
+- #14512, #?: Improve check for warning 16 (unerasable-optional-argument)
+  (Alistair O'Brien, Jacques Garrigue, review by Florian Angeletti,
+   Gabriel Scherer)
 
 - #12150: class type system improvements: self type constraints, virtual method
   inheritance in mutually recursive definition, immediate object inheritance.

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -156,7 +156,7 @@ let g = f (fun a -> ());;
 val g : ?a:'_weak1 -> unit = <fun>
 |}]
 
-(* But we can still detect if we add optional arguments *)
+(* But we can still warn if we add optional arguments *)
 let h ?b = f (fun a -> ());;
 [%%expect{|
 Line 1, characters 7-8:

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -150,7 +150,7 @@ let f k ?a = k a;;
 val f : ('a option -> 'b) -> ?a:'a -> 'b = <fun>
 |}]
 
-(* This one cannot be detected has this is just a specialization of f *)
+(* This cannot be detected as the delayed check does not apply to instances *)
 let g = f (fun a -> ());;
 [%%expect{|
 val g : ?a:'_weak1 -> unit = <fun>

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -142,3 +142,28 @@ module type Show = sig type t val show : t -> string end
 type 'a t = A : { x : string option; show : 'a -> string; } -> 'a t
 val test : ?x:string -> (module M : Show with type t = 'a) -> M.t t = <fun>
 |}]
+
+(* Support CPS *)
+
+let f k ?a = k a;;
+[%%expect{|
+val f : ('a option -> 'b) -> ?a:'a -> 'b = <fun>
+|}]
+
+(* This one cannot be detected has this is just a specialization of f *)
+let g = f (fun a -> ());;
+[%%expect{|
+val g : ?a:'_weak1 -> unit = <fun>
+|}]
+
+(* But we can still detect if we add optional arguments *)
+let h ?b = f (fun a -> ());;
+[%%expect{|
+Line 1, characters 7-8:
+1 | let h ?b = f (fun a -> ());;
+           ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
+val h : ?b:'a -> ?a:'b -> unit = <fun>
+|}]
+

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -166,4 +166,3 @@ Warning 16 [unerasable-optional-argument]: this optional argument cannot be eras
 
 val h : ?b:'a -> ?a:'b -> unit = <fun>
 |}]
-

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6308,11 +6308,8 @@ let arrow_spine env ty =
       | _ -> List.rev labels, Ret_type ty)
     else List.rev labels, Ret_cycle
   in
-  let result =
-    with_type_mark (fun mark ->
-        wrap_trace_gadt_instances env (arrow_spine_rec ~mark []) ty)
-  in
-  result
+  with_type_mark (fun mark ->
+    wrap_trace_gadt_instances env (arrow_spine_rec ~mark []) ty)
 
 let arrow_labels env ty =
   let snap = snapshot () in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6308,21 +6308,21 @@ let arrow_spine env ty =
       | _ -> List.rev labels, Ret_type ty)
     else List.rev labels, Ret_cycle
   in
-  let snap = snapshot () in
   let result =
     with_type_mark (fun mark ->
         wrap_trace_gadt_instances env (arrow_spine_rec ~mark []) ty)
   in
-  backtrack snap;
   result
 
 let arrow_labels env ty =
+  let snap = snapshot () in
   let label_tys, ret_ty_or_cycle = arrow_spine env ty in
   let is_ret_tvar =
     match ret_ty_or_cycle with
     | Ret_cycle -> false
     | Ret_type ty -> is_Tvar ty
   in
+  backtrack snap;
   List.map fst label_tys, ~is_ret_tvar
 
                               (*************************)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -371,7 +371,7 @@ val filter_method: Env.t -> string -> type_expr -> type_expr
            [Filter_method_failed] instead of [Unify]. *)
 
 (** [arrow_labels env ty] expands [ty] as an array type in [env] and
-    returns its argument labels.
+    returns its argument labels. The input types is kept unchanged.
 
     [is_ret_tvar] is [true] if the final return type is a type variable,
     indicating that the list of labels isn't necessarily exhaustive. *)
@@ -394,6 +394,8 @@ type arrow_ret =
 
 (** [arrow_spine env ty] expands [ty] as a arrow type in [env] and returns
     its arrow spine.
+    It may change the type through expansions, so if scopes matter you
+    should backtrack after using it.
 
     If [ty] is [l1:ty1 -> ... -> ln:tyn -> rty], it returns
     [([(l1, ty1); ...; (ln, tyn)], Ret_type rty)].

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -370,8 +370,8 @@ val filter_method: Env.t -> string -> type_expr -> type_expr
         (* A special case of unification (with {m : 'a; 'b}).  Raises
            [Filter_method_failed] instead of [Unify]. *)
 
-(** [arrow_labels env ty] expands [ty] as an array type in [env] and
-    returns its argument labels. The input types is kept unchanged.
+(** [arrow_labels env ty] expands [ty] as an arrow type in [env] and
+    returns its argument labels. The input type is kept unchanged.
 
     [is_ret_tvar] is [true] if the final return type is a type variable,
     indicating that the list of labels isn't necessarily exhaustive. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5697,21 +5697,13 @@ and type_function
          there might be an opportunity to improve this.
       *)
       let only_labels_function_ret_tvar ty =
-        (* [arrow_spine] does expansion and is potentially expensive;
+        (* [arrow_labels] does expansion and is potentially expensive;
            only call this when necessary. *)
-        let label_tys, ret_ty_or_cycle = arrow_spine env ty in
+        let labels, ~is_ret_tvar = arrow_labels env ty in
         let is_spine_only_labels =
-          List.for_all (fun (label, _arg_ty) -> label <> Nolabel) label_tys
+          List.for_all (fun label -> label <> Nolabel) labels
         in
-        if is_spine_only_labels
-        then (
-          match ret_ty_or_cycle with
-          | Ret_cycle -> Some `Not_tvar
-          | Ret_type ty ->
-              if is_Tvar ty
-              then Some (`Tvar ty)
-              else Some `Not_tvar )
-        else None
+        if is_spine_only_labels then Some is_ret_tvar else None
       in
       (* An optional argument [?x] is only erasable if the function's return
          type eventually becomes an unlabelled arrow type ['a -> 'b].
@@ -5732,14 +5724,14 @@ and type_function
       if is_optional arg_label
       then (
         match only_labels_function_ret_tvar ty_ret with
-        | Some (`Tvar ret_tvar) ->
+        | Some true ->
           (* We don't necessarily know [ty] is a function with only labelled
              args since unification may change this. So we add
              a delayed check. *)
           add_delayed_check (fun () ->
-              if Option.is_some (only_labels_function_ret_tvar ret_tvar)
+              if only_labels_function_ret_tvar ty_ret = Some false
               then raise_unerasable_optional_argument ())
-        | Some `Not_tvar -> raise_unerasable_optional_argument ()
+        | Some false -> raise_unerasable_optional_argument ()
         | None -> ());
       let fp_kind, fp_param =
         match default_arg with


### PR DESCRIPTION
The check for unerasable optional parameters in #14512 is too strict, warning even for functions whose return type is a type variable. This creates in particular problems with functions written in CPS to allow combining optional arguments.
This also fixes an error where `arrow_spine` was returning types after backtracking, which is strictly illegal.
Now `arrow_spine` does not backtrack, only `arrow_labels` does.
It is not clear whether exporting `arrow_spine` is useful anymore, since it is only used by `arrow_labels`.