### PR TITLE
Diacritic OCaml

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -534,6 +534,37 @@ rule token = parse
         check_label_name ~raw_escape:(escape<>"") lexbuf name;
         OPTLABEL name
       }
+  (* Grave accent diacritic on uppercase letter: emit BACKQUOTE and push
+     the base letter back into the buffer for the next token.
+     NFC precomposed forms: À È Ì Ò Ù *)
+  | '\195' ('\128' | '\136' | '\140' | '\146' | '\153')
+    (identchar_ext* as rest)
+      { let base_letter = match Lexing.lexeme_char lexbuf 1 with
+          | '\128' -> 'A'  (* À *)
+          | '\136' -> 'E'  (* È *)
+          | '\140' -> 'I'  (* Ì *)
+          | '\146' -> 'O'  (* Ò *)
+          | '\153' -> 'U'  (* Ù *)
+          | _ -> assert false
+        in
+        let rewind = 1 + String.length rest in
+        let pos = lexbuf.Lexing.lex_curr_pos in
+        Bytes.set lexbuf.Lexing.lex_buffer (pos - rewind) base_letter;
+        lexbuf.Lexing.lex_curr_pos <- pos - rewind;
+        lexbuf.Lexing.lex_curr_p <-
+          { lexbuf.Lexing.lex_curr_p with
+            pos_cnum = lexbuf.Lexing.lex_curr_p.pos_cnum - rewind };
+        BACKQUOTE }
+  (* NFD decomposed form: uppercase letter + combining grave accent U+0300 *)
+  | (['A'-'Z'] as letter) '\204' '\128' (identchar_ext* as rest)
+      { let rewind = 1 + String.length rest in
+        let pos = lexbuf.Lexing.lex_curr_pos in
+        Bytes.set lexbuf.Lexing.lex_buffer (pos - rewind) letter;
+        lexbuf.Lexing.lex_curr_pos <- pos - rewind;
+        lexbuf.Lexing.lex_curr_p <-
+          { lexbuf.Lexing.lex_curr_p with
+            pos_cnum = lexbuf.Lexing.lex_curr_p.pos_cnum - rewind };
+        BACKQUOTE }
   | lowercase identchar * as name
       { find_keyword lexbuf name }
   | uppercase identchar * as name

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -524,6 +524,78 @@ rule token = parse
       { let name = ident_for_extended lexbuf raw_name in
         check_label_name ~raw_escape:(escape<>"") lexbuf name;
         LABEL name }
+  (* Tilde diacritic on lowercase letter in label position: emit LABEL
+     with the base letter (without diacritic) as start of the label name.
+     NFC precomposed forms: ã ĩ ñ õ ũ *)
+  | '\195' ('\163' | '\177' | '\181') (identchar * as rest) ':'
+      { let base_letter = match Lexing.lexeme_char lexbuf 1 with
+          | '\163' -> "a"  (* ã *)
+          | '\177' -> "n"  (* ñ *)
+          | '\181' -> "o"  (* õ *)
+          | _ -> assert false
+        in
+        let name = base_letter ^ rest in
+        check_label_name lexbuf name;
+        LABEL name }
+  | '\196' '\169' (identchar * as rest) ':'
+      { let name = "i" ^ rest in  (* ĩ *)
+        check_label_name lexbuf name;
+        LABEL name }
+  | '\197' '\169' (identchar * as rest) ':'
+      { let name = "u" ^ rest in  (* ũ *)
+        check_label_name lexbuf name;
+        LABEL name }
+  (* NFD decomposed form: lowercase letter + combining tilde U+0303 in label *)
+  | (['a'-'z'] as letter) '\204' '\131' (identchar * as rest) ':'
+      { let name = String.make 1 letter ^ rest in
+        check_label_name lexbuf name;
+        LABEL name }
+  (* Tilde diacritic on lowercase letter without colon: emit TILDE and push
+     the base letter back into the buffer for the next token.
+     NFC precomposed forms: ã ñ õ *)
+  | '\195' ('\163' | '\177' | '\181') (identchar_ext* as rest)
+      { let base_letter = match Lexing.lexeme_char lexbuf 1 with
+          | '\163' -> 'a'  (* ã *)
+          | '\177' -> 'n'  (* ñ *)
+          | '\181' -> 'o'  (* õ *)
+          | _ -> assert false
+        in
+        let rewind = 1 + String.length rest in
+        let pos = lexbuf.Lexing.lex_curr_pos in
+        Bytes.set lexbuf.Lexing.lex_buffer (pos - rewind) base_letter;
+        lexbuf.Lexing.lex_curr_pos <- pos - rewind;
+        lexbuf.Lexing.lex_curr_p <-
+          { lexbuf.Lexing.lex_curr_p with
+            pos_cnum = lexbuf.Lexing.lex_curr_p.pos_cnum - rewind };
+        TILDE }
+  | '\196' '\169' (identchar_ext* as rest)
+      { let rewind = 1 + String.length rest in  (* ĩ *)
+        let pos = lexbuf.Lexing.lex_curr_pos in
+        Bytes.set lexbuf.Lexing.lex_buffer (pos - rewind) 'i';
+        lexbuf.Lexing.lex_curr_pos <- pos - rewind;
+        lexbuf.Lexing.lex_curr_p <-
+          { lexbuf.Lexing.lex_curr_p with
+            pos_cnum = lexbuf.Lexing.lex_curr_p.pos_cnum - rewind };
+        TILDE }
+  | '\197' '\169' (identchar_ext* as rest)
+      { let rewind = 1 + String.length rest in  (* ũ *)
+        let pos = lexbuf.Lexing.lex_curr_pos in
+        Bytes.set lexbuf.Lexing.lex_buffer (pos - rewind) 'u';
+        lexbuf.Lexing.lex_curr_pos <- pos - rewind;
+        lexbuf.Lexing.lex_curr_p <-
+          { lexbuf.Lexing.lex_curr_p with
+            pos_cnum = lexbuf.Lexing.lex_curr_p.pos_cnum - rewind };
+        TILDE }
+  (* NFD decomposed form: lowercase letter + combining tilde U+0303 *)
+  | (['a'-'z'] as letter) '\204' '\131' (identchar_ext* as rest)
+      { let rewind = 1 + String.length rest in
+        let pos = lexbuf.Lexing.lex_curr_pos in
+        Bytes.set lexbuf.Lexing.lex_buffer (pos - rewind) letter;
+        lexbuf.Lexing.lex_curr_pos <- pos - rewind;
+        lexbuf.Lexing.lex_curr_p <-
+          { lexbuf.Lexing.lex_curr_p with
+            pos_cnum = lexbuf.Lexing.lex_curr_p.pos_cnum - rewind };
+        TILDE }
   | "?"
       { QUESTION }
   | "?" (lowercase identchar * as name) ':'


### PR DESCRIPTION
```console
# type cool_ppl = [ Ève | `Lilith ];;
type cool_ppl = [ `Eve | `Lilith ]
# let la ñoneria = print_endline "woosh";;
val la : noneria -> unit = <fun>
# la ñoneria:"";;
woosh
```

The year is 2026. Unicode has reached identifiers. Let's use diacritic marks as they should be.



<sup><sub>(sorry I've used [Anthropic's](https://www.youtube.com/watch?v=2p_AxoaHeRw) [Claude](https://www.youtube.com/watch?v=kt3r3KdGQ90) for this)</sub></sup>

Further work: decide whether `caïman` resolves to `ca:iman` or `cai:man`, if `◌̂` can be used for string concatenation, and `◌̊` for function composition. 