### PR TITLE
runtime/major_gc.c: fix orphaning of ephemerons

### DIFF
--- a/Changes
+++ b/Changes
@@ -734,8 +734,9 @@ OCaml 5.5.0
   the alias twice.
   (Weixie Cui, review by Florian Angeletti)
 
-- #....: runtime, fix orphaning of ephemerons
-  (Gabriel Scherer, review by ??, report by Jan Midtgaard)
+- #14349, #14718: runtime, fix orphaning of ephemerons
+  (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
+   report by Jan Midtgaard)
 
 OCaml 5.4.0 (9 October 2025)
 ----------------------------

--- a/Changes
+++ b/Changes
@@ -734,6 +734,9 @@ OCaml 5.5.0
   the alias twice.
   (Weixie Cui, review by Florian Angeletti)
 
+- #....: runtime, fix orphaning of ephemerons
+  (Gabriel Scherer, review by ??, report by Jan Midtgaard)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -530,7 +530,9 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
 
   /* Mark all ephemerons on live list.
      (ephe_mark() may move unmarked ephemerons to the live list if
-      their data is none or immediate.) */
+      their data is none or immediate.)
+
+     See Note [invariants on orphaned ephmerons]. */
   for (value v = ephe_info->live; v != 0; v = Ephe_link(v)) {
     if (is_unmarked(v)) {
       /* This can only happen when the data is trivial. */
@@ -539,14 +541,30 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     }
   }
 
-  /* Force all ephemerons and their data on todo list to be alive */
-  if (ephe_info->todo) {
-    while (ephe_info->todo) {
-      ephe_mark (100000, 0, EPHE_MARK_FORCE_ALIVE);
+  if (caml_gc_phase == Phase_sweep_and_mark_main) {
+    /* Force all ephemerons and their data on todo list to be alive */
+    if (ephe_info->todo) {
+      while (ephe_info->todo) {
+        ephe_mark (100000, 0, EPHE_MARK_FORCE_ALIVE);
+      }
+      ephe_todo_list_emptied ();
     }
-    ephe_todo_list_emptied ();
+    /* No need to sweep ephemerons: they will be adopted before
+       the cycle completes. */
+  } else {
+    /* Ensure that ephemerons are swept, in case they stay orphaned
+       until the next GC cycle. */
+    if (ephe_info->must_sweep_ephe) {
+      ephe_info->must_sweep_ephe = 0;
+      (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
+      ephe_info->todo = ephe_info->live;
+      ephe_info->live = (value)NULL;
+    }
+    while (ephe_info->todo) {
+      ephe_sweep(domain_state, 100000);
+    }
   }
-  CAMLassert (ephe_info->todo == 0);
+  CAMLassert(ephe_info->todo == 0);
 
   if (ephe_info->live) {
     value live_tail = ephe_list_tail(ephe_info->live);
@@ -1644,9 +1662,11 @@ void caml_mark_roots_stw (int participant_count,
 
     latest_sweep_allocs = diffmod (work_counter, work_counter_at_sweep_start);
 
-    /* Adopt orphaned work from domains that were spawned and terminated in the
-       previous cycle. There must be no orphaned work remaining when this phase
-       change takes place because orphaned work contains roots.
+    /* Note [invariants on orphaned ephmerons]:
+       Here we adopt orphaned work from domains that were spawned and
+       terminated in the previous cycle. There must be no orphaned
+       work remaining when this phase change takes place because
+       orphaned work contains roots.
 
        [adopt_orphaned_work] also verifies that the ephemerons to be adopted
        all have status [UNMARKED] in this cycle.
@@ -2202,7 +2222,7 @@ mark_again:
 
         while (domain_state->ephe_info->todo != 0 &&
                (budget = get_major_slice_work(mode)) > 0) {
-          intnat left = ephe_sweep (domain_state, budget);
+          intnat left = ephe_sweep(domain_state, budget);
           intnat work_done = budget - left;
           commit_major_slice_work(work_done);
         }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -528,6 +528,17 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
       ephe_info->must_sweep_ephe == 0)
     return;
 
+  /* Mark all ephemerons on live list.
+     (ephe_mark() may move unmarked ephemerons to the live list if
+      their data is none or immediate.) */
+  for (value v = ephe_info->live; v != 0; v = Ephe_link(v)) {
+    if (is_unmarked(v)) {
+      /* This can only happen when the data is trivial. */
+      CAMLassert(Ephe_data(v) == caml_ephe_none || Is_long(Ephe_data(v)));
+      caml_darken(domain_state, v, 0);
+    }
+  }
+
   /* Force all ephemerons and their data on todo list to be alive */
   if (ephe_info->todo) {
     while (ephe_info->todo) {


### PR DESCRIPTION
`ephe_mark` will move to the 'live' list ephemerons whose data is trivial (`caml_ephe_none`, as used by weak pointers and weak arrays, or an immediate), even if they are unmarked.

This breaks an invariant assumed by the orphaning logic:

```c
    /* Adopt orphaned work from domains that were spawned and terminated in the
       previous cycle. There must be no orphaned work remaining when this phase
       change takes place because orphaned work contains roots.

       [adopt_orphaned_work] also verifies that the ephemerons to be adopted
       all have status [UNMARKED] in this cycle.

       Note that ephemerons are not orphaned in [Phase_sweep_main]. When
       orphaned, ephemerons and their data are [MARKED]. Any unadopted
       ephemerons must come from last cycle. Due to the GC cycling, the
       [MARKED] ephemerons must have status [UNMARKED] now. */
    adopt_orphaned_work (caml_global_heap_state.UNMARKED);
```

indeed, if the live-list contains UNMARKED ephemerons with trivial data, it will be orphaned as-is and will not have the expected color at the next cycle. There is also a call to `adopt_orphaned_work` during the marking phase which expected MARKED orphaned ephemerons, and which gets broken for the same reason.

The fix that is proposed here is to unconditionally mark ephemerons on the live list when they are about to get orphaned. Hopefully this is a non-invasive fix, it does not change the runtime behavior much -- in particular it is safer than disabling the optimization on ephemeron with trivial data, which could cause performance regressions.

The bug has been found and reported by @jmid in #14349. It does not occur on trunk, which does not (currently) move trivial-data ephemerons to the live list. It has not been observed under 5.4, and I do not currently understand why.

cc @damiendoligez, @NickBarnes, and in particular @stedolan