### PR TITLE
Change ordering of error message when comparing type definitions of objects

### DIFF
--- a/Changes
+++ b/Changes
@@ -189,6 +189,9 @@ Working version
 - #14695: Add hint about using type annotations to avoid scope escape errors
   (Stefan Muenzel, review by Jacques Garrigue and Florian Angeletti)
 
+- #14737: Uniformly check for missing fields first when comparing object types.
+  (Samuel Vivien, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #14620: optimize utf8 normalization and (un)capitalization functions

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1327,6 +1327,55 @@ Error: Signature mismatch:
        Type "int" is not equal to type "float"
 |}];;
 
+type s = private <m : int; n : int; ..>
+
+module M
+  : sig type t = <m : int> end
+  = struct type t = s end
+
+[%%expect{|
+type s = private < m : int; n : int; .. >
+Line 5, characters 4-25:
+5 |   = struct type t = s end
+        ^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = s end
+       is not included in
+         sig type t = < m : int > end
+       Type declarations do not match:
+         type t = s
+       is not included in
+         type t = < m : int >
+       The type "s" is not equal to the type "< m : int >"
+       The first object type has an abstract row, it cannot be closed
+|}];;
+
+type s = private <m : int; n : int; ..>
+module M
+  : sig val f : <m : int > -> unit end
+  = struct let f (_ : s) = () end
+
+[%%expect{|
+type s = private < m : int; n : int; .. >
+Line 4, characters 4-33:
+4 |   = struct let f (_ : s) = () end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : s -> unit end
+       is not included in
+         sig val f : < m : int > -> unit end
+       Values do not match:
+         val f : s -> unit
+       is not included in
+         val f : < m : int > -> unit
+       The type "s -> unit" is not compatible with the type "< m : int > -> unit"
+       Type "s" = "< m : int; n : int; .. >" is not compatible with type
+         "< m : int >"
+       The second object type has no method "n"
+|}];;
+
 type w = private float
 type q = private (int * w)
 type u = private (int * q)

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1348,7 +1348,7 @@ Error: Signature mismatch:
        is not included in
          type t = < m : int >
        The type "s" is not equal to the type "< m : int >"
-       The first object type has an abstract row, it cannot be closed
+       The second object type has no method "n"
 |}];;
 
 type s = private <m : int; n : int; ..>

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5099,11 +5099,11 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
     Tobject(ty2,_) -> eqtype_fields rename type_pairs subst env ty1 ty2
   | _ ->
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
-  eqtype rename type_pairs subst env rest1 rest2;
   match miss1, miss2 with
   | ((n, _, _)::_, _) -> raise_for Equality (Obj (Missing_field (Second, n)))
   | (_, (n, _, _)::_) -> raise_for Equality (Obj (Missing_field (First, n)))
   | [], [] ->
+      eqtype rename type_pairs subst env rest1 rest2;
       List.iter
         (function (name, k1, t1, k2, t2) ->
            eqtype_kind k1 k2;


### PR DESCRIPTION
While looking at #14364 I saw a difference between `moregen` and `eqtype` when handling the following examples :

```ocaml
type s = private <m : int; n : int; ..>

module Teqtype
  : sig type t = <m : int> end
  = struct type t = s end

module Tmoregen
  : sig val f : <m : int > -> unit end
  = struct let f (_ : s) = () end
```

The first one will fail by comparing the abstract rows while the second will fail by comparing the missing fields. I propose to change the behavior of the first case to match the second one for more consistency (and allow refactoring `moregen` and `eqtype` in a single definition).

