### PR TITLE
fix: prevent shell injection in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,28 +46,29 @@ jobs:
         id: manual
         run: >-
          tools/ci/actions/check-manual-modified.sh
-         "$GITHUB_REF_NAME"
-         "$EVENT_NAME"
-         "$PR_BASE_REF"
-         "$PR_BASE_SHA"
-         "$PR_HEAD_REF"
-         "$PR_HEAD_SHA"
-         "$EVENT_REF"
-         "$EVENT_BEFORE"
-         "$EVENT_REF"
-         "$EVENT_AFTER"
-         "$REPO_FULL_NAME"
+         "$CAMLCI_GITHUB_REF_NAME"
+         "$CAMLCI_EVENT_NAME"
+         "$CAMLCI_PR_BASE_REF"
+         "$CAMLCI_PR_BASE_SHA"
+         "$CAMLCI_PR_HEAD_REF"
+         "$CAMLCI_PR_HEAD_SHA"
+         "$CAMLCI_EVENT_REF"
+         "$CAMLCI_EVENT_BEFORE"
+         "$CAMLCI_EVENT_REF"
+         "$CAMLCI_EVENT_AFTER"
+         "$CAMLCI_REPO_FULL_NAME"
         env:
-          GITHUB_REF_NAME: ${{ github.ref }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_REF: ${{ github.event.ref }}
-          EVENT_BEFORE: ${{ github.event.before }}
-          EVENT_AFTER: ${{ github.event.after }}
-          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+          # Prefix CAMLCI used here to avoid GITHUB_REF_NAME colliding
+          CAMLCI_GITHUB_REF_NAME: ${{ github.ref }}
+          CAMLCI_EVENT_NAME: ${{ github.event_name }}
+          CAMLCI_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CAMLCI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CAMLCI_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CAMLCI_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CAMLCI_EVENT_REF: ${{ github.event.ref }}
+          CAMLCI_EVENT_BEFORE: ${{ github.event.before }}
+          CAMLCI_EVENT_AFTER: ${{ github.event.after }}
+          CAMLCI_REPO_FULL_NAME: ${{ github.event.repository.full_name }}
       - name: Configure tree
         run: |
           MAKE_ARG=-j CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-codegen-invariants --enable-dependency-generation --enable-native-toplevel --with-relative-libdir --enable-runtime-search --enable-runtime-search-target=fallback' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,17 +46,28 @@ jobs:
         id: manual
         run: >-
          tools/ci/actions/check-manual-modified.sh
-         '${{ github.ref }}'
-         '${{ github.event_name }}'
-         '${{ github.event.pull_request.base.ref }}'
-         '${{ github.event.pull_request.base.sha }}'
-         '${{ github.event.pull_request.head.ref }}'
-         '${{ github.event.pull_request.head.sha }}'
-         '${{ github.event.ref }}'
-         '${{ github.event.before }}'
-         '${{ github.event.ref }}'
-         '${{ github.event.after }}'
-         '${{ github.event.repository.full_name }}'
+         "$GITHUB_REF_NAME"
+         "$EVENT_NAME"
+         "$PR_BASE_REF"
+         "$PR_BASE_SHA"
+         "$PR_HEAD_REF"
+         "$PR_HEAD_SHA"
+         "$EVENT_REF"
+         "$EVENT_BEFORE"
+         "$EVENT_REF"
+         "$EVENT_AFTER"
+         "$REPO_FULL_NAME"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REF: ${{ github.event.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
       - name: Configure tree
         run: |
           MAKE_ARG=-j CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-codegen-invariants --enable-dependency-generation --enable-native-toplevel --with-relative-libdir --enable-runtime-search --enable-runtime-search-target=fallback' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -36,46 +36,46 @@ jobs:
       - name: Changes updated
         run: >-
           tools/ci/actions/check-changes-modified.sh
-          "$PR_ISSUE_URL"
-          "$GITHUB_REF_NAME"
+          "$CAMLCI_PR_ISSUE_URL"
+          "$CAMLCI_GITHUB_REF_NAME"
           'pull_request'
-          "$PR_BASE_REF"
-          "$PR_BASE_SHA"
-          "$PR_HEAD_REF"
-          "$PR_HEAD_SHA"
+          "$CAMLCI_PR_BASE_REF"
+          "$CAMLCI_PR_BASE_SHA"
+          "$CAMLCI_PR_HEAD_REF"
+          "$CAMLCI_PR_HEAD_SHA"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_ISSUE_URL: ${{ github.event.pull_request.issue_url }}
-          GITHUB_REF_NAME: ${{ github.ref }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CAMLCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAMLCI_PR_ISSUE_URL: ${{ github.event.pull_request.issue_url }}
+          CAMLCI_GITHUB_REF_NAME: ${{ github.ref }}
+          CAMLCI_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CAMLCI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CAMLCI_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CAMLCI_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         if: github.event_name == 'pull_request'
 
       - name: configure correctly generated
         run: >-
           tools/ci/actions/check-configure.sh
-          "$GITHUB_REF_NAME"
-          "$EVENT_NAME"
-          "$PR_BASE_REF"
-          "$PR_BASE_SHA"
-          "$PR_HEAD_REF"
-          "$PR_HEAD_SHA"
-          "$EVENT_REF"
-          "$EVENT_BEFORE"
-          "$EVENT_REF"
-          "$EVENT_AFTER"
+          "$CAMLCI_GITHUB_REF_NAME"
+          "$CAMLCI_EVENT_NAME"
+          "$CAMLCI_PR_BASE_REF"
+          "$CAMLCI_PR_BASE_SHA"
+          "$CAMLCI_PR_HEAD_REF"
+          "$CAMLCI_PR_HEAD_SHA"
+          "$CAMLCI_EVENT_REF"
+          "$CAMLCI_EVENT_BEFORE"
+          "$CAMLCI_EVENT_REF"
+          "$CAMLCI_EVENT_AFTER"
         env:
-          GITHUB_REF_NAME: ${{ github.ref }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_REF: ${{ github.event.ref }}
-          EVENT_BEFORE: ${{ github.event.before }}
-          EVENT_AFTER: ${{ github.event.after }}
+          CAMLCI_GITHUB_REF_NAME: ${{ github.ref }}
+          CAMLCI_EVENT_NAME: ${{ github.event_name }}
+          CAMLCI_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CAMLCI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CAMLCI_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CAMLCI_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CAMLCI_EVENT_REF: ${{ github.event.ref }}
+          CAMLCI_EVENT_BEFORE: ${{ github.event.before }}
+          CAMLCI_EVENT_AFTER: ${{ github.event.after }}
         if: ${{ always() }}
 
       - name: Check that no ignored files have been committed
@@ -86,26 +86,27 @@ jobs:
         id: revered
         run: >-
           tools/ci/actions/check-typo.sh
-          "$GITHUB_REF_NAME"
-          "$EVENT_NAME"
-          "$PR_BASE_REF"
-          "$PR_BASE_SHA"
-          "$PR_HEAD_REF"
-          "$PR_HEAD_SHA"
-          "$EVENT_REF"
-          "$EVENT_BEFORE"
-          "$EVENT_REF"
-          "$EVENT_AFTER"
+          "$CAMLCI_GITHUB_REF_NAME"
+          "$CAMLCI_EVENT_NAME"
+          "$CAMLCI_PR_BASE_REF"
+          "$CAMLCI_PR_BASE_SHA"
+          "$CAMLCI_PR_HEAD_REF"
+          "$CAMLCI_PR_HEAD_SHA"
+          "$CAMLCI_EVENT_REF"
+          "$CAMLCI_EVENT_BEFORE"
+          "$CAMLCI_EVENT_REF"
+          "$CAMLCI_EVENT_AFTER"
         env:
-          GITHUB_REF_NAME: ${{ github.ref }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_REF: ${{ github.event.ref }}
-          EVENT_BEFORE: ${{ github.event.before }}
-          EVENT_AFTER: ${{ github.event.after }}
+          # Prefix CAMLCI used here to avoid GITHUB_REF_NAME colliding
+          CAMLCI_GITHUB_REF_NAME: ${{ github.ref }}
+          CAMLCI_EVENT_NAME: ${{ github.event_name }}
+          CAMLCI_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CAMLCI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CAMLCI_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CAMLCI_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CAMLCI_EVENT_REF: ${{ github.event.ref }}
+          CAMLCI_EVENT_BEFORE: ${{ github.event.before }}
+          CAMLCI_EVENT_AFTER: ${{ github.event.after }}
         if: ${{ always() }}
 
       - name: check-typo on whole tree

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -36,30 +36,46 @@ jobs:
       - name: Changes updated
         run: >-
           tools/ci/actions/check-changes-modified.sh
-          '${{ github.event.pull_request.issue_url }}'
-          '${{ github.ref }}'
+          "$PR_ISSUE_URL"
+          "$GITHUB_REF_NAME"
           'pull_request'
-          '${{ github.event.pull_request.base.ref }}'
-          '${{ github.event.pull_request.base.sha }}'
-          '${{ github.event.pull_request.head.ref }}'
-          '${{ github.event.pull_request.head.sha }}'
+          "$PR_BASE_REF"
+          "$PR_BASE_SHA"
+          "$PR_HEAD_REF"
+          "$PR_HEAD_SHA"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_ISSUE_URL: ${{ github.event.pull_request.issue_url }}
+          GITHUB_REF_NAME: ${{ github.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         if: github.event_name == 'pull_request'
 
       - name: configure correctly generated
         run: >-
           tools/ci/actions/check-configure.sh
-          '${{ github.ref }}'
-          '${{ github.event_name }}'
-          '${{ github.event.pull_request.base.ref }}'
-          '${{ github.event.pull_request.base.sha }}'
-          '${{ github.event.pull_request.head.ref }}'
-          '${{ github.event.pull_request.head.sha }}'
-          '${{ github.event.ref }}'
-          '${{ github.event.before }}'
-          '${{ github.event.ref }}'
-          '${{ github.event.after }}'
+          "$GITHUB_REF_NAME"
+          "$EVENT_NAME"
+          "$PR_BASE_REF"
+          "$PR_BASE_SHA"
+          "$PR_HEAD_REF"
+          "$PR_HEAD_SHA"
+          "$EVENT_REF"
+          "$EVENT_BEFORE"
+          "$EVENT_REF"
+          "$EVENT_AFTER"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REF: ${{ github.event.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
         if: ${{ always() }}
 
       - name: Check that no ignored files have been committed
@@ -70,16 +86,26 @@ jobs:
         id: revered
         run: >-
           tools/ci/actions/check-typo.sh
-          '${{ github.ref }}'
-          '${{ github.event_name }}'
-          '${{ github.event.pull_request.base.ref }}'
-          '${{ github.event.pull_request.base.sha }}'
-          '${{ github.event.pull_request.head.ref }}'
-          '${{ github.event.pull_request.head.sha }}'
-          '${{ github.event.ref }}'
-          '${{ github.event.before }}'
-          '${{ github.event.ref }}'
-          '${{ github.event.after }}'
+          "$GITHUB_REF_NAME"
+          "$EVENT_NAME"
+          "$PR_BASE_REF"
+          "$PR_BASE_SHA"
+          "$PR_HEAD_REF"
+          "$PR_HEAD_SHA"
+          "$EVENT_REF"
+          "$EVENT_BEFORE"
+          "$EVENT_REF"
+          "$EVENT_AFTER"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REF: ${{ github.event.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
         if: ${{ always() }}
 
       - name: check-typo on whole tree

--- a/Changes
+++ b/Changes
@@ -135,6 +135,10 @@ Working version
 
 ### Build system:
 
+- #14676: Security fix: prevent shell injection in Github Actions workflows
+  (Austin Thierault, review by Antonin Décimo, Edwin Török, David Allsopp and
+   Olivier Nicole)
+
 ### Bug fixes:
 
 - #14492: Fix Obj.dup on closures.


### PR DESCRIPTION
Hello!
There's been quite a few supply chain attacks recently (e.g. https://www.wiz.io/blog/teampcp-attack-kics-github-action), and part of the attack vector has been github actions. We noticed that these workflows are theoretically vulnerable to injections (see https://docs.github.com/en/actions/reference/security/secure-use#understanding-the-risk-of-script-injections), so here's a quick fix for them! TL;DR; this just avoids expanding GHA variables directly in a run script, and instead places them in environment variables.