### PR TITLE
Follow type abbreviations for manifest types (#13872)

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,11 +8,6 @@ Working version
 - #13377, RFC 44: Primitive aliases
   (Nailen Matschke, review by Jeremy Yallop, Leo White, and Florian Angeletti)
 
-- #13872, #14736: When checking that the type representation in a type
-  declaration conforms to the given type equation, follow public type
-  abbreviations in this equation.
-  (Stefan Muenzel, request by ygrek, review by ????)
-
 ### Runtime system:
 
 - #14486, #14530: Add FreeBSD frame pointers support for AMD64 and ARM64.
@@ -77,6 +72,11 @@ Working version
 - #12150: class type system improvements: self type constraints, virtual method
   inheritance in mutually recursive definition, immediate object inheritance.
   (Leo White, review by Florian Angeletti)
+
+- #13872, #14736: When checking that the type representation in a type
+  declaration conforms to the given type equation, follow public type
+  abbreviations in this equation.
+  (Stefan Muenzel, request by ygrek, review by Florian Angeletti)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -8,6 +8,11 @@ Working version
 - #13377, RFC 44: Primitive aliases
   (Nailen Matschke, review by Jeremy Yallop, Leo White, and Florian Angeletti)
 
+- #13872, #14736: When checking that the type representation in a type
+  declaration conforms to the given type equation, follow public type
+  abbreviations in this equation.
+  (Stefan Muenzel, request by ygrek, review by ????)
+
 ### Runtime system:
 
 - #14486, #14530: Add FreeBSD frame pointers support for AMD64 and ARM64.

--- a/Changes
+++ b/Changes
@@ -73,9 +73,8 @@ Working version
   inheritance in mutually recursive definition, immediate object inheritance.
   (Leo White, review by Florian Angeletti)
 
-- #13872, #14736: When checking that the type representation in a type
-  declaration conforms to the given type equation, follow public type
-  abbreviations in this equation.
+- #13872, #14736: Expand type abbreviations when checking that a type is a
+  re-export of a previous one (e.g `type t = u = A | B`)
   (Stefan Muenzel, request by ygrek, review by Florian Angeletti)
 
 ### Code generation and optimizations:

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -255,6 +255,16 @@ Error: Signature mismatch:
        A private extensible variant would be revealed.
 |}]
 
+type m_foo = M.foo = ..
+
+[%%expect {|
+Line 1, characters 0-23:
+1 | type m_foo = M.foo = ..
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "M.foo"
+       A private extensible variant would be revealed.
+|}]
+
 
 (* Check that signatures maintain variances *)
 

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -78,11 +78,7 @@ Error: Type definition "bar" is not extensible
 type baz = bar = ..
 ;;
 [%%expect {|
-Line 1, characters 0-19:
-1 | type baz = bar = ..
-    ^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type "bar"
-       The original is abstract, but this is an extensible variant.
+type baz = bar = ..
 |}]
 
 (* Abbreviations need to match parameters *)

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -100,6 +100,18 @@ type foo += Foo of int
 val f : baz -> int = <fun>
 |}]
 
+type bar'
+
+type baz = bar' = ..
+[%%expect {|
+type bar'
+Line 3, characters 0-20:
+3 | type baz = bar' = ..
+    ^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "bar'"
+       The original is abstract, but this is an extensible variant.
+|}]
+
 (* Abbreviations need to match parameters *)
 
 type 'a foo = ..

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -81,6 +81,25 @@ type baz = bar = ..
 type baz = bar = ..
 |}]
 
+type baz += Baz of int
+;;
+[%%expect {|
+type baz += Baz of int
+|}]
+
+type foo += Foo of int
+
+let f = function
+  | Baz i -> 2 * i
+  | Foo i -> 3 * i
+  | _ -> 0
+;;
+
+[%%expect {|
+type foo += Foo of int
+val f : baz -> int = <fun>
+|}]
+
 (* Abbreviations need to match parameters *)
 
 type 'a foo = ..

--- a/testsuite/tests/typing-misc/pr13872.ml
+++ b/testsuite/tests/typing-misc/pr13872.ml
@@ -1,0 +1,15 @@
+(* TEST
+ expect;
+*)
+
+type x=T
+type a=x=T
+type y=x
+type b=y=T
+
+[%%expect{|
+type x = T
+type a = x = T
+type y = x
+type b = y = T
+|}]

--- a/testsuite/tests/typing-misc/pr13872.ml
+++ b/testsuite/tests/typing-misc/pr13872.ml
@@ -14,29 +14,27 @@ type y = x
 type b = y = T
 |}]
 
-module rec Q : sig
-  type x = private T
-end = Q
+type x' = private T
 
 [%%expect{|
-module rec Q : sig type x = private T end
+type x' = private T
 |}]
 
-type a = Q.x = T
+type a' = x' = T
 
 [%%expect{|
 Line 1, characters 0-16:
-1 | type a = Q.x = T
+1 | type a' = x' = T
     ^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type "Q.x"
+Error: This variant or record definition does not match that of type "x'"
        Private variant constructor(s) would be revealed.
 |}]
 
-type y = Q.x
+type y = x'
 type b = y = T
 
 [%%expect{|
-type y = Q.x
+type y = x'
 Line 2, characters 0-14:
 2 | type b = y = T
     ^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-misc/pr13872.ml
+++ b/testsuite/tests/typing-misc/pr13872.ml
@@ -13,3 +13,33 @@ type a = x = T
 type y = x
 type b = y = T
 |}]
+
+module rec Q : sig
+  type x = private T
+end = Q
+
+[%%expect{|
+module rec Q : sig type x = private T end
+|}]
+
+type a = Q.x = T
+
+[%%expect{|
+Line 1, characters 0-16:
+1 | type a = Q.x = T
+    ^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "Q.x"
+       Private variant constructor(s) would be revealed.
+|}]
+
+type y = Q.x
+type b = y = T
+
+[%%expect{|
+type y = Q.x
+Line 2, characters 0-14:
+2 | type b = y = T
+    ^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "y"
+       Private variant constructor(s) would be revealed.
+|}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -671,7 +671,12 @@ let check_coherence env loc dpath decl =
       begin match Btype.get_constr_desc ty with
         Tconstr(path, args, _) ->
           begin try
-            let decl' = Env.find_type path env in
+            let decl' =
+              match Ctype.extract_concrete_typedecl env ty with
+              | Typedecl (_,_,decl) -> decl
+              | Has_no_typedecl | May_have_typedecl ->
+                  Env.find_type path env
+            in
             let err =
               if List.length args <> List.length decl.type_params
               then Some Includecore.Arity


### PR DESCRIPTION
In the declaration
```ocaml
type b=y=T
```

follow type abbreviations when looking for a type declaration for `y`. This allows declarations such as
```ocaml
type x=T
type a=x=T
type y=x
type b=y=T
```

Only public abbreviations are followed


This implements the following suggestion:

> The issue was discussed again at the type-system meeting, where it looks like a *different* consensus is emerging that it would be fine to support this example instead of finding a clear way to explain why we reject it. I like this new consensus better! 

 _Originally posted by @gasche in [#13872](https://github.com/ocaml/ocaml/issues/13872#issuecomment-2792546058)_
