### PR TITLE
Add hint about type annotations for gadt equation scope

### DIFF
--- a/Changes
+++ b/Changes
@@ -132,7 +132,7 @@ Working version
   (Weixie Cui)
 
 - #14695: Add hint about using type annotations to avoid scope escape errors
-  (Stefan Muenzel, review by Jacques Garrigue)
+  (Stefan Muenzel, review by Jacques Garrigue and Florian Angeletti)
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -132,7 +132,7 @@ Working version
   (Weixie Cui)
 
 - #14695: Add hint about using type annotations to avoid scope escape errors
-  (Stefan Muenzel, review by ????)
+  (Stefan Muenzel, review by Jacques Garrigue)
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -131,6 +131,9 @@ Working version
   the alias twice.
   (Weixie Cui)
 
+- #14695: Add hint about using type annotations to avoid scope escape errors
+  (Stefan Muenzel, review by ????)
+
 ### Internal/compiler-libs changes:
 
 - #14620: optimize utf8 normalization and (un)capitalization functions

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -27,7 +27,8 @@ check-cross-references: cross-reference-checker
 	  $(ROOTDIR)/driver/main_args.ml \
 	  $(ROOTDIR)/lambda/translmod.ml \
 	  $(ROOTDIR)/typing/typemod.ml \
-	  $(ROOTDIR)/typing/typeclass.ml
+	  $(ROOTDIR)/typing/typeclass.ml \
+	  $(ROOTDIR)/typing/errortrace_report.ml
 
 # check that all standard library modules are referenced by the
 # standard library chapter of the manual

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -734,7 +734,6 @@ Error: This pattern matches values of type "GADT_ordering.point"
          "a" = "GADT_ordering.point"
        This instance of "GADT_ordering.point" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -734,7 +734,7 @@ Error: This pattern matches values of type "GADT_ordering.point"
          "a" = "GADT_ordering.point"
        This instance of "GADT_ordering.point" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -734,4 +734,6 @@ Error: This pattern matches values of type "GADT_ordering.point"
          "a" = "GADT_ordering.point"
        This instance of "GADT_ordering.point" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -734,6 +734,7 @@ Error: This pattern matches values of type "GADT_ordering.point"
          "a" = "GADT_ordering.point"
        This instance of "GADT_ordering.point" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -21,7 +21,8 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -37,7 +38,8 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -54,7 +56,8 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -71,7 +74,8 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -88,7 +92,8 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -104,7 +109,8 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -127,7 +133,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -143,7 +150,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -159,7 +167,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -175,7 +184,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -191,7 +201,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -207,7 +218,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -258,7 +270,8 @@ Error: Signature mismatch:
        The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -297,6 +310,7 @@ Error: Signature mismatch:
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -21,7 +21,7 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -38,7 +38,7 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -56,7 +56,7 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -74,7 +74,7 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -92,7 +92,7 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -109,7 +109,7 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -133,7 +133,7 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -150,7 +150,7 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -167,7 +167,7 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -184,7 +184,7 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -201,7 +201,7 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -218,7 +218,7 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -270,7 +270,7 @@ Error: Signature mismatch:
        The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -310,7 +310,7 @@ Error: Signature mismatch:
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -21,6 +21,8 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let ret_e2 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
@@ -35,6 +37,8 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let ret_ei1 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
@@ -50,6 +54,8 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let ret_ei2 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
@@ -65,6 +71,8 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 
@@ -80,6 +88,8 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let ret_g1 (type a b) (wit : (a, b) eq) (x : a) (y : b) =
@@ -94,6 +104,8 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* First reported in MPR#7617: the typechecker arbitrarily picks a
@@ -115,6 +127,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let g1 (type a b) (x : (a, b) eq) =
@@ -129,6 +143,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let g2 (type a b) (x : (a, b) eq) =
@@ -143,6 +159,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let h1 (type a b) (x : (a, b) eq) =
@@ -157,6 +175,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let h2 (type a b) (x : (a, b) eq) =
@@ -171,6 +191,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let h3 (type a b) (x : (a, b) eq) =
@@ -185,6 +207,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 module T : sig
@@ -234,6 +258,8 @@ Error: Signature mismatch:
        The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 module M = struct
@@ -271,4 +297,6 @@ Error: Signature mismatch:
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -21,9 +21,8 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let ret_e2 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
@@ -38,9 +37,8 @@ Line 3, characters 29-30:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let ret_ei1 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
@@ -56,9 +54,8 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let ret_ei2 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
@@ -74,9 +71,8 @@ Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 
@@ -92,9 +88,8 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let ret_g1 (type a b) (wit : (a, b) eq) (x : a) (y : b) =
@@ -109,9 +104,8 @@ Line 3, characters 16-17:
 Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* First reported in MPR#7617: the typechecker arbitrarily picks a
@@ -133,9 +127,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let g1 (type a b) (x : (a, b) eq) =
@@ -150,9 +143,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let g2 (type a b) (x : (a, b) eq) =
@@ -167,9 +159,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let h1 (type a b) (x : (a, b) eq) =
@@ -184,9 +175,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let h2 (type a b) (x : (a, b) eq) =
@@ -201,9 +191,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let h3 (type a b) (x : (a, b) eq) =
@@ -218,9 +207,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * b list"
        This instance of "b" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 module T : sig
@@ -270,9 +258,8 @@ Error: Signature mismatch:
        The type "'_weak1 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 module M = struct
@@ -310,7 +297,6 @@ Error: Signature mismatch:
        Type "'_weak2" is not compatible with type "T.t" = "T.u"
        This instance of "T.u" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -20,7 +20,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
@@ -34,7 +35,8 @@ Line 2, characters 37-40:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -20,7 +20,7 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -35,7 +35,7 @@ Line 2, characters 37-40:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -20,6 +20,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in g 3;;
@@ -32,6 +34,8 @@ Line 2, characters 37-40:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* Ok *)

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -20,9 +20,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in g 3;;
@@ -35,9 +34,8 @@ Line 2, characters 37-40:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* Ok *)

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -56,9 +56,8 @@ Error: The value "x" has type "t" = "bool" but an expression was expected of typ
          "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 (* val f : 'a -> 'a ty -> bool = <fun> *)
 
@@ -82,9 +81,8 @@ Error: This expression has type "bool" but an expression was expected of type
          "t" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 (* Error: This expression has type bool but an expression was expected of type
 t = int *)

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -56,7 +56,8 @@ Error: The value "x" has type "t" = "bool" but an expression was expected of typ
          "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 (* val f : 'a -> 'a ty -> bool = <fun> *)
@@ -81,7 +82,8 @@ Error: This expression has type "bool" but an expression was expected of type
          "t" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 (* Error: This expression has type bool but an expression was expected of type

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -56,6 +56,8 @@ Error: The value "x" has type "t" = "bool" but an expression was expected of typ
          "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 (* val f : 'a -> 'a ty -> bool = <fun> *)
 
@@ -79,6 +81,8 @@ Error: This expression has type "bool" but an expression was expected of type
          "t" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 (* Error: This expression has type bool but an expression was expected of type
 t = int *)

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -56,7 +56,7 @@ Error: The value "x" has type "t" = "bool" but an expression was expected of typ
          "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -82,7 +82,7 @@ Error: This expression has type "bool" but an expression was expected of type
          "t" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -168,7 +168,7 @@ Error: This pattern matches values of type "bool"
        but a pattern was expected which matches values of type "a" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -225,7 +225,7 @@ Line 3, characters 18-19:
 Error: This pattern matches values of type "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -168,9 +168,8 @@ Error: This pattern matches values of type "bool"
        but a pattern was expected which matches values of type "a" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 
@@ -225,9 +224,8 @@ Line 3, characters 18-19:
 Error: This pattern matches values of type "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -168,7 +168,8 @@ Error: This pattern matches values of type "bool"
        but a pattern was expected which matches values of type "a" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -224,7 +225,8 @@ Line 3, characters 18-19:
 Error: This pattern matches values of type "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -168,6 +168,8 @@ Error: This pattern matches values of type "bool"
        but a pattern was expected which matches values of type "a" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 
@@ -222,6 +224,8 @@ Line 3, characters 18-19:
 Error: This pattern matches values of type "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -415,7 +415,7 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -431,7 +431,7 @@ Line 3, characters 37-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -459,7 +459,7 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -477,7 +477,7 @@ Line 3, characters 36-41:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -498,7 +498,7 @@ Error: The value "M.res" has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -515,7 +515,7 @@ Line 4, characters 3-8:
 Error: The value "M.res" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -415,6 +415,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let module M = struct let g = g end in
@@ -428,6 +430,8 @@ Line 3, characters 37-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* Ambivalance via packed module *)
@@ -453,6 +457,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq)
     ((module M) : (module S with type a = a)) =
@@ -468,6 +474,8 @@ Line 3, characters 36-41:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* Ambivalance in module expression *)
@@ -486,6 +494,8 @@ Error: The value "M.res" has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in
@@ -500,4 +510,6 @@ Line 4, characters 3-8:
 Error: The value "M.res" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -415,7 +415,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
@@ -430,7 +431,8 @@ Line 3, characters 37-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -457,7 +459,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq)
@@ -474,7 +477,8 @@ Line 3, characters 36-41:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -494,7 +498,8 @@ Error: The value "M.res" has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
@@ -510,6 +515,7 @@ Line 4, characters 3-8:
 Error: The value "M.res" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -415,9 +415,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let module M = struct let g = g end in
@@ -431,9 +430,8 @@ Line 3, characters 37-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* Ambivalance via packed module *)
@@ -459,9 +457,8 @@ Error: This expression has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq)
     ((module M) : (module S with type a = a)) =
@@ -477,9 +474,8 @@ Line 3, characters 36-41:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* Ambivalance in module expression *)
@@ -498,9 +494,8 @@ Error: The value "M.res" has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in
@@ -515,7 +510,6 @@ Line 4, characters 3-8:
 Error: The value "M.res" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -25,7 +25,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 let fails (type a b) (x : (a, b) eq) =
@@ -40,7 +41,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -25,6 +25,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 let fails (type a b) (x : (a, b) eq) =
   match x, [] with
@@ -38,6 +40,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* branches must be unified! *)

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -25,9 +25,8 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 let fails (type a b) (x : (a, b) eq) =
   match x, [] with
@@ -41,9 +40,8 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* branches must be unified! *)

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -25,7 +25,7 @@ Line 4, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -41,7 +41,7 @@ Line 3, characters 4-29:
 Error: This pattern matches values of type "(a, b) eq * a list"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -394,7 +394,7 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}, Principal{|
@@ -411,7 +411,7 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -394,9 +394,8 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}, Principal{|
 Line 3, characters 26-31:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
@@ -411,9 +410,8 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let foo x =

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -394,6 +394,8 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}, Principal{|
 Line 3, characters 26-31:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
@@ -408,6 +410,8 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let foo x =

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -394,7 +394,8 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}, Principal{|
 Line 3, characters 26-31:
@@ -410,7 +411,8 @@ Error: This pattern matches values of type "N.t foo"
        but a pattern was expected which matches values of type "'a"
        This instance of "M.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -375,9 +375,8 @@ Error: The value "b" has type "bool" but an expression was expected of type
          "s" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 module Normal_constrs = struct
@@ -445,9 +444,8 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let test : type a. a t -> a = fun x ->
@@ -462,9 +460,8 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let test : type a. a t -> a = fun x ->
@@ -478,9 +475,8 @@ Line 2, characters 30-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let test (type a) x =
@@ -558,9 +554,8 @@ Error: This expression has type "int option"
        Type "int" is not compatible with type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let test2 : type a. a t -> a option = fun x ->
@@ -597,9 +592,8 @@ Line 3, characters 44-45:
 Error: The value "y" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 (* Effect of external consraints *)
@@ -720,9 +714,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
@@ -736,9 +729,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> <m : a> -> <m : b> =
@@ -779,9 +771,8 @@ Error: The value "o" has type "< m : a >" but an expression was expected of type
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
@@ -798,9 +789,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
@@ -814,9 +804,8 @@ Error: The value "o" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
@@ -830,9 +819,8 @@ Error: The value "v" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
@@ -891,9 +879,8 @@ Error: The value "o" has type "[ `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
@@ -910,9 +897,8 @@ Error: The value "o" has type "[> `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 (* Pattern matching *)
@@ -1161,9 +1147,8 @@ Error: This expression has type "< bar : int; foo : int; .. as $1 >"
        but an expression was expected of type "'a"
        This instance of "$1" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
        Hint: "$1" is a type variable introduced in the equation
          "$0" = "< bar : int; .. as $1 >"
 |}];;
@@ -1190,9 +1175,8 @@ Error: The method call "x#foo" has type "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 (* PR#5554 *)
@@ -1262,9 +1246,8 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
@@ -1282,9 +1265,8 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) =
@@ -1300,9 +1282,8 @@ Error: The value "y" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) =
@@ -1317,9 +1298,8 @@ Error: The value "x" has type "a" = "int" but an expression was expected of type
          "b" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 module M = struct
@@ -1339,9 +1319,8 @@ Error: This expression has type "'a -> 'b"
        but an expression was expected of type "M.t" = "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1362,9 +1341,8 @@ Error: The value "x" has type "M.t" = "int -> int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 module M = struct
@@ -1385,9 +1363,8 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1409,9 +1386,8 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 type (_,_) eq = Refl: ('a,'a) eq
@@ -1438,9 +1414,8 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
 |}]
 
@@ -1469,8 +1444,7 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -375,6 +375,8 @@ Error: The value "b" has type "bool" but an expression was expected of type
          "s" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 module Normal_constrs = struct
@@ -442,6 +444,8 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let test : type a. a t -> a = fun x ->
@@ -456,6 +460,8 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let test : type a. a t -> a = fun x ->
@@ -469,6 +475,8 @@ Line 2, characters 30-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let test (type a) x =
@@ -546,6 +554,8 @@ Error: This expression has type "int option"
        Type "int" is not compatible with type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let test2 : type a. a t -> a option = fun x ->
@@ -582,6 +592,8 @@ Line 3, characters 44-45:
 Error: The value "y" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 (* Effect of external consraints *)
@@ -702,6 +714,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
@@ -715,6 +729,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> <m : a> -> <m : b> =
@@ -755,6 +771,8 @@ Error: The value "o" has type "< m : a >" but an expression was expected of type
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
@@ -771,6 +789,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
@@ -784,6 +804,8 @@ Error: The value "o" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
@@ -797,6 +819,8 @@ Error: The value "v" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
@@ -855,6 +879,8 @@ Error: The value "o" has type "[ `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
@@ -871,6 +897,8 @@ Error: The value "o" has type "[> `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 (* Pattern matching *)
@@ -1119,6 +1147,8 @@ Error: This expression has type "< bar : int; foo : int; .. as $1 >"
        but an expression was expected of type "'a"
        This instance of "$1" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
        Hint: "$1" is a type variable introduced in the equation
          "$0" = "< bar : int; .. as $1 >"
 |}];;
@@ -1145,6 +1175,8 @@ Error: The method call "x#foo" has type "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 (* PR#5554 *)
@@ -1214,6 +1246,8 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
@@ -1231,6 +1265,8 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) =
@@ -1246,6 +1282,8 @@ Error: The value "y" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) =
@@ -1260,6 +1298,8 @@ Error: The value "x" has type "a" = "int" but an expression was expected of type
          "b" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 module M = struct
@@ -1279,6 +1319,8 @@ Error: This expression has type "'a -> 'b"
        but an expression was expected of type "M.t" = "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1299,6 +1341,8 @@ Error: The value "x" has type "M.t" = "int -> int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 module M = struct
@@ -1319,6 +1363,8 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1340,6 +1386,8 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 type (_,_) eq = Refl: ('a,'a) eq
@@ -1366,6 +1414,8 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
 |}]
 
@@ -1394,5 +1444,7 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -375,7 +375,8 @@ Error: The value "b" has type "bool" but an expression was expected of type
          "s" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -444,7 +445,8 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -460,7 +462,8 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -475,7 +478,8 @@ Line 2, characters 30-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -554,7 +558,8 @@ Error: This expression has type "int option"
        Type "int" is not compatible with type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -592,7 +597,8 @@ Line 3, characters 44-45:
 Error: The value "y" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -714,7 +720,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -729,7 +736,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -771,7 +779,8 @@ Error: The value "o" has type "< m : a >" but an expression was expected of type
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -789,7 +798,8 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -804,7 +814,8 @@ Error: The value "o" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -819,7 +830,8 @@ Error: The value "v" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -879,7 +891,8 @@ Error: The value "o" has type "[ `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -897,7 +910,8 @@ Error: The value "o" has type "[> `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -1147,7 +1161,8 @@ Error: This expression has type "< bar : int; foo : int; .. as $1 >"
        but an expression was expected of type "'a"
        This instance of "$1" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$1" is a type variable introduced in the equation
          "$0" = "< bar : int; .. as $1 >"
@@ -1175,7 +1190,8 @@ Error: The method call "x#foo" has type "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -1246,7 +1262,8 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -1265,7 +1282,8 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -1282,7 +1300,8 @@ Error: The value "y" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -1298,7 +1317,8 @@ Error: The value "x" has type "a" = "int" but an expression was expected of type
          "b" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 
@@ -1319,7 +1339,8 @@ Error: This expression has type "'a -> 'b"
        but an expression was expected of type "M.t" = "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -1341,7 +1362,8 @@ Error: The value "x" has type "M.t" = "int -> int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -1363,7 +1385,8 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -1386,7 +1409,8 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 
@@ -1414,7 +1438,8 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
 |}]
@@ -1444,7 +1469,8 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -375,7 +375,7 @@ Error: The value "b" has type "bool" but an expression was expected of type
          "s" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -445,7 +445,7 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -462,7 +462,7 @@ Error: This expression has type "a" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -478,7 +478,7 @@ Line 2, characters 30-42:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -558,7 +558,7 @@ Error: This expression has type "int option"
        Type "int" is not compatible with type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -597,7 +597,7 @@ Line 3, characters 44-45:
 Error: The value "y" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -720,7 +720,7 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -736,7 +736,7 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -779,7 +779,7 @@ Error: The value "o" has type "< m : a >" but an expression was expected of type
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -798,7 +798,7 @@ Error: The value "o" has type "< m : a; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -814,7 +814,7 @@ Error: The value "o" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -830,7 +830,7 @@ Error: The value "v" has type "[> `A of a ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -891,7 +891,7 @@ Error: The value "o" has type "[ `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -910,7 +910,7 @@ Error: The value "o" has type "[> `A of a | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -1161,7 +1161,7 @@ Error: This expression has type "< bar : int; foo : int; .. as $1 >"
        but an expression was expected of type "'a"
        This instance of "$1" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$1" is a type variable introduced in the equation
@@ -1190,7 +1190,7 @@ Error: The method call "x#foo" has type "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -1262,7 +1262,7 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -1282,7 +1282,7 @@ Error: The value "b" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -1300,7 +1300,7 @@ Error: The value "y" has type "b" = "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -1317,7 +1317,7 @@ Error: The value "x" has type "a" = "int" but an expression was expected of type
          "b" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
@@ -1339,7 +1339,7 @@ Error: This expression has type "'a -> 'b"
        but an expression was expected of type "M.t" = "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -1362,7 +1362,7 @@ Error: The value "x" has type "M.t" = "int -> int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -1385,7 +1385,7 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -1409,7 +1409,7 @@ Error: This expression has type "M.t" but an expression was expected of type
          "< m : 'a; .. >"
        This instance of "< m : int >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]
@@ -1438,7 +1438,7 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".
@@ -1469,7 +1469,7 @@ Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "C".

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -82,7 +82,7 @@ Line 4, characters 32-33:
 Error: The value "y" has type "a" but an expression was expected of type "t"
        This instance of "< m : int * 'a > as 'a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -82,7 +82,8 @@ Line 4, characters 32-33:
 Error: The value "y" has type "a" but an expression was expected of type "t"
        This instance of "< m : int * 'a > as 'a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -82,9 +82,8 @@ Line 4, characters 32-33:
 Error: The value "y" has type "a" but an expression was expected of type "t"
        This instance of "< m : int * 'a > as 'a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -82,6 +82,8 @@ Line 4, characters 32-33:
 Error: The value "y" has type "a" but an expression was expected of type "t"
        This instance of "< m : int * 'a > as 'a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 

--- a/testsuite/tests/typing-modular-explicits/gadt.ml
+++ b/testsuite/tests/typing-modular-explicits/gadt.ml
@@ -68,7 +68,8 @@ Line 3, characters 12-15:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}]
 

--- a/testsuite/tests/typing-modular-explicits/gadt.ml
+++ b/testsuite/tests/typing-modular-explicits/gadt.ml
@@ -68,9 +68,8 @@ Line 3, characters 12-15:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}]
 
 let f2 (type a) (x : a) (el : a t2) : int =

--- a/testsuite/tests/typing-modular-explicits/gadt.ml
+++ b/testsuite/tests/typing-modular-explicits/gadt.ml
@@ -68,7 +68,7 @@ Line 3, characters 12-15:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}]

--- a/testsuite/tests/typing-modular-explicits/gadt.ml
+++ b/testsuite/tests/typing-modular-explicits/gadt.ml
@@ -68,6 +68,8 @@ Line 3, characters 12-15:
 Error: This expression has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}]
 
 let f2 (type a) (x : a) (el : a t2) : int =

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -729,7 +729,8 @@ Error: Signature mismatch:
        The type "'_weak4 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
 |}];;
 

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -729,6 +729,8 @@ Error: Signature mismatch:
        The type "'_weak4 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
 |}];;
 
 module M: sig

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -729,7 +729,7 @@ Error: Signature mismatch:
        The type "'_weak4 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
 |}];;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -729,9 +729,8 @@ Error: Signature mismatch:
        The type "'_weak4 list ref" is not compatible with the type "T.t list ref"
        This instance of "T.t" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
 |}];;
 
 module M: sig

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -71,6 +71,8 @@ Line 7, characters 35-36:
 Error: The value "x" has type "$a" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
+       Hint: You may need to add a type annotation outside the scope of the equation.
+       (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
 

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -71,7 +71,8 @@ Line 7, characters 35-36:
 Error: The value "x" has type "$a" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation outside the scope of the equation.
+       Hint: You may need to add a type annotation to remove the ambiguity,
+       either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -71,9 +71,8 @@ Line 7, characters 35-36:
 Error: The value "x" has type "$a" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
-       Hint: A type annotation may resolve the ambiguity,
+       Hint (manual section 7.2): A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
-       (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
 

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -71,7 +71,7 @@ Line 7, characters 35-36:
 Error: The value "x" has type "$a" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
-       Hint: You may need to add a type annotation to remove the ambiguity,
+       Hint: A type annotation may resolve the ambiguity,
        either on this expression or the whole function.
        (see manual section 7.2)
        Hint: "$a" is an existential type bound by the constructor "Pair".

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -249,13 +249,13 @@ let explain_escape pre = function
       Variable_names.reserve t;
       Some(
         doc_printf "%a@ @[<hov>This instance of %a is ambiguous:@ %s@]\
-                    @,@[@{<hint>Hint@}: A type annotation may resolve \
+                    @,@[%a A type annotation may resolve \
                     the ambiguity,@,either on this \
-                    expression or the whole function. @ %a@]"
+                    expression or the whole function.@]"
           pp_doc pre
           (Style.as_inline_code type_expr_with_reserved_names) t
           "it would escape the scope of its equation"
-          Misc.print_see_manual manual_ref
+          Misc.manual_hint manual_ref
       )
   | Errortrace.Self ->
       Some (doc_printf "%a@,Self type cannot escape its class" pp_doc pre)

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -249,8 +249,8 @@ let explain_escape pre = function
       Variable_names.reserve t;
       Some(
         doc_printf "%a@ @[<hov>This instance of %a is ambiguous:@ %s@]\
-                    @,@[@{<hint>Hint@}: You may need to add a type \
-                    annotation to remove the ambiguity,@,either on this \
+                    @,@[@{<hint>Hint@}: A type annotation may resolve \
+                    the ambiguity,@,either on this \
                     expression or the whole function. @ %a@]"
           pp_doc pre
           (Style.as_inline_code type_expr_with_reserved_names) t

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -243,12 +243,18 @@ let explain_escape pre = function
         pp_doc pre pp_path (Path.Pident id)
     )
   | Errortrace.Equation Errortrace.{ty = _; expanded = t} ->
+      let[@manual.ref "s:gadts-type-inference"] manual_ref =
+        [ 7; 2 ]
+      in
       Variable_names.reserve t;
       Some(
-        doc_printf "%a@ @[<hov>This instance of %a is ambiguous:@ %s@]"
+        doc_printf "%a@ @[<hov>This instance of %a is ambiguous:@ %s@]\
+                    @,@[@{<hint>Hint@}: You may need to add a type \
+                    annotation outside the scope of the equation. @ %a@]"
           pp_doc pre
           (Style.as_inline_code type_expr_with_reserved_names) t
           "it would escape the scope of its equation"
+          Misc.print_see_manual manual_ref
       )
   | Errortrace.Self ->
       Some (doc_printf "%a@,Self type cannot escape its class" pp_doc pre)

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -250,7 +250,8 @@ let explain_escape pre = function
       Some(
         doc_printf "%a@ @[<hov>This instance of %a is ambiguous:@ %s@]\
                     @,@[@{<hint>Hint@}: You may need to add a type \
-                    annotation outside the scope of the equation. @ %a@]"
+                    annotation to remove the ambiguity,@,either on this \
+                    expression or the whole function. @ %a@]"
           pp_doc pre
           (Style.as_inline_code type_expr_with_reserved_names) t
           "it would escape the scope of its equation"

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -255,7 +255,7 @@ let explain_escape pre = function
           pp_doc pre
           (Style.as_inline_code type_expr_with_reserved_names) t
           "it would escape the scope of its equation"
-          Misc.manual_hint manual_ref
+          Misc.print_manual_hint manual_ref
       )
   | Errortrace.Self ->
       Some (doc_printf "%a@,Self type cannot escape its class" pp_doc pre)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1251,6 +1251,13 @@ let print_see_manual ppf manual_section =
     (pp_print_list ~pp_sep:(fun f () -> pp_print_char f '.') pp_print_int)
     manual_section
 
+let manual_hint ppf manual_section =
+  let open Format_doc in
+  fprintf ppf "%t (manual section %a):"
+    Style.hint
+    (pp_print_list ~pp_sep:(fun f () -> pp_print_char f '.') pp_print_int)
+    manual_section
+
 let print_if ppf flag printer arg =
   if !flag then Format.fprintf ppf "%a@." printer arg;
   arg

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1245,18 +1245,18 @@ let debug_prefix_map_flags () =
         []
   end
 
-let print_see_manual ppf manual_section =
+let print_manual_section ppf manual_section =
   let open Format_doc in
-  fprintf ppf "(see manual section %a)"
+  fprintf ppf "manual section %a"
     (pp_print_list ~pp_sep:(fun f () -> pp_print_char f '.') pp_print_int)
     manual_section
 
-let manual_hint ppf manual_section =
+let print_see_manual ppf manual_section =
+  Format_doc.fprintf ppf "(see %a)" print_manual_section manual_section
+
+let print_manual_hint ppf manual_section =
   let open Format_doc in
-  fprintf ppf "%t (manual section %a):"
-    Style.hint
-    (pp_print_list ~pp_sep:(fun f () -> pp_print_char f '.') pp_print_int)
-    manual_section
+  fprintf ppf "%t (%a):" Style.hint print_manual_section manual_section
 
 let print_if ppf flag printer arg =
   if !flag then Format.fprintf ppf "%a@." printer arg;

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -588,6 +588,9 @@ val print_if :
 val print_see_manual : int list Format_doc.printer
 (** See manual section *)
 
+val manual_hint : int list Format_doc.printer
+(** Manual hint, reserved for hints that are essentially quoting the manual *)
+
 (** {1 Displaying configuration variables} *)
 
 val show_config_and_exit : unit -> unit

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -588,7 +588,7 @@ val print_if :
 val print_see_manual : int list Format_doc.printer
 (** See manual section *)
 
-val manual_hint : int list Format_doc.printer
+val print_manual_hint : int list Format_doc.printer
 (** Manual hint, reserved for hints that are essentially quoting the manual *)
 
 (** {1 Displaying configuration variables} *)


### PR DESCRIPTION
The error message:
```
       This instance of "a" is ambiguous:
       it would escape the scope of its equation
```
Doesn't provide the user with much actionable information, unless they are already very familiar with the workings of GADTs. Thus, we provide an additional hint about annotating the type to prevent scope escape, and refer to the manual.

The motivation for this PR comes from #11648 : We may soon be able to detect scope escape in more cases, which might lead to more users encountering this error (see #14673 for examples)