### PR TITLE
Set caml_start_program on instruction boundary.

### DIFF
--- a/testsuite/tests/native-debugger/gdb-script
+++ b/testsuite/tests/native-debugger/gdb-script
@@ -1,10 +1,10 @@
 set disable-randomization off
 set debuginfod enabled off
-break *(&caml_start_program+8)
+source gdb_test.py
+break_start_program
 break caml_program
 break ocaml_to_c
 break meander.ml:5
-source gdb_test.py
 run
 print_backtrace
 continue

--- a/testsuite/tests/native-debugger/gdb_test.py
+++ b/testsuite/tests/native-debugger/gdb_test.py
@@ -19,5 +19,32 @@ class PrintBacktrace (gdb.Command):
 
 PrintBacktrace ()
 
+class BreakStartProgram (gdb.Command):
+  """Set breakpoint inside caml_start_program at a valid instruction boundary.
+     A hardcoded byte offset does not work across architectures.
+     """
+
+  def __init__ (self):
+    super (BreakStartProgram, self).__init__ (
+      "break_start_program", gdb.COMMAND_BREAKPOINTS)
+
+  def invoke (self, arg, from_tty):
+    arch = gdb.selected_inferior().architecture()
+    start = int(gdb.parse_and_eval("&caml_start_program"))
+    arch_name = arch.name()
+    # Disassemble the function entry to find the correct offset.
+    # On s390x the 3rd instruction is the shared entry point used
+    # by callbacks, so use the 2nd instruction instead.
+    if "s390" in arch_name:
+      insns = arch.disassemble(start, count=2)
+      offset = insns[1]['addr'] - start
+    else:
+      insns = arch.disassemble(start, count=3)
+      offset = insns[2]['addr'] - start
+    gdb.execute("break *(&caml_start_program+%d)" % offset)
+
+BreakStartProgram ()
+
 # Usage:
 # (gdb) print-backtrace
+# (gdb) break_start_program


### PR DESCRIPTION
Using GDB disassembly set the breakpoint on a valid instruction boundary. The instruction width varies across architectures so a hardcoded byte offset does not work.

This is a minor bug fix to https://github.com/ocaml/ocaml/pull/14482 which introduced a different fixed offset. Not worth a changes entry. cc @OlivierNicole 