### PR TITLE
array.ml, string.ml: simplify some (then|else)\s*(true|false) occurrences

### DIFF
--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -185,13 +185,12 @@ let of_list = function
       fill 1 tl
 
 let equal eq a b =
-  if length a <> length b then false else
+  length a = length b &&
   let i = ref 0 in
   let len = length a in
   while !i < len && eq (unsafe_get a !i) (unsafe_get b !i) do incr i done;
   !i = len
 
-let stdlib_compare = compare
 let compare cmp a b =
   let len_a = length a and len_b = length b in
   let diff = len_a - len_b in
@@ -251,20 +250,18 @@ let fold_right2 f a b x =
   done;
   !r
 
-let exists p a =
-  let n = length a in
-  let rec loop i =
-    if i = n then false
-    else if p (unsafe_get a i) then true
-    else loop (succ i) in
-  loop 0
-
 let for_all p a =
   let n = length a in
   let rec loop i =
-    if i = n then true
-    else if p (unsafe_get a i) then loop (succ i)
-    else false in
+    i = n || p (unsafe_get a i) && loop (succ i)
+  in
+  loop 0
+
+let exists p a =
+  let n = length a in
+  let rec loop i =
+    i < n && (p (unsafe_get a i) || loop (succ i))
+  in
   loop 0
 
 let for_all2 p l1 l2 =
@@ -272,9 +269,8 @@ let for_all2 p l1 l2 =
   and n2 = length l2 in
   if n1 <> n2 then invalid_arg "Array.for_all2"
   else let rec loop i =
-    if i = n1 then true
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then loop (succ i)
-    else false in
+    i = n1 || p (unsafe_get l1 i) (unsafe_get l2 i) && loop (succ i)
+  in
   loop 0
 
 let exists2 p l1 l2 =
@@ -282,25 +278,22 @@ let exists2 p l1 l2 =
   and n2 = length l2 in
   if n1 <> n2 then invalid_arg "Array.exists2"
   else let rec loop i =
-    if i = n1 then false
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
-    else loop (succ i) in
+    i < n1 && (p (unsafe_get l1 i) (unsafe_get l2 i) || loop (succ i))
+  in
   loop 0
 
 let mem x a =
   let n = length a in
   let rec loop i =
-    if i = n then false
-    else if stdlib_compare (unsafe_get a i) x = 0 then true
-    else loop (succ i) in
+    i < n && (Stdlib.compare (unsafe_get a i) x = 0 || loop (succ i))
+  in
   loop 0
 
 let memq x a =
   let n = length a in
   let rec loop i =
-    if i = n then false
-    else if x == (unsafe_get a i) then true
-    else loop (succ i) in
+    i < n && (x == (unsafe_get a i) || loop (succ i))
+  in
   loop 0
 
 let find_opt p a =

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -291,9 +291,7 @@ let starts_with ~prefix s =
   let len_s = length s
   and len_pre = length prefix in
   let rec aux i =
-    if i = len_pre then true
-    else if unsafe_get s i <> unsafe_get prefix i then false
-    else aux (i + 1)
+    i = len_pre || unsafe_get s i = unsafe_get prefix i && aux (succ i)
   in len_s >= len_pre && aux 0
 
 (* duplicated in string.ml *)
@@ -302,9 +300,7 @@ let ends_with ~suffix s =
   and len_suf = length suffix in
   let diff = len_s - len_suf in
   let rec aux i =
-    if i = len_suf then true
-    else if unsafe_get s (diff + i) <> unsafe_get suffix i then false
-    else aux (i + 1)
+    i = len_suf || unsafe_get s (diff + i) = unsafe_get suffix i && aux (succ i)
   in diff >= 0 && aux 0
 
 (* duplicated in string.ml *)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -472,9 +472,7 @@ let starts_with ~prefix s =
   let len_s = length s
   and len_pre = length prefix in
   let rec aux i =
-    if i = len_pre then true
-    else if unsafe_get s i <> unsafe_get prefix i then false
-    else aux (i + 1)
+    i = len_pre || unsafe_get s i = unsafe_get prefix i && aux (succ i)
   in len_s >= len_pre && aux 0
 
 (* duplicated in bytes.ml *)
@@ -483,9 +481,7 @@ let ends_with ~suffix s =
   and len_suf = length suffix in
   let diff = len_s - len_suf in
   let rec aux i =
-    if i = len_suf then true
-    else if unsafe_get s (diff + i) <> unsafe_get suffix i then false
-    else aux (i + 1)
+    i = len_suf || unsafe_get s (diff + i) = unsafe_get suffix i && aux (succ i)
   in diff >= 0 && aux 0
 
 let includes ~affix:sub =


### PR DESCRIPTION
I ran into a few "then true" in array.ml that I decided to streamline, but now I'm seeing that `(then|else)\s*(true|false)` has 167 more matches in the repository (including 55 in stdlib). So maybe there is a reason (which I do not see) to keep them?

These streamlinings could probably be made by a linter with configurable rules (as discussed with @MisterDA).

These changes are optimized away by the native compiler, but the bytecode is lighter.