### PR TITLE
Disallow empty functions

### DIFF
--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -34,6 +34,8 @@ let module_type_substitution_missing_rhs loc =
   err loc "Module type substitution with no right hand side"
 let function_without_value_parameters loc =
   err loc "Function without any value parameters"
+let function_without_cases loc =
+  err loc "Function without any branches"
 let invalid_struct_item loc =
   err loc "This kind of structure item is not allowed in this context."
 
@@ -117,6 +119,8 @@ let iterator =
     | Pexp_new id -> simple_longident id
     | Pexp_record (fields, _) ->
       List.iter (fun (id, _) -> simple_longident id) fields
+    | Pexp_function (_, _, Pfunction_cases ([], loc, _)) ->
+        function_without_cases loc
     | Pexp_function (params, _, Pfunction_body _) ->
         if
           List.for_all

--- a/testsuite/tests/parsing/broken_invariants.compilers.reference
+++ b/testsuite/tests/parsing/broken_invariants.compilers.reference
@@ -10,6 +10,7 @@ Line 1, characters 20-27:
 1 | let empty_apply = [%no_args f];;
                         ^^^^^^^
 Error: broken invariant in parsetree: Function application with no argument.
+val empty_function : 'a -> 'b = <fun>
 Line 1, characters 19-45:
 1 | let f = function [%record_with_functor_fields] -> ();;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/parsing/broken_invariants.compilers.reference
+++ b/testsuite/tests/parsing/broken_invariants.compilers.reference
@@ -10,7 +10,10 @@ Line 1, characters 20-27:
 1 | let empty_apply = [%no_args f];;
                         ^^^^^^^
 Error: broken invariant in parsetree: Function application with no argument.
-val empty_function : 'a -> 'b = <fun>
+Line 1, characters 23-37:
+1 | let empty_function = [%empty_function];;
+                           ^^^^^^^^^^^^^^
+Error: broken invariant in parsetree: Function without any branches
 Line 1, characters 19-45:
 1 | let f = function [%record_with_functor_fields] -> ();;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/parsing/broken_invariants.ml
+++ b/testsuite/tests/parsing/broken_invariants.ml
@@ -12,6 +12,7 @@
 let empty_tuple = [%tuple];;
 let empty_record = [%record];;
 let empty_apply = [%no_args f];;
+let empty_function = [%empty_function];;
 let f = function [%record_with_functor_fields] -> ();;
 [%%empty_let];;
 [%%empty_type];;

--- a/testsuite/tests/parsing/illegal_ppx.ml
+++ b/testsuite/tests/parsing/illegal_ppx.ml
@@ -31,6 +31,9 @@ let short_closed_tuple_pat loc =
   let pat = H.Pat.mk Ppat_any in
   H.Pat.tuple ~loc [Some "baz", pat] Closed
 
+let empty_function loc =
+  H.Exp.function_ ~loc [] None (Pfunction_cases ([], loc, []))
+
 let super = M.default_mapper
 let expr mapper e =
   match e.pexp_desc with
@@ -38,6 +41,7 @@ let expr mapper e =
   | Pexp_extension({txt="record";loc},_) -> empty_record loc
   | Pexp_extension({txt="no_args";loc},PStr[{pstr_desc= Pstr_eval (e,_);_}])
     -> empty_apply loc e
+  | Pexp_extension({txt="empty_function"; loc}, _) -> empty_function loc
   | _ -> super.M.expr mapper e
 
 let pat mapper p =


### PR DESCRIPTION
While reviewing #14538 I discovered that ppxs could create a function with no branches while this being rejected in the parser. I propose to fix this by adding a check to prevent such cases form being generated by a ppx.