### PR TITLE
Fix duplicate path in Name_type_mismatch ambiguous type message

### DIFF
--- a/Changes
+++ b/Changes
@@ -116,6 +116,11 @@ Working version
   avoid a possible confusion between type parameters and unbound variables.
   (Florian Angeletti, report by Florian Weimer, review by Gabriel Scherer)
 
+- #14690: Fix `Name_type_mismatch` error message when the expected type is an
+  alias: print the expanded path on the right-hand side of the equality, not
+  the alias twice.
+  (Weixie Cui)
+
 ### Internal/compiler-libs changes:
 
 - #14620: optimize utf8 normalization and (un)capitalization functions

--- a/testsuite/tests/typing-misc/errortrace_ambiguous_type_path_expansion.ml
+++ b/testsuite/tests/typing-misc/errortrace_ambiguous_type_path_expansion.ml
@@ -1,0 +1,28 @@
+(* TEST
+ expect;
+*)
+
+(* Regression test for [trees_of_type_path_expansion]: when printing a
+   [Name_type_mismatch] error, the expected record type may be a type alias
+   [outer] whose expansion is a distinct path [inner]. The message must show
+   ["outer" = "inner"], not ["outer" = "outer"]. *)
+
+module Other = struct
+  type t = { y : int }
+end
+
+type inner = { x : int }
+type outer = inner
+
+let f (r : outer) = r.Other.y
+
+[%%expect{|
+module Other : sig type t = { y : int; } end
+type inner = { x : int; }
+type outer = inner
+Line 8, characters 22-29:
+8 | let f (r : outer) = r.Other.y
+                          ^^^^^^^
+Error: The field "Other.y" belongs to the record type "Other.t"
+       but a field was expected belonging to the record type "outer" = "inner"
+|}]

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -697,7 +697,7 @@ let type_path_expansion ppf = function
 let trees_of_type_path_expansion (tp,tp') =
   let path_tree = namespaced_tree_of_path Type in
   if Path.same tp tp' then Same(path_tree tp) else
-    Diff(path_tree tp, path_tree tp)
+    Diff(path_tree tp, path_tree tp')
 
 let type_path_list ppf l =
   Fmt.pp_print_list ~pp_sep:(fun ppf () -> Fmt.pp_print_break ppf 2 0)


### PR DESCRIPTION
## Summary

When reporting a `Name_type_mismatch` error (record field or variant constructor does not belong to the expected type), the printer shows the expected record or variant type as a path expansion `alias = expanded` when the nominal path differs from its expansion.

`trees_of_type_path_expansion` built the `Diff` case with the left path twice instead of `(left, right)`, so the message incorrectly displayed `"outer" = "outer"` instead of `"outer" = "inner"` for a type alias.

## Changes

- One-line fix in `typing/errortrace_report.ml`: use `path_tree tp'` for the right-hand side of `Diff`.
- Regression test `testsuite/tests/typing-misc/errortrace_ambiguous_type_path_expansion.ml` (expect test).

## Testing

`ocamltest` on the new test; manual check that a buggy `expect` binary shows `"outer" = "outer"` while the fixed compiler shows `"outer" = "inner"`.