### PR TITLE
#14318, ocamldoc: use Module (library) for page titles

### DIFF
--- a/Changes
+++ b/Changes
@@ -141,6 +141,10 @@ Working version
 
 ### Tools:
 
+- #14318, #14709, ocamldoc: use "Module_name (Library name)" rather than
+   "Library name: Module_name" as the title of html pages.
+   (Florian Angeletti, report by Antonin Décimo, review by Nicolás Ojeda Bär)
+
 - #14499: in ocamltest, remove support for the legacy
   test syntax (with '***') and the '-translate' option
   to convert from this syntax.

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -1082,9 +1082,10 @@ class html =
     method title = match !Global.title with None -> "" | Some t -> self#escape t
 
     (** Get the title given by the user completed with the given subtitle. *)
-    method inner_title s =
-      (match self#title with "" -> "" | t -> t^" : ")^
-      (self#escape s)
+    method inner_title s = match self#title with
+      | "" -> self#escape s
+      | t -> String.concat "" [self#escape s; " ("; t; ")"]
+
 
     (** Get the page header. *)
     method print_header b ?nav ?comments title = header b ?nav ?comments title


### PR DESCRIPTION
This small PR proposes to change the title of html pages generated by ocamldoc from 
`Library name : Module_name` to `Module_name (Library name)` as suggested in #14318.