### PR TITLE
Fix swapped branches in dll.ml open_dll

### DIFF
--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -91,8 +91,8 @@ let open_dll mode name =
       begin match dll_open fullname with
       | dll ->
           let opened = match current with
-            | None -> List.remove_assoc fullname !opened_dlls
-            | Some _ -> !opened_dlls
+            | None -> !opened_dlls
+            | Some _ -> List.remove_assoc fullname !opened_dlls
           in
           opened_dlls := (fullname, Execution dll) :: opened
       | exception Failure msg ->


### PR DESCRIPTION
## Summary
- Fix swapped `None`/`Some` branches when upgrading a DLL from Checking to Execution mode in `bytecomp/dll.ml`
- When an existing Checking entry needed to be removed, the code used the unmodified list; when no entry existed, it pointlessly called `List.remove_assoc`

## Test plan
- [ ] Verify bytecode DLL loading works correctly when upgrading from checking to execution mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)