### PR TITLE
the Ephemeron change from before without the part where your program loops forever

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,11 @@ Working version
 - #13629: Major GC ephemeron cleanup.
   (Nick Barnes, review by Stephen Dolan and Tim McGilchrist).
 
+- #14292: The value returned by `Hashtbl.is_randomized` is now reflected in the
+  `R` parameter of `Sys.runtime_parameters`.
+  (Antonin Décimo, David Allsopp, Hannes Mehnert, review by
+   Nicolás Ojeda Bär)
+
 - #14384: use the statmemprof status word, rather than a distinguished
    value of a boxed float, to identify a "not really sampling"
    profile.
@@ -63,10 +68,12 @@ Working version
 - #14651: Remove S390x TSan (Thread Sanitizer) support.
   (Tim McGilchrist, review by Olivier Nicole)
 
-- #14292: The value returned by `Hashtbl.is_randomized` is now reflected in the
-  `R` parameter of `Sys.runtime_parameters`.
-  (Antonin Décimo, David Allsopp, Hannes Mehnert, review by
-   Nicolás Ojeda Bär)
+- #14657, #14679: optimize garbage-collection of ephemerons that
+  contain long dependency chains: we may still observe quadratic
+  marking behavior, but typically only for a single major GC cycle
+  after the dependency chain is introduced.
+  (Gabriel Scherer, review by Olivier Nicole, Damien Doligez,
+   Stephen Dolan)
 
 - #14482: Add DWARF CFI support to POWER backend.
   (Tim McGilchrist, review by Xavier Leroy)

--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ Working version
 
 ### Runtime system:
 
+- #14292: The value returned by `Hashtbl.is_randomized` is now reflected in the
+  `R` parameter of `Sys.runtime_parameters`.
+  (Antonin Décimo, David Allsopp, Hannes Mehnert, review by
+   Nicolás Ojeda Bär)
+
 - #14486, #14530: Add FreeBSD frame pointers support for AMD64 and ARM64.
   Document the usage of pmcstat and dtrace for generating profiling
   information.
@@ -36,10 +41,12 @@ Working version
 - #14651: Remove S390x TSan (Thread Sanitizer) support.
   (Tim McGilchrist, review by Olivier Nicole)
 
-- #14292: The value returned by `Hashtbl.is_randomized` is now reflected in the
-  `R` parameter of `Sys.runtime_parameters`.
-  (Antonin Décimo, David Allsopp, Hannes Mehnert, review by
-   Nicolás Ojeda Bär)
+- #14657, #14679: optimize garbage-collection of ephemerons that
+  contain long dependency chains: we may still observe quadratic
+  marking behavior, but typically only for a single major GC cycle
+  after the dependency chain is introduced.
+  (Gabriel Scherer, review by Olivier Nicole, Damien Doligez,
+   Stephen Dolan)
 
 - #14482: Add DWARF CFI support to POWER backend.
   (Tim McGilchrist, review by Xavier Leroy)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -323,6 +323,17 @@ static uintnat sweep_work_done_between_slices(void)
  * marked, and data values if they have any unmarked keys). Ephemeron
  * sweeping cannot mark blocks so does not need to take place in
  * rounds.
+ *
+ * Remark: if the data of ephemeron A is found to be alive before the
+ * data of ephemeron B in the current major GC cycle, then A will
+ * occur before B in the todo list for the next cycle. In other words,
+ * ephemerons dynamically get sorted in dependency order, which
+ * reduces the number of rounds necessary.
+ * In the details, this dependency order is preserved because
+ * `ephe_mark()` pushes the element of `todo` into `live`, which
+ * reverses their order, but then `ephe_sweep()` moves `live` into
+ * `todo` and pushes them into `live` again, which reverses their
+ * order a second time.
 */
 
 extern value caml_ephe_none; /* See weak.c */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -486,6 +486,9 @@ static void prepare_for_ephe_sweeping (caml_domain_state *domain_state)
   }
 }
 
+enum mark_flag { MARK_DEFAULT, MARK_NO_FINISH };
+static intnat mark(intnat budget, enum mark_flag flag);
+
 #define EPHE_MARK_DEFAULT false
 #define EPHE_MARK_FORCE_ALIVE true
 
@@ -504,7 +507,6 @@ static void prepare_for_ephe_sweeping (caml_domain_state *domain_state)
  * Returns the remaining budget.
  */
 
-static intnat mark(intnat budget);
 static intnat ephe_mark (intnat budget, uintnat round,
                          /* Forces ephemerons and their data to be alive */
                          bool force_alive)
@@ -521,6 +523,7 @@ static intnat ephe_mark (intnat budget, uintnat round,
     prev_linkp = &domain_state->ephe_info->todo;
   }
   value next = *prev_linkp;
+  bool must_mark_again = false;
   while (next != 0 && budget > 0) {
 
     /* TODO: this reproduces much of caml_ephe_clean; can we share code? */
@@ -588,7 +591,8 @@ static intnat ephe_mark (intnat budget, uintnat round,
              in the list in dependency order, so a single round suffices
              to mark all the live ones.
           */
-          budget = mark(budget);
+          budget = mark(budget, MARK_NO_FINISH);
+          must_mark_again = true;
         }
       }
       /* Move to 'live' list */
@@ -602,6 +606,11 @@ static intnat ephe_mark (intnat budget, uintnat round,
       prev_linkp = &Ephe_link(ephe);
     }
     ++ scanned;
+  }
+
+  if (must_mark_again) {
+    CAMLassert(!domain_state->marking_done);
+    mark(1, MARK_DEFAULT);
   }
 
   caml_gc_log
@@ -1661,8 +1670,14 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
   return budget;
 }
 
-/* mark until the budget runs out or marking is done */
-static intnat mark(intnat budget) {
+/* mark until the budget runs out or marking is done.
+
+   if flag == MARK_NO_FINISH, then the caller promises that mark will be
+   called again within the same GC slice, in MARK_DEFAULT mode, with a nonzero
+   budget. This allows the present call to skip the end-of-marking work (setting
+   marking_done and advancing the ephemeron round), since it will be handled by
+   the next MARK_DEFAULT call. */
+static intnat mark(intnat budget, enum mark_flag flag) {
   caml_domain_state *domain_state = Caml_state;
   CAMLassert(caml_marking_started());
   while (budget > 0 && !domain_state->marking_done) {
@@ -1686,6 +1701,8 @@ static intnat mark(intnat budget) {
             mark_slice_darken(domain_state->mark_stack, *p, &budget);
           }
         }
+      } else if (flag == MARK_NO_FINISH) {
+        break;
       } else {
         ephe_next_round ();
         domain_state->marking_done = 1;
@@ -2254,7 +2271,7 @@ mark_again:
 
     while (!domain_state->marking_done &&
            (budget = get_major_slice_work(mode)) > 0) {
-      intnat left = mark(budget);
+      intnat left = mark(budget, MARK_DEFAULT);
       intnat work_done = budget - left;
       /* It is possible to call caml_darken directly during marking,
          if we e.g. discover a continuation and mark its stack.
@@ -2519,7 +2536,7 @@ static void empty_mark_stack (void)
       /* This calls caml_mark_roots_stw with the minor heap empty */
       caml_empty_minor_heaps_once();
     }
-    mark(1000);
+    mark(1000, MARK_DEFAULT);
     caml_handle_incoming_interrupts();
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -489,6 +489,12 @@ static void prepare_for_ephe_sweeping (caml_domain_state *domain_state)
 enum mark_flag { MARK_DEFAULT, MARK_NO_FINISH };
 static intnat mark(intnat budget, enum mark_flag flag);
 
+// call this once after calling mark with MARK_NO_FINISH
+static void mark_finish (void)
+{
+  (void)mark(1, MARK_DEFAULT);
+}
+
 #define EPHE_MARK_DEFAULT false
 #define EPHE_MARK_FORCE_ALIVE true
 
@@ -610,7 +616,7 @@ static intnat ephe_mark (intnat budget, uintnat round,
 
   if (must_mark_again) {
     CAMLassert(!domain_state->marking_done);
-    mark(1, MARK_DEFAULT);
+    mark_finish();
   }
 
   caml_gc_log
@@ -1674,9 +1680,11 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
 
    if flag == MARK_NO_FINISH, then the caller promises that mark will be
    called again within the same GC slice, in MARK_DEFAULT mode, with a nonzero
-   budget. This allows the present call to skip the end-of-marking work (setting
-   marking_done and advancing the ephemeron round), since it will be handled by
-   the next MARK_DEFAULT call. */
+   budget. You can use [mark_finish()] which will use a budget of 1.
+
+   This allows the MARK_NO_FINISH call to skip the end-of-marking work
+   (setting marking_done and advancing the ephemeron round), since it will be
+   handled by the next MARK_DEFAULT call. */
 static intnat mark(intnat budget, enum mark_flag flag) {
   caml_domain_state *domain_state = Caml_state;
   CAMLassert(caml_marking_started());

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -493,6 +493,7 @@ static void prepare_for_ephe_sweeping (caml_domain_state *domain_state)
  * Returns the remaining budget.
  */
 
+static intnat mark(intnat budget);
 static intnat ephe_mark (intnat budget, uintnat round,
                          /* Forces ephemerons and their data to be alive */
                          bool force_alive)
@@ -567,6 +568,17 @@ static intnat ephe_mark (intnat budget, uintnat round,
       value data = Ephe_data(ephe);
       if (data != caml_ephe_none && Is_block(data)) {
         caml_darken (domain_state, data, 0);
+        if (!domain_state->marking_done) {
+          /* We try to mark the data fully (as budget allows); this
+             can mark the keys of some ephemerons that are later in
+             the todo list, which would otherwise have to wait for the
+             next round.
+             This is important in the happy path where ephemerons occur
+             in the list in dependency order, so a single round suffices
+             to mark all the live ones.
+          */
+          budget = mark(budget);
+        }
       }
       /* Move to 'live' list */
       caml_ephe_list_cons_inplace(ephe, &domain_state->ephe_info->live);
@@ -2288,6 +2300,7 @@ mark_again:
                (budget = get_major_slice_work(mode)) > 0) {
           intnat left = ephe_mark(budget, saved_ephe_round, EPHE_MARK_DEFAULT);
           intnat work_done = budget - left;
+          work_done += mark_work_done_between_slices();
           commit_major_slice_work (work_done);
 
           // FIXME: Can we delete this?

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -331,6 +331,17 @@ static uintnat sweep_work_done_between_slices(void)
  * marked, and data values if they have any unmarked keys). Ephemeron
  * sweeping cannot mark blocks so does not need to take place in
  * rounds.
+ *
+ * Remark: if the data of ephemeron A is found to be alive before the
+ * data of ephemeron B in the current major GC cycle, then A will
+ * occur before B in the todo list for the next cycle. In other words,
+ * ephemerons dynamically get sorted in dependency order, which
+ * reduces the number of rounds necessary.
+ * In the details, this dependency order is preserved because
+ * `ephe_mark()` pushes the element of `todo` into `live`, which
+ * reverses their order, but then `ephe_sweep()` moves `live` into
+ * `todo` and pushes them into `live` again, which reverses their
+ * order a second time.
 */
 
 extern value caml_ephe_none; /* See weak.c */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -444,6 +444,7 @@ static void record_ephe_marking_done (uintnat round)
  * Returns the remaining budget.
  */
 
+static intnat mark(intnat budget);
 static intnat ephe_mark (intnat budget, uintnat round,
                          /* Forces ephemerons and their data to be alive */
                          bool force_alive)
@@ -518,6 +519,17 @@ static intnat ephe_mark (intnat budget, uintnat round,
       value data = Ephe_data(ephe);
       if (data != caml_ephe_none && Is_block(data)) {
         caml_darken (domain_state, data, 0);
+        if (!domain_state->marking_done) {
+          /* We try to mark the data fully (as budget allows); this
+             can mark the keys of some ephemerons that are later in
+             the todo list, which would otherwise have to wait for the
+             next round.
+             This is important in the happy path where ephemerons occur
+             in the list in dependency order, so a single round suffices
+             to mark all the live ones.
+          */
+          budget = mark(budget);
+        }
       }
       /* Move to 'live' list */
       Ephe_link(ephe) = domain_state->ephe_info->live;
@@ -2235,6 +2247,7 @@ mark_again:
                (budget = get_major_slice_work(mode)) > 0) {
           intnat left = ephe_mark(budget, saved_ephe_round, EPHE_MARK_DEFAULT);
           intnat work_done = budget - left;
+          work_done += mark_work_done_between_slices();
           commit_major_slice_work (work_done);
 
           // FIXME: Can we delete this?


### PR DESCRIPTION
This PR is a second take on #14657, and I recommend reading the description there. That previous PR was reverted ( #14682 ) because it introduced a race condition that would cause the major GC to loop forever in rare cases for multi-domain programs ( #14679 ). Oops!

The previous PR did two things:
1. call `mark()` from `ephe_mark()` on each markable data, for speed gains
2. call `ephe_next_round()` *outside* `mark()` to avoid calling it many times from `ephe_mark()`.

Both are reasonable ideas, but (2) introduces a data race if `num_domains_to_mark` is decremented before `ephe_next_round()` is called -- another domain could in-between believe that marking is gone and go to the phase-change barrier to be stuck there forever, see https://github.com/ocaml/ocaml/issues/14679#issuecomment-4133296911 .

The current PR is even simpler than before because it only does (1). Actually doing (2) correctly is not so easy, so I decided to separate the two. The downsides of not doing (2) are:
- Cosmetic: the number of rounds is incremented a lot on benchmarks with plenty of ephemerons.
- Multi-domain performance: if another domain was doing ephemeron-marking at the same time, it could end up repeatedly restarting at the beginning of the todo-list; in other words, one domain marking its ephemerons list can block other domains from making progress on their own lists.
 
(One solution against this repeated-traversal risk would be to have new rounds rotate the already-traversed ephemerons at the end of the todo list, instead of keeping them at the beginning.)