### PR TITLE
[5.5] #12150 slice: fix class self type escape

### DIFF
--- a/Changes
+++ b/Changes
@@ -719,6 +719,10 @@ OCaml 5.5.0
   determining if an optional argument is non-erasable.
   (Alistair O'Brien and Florian Angeletti, review by Gabriel Scherer)
 
+- #14557, #12150, #14696: ensure that the self type of class cannot escape
+  through type constraints.
+  (Leo White, review by Florian Angeletti)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1361,6 +1361,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
   | Pcl_constraint (scl', scty) ->
       let cl, clty =
         Ctype.with_local_level_for_class begin fun () ->
+          let self_scope = Ctype.get_current_level () in
           let cl =
             Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let cl = class_expr cl_num val_env met_env virt self_scope scl' in


### PR DESCRIPTION
This small PR bookkeeping PR extracts the commit fixing the self type escape issue reported in #14557  from #12150 and backport it to 5.5 as a straightforward bug fix (while the other changes are too complex to be backported).

I am opening the PR mostly for having a clear record of the backport and I intend to merge it by the end of the day.