### PR TITLE
Major gc: clarify ephemeron counters

### DIFF
--- a/Changes
+++ b/Changes
@@ -65,6 +65,7 @@ Working version
 
 - grouped fixes in the ephemeron runtime
   + #14734: fix ephemeron orphaning (a counterpart of #14722)
+  + #14733: clarify the implementation of per-domain ephemeron work counters
   (Gabriel Scherer, review by Damien Doligez)
 
 ### Type system:

--- a/Changes
+++ b/Changes
@@ -63,6 +63,10 @@ Working version
 - #14717: assign 'unique_id' early during domain creation to help debugging
   (Gabriel Scherer, review by Olivier Nicole)
 
+- grouped fixes in the ephemeron runtime
+  + #14734: fix ephemeron orphaning (a counterpart of #14722)
+  (Gabriel Scherer, review by Damien Doligez)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776: Keep expansion and new well-foundedness check

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -42,6 +42,13 @@ Caml_inline int caml_marking_started(void)
   return caml_gc_phase != Phase_sweep_main;
 }
 
+Caml_inline bool caml_ephe_marking_ongoing(void)
+{
+  return
+    caml_marking_started()
+    && caml_gc_phase != Phase_sweep_ephe;
+}
+
 extern atomic_uintnat caml_gc_mark_phase_requested;
 intnat caml_opportunistic_major_work_available (caml_domain_state*);
 void caml_opportunistic_major_collection_slice (intnat);

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -47,6 +47,7 @@ struct caml_ephe_info {
   uintnat round;
   /* Records the number of the round of ephemeron marking most
    * recently completed in the current cycle. */
+
   struct {
     value* todop;
     uintnat round;

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -44,14 +44,6 @@ struct caml_ephe_info {
      may be unmarked if these ephemerons were the target of a blit
      operation. The data field is never unmarked. */
 
-  int must_sweep_ephe;
-  /* At the beginning of [Phase_sweep_ephe] the [live] list is moved
-     to the [todo] list since the ephemerons in the [live] list may
-     contain unmarked keys if the blit operation was performed in
-     earlier phases. This move is done exactly once per major cycle
-     per domain. This field keeps track of whether this move has been
-     done for the current cycle. */
-
   uintnat round;
   /* Records the number of the round of ephemeron marking most
    * recently completed in the current cycle. */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -2238,7 +2238,7 @@ mark_again:
     }
 
     /* Ephemerons */
-    if (caml_gc_phase != Phase_sweep_ephe) {
+    if (caml_ephe_marking_ongoing()) {
       /* Ephemeron Marking */
       saved_ephe_round = caml_atomic_counter_value(&ephe_round_info.round);
       if (domain_state->ephe_info->todo != (value) NULL &&

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -336,8 +336,10 @@ static struct {
   /* Current ephemeron round number */
 
   atomic_uintnat num_domains_done;
-  /* Number of domains that have marked all their ephemerons in the
-   * current ephemeron round. */
+  /* Number of domains that have a non-empty todo list for ephemeron marking,
+   * but have completed the current ephemeron marking round.
+   * See [has_completed_last_ephe_round]. */
+
 } ephe_round_info;
 /* In the first major cycle, there is no ephemeron marking to be done. */
 
@@ -348,10 +350,10 @@ static caml_plat_mutex ephe_lock = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Global (not per-domain) preparation work for ephemeron marking. */
 static void global_prepare_for_ephe_marking (int num_domains_in_stw) {
+  caml_atomic_counter_init(&ephe_round_info.num_domains_done, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
   caml_atomic_counter_init(&ephe_round_info.round, 1);
-  caml_atomic_counter_init(&ephe_round_info.num_domains_done, 0);
 }
 
 /* Prepare to mark ephemerons by making all 'live' ephes become 'todo' */
@@ -364,60 +366,62 @@ static void prepare_for_ephe_marking(caml_domain_state *domain)
   domain->ephe_info->cursor.todop = NULL;
   domain->ephe_info->cursor.round = 0;
 
-  if (!domain->ephe_info->todo)
+  if (!domain->ephe_info->todo) {
     caml_atomic_counter_decr(&ephe_round_info.num_domains_todo);
+    CAMLassert(caml_atomic_counter_value(&ephe_round_info.num_domains_done) <=
+               caml_atomic_counter_value(&ephe_round_info.num_domains_todo));
+  }
+}
+
+/* Ownership of [ephe_lock] is required to call this function. */
+static bool has_completed_last_ephe_round (caml_domain_state *domain_state)
+{
+  return (domain_state->ephe_info->round == ephe_round_info.round);
 }
 
 /* Move to the next global ephemeron round. Called whenever any domain
  * finishes marking. */
-
 static void ephe_next_round (void)
 {
   caml_plat_lock_blocking(&ephe_lock);
 
-  (void)caml_atomic_counter_incr(&ephe_round_info.round);
   CAMLassert(caml_atomic_counter_value(&ephe_round_info.num_domains_done) <=
              caml_atomic_counter_value(&ephe_round_info.num_domains_todo));
   caml_atomic_counter_init(&ephe_round_info.num_domains_done, 0);
+  (void)caml_atomic_counter_incr(&ephe_round_info.round);
 
   caml_plat_unlock(&ephe_lock);
 }
 
 /* Record that a domain's "todo" list has been empty during the
- * current major cycle. Triggers a fresh ephemeron round, with fewer
- * ephemeron-marking domains. */
+ * current major cycle. */
 
-static void ephe_todo_list_emptied (void)
+static void ephe_todo_list_emptied (caml_domain_state *domain_state)
 {
   /* This function is intended to be used during ephemeron marking,
      not ephemeron sweeping. */
   CAMLassert (caml_ephe_marking_ongoing());
 
   caml_plat_lock_blocking(&ephe_lock);
-
-  /* Force next ephemeron marking round in order to avoid reasoning about
-   * whether the domain has already incremented
-   * [ephe_round_info.num_domains_done] counter. */
-  caml_atomic_counter_init(&ephe_round_info.num_domains_done, 0);
-  (void)caml_atomic_counter_incr(&ephe_round_info.round);
-
-  /* Since the todo list is empty, this domain does not need to participate in
-   * further ephemeron rounds. */
+  if (has_completed_last_ephe_round(domain_state)) {
+    /* Undo the increment to [num_domains_done] */
+    (void)caml_atomic_counter_decr(&ephe_round_info.num_domains_done);
+  }
   (void)caml_atomic_counter_decr(&ephe_round_info.num_domains_todo);
   CAMLassert(caml_atomic_counter_value(&ephe_round_info.num_domains_done) <=
              caml_atomic_counter_value(&ephe_round_info.num_domains_todo));
-
   caml_plat_unlock(&ephe_lock);
 }
 
 /* Record that a domain finished ephemeron marking for the given
  * ephemeron round, without adding anything to its mark stack. */
 
-static void record_ephe_marking_done (uintnat round)
+static void record_ephe_marking_done (
+  caml_domain_state *domain_state, uintnat round)
 {
   CAMLassert (round <=
               caml_atomic_counter_value(&ephe_round_info.round));
-  CAMLassert (Caml_state->marking_done);
+  CAMLassert (domain_state->marking_done);
 
   if (round < caml_atomic_counter_value(&ephe_round_info.round)) {
     /* The world has already moved on to some other round */
@@ -428,10 +432,12 @@ static void record_ephe_marking_done (uintnat round)
   caml_plat_lock_blocking(&ephe_lock);
   if (round == caml_atomic_counter_value(&ephe_round_info.round)) {
     /* Round hasn't just advanced. */
-    Caml_state->ephe_info->round = round;
-    (void)caml_atomic_counter_incr(&ephe_round_info.num_domains_done);
-    CAMLassert(caml_atomic_counter_value(&ephe_round_info.num_domains_done) <=
-               caml_atomic_counter_value(&ephe_round_info.num_domains_todo));
+    domain_state->ephe_info->round = round;
+    if (domain_state->ephe_info->todo) {
+      (void)caml_atomic_counter_incr(&ephe_round_info.num_domains_done);
+      CAMLassert(caml_atomic_counter_value(&ephe_round_info.num_domains_done) <=
+                 caml_atomic_counter_value(&ephe_round_info.num_domains_todo));
+    }
   }
   caml_plat_unlock(&ephe_lock);
 }
@@ -654,7 +660,7 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
       while (ephe_info->todo) {
         ephe_mark(100000, 0, EPHE_MARK_FORCE_ALIVE);
       }
-      ephe_todo_list_emptied ();
+      ephe_todo_list_emptied (domain_state);
     }
   } else if (caml_gc_phase == Phase_sweep_ephe) {
     if (ephe_info->todo) {
@@ -2267,14 +2273,14 @@ mark_again:
         CAML_EV_END(EV_MAJOR_EPHE_MARK);
 
         if (domain_state->ephe_info->todo == (value)NULL) {
-          ephe_todo_list_emptied ();
+          ephe_todo_list_emptied (domain_state);
         }
 
         if (ephe_completed_marking) {
           if (!domain_state->marking_done)
             goto mark_again;
           else
-            record_ephe_marking_done(saved_ephe_round);
+            record_ephe_marking_done(domain_state, saved_ephe_round);
         }
       }
     }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -364,7 +364,6 @@ static void prepare_for_ephe_marking(caml_domain_state *domain)
   CAMLassert(domain->ephe_info->todo == (value) NULL);
   domain->ephe_info->todo = domain->ephe_info->live;
   domain->ephe_info->live = (value) NULL;
-  domain->ephe_info->must_sweep_ephe = 0;
   domain->ephe_info->round = 0;
   domain->ephe_info->cursor.todop = NULL;
   domain->ephe_info->cursor.round = 0;
@@ -439,22 +438,16 @@ static void record_ephe_marking_done (uintnat round)
 }
 
 /* Global (not per-domain) preparation work for ephemeron sweeping. */
-static void global_prepare_for_ephe_sweeping (
-  int participant_count,
-  caml_domain_state** participating)
+static void global_prepare_for_ephe_sweeping (int participant_count)
 {
   caml_atomic_counter_init(&num_domains_to_ephe_sweep, participant_count);
-  for (int i = 0; i < participant_count; i++)
-    participating[i]->ephe_info->must_sweep_ephe = 1;
 }
 
 /* Prepare to sweep ephemerons by moving the ephemerons on the live
    list to the todo list. This is needed since the live list may
    contain ephemerons with unmarked keys, which need to be
-   cleaned. This code is executed exactly once per major cycle per
-   domain, using the [ephe_info->must_sweep_ephe] state as
-   a reminder. */
-static void prepare_for_ephe_sweeping(caml_domain_state *domain_state)
+   cleaned. */
+static void prepare_for_ephe_sweeping (caml_domain_state *domain_state)
 {
   domain_state->ephe_info->todo =
     caml_ephe_list_append(
@@ -653,8 +646,7 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
 
   struct caml_ephe_info* ephe_info = domain_state->ephe_info;
   if (ephe_info->todo == 0 &&
-      ephe_info->live == 0 &&
-      ephe_info->must_sweep_ephe == 0)
+      ephe_info->live == 0)
     return;
 
   if (caml_ephe_marking_ongoing()) {
@@ -666,10 +658,6 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
       ephe_todo_list_emptied ();
     }
   } else if (caml_gc_phase == Phase_sweep_ephe) {
-    if (domain_state->ephe_info->must_sweep_ephe) {
-      domain_state->ephe_info->must_sweep_ephe = 0;
-      prepare_for_ephe_sweeping(domain_state);
-    }
     if (ephe_info->todo) {
       /* Ensure that the ephemerons of this domain are swept/cleaned, in
          case they stay orphaned until the next GC cycle. This mirrors
@@ -695,7 +683,6 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     caml_plat_unlock(&orphaned_lock);
   }
 
-  CAMLassert (ephe_info->must_sweep_ephe == 0);
   CAMLassert (ephe_info->live == 0);
   CAMLassert (ephe_info->todo == 0);
 }
@@ -2085,8 +2072,12 @@ static void stw_try_complete_gc_phase(
       caml_gc_phase = Phase_mark_final;
     } else if (is_complete_phase_mark_final()) {
       caml_gc_phase = Phase_sweep_ephe;
-      global_prepare_for_ephe_sweeping(participant_count, participating);
+      global_prepare_for_ephe_sweeping(participant_count);
     }
+  }
+
+  if (caml_gc_phase == Phase_sweep_ephe) {
+    prepare_for_ephe_sweeping(domain);
   }
 
   CAML_EV_END(EV_MAJOR_GC_PHASE_CHANGE);
@@ -2295,19 +2286,13 @@ mark_again:
     if (caml_gc_phase == Phase_sweep_ephe) {
       /* Ephemeron Sweeping */
 
-      if (domain_state->ephe_info->must_sweep_ephe) {
-        domain_state->ephe_info->must_sweep_ephe = 0;
-        prepare_for_ephe_sweeping(domain_state);
-      }
-
       if (domain_state->ephe_info->todo != 0) {
-        CAMLassert (domain_state->ephe_info->must_sweep_ephe == 0);
         /* Sweep the ephemeron todo list */
         CAML_EV_BEGIN(EV_MAJOR_EPHE_SWEEP);
 
         while (domain_state->ephe_info->todo != 0 &&
                (budget = get_major_slice_work(mode)) > 0) {
-          intnat left = ephe_sweep (domain_state, budget);
+          intnat left = ephe_sweep(domain_state, budget);
           intnat work_done = budget - left;
           commit_major_slice_work(work_done);
         }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -391,9 +391,10 @@ static void ephe_next_round (void)
 
 static void ephe_todo_list_emptied (void)
 {
-  /* If we haven't started marking, the todo list can grow (during ephemeron
-     allocation), so we should not yet announce that it has emptied */
-  CAMLassert (caml_marking_started());
+  /* This function is intended to be used during ephemeron marking,
+     not ephemeron sweeping. */
+  CAMLassert (caml_ephe_marking_ongoing());
+
   caml_plat_lock_blocking(&ephe_lock);
 
   /* Force next ephemeron marking round in order to avoid reasoning about
@@ -494,7 +495,7 @@ static intnat ephe_mark (intnat budget, uintnat round,
   caml_domain_state* domain_state = Caml_state;
   size_t scanned = 0, preserved = 0;
 
-  CAMLassert(caml_marking_started());
+  CAMLassert(caml_ephe_marking_ongoing());
   if (domain_state->ephe_info->cursor.round == round &&
       !force_alive) {
     prev_linkp = domain_state->ephe_info->cursor.todop;
@@ -656,12 +657,31 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
       ephe_info->must_sweep_ephe == 0)
     return;
 
-  /* Force all ephemerons and their data on todo list to be alive */
-  if (ephe_info->todo) {
-    while (ephe_info->todo) {
-      ephe_mark (100000, 0, EPHE_MARK_FORCE_ALIVE);
+  if (caml_ephe_marking_ongoing()) {
+    if (ephe_info->todo) {
+      /* Force all ephemerons and their data on todo list to be alive */
+      while (ephe_info->todo) {
+        ephe_mark(100000, 0, EPHE_MARK_FORCE_ALIVE);
+      }
+      ephe_todo_list_emptied ();
     }
-    ephe_todo_list_emptied ();
+  } else if (caml_gc_phase == Phase_sweep_ephe) {
+    if (domain_state->ephe_info->must_sweep_ephe) {
+      domain_state->ephe_info->must_sweep_ephe = 0;
+      prepare_for_ephe_sweeping(domain_state);
+    }
+    if (ephe_info->todo) {
+      /* Ensure that the ephemerons of this domain are swept/cleaned, in
+         case they stay orphaned until the next GC cycle. This mirrors
+         the logic in [major_collection_slice] for [Phase_sweep_ephe]. */
+      while (ephe_info->todo) {
+        ephe_sweep(domain_state, 100000);
+      }
+      (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
+    }
+  } else {
+    /* other phases do not use a ephemeron todo-list */
+    CAMLassert(ephe_info->todo == 0);
   }
   CAMLassert (ephe_info->todo == 0);
 
@@ -675,10 +695,6 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     caml_plat_unlock(&orphaned_lock);
   }
 
-  if (ephe_info->must_sweep_ephe) {
-    ephe_info->must_sweep_ephe = 0;
-    (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
-  }
   CAMLassert (ephe_info->must_sweep_ephe == 0);
   CAMLassert (ephe_info->live == 0);
   CAMLassert (ephe_info->todo == 0);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -353,9 +353,6 @@ static void global_prepare_for_ephe_marking (int num_domains_in_stw) {
                            num_domains_in_stw);
   caml_atomic_counter_init(&ephe_round_info.round, 1);
   caml_atomic_counter_init(&ephe_round_info.num_domains_done, 0);
-  caml_atomic_counter_init(&num_domains_to_ephe_sweep, 0);
-  /* Will be set to the correct number when switching to
-     [Phase_sweep_ephe] */
 }
 
 /* Prepare to mark ephemerons by making all 'live' ephes become 'todo' */
@@ -1934,7 +1931,6 @@ static void stw_cycle_all_domains(
              caml_atomic_counter_value(&ephe_round_info.num_domains_done));
   CAMLassert(caml_atomic_counter_value(&num_domains_to_mark) == 0);
   CAMLassert(caml_atomic_counter_value(&num_domains_to_sweep) == 0);
-  CAMLassert(caml_atomic_counter_value(&num_domains_to_ephe_sweep) == 0);
 
   caml_empty_minor_heap_no_major_slice_from_stw
                         (domain, (void*)0, participating_count, participating);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -329,9 +329,8 @@ extern value caml_ephe_none; /* See weak.c */
 
 static struct {
   atomic_uintnat num_domains_todo;
-  /* Number of domains that need to mark their ephemerons in the
-   * current major GC cycle. This field is decremented when a domain's
-   * todo list becomes empty.  */
+  /* Number of domains that have a non-empty todo list for ephemeron marking.
+   * (unspecified outside the marking phase) */
 
   atomic_uintnat round;
   /* Current ephemeron round number */
@@ -364,6 +363,9 @@ static void prepare_for_ephe_marking(caml_domain_state *domain)
   domain->ephe_info->round = 0;
   domain->ephe_info->cursor.todop = NULL;
   domain->ephe_info->cursor.round = 0;
+
+  if (!domain->ephe_info->todo)
+    caml_atomic_counter_decr(&ephe_round_info.num_domains_todo);
 }
 
 /* Move to the next global ephemeron round. Called whenever any domain
@@ -1771,6 +1773,8 @@ void caml_mark_roots_stw (int participant_count,
        ephemerons must come from last cycle. Due to the GC cycling, the
        [MARKED] ephemerons must have status [UNMARKED] now. */
     adopt_orphaned_work (caml_global_heap_state.UNMARKED);
+
+    global_prepare_for_ephe_marking(participant_count);
   }
 
   caml_domain_state* domain = Caml_state;
@@ -1802,9 +1806,6 @@ void caml_mark_roots_stw (int participant_count,
 
   caml_gc_log("Marking started, %ld entries on mark stack",
               (long)domain->mark_stack->count);
-
-  if (domain->ephe_info->todo == (value) NULL)
-    ephe_todo_list_emptied();
 
   /* Wait until global roots are marked before leaving the slice,
      using the time to do some opportunistic work. Mutators can alter
@@ -1891,7 +1892,6 @@ static void cycle_major_heap_from_stw_single(
                work_counter_at_sweep_start);
   work_counter_min_before_mark = work_counter + caml_small_heap_limit;
   atomic_store(&caml_gc_mark_phase_requested, 0);
-  global_prepare_for_ephe_marking(num_domains_in_stw);
 
   caml_atomic_counter_init(&num_domains_to_final_update_first,
                            num_domains_in_stw);
@@ -2525,7 +2525,6 @@ int caml_init_major_gc(caml_domain_state* d) {
     d->sweeping_done = 1;
     d->marking_done = 0;
     (void)caml_atomic_counter_incr(&num_domains_to_mark);
-    (void)caml_atomic_counter_incr(&ephe_round_info.num_domains_todo);
   } else {
     /* This fresh domain will allocate MARKED in this cycle,
      * so doesn't need to mark. */


### PR DESCRIPTION
This PR, which sits on top of #14732 and #14734, clarifies the semantics of `ephe_round_info.num_domains_{todo,done}`: it gives them a clear description in terms of domain-local state (they are counts of domains satisfying a certain condition), and changes the code to respect this description. The resulting code is easier to reason about, and in particular we get rid of a pessimistic `ephe_next_round` call in `ephe_todo_list_emptied` (coming from a lack of clarity in the definition of `num_domains_done`), which could be a noticeable performance improvement in ephemeron-heavy multicore benchmarks.

The code changes are subtle and require good knowledge of the pre-existing major GC logic. Expert reviewers would be @damiendoligez, @kayceesrk, @NickBarnes or @stedolan.

This is part of a multi-PR change to simplify the ephemeron orphaning and adoption logic, following #14720.

One of the techniques used in the PR, for both ephemeron marking and ephemeron sweeping, is to move the setup code for each pass to happen during the synchronous phase change that precedes it:
- For ephemeron marking, this was done at the beginning of the major GC cycle rather than at the beginning of the phase, which is awkward for domains that get created or terminated in-between.
- For ephemeron sweeping, this was done asynchronously by each domain during the major slice after the phase change, with this logic partly duplicated in the orphaning code in case orphaning would happen first
