### PR TITLE
Fix ocamlprof: capitalize module names to follow OCaml conventions

### DIFF
--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -453,8 +453,7 @@ let dumpfile = ref "ocamlprof.dump"
 let process_intf_file filename = null_rewrite filename
 
 let process_impl_file filename =
-   let modname = Filename.basename(Filename.chop_extension filename) in
-       (* FIXME should let modname = String.capitalize modname *)
+   let modname = String.capitalize (Filename.basename(Filename.chop_extension filename)) in
    if !instr_mode then begin
      (* Instrumentation mode *)
      set_flags !modes;


### PR DESCRIPTION
## Summary

Fixes a long-standing FIXME in `ocamlprof.ml` by capitalizing module names to follow OCaml naming conventions.

## Problem

The `process_impl_file` function in `tools/ocamlprof.ml` contained a FIXME comment noting that module names should be capitalized:

```ocaml
let modname = Filename.basename(Filename.chop_extension filename) in
    (* FIXME should let modname = String.capitalize modname *)
```

Without this capitalization, profiling output would use lowercase module names (e.g., `my_module`) which doesn't follow OCaml's convention that module names start with an uppercase letter.

## Solution

Apply `String.capitalize` to the module name:

```ocaml
let modname = String.capitalize (Filename.basename(Filename.chop_extension filename)) in
```

This ensures that profiling output uses properly capitalized module names (e.g., `My_module`) consistent with OCaml conventions.

## Testing

Manual verification that `String.capitalize` is already used elsewhere in the file (lines 138-139, 433-434), confirming the module is available.

## Changelog entry

```
- #ocamlprof: fix module name capitalization in profiling output
```