### PR TITLE
Fix a test introduced in #14380

### DIFF
--- a/testsuite/tests/atomic-locs/check-reserved-bits.sh
+++ b/testsuite/tests/atomic-locs/check-reserved-bits.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+if [ 0 = `$ocamlrun $ocamlopt_byte -config-var reserved_header_bits` ]; then
+  exit $TEST_PASS
+else
+  exit $TEST_SKIP
+fi

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -68,6 +68,8 @@ end
    linux;
    no-flambda; (* the output will be slightly different under Flambda *)
    not tsan; (* TSan modifies the generated code *)
+   script = "sh ${test_source_directory}/check-reserved-bits.sh";
+   script;
 
    setup-ocamlopt.byte-build-env;
    flags = "-c -dcmm -dno-locations -dno-unique-ids";

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -182,6 +182,7 @@ let configuration_variables () =
   p_bool "native_dynlink" native_dynlink;
   p_bool "naked_pointers" naked_pointers;
   p_bool "with_codegen_invariants" with_codegen_invariants;
+  p_int "reserved_header_bits" reserved_header_bits;
 
   p "exec_magic_number" exec_magic_number;
   p "cmi_magic_number" cmi_magic_number;


### PR DESCRIPTION
The test fails when `reserved_header_bits` is not 0. In this case, we skip the test. In order to do that, we have to add `reserved_header_bits` to the config variables printed by `-config` and `-config-var`.

co-authored with Olivier Nicole

see also #14380
