### PR TITLE
Simplify handling of field kinds in eqtype and moregen

### DIFF
--- a/Changes
+++ b/Changes
@@ -213,6 +213,9 @@ Working version
   rectypes and module aliases.
   (Brandon Stride)
 
+- #14738: Clean code of moregen_kind and eqtype_kind as only one case was
+  possible. (Samuel Vivien, review by Florian Angeletti)
+
 ### Build system:
 
 ### Bug fixes:

--- a/Changes
+++ b/Changes
@@ -213,8 +213,9 @@ Working version
   rectypes and module aliases.
   (Brandon Stride)
 
-- #14738: Clean code of moregen_kind and eqtype_kind as only one case was
-  possible. (Samuel Vivien, review by Florian Angeletti)
+- #14738: Improved error message for mismatched privacy level on method types
+  when mixing self types, local modules and first class modules.
+  (Samuel Vivien, review by Florian Angeletti, Jacques Garrigue)
 
 ### Build system:
 

--- a/testsuite/tests/typing-objects/field_kind.ml
+++ b/testsuite/tests/typing-objects/field_kind.ml
@@ -7,6 +7,7 @@ type _ t = Int : int t;;
 type _ t = Int : int t
 |}]
 
+(** Test unification of kinds *)
 let o =
   object (self)
     method private x = 3
@@ -73,4 +74,233 @@ Warning 15 [implicit-public-methods]: the following private methods were made
 
 val o3 : < m : 'a -> int; x : int > as 'a = <obj>
 val aargh : unit = ()
+|}]
+
+module type T = sig type t end
+let type_of (type r) (x:r) = (module struct type t = r end: T with type t = r)
+
+[%%expect{|
+module type T = sig type t end
+val type_of : 'r -> (module T with type t = 'r) = <fun>
+|}]
+
+(** Test moregen of kinds *)
+let moregen_public_public = object (self)
+  method n = 0
+  initializer
+     let module M = (val type_of self) in
+     let module N: sig val s: unit -> M.t end = struct
+       let s () : <n : int> = assert false
+     end
+     in
+     ()
+end
+
+[%%expect{|
+val moregen_public_public : < n : int > = <obj>
+|}, Principal{|
+Line 4, characters 20-38:
+4 |      let module M = (val type_of self) in
+                        ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+val moregen_public_public : < n : int > = <obj>
+|}]
+
+let moregen_public_private = object (self)
+  method private n = 0
+  initializer
+     let module M = (val type_of self) in
+     let module N: sig val s: unit -> M.t end = struct
+       let s () : <n : int> = assert false
+     end
+     in
+     ()
+end
+
+[%%expect{|
+Uncaught exception: Ctype.Public_method_to_private_method
+
+|}, Principal{|
+Line 4, characters 20-38:
+4 |      let module M = (val type_of self) in
+                        ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+Uncaught exception: Ctype.Public_method_to_private_method
+
+|}]
+
+let moregen_private_public = object (self)
+  method private n = 0
+  initializer
+     let module M = (val type_of self) in
+     let module N: sig val s: unit -> <n : int> end = struct
+       let s () : M.t = assert false
+     end
+     in
+     ()
+end
+
+[%%expect{|
+Lines 1-10, characters 29-3:
+ 1 | .............................object (self)
+ 2 |   method private n = 0
+ 3 |   initializer
+ 4 |      let module M = (val type_of self) in
+ 5 |      let module N: sig val s: unit -> <n : int> end = struct
+ 6 |        let s () : M.t = assert false
+ 7 |      end
+ 8 |      in
+ 9 |      ()
+10 | end
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "n".
+
+val moregen_private_public : < n : int > = <obj>
+|}, Principal{|
+Line 4, characters 20-38:
+4 |      let module M = (val type_of self) in
+                        ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+Lines 1-10, characters 29-3:
+ 1 | .............................object (self)
+ 2 |   method private n = 0
+ 3 |   initializer
+ 4 |      let module M = (val type_of self) in
+ 5 |      let module N: sig val s: unit -> <n : int> end = struct
+ 6 |        let s () : M.t = assert false
+ 7 |      end
+ 8 |      in
+ 9 |      ()
+10 | end
+Warning 15 [implicit-public-methods]: the following private methods were made
+  public implicitly: "n".
+
+val moregen_private_public : < n : int > = <obj>
+|}]
+
+let moregen_private_private = object (self)
+  method private n = 0
+  initializer
+     let module M1 = (val type_of self) in
+     let module M2 = (val type_of self) in
+     let module N: sig val s: unit -> M1.t end = struct
+       let s () : M2.t = assert false
+     end
+     in
+     ()
+end
+
+[%%expect{|
+val moregen_private_private : <  > = <obj>
+|}, Principal{|
+Line 4, characters 21-39:
+4 |      let module M1 = (val type_of self) in
+                         ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+Line 5, characters 21-39:
+5 |      let module M2 = (val type_of self) in
+                         ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+val moregen_private_private : <  > = <obj>
+|}]
+
+(** Test eqtype of kinds *)
+let eqtype_public_public = object (self)
+  method n = 0
+  method k: unit =
+     let module M = (val type_of self) in
+     let module N: sig type t = M.t end = struct
+             type t = <n: int; k:unit >
+     end
+     in
+     ()
+end
+
+[%%expect{|
+val eqtype_public_public : < k : unit; n : int > = <obj>
+|}, Principal{|
+Line 4, characters 20-38:
+4 |      let module M = (val type_of self) in
+                        ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+val eqtype_public_public : < k : unit; n : int > = <obj>
+|}]
+
+let eqtype_public_private = object (self)
+  method private n = 0
+  method k: unit =
+     let module M = (val type_of self) in
+     let module N: sig type t = M.t end = struct
+             type t = <n: int; k:unit >
+     end
+     in
+     ()
+end
+
+[%%expect{|
+Uncaught exception: Ctype.Unify_trace(0)
+
+|}, Principal{|
+Line 4, characters 20-38:
+4 |      let module M = (val type_of self) in
+                        ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+Uncaught exception: Ctype.Unify_trace(0)
+
+|}]
+
+let eqtype_private_public = object (self)
+  method private n = 0
+  method k: unit =
+     let module M = (val type_of self) in
+     let module N: sig type t = <n: int; k:unit > end = struct
+             type t = M.t
+     end
+     in
+     ()
+end
+
+[%%expect{|
+Uncaught exception: Ctype.Unify_trace(0)
+
+|}, Principal{|
+Line 4, characters 20-38:
+4 |      let module M = (val type_of self) in
+                        ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+Uncaught exception: Ctype.Unify_trace(0)
+
+|}]
+
+let eqtype_private_private = object (self)
+  method private n = 0
+  method k: unit =
+     let module M1 = (val type_of self) in
+     let module M2 = (val type_of self) in
+     let module N: sig type t = M2.t end = struct
+             type t = M1.t
+     end
+     in
+     ()
+end
+
+[%%expect{|
+val eqtype_private_private : < k : unit > = <obj>
+|}, Principal{|
+Line 4, characters 21-39:
+4 |      let module M1 = (val type_of self) in
+                         ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+Line 5, characters 21-39:
+5 |      let module M2 = (val type_of self) in
+                         ^^^^^^^^^^^^^^^^^^
+Warning 18 [not-principal]: this module unpacking is not principal.
+
+val eqtype_private_private : < k : unit > = <obj>
 |}]

--- a/testsuite/tests/typing-objects/field_kind.ml
+++ b/testsuite/tests/typing-objects/field_kind.ml
@@ -119,15 +119,46 @@ let moregen_public_private = object (self)
 end
 
 [%%expect{|
-Uncaught exception: Ctype.Public_method_to_private_method
-
+Lines 5-7, characters 48-8:
+5 | ................................................struct
+6 |        let s () : <n : int> = assert false
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val s : unit -> < n : int > end
+       is not included in
+         sig val s : unit -> M.t end
+       Values do not match:
+         val s : unit -> < n : int >
+       is not included in
+         val s : unit -> M.t
+       The type "unit -> < n : int >" is not compatible with the type
+         "unit -> M.t"
+       Type "< n : int >" is not compatible with type "M.t" = "<  >"
+       The method "n" is public and was expected to be private
 |}, Principal{|
 Line 4, characters 20-38:
 4 |      let module M = (val type_of self) in
                         ^^^^^^^^^^^^^^^^^^
 Warning 18 [not-principal]: this module unpacking is not principal.
-Uncaught exception: Ctype.Public_method_to_private_method
 
+Lines 5-7, characters 48-8:
+5 | ................................................struct
+6 |        let s () : <n : int> = assert false
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val s : unit -> < n : int > end
+       is not included in
+         sig val s : unit -> M.t end
+       Values do not match:
+         val s : unit -> < n : int >
+       is not included in
+         val s : unit -> M.t
+       The type "unit -> < n : int >" is not compatible with the type
+         "unit -> M.t"
+       Type "< n : int >" is not compatible with type "M.t" = "<  >"
+       The method "n" is public and was expected to be private
 |}]
 
 let moregen_private_public = object (self)
@@ -142,42 +173,46 @@ let moregen_private_public = object (self)
 end
 
 [%%expect{|
-Lines 1-10, characters 29-3:
- 1 | .............................object (self)
- 2 |   method private n = 0
- 3 |   initializer
- 4 |      let module M = (val type_of self) in
- 5 |      let module N: sig val s: unit -> <n : int> end = struct
- 6 |        let s () : M.t = assert false
- 7 |      end
- 8 |      in
- 9 |      ()
-10 | end
-Warning 15 [implicit-public-methods]: the following private methods were made
-  public implicitly: "n".
-
-val moregen_private_public : < n : int > = <obj>
+Lines 5-7, characters 54-8:
+5 | ......................................................struct
+6 |        let s () : M.t = assert false
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val s : unit -> M.t end
+       is not included in
+         sig val s : unit -> < n : int > end
+       Values do not match:
+         val s : unit -> M.t
+       is not included in
+         val s : unit -> < n : int >
+       The type "unit -> M.t" is not compatible with the type
+         "unit -> < n : int >"
+       Type "M.t" = "<  >" is not compatible with type "< n : int >"
+       The method "n" is private and was expected to be public
 |}, Principal{|
 Line 4, characters 20-38:
 4 |      let module M = (val type_of self) in
                         ^^^^^^^^^^^^^^^^^^
 Warning 18 [not-principal]: this module unpacking is not principal.
 
-Lines 1-10, characters 29-3:
- 1 | .............................object (self)
- 2 |   method private n = 0
- 3 |   initializer
- 4 |      let module M = (val type_of self) in
- 5 |      let module N: sig val s: unit -> <n : int> end = struct
- 6 |        let s () : M.t = assert false
- 7 |      end
- 8 |      in
- 9 |      ()
-10 | end
-Warning 15 [implicit-public-methods]: the following private methods were made
-  public implicitly: "n".
-
-val moregen_private_public : < n : int > = <obj>
+Lines 5-7, characters 54-8:
+5 | ......................................................struct
+6 |        let s () : M.t = assert false
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val s : unit -> M.t end
+       is not included in
+         sig val s : unit -> < n : int > end
+       Values do not match:
+         val s : unit -> M.t
+       is not included in
+         val s : unit -> < n : int >
+       The type "unit -> M.t" is not compatible with the type
+         "unit -> < n : int >"
+       Type "M.t" = "<  >" is not compatible with type "< n : int >"
+       The method "n" is private and was expected to be public
 |}]
 
 let moregen_private_private = object (self)
@@ -243,15 +278,42 @@ let eqtype_public_private = object (self)
 end
 
 [%%expect{|
-Uncaught exception: Ctype.Unify_trace(0)
-
+Lines 5-7, characters 42-8:
+5 | ..........................................struct
+6 |              type t = <n: int; k:unit >
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < k : unit; n : int > end
+       is not included in
+         sig type t = M.t end
+       Type declarations do not match:
+         type t = < k : unit; n : int >
+       is not included in
+         type t = M.t
+       The type "< k : unit; n : int >" is not equal to the type "M.t"
+       The method "n" is public and was expected to be private
 |}, Principal{|
 Line 4, characters 20-38:
 4 |      let module M = (val type_of self) in
                         ^^^^^^^^^^^^^^^^^^
 Warning 18 [not-principal]: this module unpacking is not principal.
-Uncaught exception: Ctype.Unify_trace(0)
 
+Lines 5-7, characters 42-8:
+5 | ..........................................struct
+6 |              type t = <n: int; k:unit >
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < k : unit; n : int > end
+       is not included in
+         sig type t = M.t end
+       Type declarations do not match:
+         type t = < k : unit; n : int >
+       is not included in
+         type t = M.t
+       The type "< k : unit; n : int >" is not equal to the type "M.t"
+       The method "n" is public and was expected to be private
 |}]
 
 let eqtype_private_public = object (self)
@@ -266,15 +328,42 @@ let eqtype_private_public = object (self)
 end
 
 [%%expect{|
-Uncaught exception: Ctype.Unify_trace(0)
-
+Lines 5-7, characters 56-8:
+5 | ........................................................struct
+6 |              type t = M.t
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = M.t end
+       is not included in
+         sig type t = < k : unit; n : int > end
+       Type declarations do not match:
+         type t = M.t
+       is not included in
+         type t = < k : unit; n : int >
+       The type "M.t" is not equal to the type "< k : unit; n : int >"
+       The method "n" is private and was expected to be public
 |}, Principal{|
 Line 4, characters 20-38:
 4 |      let module M = (val type_of self) in
                         ^^^^^^^^^^^^^^^^^^
 Warning 18 [not-principal]: this module unpacking is not principal.
-Uncaught exception: Ctype.Unify_trace(0)
 
+Lines 5-7, characters 56-8:
+5 | ........................................................struct
+6 |              type t = M.t
+7 |      end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = M.t end
+       is not included in
+         sig type t = < k : unit; n : int > end
+       Type declarations do not match:
+         type t = M.t
+       is not included in
+         type t = < k : unit; n : int >
+       The type "M.t" is not equal to the type "< k : unit; n : int >"
+       The method "n" is private and was expected to be public
 |}]
 
 let eqtype_private_private = object (self)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -113,9 +113,6 @@ let raise_unexplained_for tr_exn =
 let raise_for tr_exn e =
   raise_trace_for tr_exn [e]
 
-(* Thrown from [moregen_kind] *)
-exception Public_method_to_private_method
-
 let escape kind = {kind; context = None}
 let escape_exn kind = Escape (escape kind)
 let scope_escape_exn ty = escape_exn (Equation ty)
@@ -4691,20 +4688,21 @@ and moregen_fields type_pairs env ty1 ty2 =
     (build_fields (get_level ty2) miss2 rest2);
   List.iter
     (fun (name, k1, t1, k2, t2) ->
-       (* The below call should never throw [Public_method_to_private_method] *)
-       moregen_kind k1 k2;
+       moregen_kind name k1 k2;
        try moregen type_pairs env t1 t2 with Moregen_trace trace ->
          raise_trace_for Moregen
            (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
     )
     pairs
 
-and moregen_kind k1 k2 =
-  match field_kind_repr k1, field_kind_repr k2 with
-    (Fprivate, (Fprivate | Fpublic)) -> link_kind ~inside:k1 k2
-  | (Fpublic, Fpublic)               -> ()
-  | (Fpublic, Fprivate)              -> raise Public_method_to_private_method
-  | (Fabsent, _) | (_, Fabsent)      -> assert false
+and moregen_kind name k1 k2 =
+  let k1 = field_kind_repr k1 in
+  let k2 = field_kind_repr k2 in
+  match k1, k2 with
+  | (Fpublic, Fpublic)
+  | (Fprivate, Fprivate)               -> ()
+  | _ ->
+    raise_for Moregen (Obj (Kind_differ (name, k1, k2)))
 
 and moregen_row type_pairs env row1 row2 =
   let Row {fields = row1_fields; more = rm1; closed = row1_closed} =
@@ -5106,7 +5104,7 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
   | [], [] ->
       List.iter
         (function (name, k1, t1, k2, t2) ->
-           eqtype_kind k1 k2;
+           eqtype_kind name k1 k2;
            try
              eqtype rename type_pairs subst env t1 t2;
            with Equality_trace trace ->
@@ -5114,15 +5112,14 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
                (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace))
         pairs
 
-and eqtype_kind k1 k2 =
+and eqtype_kind name k1 k2 =
   let k1 = field_kind_repr k1 in
   let k2 = field_kind_repr k2 in
   match k1, k2 with
   | (Fprivate, Fprivate)
   | (Fpublic, Fpublic)   -> ()
-  | _                    -> raise_unexplained_for Unify
-                            (* It's probably not possible to hit this case with
-                               real OCaml code *)
+  | _                    ->
+    raise_for Equality (Obj (Kind_differ (name, k1, k2)))
 
 and eqtype_row rename type_pairs subst env row1 row2 =
   (* Try expansion, needed when called from Includecore.type_manifest *)

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -160,6 +160,7 @@ let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
     Incompatible_fields { name; diff = swap_diff diff}
   | Obj (Missing_field(pos,s)) -> Obj (Missing_field(swap_position pos,s))
   | Obj (Abstract_row pos) -> Obj (Abstract_row (swap_position pos))
+  | Obj (Kind_differ (name, k1, k2)) -> Obj (Kind_differ (name, k2, k1))
   | Variant (Fixed_row(pos,k,f)) ->
     Variant (Fixed_row(swap_position pos,k,f))
   | Variant (No_tags(pos,f)) ->

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -105,6 +105,8 @@ type 'variety obj =
   | Abstract_row : position -> _ obj
   (* Unification *)
   | Self_cannot_be_closed : unification obj
+  (* Equality & Moregen *)
+  | Kind_differ : string * field_kind_view * field_kind_view -> comparison obj
 
 type first_class_module =
     | Package_cannot_scrape of Path.t

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -87,6 +87,8 @@ type 'variety obj =
   | Abstract_row : position -> _ obj
   (* Unification *)
   | Self_cannot_be_closed : unification obj
+  (* Equality & Moregen *)
+  | Kind_differ : string * field_kind_view * field_kind_view -> comparison obj
 
 type first_class_module =
     | Package_cannot_scrape of Path.t

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -276,6 +276,13 @@ let explain_object (type variety) : variety Errortrace.obj -> _ = function
       Some (doc_printf
               "@,Self type cannot be unified with a closed object type"
            )
+  | Errortrace.Kind_differ (f, k1, k2) -> Some(
+      doc_printf
+        "@,@[The method %a is %s and was expected to be %s@]"
+          Style.inline_code f
+          (match k1 with Fpublic -> "public" | _ -> "private")
+          (match k2 with Fpublic -> "public" | _ -> "private")
+    )
 
 let explain_incompatible_fields name (diff: Types.type_expr Errortrace.diff) =
   Variable_names.reserve diff.got;


### PR DESCRIPTION
After discussion with @Octachron  we came to the conclusion that when comparing objects type in `eqtype` or in `moregen` only public fields could be possible. As such I propose to simplify both comparison functions to only check this invariant rather than handling an unreachable case.