### PR TITLE
Fixes for some POSIX thread-safe functions in libunix

### DIFF
--- a/Changes
+++ b/Changes
@@ -586,9 +586,11 @@ OCaml 5.5.0
 
 ### Other libraries:
 
-- #13700, #14454: Use POSIX thread-safe getgrnam_r, getgrgid_r, getpwnam_r,
-  getpwuid_r, gmtime_r, localtime_r, getlogin_r, and fix mktime error checking.
-  (Antonin Décimo, review by David Allsopp, Stefan Muenzel, and Miod Vallat)
+- #13700, #14454, #14715: Use POSIX thread-safe getgrnam_r, getgrgid_r,
+  getpwnam_r, getpwuid_r, gmtime_r, localtime_r, getlogin_r, and fix mktime
+  error checking.
+  (Antonin Décimo, review by Florian Angeletti, David Allsopp, Stefan Muenzel,
+   Gabriel Scherer, and Miod Vallat)
 
 - #14406: Better handling of address length for unix sockets, improving Haiku
   compatibility.

--- a/otherlibs/unix/getgr.c
+++ b/otherlibs/unix/getgr.c
@@ -69,21 +69,23 @@ CAMLprim value caml_unix_getgrnam(value name)
     }
     buffer = newbuffer;
   }
-  if (e != 0) {
+  if (entry == NULL) {
     caml_stat_free(buffer);
-    if (e == EINTR)
+    if (e != 0)
+      caml_unix_error(e, "getgrnam", Nothing);
+    caml_raise_not_found();
+  }
+  res = alloc_group_entry(entry);
+  caml_stat_free(buffer);
 #else
   errno = 0;
   entry = getgrnam(String_val(name));
   if (entry == NULL) {
     if (errno == EINTR)
-#endif
-      caml_unix_error(EINTR, "getgrnam", Nothing);
-    caml_raise_not_found();
+      caml_uerror("getgrnam", Nothing);
+    caml_raise_not_found();     /* ignore errors */
   }
   res = alloc_group_entry(entry);
-#ifdef HAVE_GETGRNAM_R
-  caml_stat_free(buffer);
 #endif
   return res;
 }
@@ -99,7 +101,7 @@ CAMLprim value caml_unix_getgrgid(value gid)
   struct group result;
   char *buffer = caml_stat_alloc_noexc(len);
   if (buffer == NULL)
-    caml_unix_error(ENOMEM, "getgrid", Nothing);
+    caml_unix_error(ENOMEM, "getgrgid", Nothing);
   int e;
   while ((e = getgrgid_r(Int_val(gid), &result, buffer, len, &entry))
          == ERANGE) {
@@ -108,25 +110,27 @@ CAMLprim value caml_unix_getgrgid(value gid)
     if (len > CAML_GETGR_R_SIZE_MAX ||
         (newbuffer = caml_stat_resize_noexc(buffer, len)) == NULL) {
       caml_stat_free(buffer);
-      caml_unix_error(ENOMEM, "getgrid", Nothing);
+      caml_unix_error(ENOMEM, "getgrgid", Nothing);
     }
     buffer = newbuffer;
   }
-  if (e != 0) {
+  if (entry == NULL) {
     caml_stat_free(buffer);
-    if (e == EINTR)
+    if (e != 0)
+      caml_unix_error(e, "getgrgid", Nothing);
+    caml_raise_not_found();
+  }
+  res = alloc_group_entry(entry);
+  caml_stat_free(buffer);
 #else
   errno = 0;
   entry = getgrgid(Int_val(gid));
   if (entry == NULL) {
     if (errno == EINTR)
-#endif
-      caml_unix_error(EINTR, "getgrgid", Nothing);
-    caml_raise_not_found();
+      caml_uerror("getgrgid", Nothing);
+    caml_raise_not_found();     /* ignore errors */
   }
   res = alloc_group_entry(entry);
-#ifdef HAVE_GETGRGID_R
-  caml_stat_free(buffer);
 #endif
   return res;
 }

--- a/otherlibs/unix/getlogin.c
+++ b/otherlibs/unix/getlogin.c
@@ -14,6 +14,7 @@
 /**************************************************************************/
 
 #include <caml/alloc.h>
+#include <caml/memory.h>
 #include "caml/unixsupport.h"
 #include <limits.h>
 #include <unistd.h>
@@ -42,7 +43,7 @@ CAMLprim value caml_unix_getlogin(value unit)
     bufsize *= 2;
     char *newname;
     if (bufsize > CAML_LOGIN_NAME_MAX ||
-        (newname = caml_stat_realloc(name)) == NULL) {
+        (newname = caml_stat_resize_noexc(name, bufsize)) == NULL) {
       caml_stat_free(name);
       caml_unix_error(ENOMEM, "getlogin", Nothing);
     }
@@ -50,15 +51,15 @@ CAMLprim value caml_unix_getlogin(value unit)
   }
   if (e != 0) {
     caml_stat_free(name);
-#else
-  name = getlogin();
-  if (name == NULL) {
-#endif
-    caml_unix_error(ENOENT, "getlogin", Nothing);
+    caml_unix_error(e, "getlogin", Nothing);
   }
   res = caml_copy_string(name);
-#ifdef HAVE_GETLOGIN_R
   caml_stat_free(name);
+#else
+  name = getlogin();
+  if (name == NULL)
+    caml_unix_error(ENOENT, "getlogin", Nothing); /* ignore errors */
+  res = caml_copy_string(name);
 #endif
   return res;
 }

--- a/otherlibs/unix/getpw.c
+++ b/otherlibs/unix/getpw.c
@@ -75,21 +75,23 @@ CAMLprim value caml_unix_getpwnam(value name)
     }
     buffer = newbuffer;
   }
-  if (e != 0) {
+  if (entry == NULL) {
     caml_stat_free(buffer);
-    if (e == EINTR)
+    if (e != 0)
+      caml_unix_error(e, "getpwnam", Nothing);
+    caml_raise_not_found();
+  }
+  res = alloc_passwd_entry(entry);
+  caml_stat_free(buffer);
 #else
   errno = 0;
   entry = getpwnam(String_val(name));
   if (entry == NULL) {
     if (errno == EINTR)
-#endif
-      caml_unix_error(EINTR, "getpwnam", Nothing);
-    caml_raise_not_found();
+      caml_uerror("getpwnam", Nothing);
+    caml_raise_not_found();     /* ignore errors */
   }
   res = alloc_passwd_entry(entry);
-#ifdef HAVE_GETPWNAM_R
-  caml_stat_free(buffer);
 #endif
   return res;
 }
@@ -103,7 +105,7 @@ CAMLprim value caml_unix_getpwuid(value uid)
   long initlen = sysconf(_SC_GETPW_R_SIZE_MAX);
   size_t len = initlen <= 0 ? /* default */ 1024 : (size_t) initlen;
   struct passwd result;
-  char *buffer = caml_stat_alloc(len);
+  char *buffer = caml_stat_alloc_noexc(len);
   if (buffer == NULL)
     caml_unix_error(ENOMEM, "getpwuid", Nothing);
   int e;
@@ -118,21 +120,23 @@ CAMLprim value caml_unix_getpwuid(value uid)
     }
     buffer = newbuffer;
   }
-  if (e != 0) {
+  if (entry == NULL) {
     caml_stat_free(buffer);
-    if (e == EINTR)
+    if (e != 0)
+      caml_unix_error(e, "getpwuid", Nothing);
+    caml_raise_not_found();
+  }
+  res = alloc_passwd_entry(entry);
+  caml_stat_free(buffer);
 #else
   errno = 0;
   entry = getpwuid(Int_val(uid));
   if (entry == NULL) {
     if (errno == EINTR)
-#endif
-      caml_unix_error(EINTR, "getpwuid", Nothing);
-    caml_raise_not_found();
+      caml_uerror("getpwuid", Nothing);
+    caml_raise_not_found();     /* ignore errors */
   }
   res = alloc_passwd_entry(entry);
-#ifdef HAVE_GETPWUID_R
-  caml_stat_free(buffer);
 #endif
   return res;
 }

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -331,6 +331,7 @@
 #undef HAVE_GETGRGID_R
 #undef HAVE_GETPWNAM_R
 #undef HAVE_GETPWUID_R
+#undef HAVE_GETLOGIN_R
 
 /* 3. Language extensions. */
 


### PR DESCRIPTION
Fix a few issues introduced in #13700, found with Claude Code. Bugs and fixes are mine.

1. POSIX says `getgrnam_r` returns `0` and sets `*result = NULL` when a group is not found. The code only checks if `(e != 0)`, then calls `alloc_group_entry(entry)` which dereferences the `NULL` `entry`. Fix it by checking `entry` first.  
  Similar pattern in other functions.
2. Fix `HAVE_GETLOGIN_R` not being listed in `<caml/s.h.in>`, leading to the function `getlogin_r` not being used, and incorrect code.
3. Fix typo `getgrid` → `getgrgid`.
4. Use `caml_stat_alloc_noexc` instead of `caml_stat_alloc`.
   `caml_unix_getpwuid` uses `caml_stat_alloc(len)` which never returns `NULL` (raises on failure), making the subsequent `NULL` check dead code. The error path intending to raise `Unix_error(ENOMEM, "getpwuid", "")` is unreachable. The sibling `caml_unix_getpwnam` correctly uses `caml_stat_alloc_noexc`.

Please cherry-pick for OCaml 5.5 @Octachron.