### PR TITLE
Warn if C format specifier and argument differ in signedness (`-Wformat-signedness`)

### DIFF
--- a/Changes
+++ b/Changes
@@ -56,6 +56,10 @@ Working version
   `char[N]` with the C compiler `-Wwrite-strings` flag.
   (Antonin Décimo, review by Xavier Leroy and Olivier Nicole)
 
+- #14694: Warn if C format specifier and argument differ in signedness
+  (-Wformat-signedness).
+  (Antonin Décimo, review by Léo Andrès)
+
 - #14717: assign 'unique_id' early during domain creation to help debugging
   (Gabriel Scherer, review by Olivier Nicole)
 

--- a/configure
+++ b/configure
@@ -15552,6 +15552,7 @@ done
 
 # Additional warnings
 for flag in \
+  '-Wformat-signedness' \
   '-Wold-style-declaration' \
   '-Wwrite-strings' \
 ; do

--- a/configure.ac
+++ b/configure.ac
@@ -1074,6 +1074,7 @@ done
 
 # Additional warnings
 for flag in \
+  '-Wformat-signedness' \
   '-Wold-style-declaration' \
   '-Wwrite-strings' \
 ; do

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -401,7 +401,7 @@ CAMLprim value caml_runtime_parameters (value unit)
   const char *no_tweaks = "";
   value res = caml_alloc_sprintf
       ("b=%d,c=%"F_Z",e=%"F_Z",l=%"F_Z",M=%"F_Z",m=%"F_Z",n=%"F_Z","
-       "o=%"F_Z",p=%d,R=%u,s=%"F_S",t=%"F_Z",v=%"F_Z",V=%"F_Z",W=%"F_Z"%s",
+       "o=%"F_Z",p=%d,R=%d,s=%"F_S",t=%"F_Z",v=%"F_Z",V=%"F_Z",W=%"F_Z"%s",
        /* b */ (int) Caml_state->backtrace_active,
        /* c */ caml_params->cleanup_on_exit,
        /* e */ caml_params->runtime_events_log_wsize,

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -124,7 +124,7 @@ void caml_disasm_instr(code_t pc)
 void
 caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
 {
-  fprintf (f, "%#" CAML_PRIxNAT, v);
+  fprintf (f, "%#" CAML_PRIxNAT, (uintnat) v);
   if (!v)
     return;
   if (prog && v % sizeof (int) == 0
@@ -183,7 +183,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
         };
         if (i > 0)
           putc (' ', f);
-        fprintf (f, "%#" CAML_PRIxNAT, Field (v, i));
+        fprintf (f, "%#" CAML_PRIxNAT, (uintnat) Field (v, i));
       };
       if (s > 0)
         putc (')', f);
@@ -200,7 +200,7 @@ caml_trace_accu_sp_file (value accu, value * sp, code_t prog, asize_t proglen,
   fprintf (f, "accu=");
   caml_trace_value_file (accu, prog, proglen, f);
   fprintf (f, "\n sp=%#" CAML_PRIxNAT " @%ld:",
-           (intnat) sp, (long) (Stack_high(Caml_state->current_stack) - sp));
+           (uintnat) sp, (long) (Stack_high(Caml_state->current_stack) - sp));
   for (p = sp, i = 0;
        i < 12 + (1 << caml_params->trace_level) &&
          p < Stack_high(Caml_state->current_stack);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1420,7 +1420,7 @@ do_resume: {
 #ifdef _MSC_VER
       CAMLunreachable();
 #else
-      caml_fatal_error("bad opcode (%" CAML_PRIxNAT ")", (intnat) *(pc-1));
+      caml_fatal_error("bad opcode (%" CAML_PRIxNAT ")", (uintnat) *(pc-1));
 #endif
     }
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1009,17 +1009,17 @@ update_major_slice_work(intnat howmuch,
 
   CAML_GC_MESSAGE(SLICESIZE, "heap_words = %" CAML_PRIuNAT "\n",
                   heap_words);
-  CAML_GC_MESSAGE(SLICESIZE, "allocated_words = %" CAML_PRIuNAT "\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words = %" CAML_PRIdNAT "\n",
                    my_alloc_count);
-  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_direct = %" CAML_PRIuNAT "\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_direct = %" CAML_PRIdNAT "\n",
                    my_alloc_direct_count);
-  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_suspended = %" CAML_PRIuNAT "\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_suspended = %" CAML_PRIdNAT "\n",
                    my_alloc_suspended_count);
-  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_resumed = %" CAML_PRIuNAT "\n",
+  CAML_GC_MESSAGE(SLICESIZE, "allocated_words_resumed = %" CAML_PRIdNAT "\n",
                    my_alloc_resumed_count);
   CAML_GC_MESSAGE(SLICESIZE, "alloc work-to-do = %" CAML_PRIdNAT "\n",
                    alloc_work);
-  CAML_GC_MESSAGE(SLICESIZE, "dependent_words = %" CAML_PRIuNAT "\n",
+  CAML_GC_MESSAGE(SLICESIZE, "dependent_words = %" CAML_PRIdNAT "\n",
                    my_dependent_count);
   CAML_GC_MESSAGE(SLICESIZE, "dependent work-to-do = %" CAML_PRIdNAT "\n",
                   dependent_work);
@@ -1068,16 +1068,16 @@ update_major_slice_work(intnat howmuch,
 
   caml_gc_log("Updated major work: [%c] "
               " %" CAML_PRIuNAT " heap_words, "
-              " %" CAML_PRIuNAT " allocated, "
-              " %" CAML_PRIuNAT " allocated (direct), "
-              " %" CAML_PRIuNAT " allocated (suspended), "
-              " %" CAML_PRIuNAT " allocated (resumed), "
+              " %" CAML_PRIdNAT " allocated, "
+              " %" CAML_PRIdNAT " allocated (direct), "
+              " %" CAML_PRIdNAT " allocated (suspended), "
+              " %" CAML_PRIdNAT " allocated (resumed), "
               " %" CAML_PRIdNAT " alloc_work, "
               " %" CAML_PRIdNAT " dependent_work, "
               " %" CAML_PRIdNAT " extra_work, "
               " %" CAML_PRIuNAT " work counter %s, "
               " %" CAML_PRIuNAT " alloc counter, "
-              " %" CAML_PRIuNAT " slice target, "
+              " %" CAML_PRIdNAT " slice target, "
               " %" CAML_PRIdNAT " slice budget"
               ,
               caml_gc_phase_char(may_access_gc_phase),
@@ -1244,7 +1244,7 @@ static void mark_stack_prune(struct mark_stack* stk)
     ++old_compressed_entries;
   }
   if (old_compressed_entries > 0) {
-    caml_gc_log("Preserved %" CAML_PRIdNAT " compressed entries",
+    caml_gc_log("Preserved %" CAML_PRIuNAT " compressed entries",
                 old_compressed_entries);
   }
   caml_addrmap_clear(&stk->compressed_stack);
@@ -1267,9 +1267,9 @@ static void mark_stack_prune(struct mark_stack* stk)
     }
   }
 
-  caml_gc_log("Compressed %" CAML_PRIdNAT " mark stack words into "
-              "%" CAML_PRIdNAT " mark stack entries and "
-              "%" CAML_PRIdNAT " compressed entries",
+  caml_gc_log("Compressed %" CAML_PRIuNAT " mark stack words into "
+              "%" CAML_PRIuNAT " mark stack entries and "
+              "%" CAML_PRIuNAT " compressed entries",
               total_words, new_stk_count,
               compressed_entries+old_compressed_entries);
 
@@ -1403,7 +1403,7 @@ static intnat mark_stack_push_block(struct mark_stack* stk, value block)
 static void shrink_mark_stack (void)
 {
   struct mark_stack* stk = Caml_state->mark_stack;
-  intnat init_stack_bsize = MARK_STACK_INIT_SIZE * sizeof(mark_entry);
+  uintnat init_stack_bsize = MARK_STACK_INIT_SIZE * sizeof(mark_entry);
   mark_entry* shrunk_stack;
 
   caml_gc_log ("Shrinking mark stack to %" CAML_PRIuNAT "k bytes\n",

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -332,11 +332,11 @@ void* caml_mem_map(uintnat size, int reserve_only)
   void* mem = caml_plat_mem_map(size, reserve_only);
 
   if (mem == 0) {
-    CAML_GC_MESSAGE(ADDRSPACE, "mmap %" CAML_PRIdNAT " bytes failed", size);
+    CAML_GC_MESSAGE(ADDRSPACE, "mmap %" CAML_PRIuNAT " bytes failed", size);
     return 0;
   }
 
-  CAML_GC_MESSAGE(ADDRSPACE, "mmap %" CAML_PRIdNAT " bytes at %p for heaps\n",
+  CAML_GC_MESSAGE(ADDRSPACE, "mmap %" CAML_PRIuNAT " bytes at %p for heaps\n",
                   size, mem);
 
 #ifdef DEBUG
@@ -349,7 +349,7 @@ void* caml_mem_map(uintnat size, int reserve_only)
 void* caml_mem_commit(void* mem, uintnat size)
 {
   CAMLassert(Is_page_aligned(size));
-  CAML_GC_MESSAGE(ADDRSPACE, "commit %" CAML_PRIdNAT " bytes at %p for heaps\n",
+  CAML_GC_MESSAGE(ADDRSPACE, "commit %" CAML_PRIuNAT " bytes at %p for heaps\n",
                   size, mem);
   return caml_plat_mem_commit(mem, size);
 }
@@ -358,7 +358,7 @@ void caml_mem_decommit(void* mem, uintnat size)
 {
   if (size) {
     CAML_GC_MESSAGE(ADDRSPACE,
-                    "decommit %" CAML_PRIdNAT " bytes at %p for heaps\n",
+                    "decommit %" CAML_PRIuNAT " bytes at %p for heaps\n",
                     size, mem);
     caml_plat_mem_decommit(mem, size);
   }
@@ -371,7 +371,7 @@ void caml_mem_unmap(void* mem, uintnat size)
   CAMLassert(caml_lf_skiplist_find(&mmap_blocks, (uintnat)mem, &data) != 0);
   CAMLassert(data == size);
 #endif
-  CAML_GC_MESSAGE(ADDRSPACE, "munmap %" CAML_PRIdNAT " bytes at %p for heaps\n",
+  CAML_GC_MESSAGE(ADDRSPACE, "munmap %" CAML_PRIuNAT " bytes at %p for heaps\n",
                   size, mem);
   caml_plat_mem_unmap(mem, size);
 #ifdef DEBUG

--- a/runtime/sak.c
+++ b/runtime/sak.c
@@ -98,7 +98,7 @@ unsigned print_utf8_as_utf16(const char *c) {
 
   /* Encode UTF16 */
   if (printable(uc)) {
-    printf("%c", uc);
+    printf("%c", (char) uc);
   } else {
     if (uc <= 0xd7ff || (uc >= 0xe000 && uc <= 0xffff)) {
       printf(F16, uc);
@@ -133,7 +133,7 @@ unsigned print_utf16_as_utf8(const wchar_t *c) {
   /* Encode UTF-8 */
   /* All non-printable characters are encoded, this is easier to proof-read */
   if (printable(uc)) {
-    printf("%c", uc);
+    printf("%c", (char) uc);
   } else {
     if (uc < 0x80) {
       printf(F8, uc);

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -169,7 +169,7 @@ CAMLexport void caml_do_exit(int retcode)
                       (intnat) majwords);
       CAML_GC_MESSAGE(STATS, "minor_collections: %" CAML_PRIdNAT "\n",
                       (intnat) atomic_load(&caml_minor_collections_count));
-      CAML_GC_MESSAGE(STATS, "major_collections: %" CAML_PRIdNAT "\n",
+      CAML_GC_MESSAGE(STATS, "major_collections: %" CAML_PRIuNAT "\n",
                       caml_major_cycles_completed);
       CAML_GC_MESSAGE(STATS, "forced_major_collections: %" CAML_PRIdNAT "\n",
                       (intnat) s.alloc_stats.forced_major_collections);

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -174,7 +174,7 @@ token\n", virtual_input_file_name, lineno, s);
 
 void too_many_entries(void)
 {
-    fprintf(stderr, "File \"%s\", line %d: more than %u entry points\n",
+    fprintf(stderr, "File \"%s\", line %d: more than %d entry points\n",
             virtual_input_file_name, lineno, MAX_ENTRY_POINT);
     done(1);
 }


### PR DESCRIPTION
A new entry in my everlasting quest to use more warnings from C compilers. This one fixes discrepancies between a format specifier and the actual argument.

The `%…x` family of format specifiers expects an unsigned integer type. The `%c` format specifier expects a `char`.

> If `-Wformat` is specified, also warn if the format string requires an unsigned argument and the argument is signed and vice versa.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-signedness

`-Wall` turns on the `-Wformat=1` warning flag.

> - signedness of format specifier `A` is incompatible with `B`
> - format specifies type `A` but the argument has type/underlying
>   type `B`, which differs in signedness

https://clang.llvm.org/docs/DiagnosticsReference.html#wformat-signedness