### PR TITLE
runtime: assign the 'unique_id' early during domain creation

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,9 @@ Working version
 - #14482: Add DWARF CFI support to POWER backend.
   (Tim McGilchrist, review by Xavier Leroy)
 
+- #14717: assign 'unique_id' early during domain creation to help debugging
+  (Gabriel Scherer, review by Olivier Nicole)
+
 ### Type system:
 
 * #11648: Keep expansion and new well-foundedness check implementation.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -876,7 +876,6 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   /* Set domain_self if we have successfully allocated the
    * caml_domain_state. Otherwise domain_self will be NULL and it's up
    * to the caller to deal with that. */
-
   domain_self = d;
   caml_state = domain_state;
 
@@ -888,6 +887,9 @@ static void domain_create(uintnat initial_minor_heap_wsize,
                         memory_order_release);
 
   domain_state->id = d->id;
+
+  s->unique_id = fresh_domain_unique_id();
+  domain_state->unique_id = s->unique_id;
 
   /* Tell memprof system about the new domain before either (a) new
    * domain can allocate anything or (b) parent domain can go away. */
@@ -952,11 +954,8 @@ static void domain_create(uintnat initial_minor_heap_wsize,
     goto alloc_main_stack_failure;
   }
 
-  /* No remaining failure cases: domain creation is going to succeed,
-   * so we can update globally-visible state without needing to unwind
-   * it. */
-  s->unique_id = fresh_domain_unique_id();
-  domain_state->unique_id = s->unique_id;
+  /* No remaining failure cases. */
+
   s->running = 1;
 
   domain_state->c_stack = NULL;


### PR DESCRIPTION
I am debugging a runtime failure #14349 in a program that creates and terminates a *lot* of domains. I am printing the unique identifier of each domain in log messages to be able to follow what is going on. This does not work very well because during domain initialization, the unique-identifier is not assigned yet, so I see the unique_id of the previous domain whose domain slot is reused.

The present PR ensures that a domain's `unique_id` is assigned early during domain creation.

This effectively reverts a part of #12911, where @NickBarnes did the opposite change. The important part of that PR, I think, is to not increment `caml_num_domains_running` until the end of the domain-creation code. I don't think that avoiding increments of `unique_id` is necessary, and for my debugging/logging use-case it is a hindrance.