### PR TITLE
Remove caml_stat_alloc_aligned[_noexc] as they aren't used

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -96,23 +96,6 @@ CAMLextern caml_stat_block caml_stat_alloc(asize_t);
 CAMLmalloc(caml_stat_free, 1, 1)
 CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
 
-/* [caml_stat_alloc_aligned(size, modulo, block*)] allocates a memory block of
-   the requested [size] (in bytes), the starting address of which is aligned to
-   the provided [modulo] value. The function returns the aligned address, as
-   well as the unaligned [block] (as an output parameter). It throws an OCaml
-   exception in case the request fails, and so requires the runtime lock.
-*/
-CAMLaligned_alloc(caml_stat_free, 1, 1, 2) CAMLreturns_nonnull()
-CAMLextern void* caml_stat_alloc_aligned(asize_t, int modulo, caml_stat_block*);
-
-/* [caml_stat_alloc_aligned_noexc] is a variant of [caml_stat_alloc_aligned]
-   that returns NULL in case the request fails, and doesn't require the runtime
-   lock to be held.
-*/
-CAMLaligned_alloc(caml_stat_free, 1, 1, 2)
-CAMLextern void* caml_stat_alloc_aligned_noexc(asize_t, int modulo,
-                                               caml_stat_block*);
-
 /* [caml_stat_calloc_noexc(num, size)] allocates a block of memory for an array
    of [num] elements, each of them [size] bytes long, and initializes all its
    bits to zero, effectively allocating a zero-initialized memory block of

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -635,9 +635,6 @@ CAMLextern int caml_read_directory(char_os * dirname,
                                    struct ext_table * contents);
 
 /* Deprecated aliases */
-#define caml_aligned_malloc \
-   CAML_DEPRECATED("caml_aligned_malloc", "caml_stat_alloc_aligned_noexc") \
-   caml_stat_alloc_aligned_noexc
 #define caml_strdup \
    CAML_DEPRECATED("caml_strdup", "caml_stat_strdup") \
    caml_stat_strdup

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -585,44 +585,6 @@ CAMLexport caml_stat_block caml_stat_alloc_noexc(asize_t sz)
   }
 }
 
-/* [sz] and [modulo] are numbers of bytes */
-CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
-                                               caml_stat_block *b)
-{
-  char *raw_mem;
-  uintnat aligned_mem;
-  CAMLassert(0 <= modulo);
-  CAMLassert(modulo < Page_size);
-  raw_mem = (char *) caml_stat_alloc_noexc(sz + Page_size);
-  if (raw_mem == NULL) return NULL;
-  *b = raw_mem;
-  raw_mem += modulo;                /* Address to be aligned */
-  aligned_mem = (((uintnat) raw_mem / Page_size + 1) * Page_size);
-#ifdef DEBUG
-  {
-    uintnat *p0 = (void *) *b;
-    uintnat *p1 = (void *) (aligned_mem - modulo);
-    uintnat *p2 = (void *) (aligned_mem - modulo + sz);
-    uintnat *p3 = (void *) ((char *) *b + sz + Page_size);
-    for (uintnat *p = p0; p < p1; p++) *p = Debug_filler_align;
-    for (uintnat *p = p1; p < p2; p++) *p = Debug_uninit_align;
-    for (uintnat *p = p2; p < p3; p++) *p = Debug_filler_align;
-  }
-#endif
-  return (char *) (aligned_mem - modulo);
-}
-
-/* [sz] and [modulo] are numbers of bytes */
-CAMLexport void* caml_stat_alloc_aligned(asize_t sz, int modulo,
-                                         caml_stat_block *b)
-{
-  void *result = caml_stat_alloc_aligned_noexc(sz, modulo, b);
-  /* malloc() may return NULL if size is 0 */
-  if ((result == NULL) && (sz != 0))
-    caml_raise_out_of_memory();
-  return result;
-}
-
 /* [sz] is a number of bytes */
 CAMLexport caml_stat_block caml_stat_alloc(asize_t sz)
 {


### PR DESCRIPTION
These two functions aren't used in the OCaml runtime. They allocate at a specified offset from a page boundary (not at any particular alignment, so the name is misleading and the `CAMLaligned_alloc` macro is incorrect). I believe (cite: @stedolan) they were originally used in OCaml 4 to get heap chunks, to ensure that OCaml 4's page table was correct.

One of these functions is currently used, unnecessarily, in the OxCaml runtime, with `modulo == 0`. This led to a failure on the Clang/ARM build of the 5.4 merge into OxCaml: the `CAMLaligned_alloc` macro use, added between Ocaml 5.2 and 5.4, asserts that the `modulo` argument is an alignment.