### PR TITLE
Atomic.fold_update

### DIFF
--- a/Changes
+++ b/Changes
@@ -94,8 +94,9 @@ Working version
 
 ### Standard library:
 
-- #10798: Atomic helper function
+- #10798, ...: Atomic helper functions
     update : ('a -> 'a) -> 'a t -> unit
+    fold_update : ('a -> 'acc * 'a) -> 'a t -> 'acc
   (Gabriel Scherer, review by Simon Cruanes, Stephen Dolan,
    Xavier Leroy, Guillaume Munch-Maccagnoni, Vesa Karvonen,
    Noah Bogart, Léo Andrès and Olivier Nicole)

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -745,6 +745,24 @@ allowing competing domains to make progress before retrying the failed
 operation. This lock-free stack implementation is called a
 \href{https://en.wikipedia.org/wiki/Treiber_stack}{Treiber stack}.
 
+We also provide convenience functions to encapsulate this retry-loop update
+pattern:
+\begin{caml_example*}{verbatim}
+module Lockfree_stack = struct
+  type 'a t = 'a list Atomic.t
+
+  let make () = Atomic.make []
+
+  let push r v =
+    Atomic.update (fun s -> v :: s) r
+
+  let rec pop r =
+    Atomic.fold_update (function
+    | [] -> None, []
+    | x::xs -> Some x, xs
+    ) r
+end
+\end{caml_example*}
 
 \subsection{s:atomic-record-fields}{Atomic record fields}
 

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -133,6 +133,15 @@ module Loc = struct
       then ()
       else loop ~backoff:(Backoff.once backoff) f t
     in loop ~backoff:Backoff.default f t
+
+  let fold_update f t =
+    let rec loop ~backoff f t =
+      let v_old = get t in
+      let (acc, v_new) = f v_old in
+      if v_old == v_new || compare_and_set t v_old v_new
+      then acc
+      else loop ~backoff:(Backoff.once backoff) f t
+    in loop ~backoff:Backoff.default f t
 end
 
 type !'a t =
@@ -162,6 +171,8 @@ let decr t =
 
 let update f t =
   Loc.update f [%atomic.loc t.contents]
+let fold_update f t =
+  Loc.fold_update f [%atomic.loc t.contents]
 
 module Array = struct
   type !'a t =
@@ -220,6 +231,12 @@ module Array = struct
   let[@inline] update f t i =
     check_array_bound t i;
     unsafe_update f t i
+
+  let[@inline] unsafe_fold_update f t i =
+    Loc.fold_update f (unsafe_index t i)
+  let[@inline] fold_update f t i =
+    check_array_bound t i;
+    unsafe_fold_update f t i
 
   let make len v =
     if len < 0 then

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -87,6 +87,32 @@ let global_push elem = Atomic.update (List.cons elem) global_list
 *)
 val update : ('a -> 'a) -> 'a t -> unit
 
+(** [fold_update f r] updates [r] in a way similar to {!update}, and
+    also accumulates a result from the current value of the
+    reference. More precisely, if [v] is the current value of [r] and
+    [f v] is [(acc, v')], it will set [r] to [v'] and return [acc], or
+    retry (calling [f] again) if [r] was concurrently changed to
+    a physically different value.
+
+    Remark: no [set] is performed when [v'] is physically equal to [v].
+
+    Example:
+{[
+let global_list = Atomic.make []
+let global_pop =
+  Atomic.fold_update (function
+  | [] -> None, []
+  | x::xs -> Some x, xs
+  ) global_list
+]}
+    Notice that there is no [set] in the empty list case, as
+    the input is returned unchanged.
+
+    @since 5.6
+*)
+val fold_update : ('a -> 'acc * 'a) -> 'a t -> 'acc
+
+
 (** Atomic "locations", such as record fields.
 
     @since 5.4 *)
@@ -114,6 +140,7 @@ module Loc : sig
   val incr : int t -> unit
   val decr : int t -> unit
   val update : ('a -> 'a) -> 'a t -> unit
+  val fold_update : ('a -> 'acc * 'a) -> 'a t -> 'acc
 end
 
 
@@ -162,6 +189,11 @@ module Array : sig
     ('a -> 'a) -> 'a t -> int -> unit
   val update :
     ('a -> 'a) -> 'a t -> int -> unit
+
+  val unsafe_fold_update :
+    ('a -> 'acc * 'a) -> 'a t -> int -> 'acc
+  val fold_update :
+    ('a -> 'acc * 'a) -> 'a t -> int -> 'acc
 end
 
 (** {1:examples Examples}
@@ -270,6 +302,18 @@ end
     with {!Atomic.update} instead:
 
     {[
-    let push stack elt = Atomic.update (fun li -> elt :: li) stack
+    let push stack elt =
+      Atomic.update (fun li -> elt :: li) stack
     ]}
-  *)
+
+    [pop] also returns a value in addition to updating the stack, so
+    it needs {!Atomic.fold_update}:
+
+    {[
+    let pop stack =
+      Atomic.fold_update (function
+      | [] -> None, []
+      | x::xs -> Some x, xs
+      ) stack
+    ]}
+*)

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -103,10 +103,8 @@ module DLS = struct
 
   let parent_keys = Atomic.make ([] : key_initializer list)
 
-  let rec add_parent_key ki =
-    let l = Atomic.get parent_keys in
-    if not (Atomic.compare_and_set parent_keys l (ki :: l))
-    then add_parent_key ki
+  let add_parent_key ki =
+    Atomic.update (fun l -> ki :: l) parent_keys
 
   let new_key ?split_from_parent init_orphan =
     let idx = Atomic.fetch_and_add key_counter 1 in

--- a/testsuite/tests/atomic-locs/cmm.compilers.reference
+++ b/testsuite/tests/atomic-locs/cmm.compilers.reference
@@ -6,49 +6,49 @@ cmm:
  "camlCmm.9":
  addr "caml_curry2"
  int 144115188075855879
- addr "camlCmm.set_327")
+ addr "camlCmm.set_333")
 (data
  int 4087
  "camlCmm.8":
  addr "caml_curry2"
  int 144115188075855879
- addr "camlCmm.explicit_set_331")
+ addr "camlCmm.explicit_set_337")
 (data
  int 4087
  "camlCmm.7":
  addr "caml_curry3"
  int 216172782113783815
- addr "camlCmm.cas_335")
+ addr "camlCmm.cas_341")
 (data
  int 4087
  "camlCmm.6":
  addr "caml_curry2"
  int 144115188075855879
- addr "camlCmm.array_get_341")
+ addr "camlCmm.array_get_347")
 (data
  int 4087
  "camlCmm.5":
  addr "caml_curry2"
  int 144115188075855879
- addr "camlCmm.unsafe_array_get_373")
+ addr "camlCmm.unsafe_array_get_387")
 (data
  int 4087
  "camlCmm.4":
  addr "caml_curry3"
  int 216172782113783815
- addr "camlCmm.array_set_377")
+ addr "camlCmm.array_set_391")
 (data
  int 4087
  "camlCmm.3":
  addr "caml_curry3"
  int 216172782113783815
- addr "camlCmm.unsafe_array_set_382")
+ addr "camlCmm.unsafe_array_set_396")
 (data
  int 4087
  "camlCmm.2":
  addr "caml_curry4"
  int 288230376151711751
- addr "camlCmm.array_cas_387")
+ addr "camlCmm.array_cas_401")
 (data
  int 3063
  "camlCmm.14":
@@ -57,26 +57,26 @@ cmm:
 (data
  int 3063
  "camlCmm.13":
- addr "camlCmm.standard_atomic_set_301"
+ addr "camlCmm.standard_atomic_set_305"
  int 72057594037927941)
 (data
  int 4087
  "camlCmm.12":
  addr "caml_curry3"
  int 216172782113783815
- addr "camlCmm.standard_atomic_cas_304")
-(data int 3063 "camlCmm.11": addr "camlCmm.get_313" int 72057594037927941)
+ addr "camlCmm.standard_atomic_cas_308")
+(data int 3063 "camlCmm.11": addr "camlCmm.get_317" int 72057594037927941)
 (data
  int 3063
  "camlCmm.10":
- addr "camlCmm.explicit_get_316"
+ addr "camlCmm.explicit_get_320"
  int 72057594037927941)
 (data
  int 4087
  "camlCmm.1":
  addr "caml_curry4"
  int 288230376151711751
- addr "camlCmm.unsafe_array_cas_393")
+ addr "camlCmm.unsafe_array_cas_407")
 (data
  int 18176
  global "camlCmm"
@@ -101,46 +101,46 @@ cmm:
 (data global "camlCmm.gc_roots" "camlCmm.gc_roots": addr "camlCmm" int 0)
 (function camlCmm.standard_atomic_get_274 (r: val) (load_mut_atomic val r))
 
-(function camlCmm.standard_atomic_set_301 (r: val) (load_mut_atomic val r))
+(function camlCmm.standard_atomic_set_305 (r: val) (load_mut_atomic val r))
 
-(function camlCmm.standard_atomic_cas_304 (r: val oldv: val newv: val)
+(function camlCmm.standard_atomic_cas_308 (r: val oldv: val newv: val)
  (extcall "caml_atomic_cas_field" r 1 oldv newv int,int,int,int->val))
 
-(function camlCmm.get_313 (r: val) (load_mut_atomic val (+a r 8)))
+(function camlCmm.get_317 (r: val) (load_mut_atomic val (+a r 8)))
 
-(function camlCmm.explicit_get_316 (r: val) (load_mut_atomic val (+a r 8)))
+(function camlCmm.explicit_get_320 (r: val) (load_mut_atomic val (+a r 8)))
 
-(function camlCmm.set_327 (r: val v: val)
+(function camlCmm.set_333 (r: val v: val)
  (extcall "caml_atomic_exchange_field" r 3 v int,int,int->unit) 1)
 
-(function camlCmm.explicit_set_331 (r: val v: val)
+(function camlCmm.explicit_set_337 (r: val v: val)
  (let t (alloc 2048 r 3)
    (extcall "caml_atomic_exchange_field" (load val t) (load int (+a t 8)) v
      int,int,int->unit)
    1))
 
-(function camlCmm.cas_335 (r: val oldv: val newv: val)
+(function camlCmm.cas_341 (r: val oldv: val newv: val)
  (extcall "caml_atomic_cas_field" r 3 oldv newv int,int,int,int->val))
 
-(function camlCmm.array_get_341 (arr: val i: int)
+(function camlCmm.array_get_347 (arr: val i: int)
  (checkbound (or (>>u (load int (+a arr -8)) 9) 1) i) []
  (load_mut_atomic val (+a (+a arr (<< i 2)) -4)))
 
-(function camlCmm.unsafe_array_get_373 (arr: val i: int)
+(function camlCmm.unsafe_array_get_387 (arr: val i: int)
  (load_mut_atomic val (+a (+a arr (<< i 2)) -4)))
 
-(function camlCmm.array_set_377 (arr: val i: int v: val)
+(function camlCmm.array_set_391 (arr: val i: int v: val)
  (checkbound (or (>>u (load int (+a arr -8)) 9) 1) i) []
  (extcall "caml_atomic_exchange_field" arr i v int,int,int->unit) 1)
 
-(function camlCmm.unsafe_array_set_382 (arr: val i: int v: val)
+(function camlCmm.unsafe_array_set_396 (arr: val i: int v: val)
  (extcall "caml_atomic_exchange_field" arr i v int,int,int->unit) 1)
 
-(function camlCmm.array_cas_387 (arr: val i: int oldv: val newv: val)
+(function camlCmm.array_cas_401 (arr: val i: int oldv: val newv: val)
  (checkbound (or (>>u (load int (+a arr -8)) 9) 1) i) []
  (extcall "caml_atomic_cas_field" arr i oldv newv int,int,int,int->val))
 
-(function camlCmm.unsafe_array_cas_393 (arr: val i: int oldv: val newv: val)
+(function camlCmm.unsafe_array_cas_407 (arr: val i: int oldv: val newv: val)
  (extcall "caml_atomic_cas_field" arr i oldv newv int,int,int,int->val))
 
 (function camlCmm.entry ()

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -48,3 +48,17 @@ let () =
     i + 1
   ) r;
   assert (Atomic.get r = 11)
+
+let () =
+  let r = Atomic.make 1 in
+  let v =
+    Atomic.fold_update (fun i ->
+      begin
+        (* simulate concurrent modifications *)
+        if i < 10 then Atomic.incr r;
+      end;
+      2 * i, i + 1
+    ) r
+  in
+  assert (v = 20);
+  assert (Atomic.get r = 11)

--- a/testsuite/tests/lib-dynlink-domains/store.ml
+++ b/testsuite/tests/lib-dynlink-domains/store.ml
@@ -1,7 +1,3 @@
 let store: string list Atomic.t = Atomic.make []
 
-let add x =
-  let rec swap prev =
-    if Atomic.compare_and_set store prev (x :: prev) then ()
-    else swap (Atomic.get store) in
-  swap (Atomic.get store)
+let add x = Atomic.update (fun prev -> x :: prev) store


### PR DESCRIPTION
```ocaml
val fold_update : ('a -> 'acc * 'a) -> 'a Atomic.t -> 'acc
```

This is a follow-up to #10798 which adds `val update : ('a -> 'a) -> 'a Atomic.t -> unit`. The motivation is to be able to implement `pop` in addition to `push` for the Treiber stack, more generally perform updates that also return a value.

The naming, type variable conventions and tuple order are inspired from `fold_map`-family functions:

```ocaml
val List.fold_left_map : ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
```

(Edit: I initially had a claim that it is also "somehow consistent" with `Seq.unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t`, but I don't find this convincing anymore. My best save would be to say that `unfold` is a dual operation, so it okay if the tuple is in the opposite order?) 

Note that (unlike Haskell `foldMap`) the naming does *not* follow the pattern that `foo_bar` can be understood as the composition of `foo` and `bar`, with `bar` applied first to the input. On the other hand, `update` returns `unit` so `fold ... (update ...)` would not be interesting: there is no risk of conflict between two plausible interpretations of the name.

Finally, here are pointers to the comments from #10798 which discussed naming (that PR initially came with a `modify_get` function with exactly the type and behavior of `fold_update`, but it proved contentious and was dropped):
- @NoahTheDuke had feedback on Clojure naming conventions for these functions ( https://github.com/ocaml/ocaml/pull/10798#issuecomment-2302682416 ) In particular he made the point that it would be nice to have a function that returns the value after the update, which `fold_update` can do but at the cost of some verbosity (a `let`-binding and a tuple).
- @dbuenzli and the stdlib committee suggested `map_update` for this function ( https://github.com/ocaml/ocaml/pull/10798#issuecomment-3853954400 )
- @c-cube asked for this function with a 🙏 emoji ( https://github.com/ocaml/ocaml/pull/10798#issuecomment-4184977440 )