### PR TITLE
Major gc: fix ephemeron orphaning

### DIFF
--- a/Changes
+++ b/Changes
@@ -63,6 +63,10 @@ Working version
 - #14717: assign 'unique_id' early during domain creation to help debugging
   (Gabriel Scherer, review by Olivier Nicole)
 
+- grouped fixes in the ephemeron runtime
+  + #14734: fix ephemeron orphaning (a counterpart of #14722)
+  (Gabriel Scherer, review by Damien Doligez)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776: Keep expansion and new well-foundedness check

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -42,6 +42,13 @@ Caml_inline int caml_marking_started(void)
   return caml_gc_phase != Phase_sweep_main;
 }
 
+Caml_inline bool caml_ephe_marking_ongoing(void)
+{
+  return
+    caml_marking_started()
+    && caml_gc_phase != Phase_sweep_ephe;
+}
+
 extern atomic_uintnat caml_gc_mark_phase_requested;
 intnat caml_opportunistic_major_work_available (caml_domain_state*);
 void caml_opportunistic_major_collection_slice (intnat);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -2238,7 +2238,7 @@ mark_again:
     }
 
     /* Ephemerons */
-    if (caml_gc_phase != Phase_sweep_ephe) {
+    if (caml_ephe_marking_ongoing()) {
       /* Ephemeron Marking */
       saved_ephe_round = caml_atomic_counter_value(&ephe_round_info.round);
       if (domain_state->ephe_info->todo != (value) NULL &&

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -391,9 +391,10 @@ static void ephe_next_round (void)
 
 static void ephe_todo_list_emptied (void)
 {
-  /* If we haven't started marking, the todo list can grow (during ephemeron
-     allocation), so we should not yet announce that it has emptied */
-  CAMLassert (caml_marking_started());
+  /* This function is intended to be used during ephemeron marking,
+     not ephemeron sweeping. */
+  CAMLassert (caml_ephe_marking_ongoing());
+
   caml_plat_lock_blocking(&ephe_lock);
 
   /* Force next ephemeron marking round in order to avoid reasoning about
@@ -494,7 +495,7 @@ static intnat ephe_mark (intnat budget, uintnat round,
   caml_domain_state* domain_state = Caml_state;
   size_t scanned = 0, preserved = 0;
 
-  CAMLassert(caml_marking_started());
+  CAMLassert(caml_ephe_marking_ongoing());
   if (domain_state->ephe_info->cursor.round == round &&
       !force_alive) {
     prev_linkp = domain_state->ephe_info->cursor.todop;
@@ -656,12 +657,31 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
       ephe_info->must_sweep_ephe == 0)
     return;
 
-  /* Force all ephemerons and their data on todo list to be alive */
-  if (ephe_info->todo) {
-    while (ephe_info->todo) {
-      ephe_mark (100000, 0, EPHE_MARK_FORCE_ALIVE);
+  if (caml_ephe_marking_ongoing()) {
+    if (ephe_info->todo) {
+      /* Force all ephemerons and their data on todo list to be alive */
+      while (ephe_info->todo) {
+        ephe_mark(100000, 0, EPHE_MARK_FORCE_ALIVE);
+      }
+      ephe_todo_list_emptied ();
     }
-    ephe_todo_list_emptied ();
+  } else if (caml_gc_phase == Phase_sweep_ephe) {
+    if (domain_state->ephe_info->must_sweep_ephe) {
+      domain_state->ephe_info->must_sweep_ephe = 0;
+      prepare_for_ephe_sweeping(domain_state);
+    }
+    if (ephe_info->todo) {
+      /* Ensure that the ephemerons of this domain are swept/cleaned, in
+         case they stay orphaned until the next GC cycle. This mirrors
+         the logic in [major_collection_slice] for [Phase_sweep_ephe]. */
+      while (ephe_info->todo) {
+        ephe_sweep(domain_state, 100000);
+      }
+      (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
+    }
+  } else {
+    /* other phases do not use a ephemeron todo-list */
+    CAMLassert(ephe_info->todo == 0);
   }
   CAMLassert (ephe_info->todo == 0);
 
@@ -675,10 +695,6 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     caml_plat_unlock(&orphaned_lock);
   }
 
-  if (ephe_info->must_sweep_ephe) {
-    ephe_info->must_sweep_ephe = 0;
-    (void)caml_atomic_counter_decr(&num_domains_to_ephe_sweep);
-  }
   CAMLassert (ephe_info->must_sweep_ephe == 0);
   CAMLassert (ephe_info->live == 0);
   CAMLassert (ephe_info->todo == 0);


### PR DESCRIPTION
This commit is basically a 'trunk' counterpart of #14722, which targets 5.5.

The current ephemeron-orphaning logic does not handle the case where it would run during the ephemeron-sweeping phase. In theory this could result in ephemerons not being swept/cleaned because they are orphaned, and become adopted on the next cycle with dangling pointers.

This bug would be hard to reproduce, but still a bug:

- The domain-termination logic forces the phase to be at least [Phase_sweep_and_mark_main] before it calls the orphaning code, and in practice the phase is almost always [Phase_sweep_and_main] during orphaning. But on 5.5, with the repro-case of #14349, there are cases where orphaning happens during [Phase_sweep_ephe].

- Orphan ephemerons typically get adopted before the current cycle stops. But in the repr-case of #14349 there are cases where the cycle terminates without adopting all ephemerons.

cc @damiendoligez, @OlivierNicole