### PR TITLE
shortcut on physical equality for `=`

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,11 @@ Working version
 - #14482: Add DWARF CFI support to POWER backend.
   (Tim McGilchrist, review by Xavier Leroy)
 
+- #14731: Enforce that `t == u` implies `t = u` for non-float values, even
+  recursively inside other values (meaning that
+  `t == u` implies, say, `[t;t] = [u]@[u]`).
+  (Simon Cruanes)
+
 ### Type system:
 
 * #11648: Keep expansion and new well-foundedness check implementation.

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -290,6 +290,13 @@ static intnat do_compare_val(struct compare_stack* stk,
         break;
       }
       default: {
+        /* Physical equality on regular (scanned) blocks is safe even for
+           non-total comparison (=): NaN can only appear in Double_tag and
+           Double_array_tag blocks, both handled by their own cases above.
+           This avoids recursing into closures or other incomparable fields
+           when comparing shared subvalues (e.g. channels, existential GADTs
+           containing vtables). */
+        if (v1 == v2) goto next_item;
         mlsize_t sz1 = Wosize_val(v1);
         mlsize_t sz2 = Wosize_val(v2);
         /* Compare sizes first for speed */

--- a/testsuite/tests/basic/compare_physical_eq.ml
+++ b/testsuite/tests/basic/compare_physical_eq.ml
@@ -1,0 +1,63 @@
+(* TEST *)
+
+(* Tests for the physical equality shortcut in compare.c (default case).
+   A record with a closure field (fn) will raise Invalid_argument if compare
+   recurses into it. The shortcut fires when v1 == v2, skipping field traversal.
+   To verify the patch is load-bearing: comment out the line
+     [if (v1 == v2) goto next_item;]
+   in runtime/compare.c (default case, ~line 299), rebuild, and confirm that
+   tests 1-4 and 6 fail (raise Invalid_argument). Restore the line to pass. *)
+
+let test n check res =
+  print_string "Test "; print_int n;
+  if check res then print_string " passed.\n" else print_string " FAILED.\n";
+  flush stdout
+
+let eqtrue (b : bool) = b
+
+let eqfun delayed_check =
+  match delayed_check () with
+  | exception Invalid_argument _ -> true
+  | _ -> false
+
+(* fn field: without the patch, any (=) that recurses into it will raise *)
+type foo = { id: int; fn: unit -> unit }
+type bar = { id: int; fn: unit -> unit; data: int list; extra: float }
+type outer = { id: int; fn: unit -> unit; inner: inner }
+and inner = { id: int; fn: unit -> unit; x: int; y: float }
+
+let () =
+  (* Test 1: simple record, compared to itself (shortcut at record level) *)
+  let v = { id = 1; fn = (fun () -> ()) } in
+  test 1 eqtrue (v = v);
+
+  (* Test 2: record with more fields, compared to itself *)
+  let v = { id = 2; fn = (fun () -> ()); data = [1; 2; 3]; extra = 3.14 } in
+  test 2 eqtrue (v = v);
+
+  (* Test 3: nested record, both levels carry a closure *)
+  let v = { id = 3; fn = (fun () -> ());
+            inner = { id = 30; fn = (fun () -> ()); x = 10; y = 2.71 } } in
+  test 3 eqtrue (v = v);
+
+  (* Test 4: two distinct list allocations containing the same (shared) item.
+     The list cons cells are different pointers so no shortcut there, but when
+     compare recurses into elements it finds item == item, so shortcut fires. *)
+  let item = { id = 4; fn = (fun () -> ()) } in
+  let lst1 = [item; item] in
+  let lst2 = Sys.opaque_identity ([item]@[item]) in
+  assert (lst1 != lst2); (* distinct list allocations *)
+  test 4 eqtrue (lst1 = lst2);
+
+  (* Test 5: two different foo allocations with same id but distinct closures.
+     They are NOT physically equal, so the shortcut does not fire and compare
+     will recurse into fn, which should raise Invalid_argument. *)
+  let v1 = { id = 42; fn = (fun () -> ()) } in
+  let v2 = { id = 42; fn = (fun () -> ()) } in
+  test 5 eqfun (fun () -> v1 = v2);
+
+  (* Test 6: physical equality and structural equality coincide *)
+  let v = { id = 7; fn = ignore } in
+  test 6 eqtrue (v == v && v = v);
+
+  ()

--- a/testsuite/tests/basic/compare_physical_eq.reference
+++ b/testsuite/tests/basic/compare_physical_eq.reference
@@ -1,0 +1,6 @@
+Test 1 passed.
+Test 2 passed.
+Test 3 passed.
+Test 4 passed.
+Test 5 passed.
+Test 6 passed.


### PR DESCRIPTION
currently, only `Stdlib.compare` will shortcut if the two values are physically equal. This patch also enables this behavior for non-float values (to work around the NaN != Nan issue).

What this enables is a way to conflate structural equality with physical equality, for any block whose first value is unique (a stable substitute for the physical address, if you will).

For example, talking about HOAS terms, you could have:

```ocaml
type t = {
  id: int; (* unique *)
  view: term_view;
}

and term_view =
  | App of t * t
  | Var of string
  | Fun of (string -> t) (* oh no! closure! *)

let mk_term : term_view -> t =
  let n = Atomic.make 0 in
  fun view -> { id=Atomic.fetch_and_add n 1; view }

let () = assert (
  mk_term (Fun (fun "x" -> mk_term @@ Var "x"))
  <> mk_term (Fun (fun "y" -> mk_term @@ Var "y")))
```

on trunk, comparing a `Fun` term with itself using `=` will raise an exception about comparing functional values, because `=` will recursive inside the view. With the present PR: `t = t` shortcuts because of physical equality, `t = u` stops at the `id`. There is no case where it fails.

AI disclosure: the test was written by claude under close supervision.