### PR TITLE
Fix hidden directory files leaking into visible table

### DIFF
--- a/Changes
+++ b/Changes
@@ -933,6 +933,11 @@ OCaml 5.5.0
 - #14667: enable application related warnings for module-dependent functions
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14702: Fix hidden directory files leaking into the visible load path table.
+  When a hidden directory contained a file whose basename was already present,
+  the file could be incorrectly added to the visible table.
+  (Hugo Heuzard, review by Florian Angeletti)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -146,9 +146,10 @@ let remove_dir dir =
 let add (dir : Dir.t) =
   assert (not Config.merlin || Local_store.is_bound ());
   let update base fn visible_files hidden_files =
-    if dir.hidden && not (STbl.mem !hidden_files base) then
-      STbl.replace !hidden_files base fn
-    else if not (STbl.mem !visible_files base) then
+    if dir.hidden then begin
+      if not (STbl.mem !hidden_files base) then
+        STbl.replace !hidden_files base fn
+    end else if not (STbl.mem !visible_files base) then
       STbl.replace !visible_files base fn
   in
   List.iter


### PR DESCRIPTION
## Summary

- Fix a bug in `Load_path.add` where adding two hidden directories with overlapping basenames caused the second directory's files to leak into the visible files table
- When `dir.hidden` was true and the basename was already in `hidden_files`, the condition `dir.hidden && not (STbl.mem !hidden_files base)` evaluated to false, falling through to the `else if` branch which added the file to `visible_files`
- Fix by separating the hidden and visible cases with `begin`/`end` so a hidden dir never touches the visible table

## Note

The bug is only in the `add`/`append_dir`/`add_dir` code path. The `init` function (used at compiler startup with `-H` flags) uses `prepend_add` which does not have this issue. The bug affects API consumers (Merlin ?) that dynamically add hidden directories after initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)