### PR TITLE
Permanently silence trigraph warnings with escaping

### DIFF
--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -55,19 +55,23 @@ let emit_symbol s =
 let emit_string_literal s =
   let last_was_escape = ref false in
   emit_string "\"";
+  (* Avoid producing '??' to avoid triggering assembler warnings about trigraphs *)
+  let last_was_question_mark = ref false in
   for i = 0 to String.length s - 1 do
     let c = s.[i] in
     if c >= '0' && c <= '9' then
       if !last_was_escape
       then Printf.fprintf !output_channel "\\%o" (Char.code c)
       else output_char !output_channel c
-    else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' then begin
+    else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' &&
+              (c <> '?' || not !last_was_question_mark) then begin
       output_char !output_channel c;
       last_was_escape := false
     end else begin
       Printf.fprintf !output_channel "\\%o" (Char.code c);
       last_was_escape := true
-    end
+    end;
+    last_was_question_mark := (c = '?')
   done;
   emit_string "\""
 

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -55,7 +55,7 @@ let emit_symbol s =
 let emit_string_literal s =
   let last_was_escape = ref false in
   emit_string "\"";
-  (* Avoid producing '??' to avoid triggering assembler warnings about trigraphs *)
+  (* Avoid producing '??' to avoid assembler warnings about trigraphs *)
   let last_was_question_mark = ref false in
   for i = 0 to String.length s - 1 do
     let c = s.[i] in

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -54,19 +54,23 @@ let windows =
 let string_of_string_literal s =
   let b = Buffer.create (String.length s + 2) in
   let last_was_escape = ref false in
+  (* Avoid producing '??' to avoid triggering assembler warnings about trigraphs *)
+  let last_was_question_mark = ref false in
   for i = 0 to String.length s - 1 do
     let c = s.[i] in
     if c >= '0' && c <= '9' then
       if !last_was_escape
       then Printf.bprintf b "\\%o" (Char.code c)
       else Buffer.add_char b c
-    else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' then begin
+    else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' &&
+              (c <> '?' || not !last_was_question_mark) then begin
       Buffer.add_char b c;
       last_was_escape := false
     end else begin
       Printf.bprintf b "\\%o" (Char.code c);
       last_was_escape := true
-    end
+    end;
+    last_was_question_mark := (c = '?')
   done;
   Buffer.contents b
 

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -54,7 +54,7 @@ let windows =
 let string_of_string_literal s =
   let b = Buffer.create (String.length s + 2) in
   let last_was_escape = ref false in
-  (* Avoid producing '??' to avoid triggering assembler warnings about trigraphs *)
+  (* Avoid producing '??' to avoid assembler warnings about trigraphs *)
   let last_was_question_mark = ref false in
   for i = 0 to String.length s - 1 do
     let c = s.[i] in

--- a/configure
+++ b/configure
@@ -19437,9 +19437,6 @@ esac ;; #(
     default_as="ml64 -nologo -Cp -c -Fo"
     default_aspp="$default_as"
     as_is_cc=false ;; #(
-  *-*-darwin*,clang-*) :
-    default_as="$CC -c -Wno-trigraphs"
-    default_aspp="$default_as" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1879,10 +1879,7 @@ AS_CASE([$as_target,$ocaml_cc_vendor],
   [x86_64-pc-windows,*],
     [default_as="ml64 -nologo -Cp -c -Fo"
     default_aspp="$default_as"
-    as_is_cc=false],
-  [*-*-darwin*,clang-*],
-    [default_as="$CC -c -Wno-trigraphs"
-    default_aspp="$default_as"])
+    as_is_cc=false])
 
 AS_IF([test -z "$default_as"],[default_as="$CC -c"])
 AS_IF([test -z "$default_aspp"],[default_aspp="$CC -c"])


### PR DESCRIPTION
A perennial problem is that some C toolchains warn about the use of trigraphs (a C89 misfeature), which fires on innocuous strings that happen to contain sequences like `"??!"`. See #1093, #6373, #14543.

The previous approach has been to try to detect the platforms on which this pointless warning is triggered and disable the warning with `-Wno-trigraphs`. This patch has as a different approach: change the assembly output so that it never contains a trigraph sequence, by escaping the second of a sequence of two question marks. This means we can delete the platform-detection logic, since the warning should no longer fire in any case. (This is more or less the same as @xavierleroy's [suggestion on 1093](https://github.com/ocaml/ocaml/pull/1093#issuecomment-285648346), except that by doing it by escaping rather than by individual `.byte` directives we avoid the compile-time performance worries).

(The escaping logic has at some point in the past been copypasted into two locations. I just edited both here, but it's probably worth unifying these sometime)