### PR TITLE
modular explicits: enable module-dependent function tracing in toplevel

### DIFF
--- a/.depend
+++ b/.depend
@@ -7843,6 +7843,7 @@ toplevel/byte/trace.cmo : \
     utils/misc.cmi \
     bytecomp/meta.cmi \
     parsing/longident.cmi \
+    parsing/location.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi \
     toplevel/byte/trace.cmi
@@ -7856,6 +7857,7 @@ toplevel/byte/trace.cmx : \
     utils/misc.cmx \
     bytecomp/meta.cmx \
     parsing/longident.cmx \
+    parsing/location.cmx \
     typing/ctype.cmx \
     parsing/asttypes.cmx \
     toplevel/byte/trace.cmi

--- a/Changes
+++ b/Changes
@@ -420,6 +420,9 @@ Working version
   for OCaml code.
   (Tim McGilchrist, review by Miod Vallat, Zane Hambly and Olivier Nicole)
 
+- #14707: Limited support for tracing module-dependent functions in the toplevel
+  (Florian Angeletti, review by Olivier Nicole)
+
 - #14727: Reduce memory usage when refuting a pattern clause with a large
   counter-example search space.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -41,7 +41,7 @@ let dir_trace ppf lid =
           && (match
                 Types.get_desc
                   (Ctype.expand_head !Topcommon.toplevel_env desc.val_type)
-              with Tarrow _ -> true | _ -> false)
+              with Tarrow _ | Tfunctor _ -> true | _ -> false)
           then begin
           match is_traced clos with
           | Some opath ->

--- a/toplevel/byte/trace.ml
+++ b/toplevel/byte/trace.ml
@@ -66,15 +66,25 @@ let print_label ppf l =
 
 (* If a function returns a functional value, wrap it into a trace code *)
 
+let split_arrow env ty =
+  match get_desc (Ctype.expand_head env ty) with
+  | Tarrow(l, t1, t2, _) -> Some (l, t1, env, t2)
+  | Tfunctor (l,id,pack,t2) ->
+      let t1 = Ctype.newty (Tpackage pack) in
+      let env, t2 = Ctype.open_tfunctor ~loc:Location.none env id pack t2 in
+      Some (l, t1, env, t2)
+  | _ -> None
+
 let rec instrument_result env name ppf clos_typ =
-  match get_desc (Ctype.expand_head env clos_typ) with
-  | Tarrow(l, t1, t2, _) ->
+  match split_arrow env clos_typ with
+  | None -> fun v -> v
+  | Some (l,t1,newenv,t2) ->
       let starred_name =
         match name with
         | Lident s -> Lident(s ^ "*" )
         | Ldot(lid, id) -> Ldot(lid, { id with txt = id.txt ^ "*" })
         | Lapply _ -> fatal_error "Trace.instrument_result" in
-      let trace_res = instrument_result env starred_name ppf t2 in
+      let trace_res = instrument_result newenv starred_name ppf t2 in
       (fun clos_val ->
         Obj.repr (fun arg ->
           if not !may_trace then
@@ -102,7 +112,6 @@ let rec instrument_result env name ppf clos_typ =
               may_trace := true;
               raise exn
           end))
-  | _ -> (fun v -> v)
 
 (* Same as instrument_result, but for a toplevel closure (modified in place) *)
 
@@ -110,9 +119,9 @@ exception Dummy
 let _ = Dummy
 
 let instrument_closure env name ppf clos_typ =
-  match get_desc (Ctype.expand_head env clos_typ) with
-  | Tarrow(l, t1, t2, _) ->
-      let trace_res = instrument_result env name ppf t2 in
+  match split_arrow env clos_typ with
+  | Some(l, t1, newenv, t2) ->
+      let trace_res = instrument_result newenv name ppf t2 in
       (fun actual_code closure arg ->
         if not !may_trace then begin
           try invoke_traced_function actual_code closure arg
@@ -141,7 +150,7 @@ let instrument_closure env name ppf clos_typ =
             may_trace := true;
             raise exn
         end)
-  | _ -> assert false
+  | None -> assert false
 
 (* Given the address of a closure, find its tracing info *)
 


### PR DESCRIPTION
This small PR "enables" tracing in the REPL for module-dependent function. For instance,

```ocaml
module type Show = sig
  type t
  val show: t -> string
  type f = int -> string
end

let show (module M:Show) x: M.f = fun u -> M.show x ^ string_of_int u 
module I = struct
  type t = int
  type f = int -> string
  let show = string_of_int
end

#trace show;;
let z = show (module I) 0 1
```
>```
>show <-- <module>
>show --> <fun>
>show* <-- <abstr>
>show* --> <abstr>
>show** <-- 1
>show** --> "01"
>```

However, like for ordinary functions, tracing doesn't support printing polymorphic arguments or module-dependent function. Thus the usability on `#trace` for module-dependent functions  is quite limited.