### PR TITLE
Add regression test for rectypes keep expansion

### DIFF
--- a/Changes
+++ b/Changes
@@ -198,6 +198,10 @@ Working version
 - #14654: Fix non-exhaustive directive rule in lexer.
   (Antonin Décimo, review by Martin Jambon and Gabriel Scherer)
 
+- #14730: Test keep-expansion (#11648) against overflow in the presence of
+  rectypes and module aliases.
+  (Brandon Stride)
+
 ### Build system:
 
 ### Bug fixes:

--- a/testsuite/tests/typing-rectypes-bugs/module_alias_wrapper.ml
+++ b/testsuite/tests/typing-rectypes-bugs/module_alias_wrapper.ml
@@ -4,6 +4,8 @@
  expect;
 *)
 
+(* PR14730 tests #11648 *)
+
 module Empty = struct end
 
 module Empty_wrapper = struct

--- a/testsuite/tests/typing-rectypes-bugs/module_alias_wrapper.ml
+++ b/testsuite/tests/typing-rectypes-bugs/module_alias_wrapper.ml
@@ -1,0 +1,41 @@
+(* TEST
+ flags = " -rectypes ";
+ ocamlrunparam += "l=1000000";
+ expect;
+*)
+
+module Empty = struct end
+
+module Empty_wrapper = struct
+  module Empty = Empty
+end
+
+open Empty_wrapper
+
+module Make (_ : sig end) = struct
+  type (_, 't) open_t = A : 't -> (int, 't) open_t
+end
+
+open Make (Empty)
+
+type int_t = (int, int_t) open_t
+
+type 'a t = ('a, int_t) open_t
+type any = Any : 'a t -> any
+
+let hang (f : any -> bool) (v : any) : bool =
+  match v with
+  | Any A a -> f (Any a)
+[%%expect{|
+module Empty : sig end
+module Empty_wrapper : sig module Empty = Empty end
+module Make :
+  sig end -> sig type (_, 't) open_t = A : 't -> (int, 't) open_t end
+type ('a, 't) open_t =
+  ('a, 't) Make(Empty_wrapper.Empty).open_t =
+    A : 't -> (int, 't) open_t
+type int_t = (int, int_t) open_t
+type 'a t = ('a, int_t) open_t
+type any = Any : 'a t -> any
+val hang : (any -> bool) -> any -> bool = <fun>
+|}]


### PR DESCRIPTION
I just burned a few hours chasing a minimal example for an infinite loop in the type checker only to then try `trunk` and see that it was fixed by #11648.

This PR simply adds a test to prevent it from regressing to pre-keep-expansion behavior because it seems different enough from any previously-open issue fixed by those changes.

For context, there is stack overflow when type checking this program on OCaml 4.14, and there is nontermination on 5.2 and 5.5~alpha3 (among others that I didn't try, I'm sure), and also on `trunk` immediately before keep expansion. After keep expansion, this type checks. I can't seem to get it any smaller and still exhibit the same behavior.