### PR TITLE
runtime/major_gc.c: continue fixing orphaning of ephemerons

### DIFF
--- a/Changes
+++ b/Changes
@@ -738,7 +738,7 @@ OCaml 5.5.0
   the alias twice.
   (Weixie Cui, review by Florian Angeletti)
 
-- #14349, #14718: runtime, fix in the orphaning of ephemerons
+- #14349, #14718, #14722: runtime, fix in the orphaning of ephemerons
   (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
    report by Jan Midtgaard)
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -343,6 +343,40 @@ static void record_ephe_marking_done (uintnat ephe_cycle)
   caml_plat_unlock(&ephe_lock);
 }
 
+Caml_inline value ephe_list_tail(value e)
+{
+  value last = 0;
+  while (e != 0) {
+    CAMLassert (Tag_val(e) == Abstract_tag);
+    last = e;
+    e = Ephe_link(e);
+  }
+  return last;
+}
+
+/* Prepare to mark ephemerons by moving the ephemerons on the live
+   list to the todo list. This is needed since the live list may
+   contain ephemerons with unmarked keys, which need to be
+   cleaned. This code is executed exactly once per major cycle per
+   domain, using the [ephe_info->must_sweep_ephe] state as
+   a reminder. */
+static void prepare_for_ephe_sweeping(caml_domain_state *domain_state)
+{
+  value e = ephe_list_tail (domain_state->ephe_info->todo);
+  if (e == (value)NULL) {
+    domain_state->ephe_info->todo = domain_state->ephe_info->live;
+  } else {
+    CAMLassert(Ephe_link(e) == (value)NULL);
+    Ephe_link(e) = domain_state->ephe_info->live;
+  }
+  domain_state->ephe_info->live = (value)NULL;
+  /* If the todo list is empty, then the domain has no ephemeron
+     sweeping work to do. */
+  if (domain_state->ephe_info->todo == (value)NULL) {
+      (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
+  }
+}
+
 #define EPHE_MARK_DEFAULT 0
 #define EPHE_MARK_FORCE_ALIVE 1
 
@@ -491,17 +525,6 @@ static struct {
 
 static caml_plat_mutex orphaned_lock = CAML_PLAT_MUTEX_INITIALIZER;
 
-Caml_inline value ephe_list_tail(value e)
-{
-  value last = 0;
-  while (e != 0) {
-    CAMLassert (Tag_val(e) == Abstract_tag);
-    last = e;
-    e = Ephe_link(e);
-  }
-  return last;
-}
-
 #ifdef DEBUG
 static void orph_ephe_list_verify_status (int status)
 {
@@ -531,6 +554,7 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
   /* Mark all ephemerons on live list.
      (ephe_mark() may move unmarked ephemerons to the live list if
       their data is none or immediate.)
+
      See Note [invariants on orphaned ephemerons]. */
   for (value v = ephe_info->live; v != 0; v = Ephe_link(v)) {
     if (is_unmarked(v)) {
@@ -540,14 +564,34 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     }
   }
 
-  /* Force all ephemerons and their data on todo list to be alive */
-  if (ephe_info->todo) {
-    while (ephe_info->todo) {
-      ephe_mark (100000, 0, EPHE_MARK_FORCE_ALIVE);
+  if (caml_gc_phase == Phase_sweep_and_mark_main
+      || caml_gc_phase == Phase_mark_final)
+  {
+    /* Force all ephemerons and their data on todo list to be alive */
+    if (ephe_info->todo) {
+      while (ephe_info->todo) {
+        ephe_mark (100000, 0, EPHE_MARK_FORCE_ALIVE);
+      }
+      ephe_todo_list_emptied ();
     }
-    ephe_todo_list_emptied ();
+    /* No need to sweep ephemerons: they will be adopted before
+       the cycle completes. */
+  } else {
+    /* Ensure that the ephemerons of this domain are swept/cleaned, in
+       case they stay orphaned until the next GC cycle. This mirrors
+       the logic in [major_collection_slice] for [Phase_sweep_ephe]. */
+    if (ephe_info->must_sweep_ephe) {
+      ephe_info->must_sweep_ephe = 0;
+      prepare_for_ephe_sweeping(domain_state);
+    }
+    if (ephe_info->todo) {
+      while (ephe_info->todo) {
+        ephe_sweep(domain_state, 100000);
+      }
+      (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
+    }
   }
-  CAMLassert (ephe_info->todo == 0);
+  CAMLassert(ephe_info->todo == 0);
 
   if (ephe_info->live) {
     value live_tail = ephe_list_tail(ephe_info->live);
@@ -560,10 +604,6 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     caml_plat_unlock(&orphaned_lock);
   }
 
-  if (ephe_info->must_sweep_ephe) {
-    ephe_info->must_sweep_ephe = 0;
-    (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
-  }
   CAMLassert (ephe_info->must_sweep_ephe == 0);
   CAMLassert (ephe_info->live == 0);
   CAMLassert (ephe_info->todo == 0);
@@ -1645,8 +1685,7 @@ void caml_mark_roots_stw (int participant_count,
 
     latest_sweep_allocs = diffmod (work_counter, work_counter_at_sweep_start);
 
-    /* Note [invariants on orphaned ephemerons].
-
+    /* Note [invariants on orphaned ephmerons]:
        Here we adopt orphaned work from domains that were spawned and
        terminated in the previous cycle. There must be no orphaned
        work remaining when this phase change takes place because
@@ -2177,26 +2216,8 @@ mark_again:
       /* Ephemeron Sweeping */
 
       if (domain_state->ephe_info->must_sweep_ephe) {
-        /* Move the ephemerons on the live list to the todo list. This is
-           needed since the live list may contain ephemerons with unmarked
-           keys, which need to be cleaned. This code is executed exactly once
-           per major cycle per domain. */
         domain_state->ephe_info->must_sweep_ephe = 0;
-
-        value e = ephe_list_tail (domain_state->ephe_info->todo);
-        if (e == (value)NULL) {
-          domain_state->ephe_info->todo = domain_state->ephe_info->live;
-        } else {
-          CAMLassert(Ephe_link(e) == (value)NULL);
-          Ephe_link(e) = domain_state->ephe_info->live;
-        }
-        domain_state->ephe_info->live = (value)NULL;
-
-        /* If the todo list is empty, then the ephemeron has no sweeping work
-         * to do. */
-        if (domain_state->ephe_info->todo == 0) {
-          (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
-        }
+        prepare_for_ephe_sweeping(domain_state);
       }
 
       if (domain_state->ephe_info->todo != 0) {
@@ -2206,7 +2227,7 @@ mark_again:
 
         while (domain_state->ephe_info->todo != 0 &&
                (budget = get_major_slice_work(mode)) > 0) {
-          intnat left = ephe_sweep (domain_state, budget);
+          intnat left = ephe_sweep(domain_state, budget);
           intnat work_done = budget - left;
           commit_major_slice_work(work_done);
         }


### PR DESCRIPTION
The commit in the present PR sits on top of #14718.

It fixes a separate bug that I also found by studying #14349, for which I had previously submitted the fix #14717 against trunk. I closed that fix because I think this should be fixed on top of 5.5 first, which is the version where we can reproduce the bugs. The fix I propose here is different than the one in #14717. (In #14717, my first fix was wrong, and my second fix is to add more per-domain state to track things. In the present PR I use a slightly different approach that does not require adding per-domain state, only checking the current GC phase; so the logic is arguably simpler, but reasoning about the correctness of the result is in fact not as easy.)

(What follows is the commit message of the one commit in this PR.)

Before this patch we have a bug where a domain that joins during a
major GC cycle and terminates during the same cycle can result in a
call to [ephe_todo_list_emptied()], which decrements
[num_domains_todo], while this domain has not been taken into account
in the [num_domains_todo] value set at the beginning of the
cycle. (This causes an assertion failure in debug mode in #14349.)

In this commit we change the logic in [caml_orphan_ephemerons] to
depend on the GC phase:
- we only call [ephe_todo_list_emptied()] during the mark phase
- during the ephe-sweep phase we instead clean the ephemerons
  as the normal GC phase would, to ensure that they do not become
  dead pointers while they are orphaned

It is not obvious that this is enough, but I believe that it is for
the following obscure reasons:

- During [Phase_sweep], no orphaning happens.
  If new domains get created, [caml_init_major_gc] will increment
  [ephe_info.num_domains_todo].
- During [Phase_sweep_and_mark_main], orphaning can happen,
  and [ephe_todo_list_emptied] can be called if it is non-empty.
  But only domains that were created during an earlier cycle can
  have a non-empty todo-list at that point, as the todo-list is
  populated during [mark_roots_stw], and in particular allocating
  new ephemerons pushes to the live list.
- During [Phase_mark_final] and [Phase_sweep_ephe] we do not call
  [ephe_todo_list_emptied] anymore.
