### PR TITLE
Various small libunix fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,16 +339,21 @@ Working version
 
 ### Other libraries:
 
-* #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to
-  `ENOTDIR` instead of `EUNKNOWNERR(-267)` when raised by functions in the
-  `Unix` module (eg `Unix.opendir`).
-  (Nicolás Ojeda Bär, report by Adrián Montesinos González, review by Gabriel
-  Scherer)
+- #14740: Various fixes in libunix. Fix compilation failures if gethostname or
+  IPv6 are not available. Add blocking sections to the wrappers of realpath and
+  lockf. Fix missing root registration.
+  (Antonin Décimo, review by Gabriel Scherer)
 
 - #14764: Fix a bug in the Win32 implementation of the `Unix` library that could
   result in some file descriptors being dropped from the result of `Unix.select`
   under certain circumstances.
   (Zhang Rui, review by Nicolás Ojeda Bär, Antonin Décimo and David Allsopp)
+
+* #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to
+  `ENOTDIR` instead of `EUNKNOWNERR(-267)` when raised by functions in the
+  `Unix` module (eg `Unix.opendir`).
+  (Nicolás Ojeda Bär, report by Adrián Montesinos González, review by Gabriel
+  Scherer)
 
 - #14984: Cache one write buffer for each domain in
   `Runtime_events.User.write`, instead of a list for each thread. A write of

--- a/otherlibs/unix/fcntl.c
+++ b/otherlibs/unix/fcntl.c
@@ -51,6 +51,6 @@ CAMLprim value caml_unix_set_close_on_exec(value fd)
 
 CAMLprim value caml_unix_clear_close_on_exec(value fd)
 {
-  caml_unix_clear_cloexec(Int_val(fd), "set_close_on_exec", Nothing);
+  caml_unix_clear_cloexec(Int_val(fd), "clear_close_on_exec", Nothing);
   return Val_unit;
 }

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -84,7 +84,7 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
   struct hostent * hp;
   int addr_type = AF_INET;
   socklen_t addr_len = 4;
-#if HAS_IPV6
+#ifdef HAS_IPV6
   struct in6_addr in6;
   if (caml_string_length(a) == 16) {
     addr_type = AF_INET6;
@@ -95,7 +95,7 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
 #endif
     in4 = GET_INET_ADDR(a);
     addr = (char *)&in4;
-#if HAS_IPV6
+#ifdef HAS_IPV6
   }
 #endif
 #if !defined(HAS_GETHOSTBYADDR_R)

--- a/otherlibs/unix/gethostname.c
+++ b/otherlibs/unix/gethostname.c
@@ -21,7 +21,7 @@
 #endif
 #include "caml/unixsupport.h"
 
-#ifdef HAS_GETHOSTNAME
+#if defined(HAS_GETHOSTNAME)
 
 #ifndef MAXHOSTNAMELEN
 #define MAXHOSTNAMELEN 256
@@ -35,8 +35,7 @@ CAMLprim value caml_unix_gethostname(value unit)
   return caml_copy_string(name);
 }
 
-#else
-#ifdef HAS_UNAME
+#elif defined(HAS_UNAME)
 
 #include <sys/utsname.h>
 
@@ -52,5 +51,4 @@ CAMLprim value caml_unix_gethostname(value unit)
 CAMLprim value caml_unix_gethostname(value unit)
 { caml_invalid_argument("gethostname not implemented"); }
 
-#endif
 #endif

--- a/otherlibs/unix/gethostname.c
+++ b/otherlibs/unix/gethostname.c
@@ -44,7 +44,7 @@ CAMLprim value caml_unix_gethostname(value unit)
 {
   struct utsname un;
   uname(&un);
-  return copy_string(un.nodename);
+  return caml_copy_string(un.nodename);
 }
 
 #else

--- a/otherlibs/unix/link_unix.c
+++ b/otherlibs/unix/link_unix.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdbool.h>
 
 CAMLprim value caml_unix_link(value follow, value path1, value path2)
 {
@@ -32,19 +33,22 @@ CAMLprim value caml_unix_link(value follow, value path1, value path2)
   char * p1;
   char * p2;
   int ret;
+  bool follow_is_none = Is_none(follow);
   caml_unix_check_path(path1, "link");
   caml_unix_check_path(path2, "link");
   p1 = caml_stat_strdup(String_val(path1));
   p2 = caml_stat_strdup(String_val(path2));
+# ifdef AT_SYMLINK_FOLLOW
+  int flags =
+    Is_some(follow) && Bool_val(Some_val(follow))
+    ? AT_SYMLINK_FOLLOW
+    : 0;
+# endif
   caml_enter_blocking_section();
-  if (Is_none(follow))
+  if (follow_is_none)
     ret = link(p1, p2);
   else {
 # ifdef AT_SYMLINK_FOLLOW
-    int flags =
-      Is_some(follow) && Bool_val(Some_val(follow))
-      ? AT_SYMLINK_FOLLOW
-      : 0;
     ret = linkat(AT_FDCWD, p1, AT_FDCWD, p2, flags);
 # else
     ret = -1; errno = ENOSYS;

--- a/otherlibs/unix/lockf_unix.c
+++ b/otherlibs/unix/lockf_unix.c
@@ -93,10 +93,14 @@ static const int lock_command_table[] = {
   F_ULOCK, F_LOCK, F_TLOCK, F_TEST, F_LOCK, F_TLOCK
 };
 
-CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
+CAMLprim value caml_unix_lockf(value fd, value vcmd, value span)
 {
-  if (lockf(Int_val(fd), lock_command_table[Int_val(cmd)], Long_val(span))
-      == -1) caml_uerror("lockf", Nothing);
+  int ret;
+  int cmd = lock_command_table[Int_val(vcmd)];
+  if (cmd == F_BLOCK) caml_enter_blocking_section();
+  ret = lockf(Int_val(fd), cmd, Long_val(span));
+  if (cmd == F_BLOCK) caml_leave_blocking_section();
+  if (ret == -1) caml_uerror("lockf", Nothing);
   return Val_unit;
 }
 

--- a/otherlibs/unix/lockf_unix.c
+++ b/otherlibs/unix/lockf_unix.c
@@ -31,7 +31,7 @@ CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
 
   fildes = Int_val(fd);
   size = Long_val(span);
-  l.l_whence = 1;
+  l.l_whence = SEEK_CUR;
   if (size < 0) {
     l.l_start = size;
     l.l_len = -size;

--- a/otherlibs/unix/lockf_unix.c
+++ b/otherlibs/unix/lockf_unix.c
@@ -84,9 +84,7 @@ CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
   return Val_unit;
 }
 
-#else
-
-#ifdef HAS_LOCKF
+#elif defined(HAS_LOCKF)
 #include <unistd.h>
 
 static const int lock_command_table[] = {
@@ -109,5 +107,4 @@ CAMLprim value caml_unix_lockf(value fd, value vcmd, value span)
 CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
 { caml_invalid_argument("lockf not implemented"); }
 
-#endif
 #endif

--- a/otherlibs/unix/mmap_unix.c
+++ b/otherlibs/unix/mmap_unix.c
@@ -50,20 +50,19 @@ extern value caml_unix_mapped_alloc(int, int, void *, intnat *);
 static int caml_grow_file(int fd, file_offset size)
 {
   char c;
-  int p;
 
   /* First use pwrite for growing - it is a conservative method, as it
      can never happen that we shrink by accident
    */
 #ifdef HAS_PWRITE
   c = 0;
-  p = pwrite(fd, &c, 1, size - 1);
+  ssize_t p = pwrite(fd, &c, 1, size - 1);
 #else
 
   /* Emulate pwrite with lseek. This should only be necessary on ancient
      systems nowadays
    */
-  file_offset currpos;
+  file_offset currpos, p;
   currpos = lseek(fd, 0, SEEK_CUR);
   if (currpos != -1) {
     p = lseek(fd, size - 1, SEEK_SET);
@@ -87,7 +86,7 @@ static int caml_grow_file(int fd, file_offset size)
     p = ftruncate(fd, size);
   }
 #endif
-  return p;
+  return (int) p;
 }
 
 

--- a/otherlibs/unix/putenv.c
+++ b/otherlibs/unix/putenv.c
@@ -36,7 +36,7 @@ CAMLprim value caml_unix_putenv(value name, value val)
 
   if (! (caml_string_is_c_safe(name) && caml_string_is_c_safe(val)))
     caml_unix_error(EINVAL, "putenv", name);
-  s = caml_stat_strconcat(3, name, "=", val);
+  s = caml_stat_strconcat(3, String_val(name), "=", String_val(val));
   p = caml_stat_strdup_to_os(s);
   caml_stat_free(s);
   ret = putenv_os(p);

--- a/otherlibs/unix/realpath_unix.c
+++ b/otherlibs/unix/realpath_unix.c
@@ -24,11 +24,15 @@
 CAMLprim value caml_unix_realpath (value p)
 {
   CAMLparam1 (p);
-  char *r;
+  char *path, *r;
   value rp;
 
   caml_unix_check_path (p, "realpath");
-  r = realpath (String_val (p), NULL);
+  path = caml_stat_strdup(String_val(p));
+  caml_enter_blocking_section();
+  r = realpath (path, NULL);
+  caml_leave_blocking_section();
+  caml_stat_free(path);
   if (r == NULL) { caml_uerror ("realpath", p); }
   rp = caml_copy_string (r);
   free (r);

--- a/otherlibs/unix/realpath_win32.c
+++ b/otherlibs/unix/realpath_win32.c
@@ -37,9 +37,11 @@ CAMLprim value caml_unix_realpath (value p)
 
   caml_unix_check_path (p, "realpath");
   wp = caml_stat_strdup_to_utf16 (String_val (p));
+  caml_enter_blocking_section();
   h = CreateFile (wp, 0,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
                   OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  caml_leave_blocking_section();
   caml_stat_free (wp);
 
   if (h == INVALID_HANDLE_VALUE)
@@ -48,7 +50,9 @@ CAMLprim value caml_unix_realpath (value p)
     caml_uerror ("realpath", p);
   }
 
+  caml_enter_blocking_section();
   wr_len = GetFinalPathNameByHandle (h, NULL, 0, VOLUME_NAME_DOS);
+  caml_leave_blocking_section();
   if (wr_len == 0)
   {
     caml_win32_maperr (GetLastError ());
@@ -57,7 +61,9 @@ CAMLprim value caml_unix_realpath (value p)
   }
 
   wr = caml_stat_alloc ((wr_len + 1) * sizeof (wchar_t));
+  caml_enter_blocking_section();
   wr_len = GetFinalPathNameByHandle (h, wr, wr_len, VOLUME_NAME_DOS);
+  caml_leave_blocking_section();
 
   if (wr_len == 0)
   {

--- a/otherlibs/unix/rename.c
+++ b/otherlibs/unix/rename.c
@@ -22,6 +22,7 @@
 
 CAMLprim value caml_unix_rename(value oldname, value newname)
 {
+  CAMLparam2(oldname, newname);
   char_os * p_old;
   char_os * p_new;
   int ret;
@@ -36,5 +37,5 @@ CAMLprim value caml_unix_rename(value oldname, value newname)
   caml_stat_free(p_old);
   if (ret == -1)
     caml_uerror("rename", oldname);
-  return Val_unit;
+  CAMLreturn(Val_unit);
 }

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -89,8 +89,9 @@ void caml_unix_get_sockaddr(value vaddr,
       s_inet6->sin6_len = sizeof(struct sockaddr_in6);
 #endif
       *addr_len = sizeof(struct sockaddr_in6);
-    } else {
+    } else
 #endif
+    {
       struct sockaddr_in *s_inet = (struct sockaddr_in *) addr;
       memset(s_inet, 0, sizeof(struct sockaddr_in));
       s_inet->sin_family = AF_INET;

--- a/otherlibs/unix/write_unix.c
+++ b/otherlibs/unix/write_unix.c
@@ -15,6 +15,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <stdbool.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -66,6 +67,7 @@ CAMLprim value caml_unix_write_bigarray(value vfd, value vbuf,
   ofs = Long_val(vofs);
   len = Long_val(vlen);
   int fd = Int_val(vfd);
+  bool single = Bool_val(vsingle);
   written = 0;
   caml_enter_blocking_section();
   while (len > 0) {
@@ -78,7 +80,7 @@ CAMLprim value caml_unix_write_bigarray(value vfd, value vbuf,
     written += ret;
     ofs += ret;
     len -= ret;
-    if (Bool_val(vsingle)) break;
+    if (single) break;
   }
   caml_leave_blocking_section();
   CAMLreturn(Val_long(written));


### PR DESCRIPTION
I got curious and asked my LLM to "find bugs in otherlib/unix" and it raised a few issues. It's all quite minor. Fixes are mine.
- Two compilation failures in legacy/fallback implementations.
- Missing blocking sections in `realpath` (since we have blocking sections for `readlink` this seems sensible) and in the fallback implementation of `lockf`;
- missing root registration / value accessed inside a blocking section;
- other little things.

This PR can be reviewed commit-by-commit.
Possible candidate for inclusion in 5.5?