### PR TITLE
Add Domain.max_domains to expose the configured maximum domain count

### DIFF
--- a/Changes
+++ b/Changes
@@ -97,7 +97,7 @@ Working version
 
 ### Standard library:
 
-- #XXXX: Add Domain.max_domains to expose the maximum number of domains
+- #14741: Add Domain.max_domains to expose the maximum number of domains
   supported by the runtime, as configured via the d parameter of
   OCAMLRUNPARAM.
   (Tim McGilchrist, review by ???)

--- a/Changes
+++ b/Changes
@@ -97,6 +97,11 @@ Working version
 
 ### Standard library:
 
+- #XXXX: Add Domain.max_domains to expose the maximum number of domains
+  supported by the runtime, as configured via the d parameter of
+  OCAMLRUNPARAM.
+  (Tim McGilchrist, review by ???)
+
 - #10798: Atomic helper function
     update : ('a -> 'a) -> 'a t -> unit
   (Gabriel Scherer, review by Simon Cruanes, Stephen Dolan,

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2501,6 +2501,11 @@ CAMLprim value caml_domain_count(value unused)
   return Val_long(atomic_load_relaxed(&caml_num_domains_running));
 }
 
+CAMLprim value caml_domain_max_domains(value unused)
+{
+  return Val_long(caml_params->max_domains);
+}
+
 CAMLprim value caml_recommended_domain_count(value unused)
 {
   intnat n = -1;

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -43,6 +43,8 @@ module Raw = struct
     = "caml_ml_domain_cpu_relax"
   external get_domain_count: unit -> int
     = "caml_domain_count" [@@noalloc]
+  external get_max_domains: unit -> int
+    = "caml_domain_max_domains" [@@noalloc]
   external get_recommended_domain_count: unit -> int
     = "caml_recommended_domain_count" [@@noalloc]
 end
@@ -303,4 +305,5 @@ let join { term_sync ; _ } =
   | Error (ex, bt) -> Printexc.raise_with_backtrace ex bt
 
 let count = Raw.get_domain_count
+let max_domains = Raw.get_max_domains
 let recommended_domain_count = Raw.get_recommended_domain_count

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -95,6 +95,14 @@ val count : unit -> int
 
     @since 5.5 *)
 
+val max_domains : unit -> int
+(** The maximum number of domains that can be running simultaneously.
+    This is determined by the [d] parameter of the [OCAMLRUNPARAM] environment
+    variable, defaulting to [128] on 64-bit platforms and [16] on 32-bit
+    platforms. The upper limit is [4096].
+
+    @since 5.6 *)
+
 val recommended_domain_count : unit -> int
 (** The recommended maximum number of domains which should be running
     simultaneously (including domains already running).

--- a/testsuite/tests/backtrace/backtrace_domain_join.reference
+++ b/testsuite/tests/backtrace/backtrace_domain_join.reference
@@ -9,7 +9,7 @@ Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 1
 Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
 Called from Backtrace_domain_join.bar in file "backtrace_domain_join.ml", line 10, characters 7-16
 Called from Backtrace_domain_join.foo in file "backtrace_domain_join.ml", line 14, characters 7-16
-Called from Stdlib__Domain.spawn.body in file "domain.ml", line 270, characters 16-20
-Re-raised at Stdlib__Domain.spawn.body in file "domain.ml", line 286, characters 8-17
-Re-raised at Stdlib__Domain.join in file "domain.ml", line 303, characters 22-57
+Called from Stdlib__Domain.spawn.body in file "domain.ml", line 272, characters 16-20
+Re-raised at Stdlib__Domain.spawn.body in file "domain.ml", line 288, characters 8-17
+Re-raised at Stdlib__Domain.join in file "domain.ml", line 305, characters 22-57
 Called from Backtrace_domain_join in file "backtrace_domain_join.ml", line 19, characters 8-37

--- a/testsuite/tests/parallel/recommended_domain_count.ml
+++ b/testsuite/tests/parallel/recommended_domain_count.ml
@@ -7,4 +7,8 @@ external get_max_domains : unit -> int = "caml_get_max_domains"
 let _ =
   assert (Domain.recommended_domain_count () > 0);
   assert (Domain.recommended_domain_count () <= (get_max_domains ()));
+  (* Domain.max_domains should agree with the C-level value *)
+  assert (Domain.max_domains () = get_max_domains ());
+  assert (Domain.max_domains () >= 1);
+  assert (Domain.recommended_domain_count () <= Domain.max_domains ());
   print_string "passed\n"


### PR DESCRIPTION
Expose the runtime's configured maximum number of domains via a new Domain.max_domains function. This value is set by the d parameter of OCAMLRUNPARAM (defaulting to 128 on 64-bit and 16 on 32-bit platforms).

Follows on from https://github.com/ocaml/ocaml/pull/13272.

This functionality is useful for performance tools like `olly`.