### PR TITLE
Add overflow checking to caml_ba_reshape

### DIFF
--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -1373,7 +1373,9 @@ CAMLprim value caml_ba_reshape(value vb, value vdim)
     dim[i] = Long_val(Field(vdim, i));
     if (dim[i] < 0)
       caml_invalid_argument("Bigarray.reshape: negative dimension");
-    num_elts *= dim[i];
+    if (caml_umul_overflow(num_elts, (uintnat)dim[i], &num_elts))
+      /* Since the old dims didn't overflow, an overflow must be a mismatch */
+      caml_invalid_argument("Bigarray.reshape: size mismatch");
   }
   /* Check that sizes agree */
   if (num_elts != caml_ba_num_elts(b))

--- a/testsuite/tests/lib-bigarray/reshape_overflow.ml
+++ b/testsuite/tests/lib-bigarray/reshape_overflow.ml
@@ -1,0 +1,12 @@
+(* TEST *)
+open Printf
+open Bigarray
+
+let () =
+  let ba = Array1.create int c_layout 0 in
+  match reshape (genarray_of_array1 ba) (Array.init 8 (fun _ -> 1 lsl 16)) with
+  | ba ->
+     printf "out of bounds read: %d\n"
+       (Genarray.get ba (Array.init 8 (fun _ -> 10)))
+  | exception exn ->
+     printf "ok: %s\n" (Printexc.to_string exn)

--- a/testsuite/tests/lib-bigarray/reshape_overflow.reference
+++ b/testsuite/tests/lib-bigarray/reshape_overflow.reference
@@ -1,0 +1,1 @@
+ok: Invalid_argument("Bigarray.reshape: size mismatch")


### PR DESCRIPTION
This function multiplied a user-specified set of dimensions without overflow checking, which is a bug. See #14655 / #14674 for discussion.

(This should be backported to the 4.14 branch, where it fixes an out-of-bounds read / segfault. On 5.x, it just makes the error message nicer.)