### PR TITLE
Fix test requiring Unix

### DIFF
--- a/testsuite/tests/bytecode-opcode-coverage/run.ml
+++ b/testsuite/tests/bytecode-opcode-coverage/run.ml
@@ -2,6 +2,7 @@
  include ocamlcommon;
  include ocamlbytecomp;
  include unix;
+ hasunix;
  flags = "-w -a";
  readonly_files = "test.ml";
  setup-ocamlc.byte-build-env;


### PR DESCRIPTION
Fix test introduced in #14534 that was missing the `hasunix` precondition.