### PR TITLE
modular explicit: #14719, fix syntactic arity constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -975,6 +975,9 @@ OCaml 5.5.0
   the file could be incorrectly added to the visible table.
   (Hugo Heuzard, review by Florian Angeletti)
 
+- #14719, #14721: compute arity correctly for module-dependent function
+  (Florian Angeletti, report by Jeremy Yallop, review by Stefan Muenzel)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/testsuite/tests/typing-gadts/syntactic-arity.ml
+++ b/testsuite/tests/typing-gadts/syntactic-arity.ml
@@ -160,3 +160,49 @@ Error: The syntactic arity of the function doesn't match the type constraint:
           where "gadt_pat" is the pattern with the GADT constructor that
           introduces the local type equation on "a".
 |}];;
+
+(** Interaction with module dependent function *)
+
+
+module type t = sig type _ t end
+let f (type a) (module X: t) (Equal : (a X.t, int) Type.eq) : string = ""
+ [%%expect {|
+module type t = sig type _ t end
+val f : (module X : t) -> ('a X.t, int) Type.eq -> string = <fun>
+|}]
+
+module type T = sig
+  type t
+  val x: t
+  type f = int -> int
+ end
+
+let ok (type a) (module M:T) ?opt:((Eq : (a, M.f) eq) = assert false) () : a =
+  function x -> x + 1;;
+[%%expect {|
+module type T = sig type t val x : t type f = int -> int end
+val ok : (module M : T) -> ?opt:('a -> 'b, M.f) eq -> unit -> 'a -> 'b =
+  <fun>
+|}]
+
+let fail: type a. (module M:T) -> (a,M.f) eq -> a =
+  fun (module M) Eq x -> 1 + x
+[%%expect{|
+Line 2, characters 2-30:
+2 |   fun (module M) Eq x -> 1 + x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The syntactic arity of the function doesn't match the type constraint:
+       This function has 3 syntactic arguments, but its type is constrained to
+         "(module M : T) -> (a, M.f) eq -> a".
+        Hint: consider splitting the function definition into
+          "fun ... gadt_pat -> fun ..."
+          where "gadt_pat" is the pattern with the GADT constructor that
+          introduces the local type equation on "a".
+|}]
+
+let ok: (module M:T) -> M.f =
+  fun (module M) x -> 1 + x
+
+[%%expect{|
+val ok : (module M : T) -> M.f = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4084,6 +4084,28 @@ let filter_functor env t l =
                   env
                   (Diff { got = t'; expected = t } :: trace)))
 
+let filter_arity env l t =
+  match expand_head_trace env t with
+  | exception Unify_trace trace ->
+      let t', _, _ = function_type l ~param_hole:false (get_level t) in
+      Error (Unification_error
+               (expand_to_unification_error
+                  env
+                  (Diff { got = t'; expected = t } :: trace)))
+  | t ->
+      match get_desc t with
+      | Tvar _ ->
+          let t', _, ty_ret =
+            function_type l ~param_hole:false (get_level t)
+          in
+          link_type t t';
+          Ok (env, ty_ret)
+      | Tarrow(_, _, ty_ret, _) -> Ok (env, ty_ret)
+      | Tfunctor (_, id, pack, ct) ->
+            let env, ret = open_tfunctor ~loc:Location.none env id pack ct in
+            Ok (env, ret)
+      | _ -> Error Not_a_function
+
 let is_really_poly env ty =
   let snap = Btype.snapshot () in
   let really_poly =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4002,23 +4002,36 @@ let function_type l ~param_hole level =
   let t' = newty2 ~level (Tarrow (l, t1, t2, commu_ok)) in
   t', t1, t2
 
+let arrow_unification_error ~in_apply env t t' trace =
+  let diff =
+    if in_apply then
+      Diff { got = t; expected = t' }
+    else
+      Diff { got = t'; expected = t }
+  in
+  Error (Unification_error (expand_to_unification_error env (diff :: trace)))
+
+let arrow_unify_var ~param_hole l t =
+  let t', ty_param, ty_ret =
+    function_type l ~param_hole (get_level t)
+  in
+  link_type t t';
+  { ty_param; ty_ret }
+
 let filter_arrow env ~in_apply t l ~param_hole =
   match expand_head_trace env t with
+  | exception Unify_trace trace ->
+      let t', _, _ = function_type l ~param_hole (get_level t) in
+      arrow_unification_error ~in_apply env t t' trace
   | t ->
-    begin
-      match get_desc t with
-      | Tvar _ ->
-          let t', ty_param, ty_ret =
-            function_type l ~param_hole (get_level t)
-          in
-          link_type t t';
-          Ok { ty_param; ty_ret }
-      | Tarrow(l', ty_param, ty_ret, _) ->
-          if l = l' || !Clflags.classic && l = Nolabel && not (is_optional l')
-          then Ok { ty_param; ty_ret }
-          else Error (Label_mismatch
-                          { got = l; expected = l'; expected_type = t })
-      | Tfunctor (l', id_us, pack, ty_ret) ->
+    match get_desc t with
+    | Tvar _ -> Ok (arrow_unify_var ~param_hole l t)
+    | Tarrow(l', ty_param, ty_ret, _) ->
+        if l = l' || !Clflags.classic && l = Nolabel && not (is_optional l')
+        then Ok { ty_param; ty_ret }
+        else Error (Label_mismatch
+                      { got = l; expected = l'; expected_type = t })
+    | Tfunctor (l', id_us, pack, ty_ret) ->
         if not (l = l'
                 || !Clflags.classic && l = Nolabel && not (is_optional l'))
         then Error (Label_mismatch
@@ -4029,81 +4042,49 @@ let filter_arrow env ~in_apply t l ~param_hole =
             instance_funct_nondep_inplace env { id_us; pack; ty = ty_ret } mty
           with
           | exception Unify_trace trace ->
-            let t' =
-              newty (Tarrow (l, newmono_package pack, newvar (), commu_ok))
-            in
-            let diff =
-              if in_apply then
-                Diff { got = t; expected = t' }
-              else
-                Diff { got = t'; expected = t }
-            in
-            Error (Unification_error
-                    (expand_to_unification_error env (diff :: trace)))
+              let pack = newmono_package pack in
+              let t' = newty (Tarrow (l, pack, newvar (), commu_ok)) in
+              arrow_unification_error ~in_apply env t t' trace
           | () ->
-            let ty_param = newmono_package ~level:(get_level t) pack in
-            let t' = newty2 ~level:(get_level t)
-                        (Tarrow (l, ty_param, ty_ret, commu_ok))
-            in
-            link_type t t';
-            Ok { ty_param; ty_ret }
-          end
-      | _ ->
-          Error Not_a_function
-    end
-  | exception Unify_trace trace ->
-      let t', _, _ = function_type l ~param_hole (get_level t) in
-      let diff =
-        if in_apply then
-          Diff { got = t; expected = t' }
-        else
-          Diff { got = t'; expected = t }
-      in
-      Error (Unification_error
-              (expand_to_unification_error
-                  env
-                  (diff :: trace)))
+              let ty_param = newmono_package ~level:(get_level t) pack in
+              let t' = newty2 ~level:(get_level t)
+                  (Tarrow (l, ty_param, ty_ret, commu_ok))
+              in
+              link_type t t';
+              Ok { ty_param; ty_ret }
+        end
+    | _ -> Error Not_a_function
 
 let filter_functor env t l =
   match expand_head_trace env t with
+  | exception Unify_trace trace ->
+      let t', _, _ = function_type l ~param_hole:false (get_level t) in
+      arrow_unification_error ~in_apply:true env t t' trace
   | t ->
-    begin
       match get_desc t with
       | Tfunctor (l', id, pack, ct) ->
-        if compatible_labels ~in_pattern_mode:false l l'
-        then Ok (Some (id, pack, ct))
-        else Error (Label_mismatch
-                      { got = l; expected = l'; expected_type = t })
+          if compatible_labels ~in_pattern_mode:false l l'
+          then Ok (Some (id, pack, ct))
+          else Error (Label_mismatch
+                        { got = l; expected = l'; expected_type = t })
       | Tvar _ -> Ok None
       | _ -> Error Not_a_function
-    end
-  | exception Unify_trace trace ->
-      let t', _, _ = function_type l ~param_hole:false (get_level t) in
-      Error (Unification_error
-              (expand_to_unification_error
-                  env
-                  (Diff { got = t'; expected = t } :: trace)))
 
 let filter_arity env l t =
+  let param_hole = false in
   match expand_head_trace env t with
   | exception Unify_trace trace ->
-      let t', _, _ = function_type l ~param_hole:false (get_level t) in
-      Error (Unification_error
-               (expand_to_unification_error
-                  env
-                  (Diff { got = t'; expected = t } :: trace)))
+      let t', _, _ = function_type l ~param_hole (get_level t) in
+      arrow_unification_error ~in_apply:false env t t' trace
   | t ->
       match get_desc t with
       | Tvar _ ->
-          let t', _, ty_ret =
-            function_type l ~param_hole:false (get_level t)
-          in
-          link_type t t';
-          Ok (env, ty_ret)
+          let ft = arrow_unify_var ~param_hole l t in
+          Ok (env, ft.ty_ret)
       | Tarrow(_, _, ty_ret, _) -> Ok (env, ty_ret)
       | Tfunctor (_, id, pack, ct) ->
-            let env, ret = open_tfunctor ~loc:Location.none env id pack ct in
-            Ok (env, ret)
+          let env, ret = open_tfunctor ~loc:Location.none env id pack ct in
+          Ok (env, ret)
       | _ -> Error Not_a_function
 
 let is_really_poly env ty =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4070,7 +4070,7 @@ let filter_functor env t l =
       | Tvar _ -> Ok None
       | _ -> Error Not_a_function
 
-let filter_arity env l t =
+let filter_arity env t l =
   let param_hole = false in
   match expand_head_trace env t with
   | exception Unify_trace trace ->

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -374,6 +374,11 @@ val filter_functor:
            Returns a result instead of raising [Unify].
            May return [Some _] when the type is not principally known,
            so you should check for principality. *)
+val filter_arity:
+  Env.t -> arg_label -> type_expr ->
+  (Env.t * type_expr, filter_arrow_failure) result
+(* A specialized case of unification with [ l:_ -> 'a ] for all arrows *)
+
 val is_really_poly : Env.t -> type_expr -> bool
 val filter_method: Env.t -> string -> type_expr -> type_expr
         (* A special case of unification (with {m : 'a; 'b}).  Raises

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -375,7 +375,7 @@ val filter_functor:
            May return [Some _] when the type is not principally known,
            so you should check for principality. *)
 val filter_arity:
-  Env.t -> arg_label -> type_expr ->
+  Env.t -> type_expr -> arg_label ->
   (Env.t * type_expr, filter_arrow_failure) result
 (* A specialized case of unification with [ l:_ -> 'a ] for all arrows *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4412,8 +4412,11 @@ and type_expect_
         type_function env params body_constraint body ty_expected ~in_function
           ~first:true
       in
-      if contains_gadt = Contains_gadt then
-        enforce_syntactic_arity ~loc env exp_type result_params body;
+      begin match contains_gadt with
+      | No_gadt -> ()
+      | Contains_gadt ->
+          enforce_syntactic_arity ~loc env exp_type result_params body
+      end;
       let params =
         List.map (fun { param; has_poly = _ } -> param) result_params
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4072,6 +4072,75 @@ let lower_args outer_level env ty_fun =
   let ty = instance ty_fun in
   wrap_trace_gadt_instances env (lower_args env TypeSet.empty) ty
 
+
+let enforce_syntactic_arity ~loc env exp_type result_params body =
+  (* Require that the n-ary function is known to have at least n arrows
+     in the type. This prevents GADT equations introduced by the parameters
+     from hiding arrows from the resulting type.
+
+     Performance hack: Only do this check when any of [params] contains a
+     GADT, as this is the only opportunity for arrows to be hidden from the
+     resulting type.
+  *)
+  (* Assert that [ty] is a function, and return its return type. *)
+  let filter_ty_ret_exn arg_label (env,ty) =
+    match filter_arity env arg_label ty with
+    | Ok (env,ty_ret) -> env, ty_ret
+    | Error error ->
+        let trace =
+          match error with
+          | Unification_error trace -> trace
+          | Not_a_function ->
+              let tarrow =
+                (newty
+                   (Tarrow
+                      (arg_label,
+                       newmono (newvar ()),
+                       newvar (),
+                       commu_ok)));
+              in
+              (* We go to some trouble to try to generate a unification
+                 error to help the error printing code's heuristic to
+                 identify the type equation at fault.
+              *)
+              (try
+                 unify env tarrow ty;
+                 fatal_error "unification unexpectedly succeeded"
+               with Unify trace -> trace)
+          | Label_mismatch _ ->
+              fatal_error
+                "Label_mismatch not expected as this point; this should\
+                 have been caught when the function was typechecked."
+        in
+        let syntactic_arity =
+          List.length result_params +
+          (match body with
+           | Tfunction_body _ -> 0
+           | Tfunction_cases _ -> 1)
+        in
+        let err =
+          Function_arity_type_clash
+            { syntactic_arity;
+              type_constraint = exp_type;
+              trace;
+            }
+        in
+        raise (Error (loc, env, err))
+  in
+  let env_ret_ty =
+    List.fold_left (fun env_ret_ty {param; _ } ->
+        filter_ty_ret_exn param.fp_arg_label env_ret_ty
+      )
+      (env, exp_type)
+      result_params
+  in
+  match body with
+  | Tfunction_body _ -> ()
+  | Tfunction_cases _ ->
+      ignore
+        (filter_ty_ret_exn Nolabel env_ret_ty : Env.t * type_expr)
+
+
 (* Generalize expressions *)
 let may_lower_contravariant env exp =
   if maybe_expansive exp then lower_contravariant env exp.exp_type
@@ -4343,77 +4412,8 @@ and type_expect_
         type_function env params body_constraint body ty_expected ~in_function
           ~first:true
       in
-      (* Require that the n-ary function is known to have at least n arrows
-         in the type. This prevents GADT equations introduced by the parameters
-         from hiding arrows from the resulting type.
-
-         Performance hack: Only do this check when any of [params] contains a
-         GADT, as this is the only opportunity for arrows to be hidden from the
-         resulting type.
-      *)
-      begin match contains_gadt with
-      | No_gadt -> ()
-      | Contains_gadt ->
-          (* Assert that [ty] is a function, and return its return type. *)
-          let filter_ty_ret_exn ty arg_label ~param_hole =
-            match
-              filter_arrow env ~in_apply:false ty arg_label ~param_hole
-            with
-            | Ok { ty_ret; _ } -> ty_ret
-            | Error error ->
-                let trace =
-                  match error with
-                  | Unification_error trace -> trace
-                  | Not_a_function ->
-                      let tarrow =
-                        (newty
-                          (Tarrow
-                            (arg_label,
-                             newmono (newvar ()),
-                             newvar (),
-                             commu_ok)));
-                      in
-                      (* We go to some trouble to try to generate a unification
-                        error to help the error printing code's heuristic to
-                        identify the type equation at fault.
-                      *)
-                      (try
-                        unify env tarrow ty;
-                        fatal_error "unification unexpectedly succeeded"
-                      with Unify trace -> trace)
-                  | Label_mismatch _ ->
-                      fatal_error
-                        "Label_mismatch not expected as this point; this should\
-                        have been caught when the function was typechecked."
-                in
-                let syntactic_arity =
-                  List.length result_params +
-                    (match body with
-                      | Tfunction_body _ -> 0
-                      | Tfunction_cases _ -> 1)
-                in
-                let err =
-                  Function_arity_type_clash
-                    { syntactic_arity;
-                      type_constraint = exp_type;
-                      trace;
-                    }
-                in
-                raise (Error (loc, env, err))
-          in
-          let ret_ty =
-            List.fold_left (fun ret_ty { param; has_poly } ->
-                filter_ty_ret_exn ret_ty param.fp_arg_label ~param_hole:has_poly
-              )
-              exp_type
-              result_params
-          in
-          match body with
-          | Tfunction_body _ -> ()
-          | Tfunction_cases _ ->
-              ignore
-                (filter_ty_ret_exn ret_ty Nolabel ~param_hole:false : type_expr)
-      end;
+      if contains_gadt = Contains_gadt then
+        enforce_syntactic_arity ~loc env exp_type result_params body;
       let params =
         List.map (fun { param; has_poly = _ } -> param) result_params
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4084,7 +4084,7 @@ let enforce_syntactic_arity ~loc env exp_type result_params body =
   *)
   (* Assert that [ty] is a function, and return its return type. *)
   let filter_ty_ret_exn arg_label (env,ty) =
-    match filter_arity env arg_label ty with
+    match filter_arity env ty arg_label with
     | Ok (env,ty_ret) -> env, ty_ret
     | Error error ->
         let trace =


### PR DESCRIPTION
This PR fixes the spurious syntactic arity error reported in #14719 by taking in account module-dependent arrow when enforcing that the syntactic arity of a function is not strictly greater that the arity of its type.

Close #14719