### PR TITLE
memory-model tests: fix default test size

### DIFF
--- a/testsuite/tests/memory-model/opt.ml
+++ b/testsuite/tests/memory-model/opt.ml
@@ -10,8 +10,8 @@ let (default_avail, default_size, default_nruns) =
   else (2, 1000, 10)
 
 let verbose = ref false
-and size = ref 5000
-and nruns = ref 20
+and size = ref default_size
+and nruns = ref default_nruns
 and navail = ref default_avail
 
 module type Config = sig


### PR DESCRIPTION
The `default_*` variables were introduced in
0b8908f80eb7c36506fe3841995ce73e79a8fc54 but they remained unused.

This change brings the time of forbidden.ml from 7s to 2s on my machine, and the time of publish.ml from 2s to 1s.