### PR TITLE
Fix shell error in case of absence of ocamlopt in testsuite

### DIFF
--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -88,6 +88,13 @@ let libwin32unix = make
     "win32 variant of the unix library available"
     "win32 variant of the unix library not available")
 
+let has_reserved_header_bits = make
+  ~name:"has_reserved_header_bits"
+  ~description:"Pass if some of the bits in the header are reserved"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.reserved_header_bits <> 0)
+    (Printf.sprintf "%d bits reserved" Ocamltest_config.reserved_header_bits)
+    "No header bits are reserved")
+
 let hassysthreads = make
   ~name:"hassysthreads"
   ~description:"Pass if the systhreads library is available"
@@ -415,6 +422,7 @@ let _ =
     dumpenv;
     hasunix;
     hassysthreads;
+    has_reserved_header_bits;
     hasstr;
     multicore;
     libunix;

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -110,3 +110,5 @@ let tsan = @tsan@
 let has_relative_libdir = @target_libdir_is_relative@
 
 let suffixing = @suffixing@
+
+let reserved_header_bits = @reserved_header_bits@

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -158,3 +158,6 @@ val has_relative_libdir : bool
 val suffixing : bool
 (** Whether C stub library filenames are being mangled with the Bytecode
     Runtime ID and {!Config.target}. *)
+
+val reserved_header_bits : int
+(** How many bits of a block's header are reserved *)

--- a/testsuite/tests/atomic-locs/check-reserved-bits.sh
+++ b/testsuite/tests/atomic-locs/check-reserved-bits.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-if [ 0 = `$ocamlrun $ocamlopt_byte -config-var reserved_header_bits` ]; then
-  exit $TEST_PASS
-else
-  exit $TEST_SKIP
-fi

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -68,8 +68,7 @@ end
    linux;
    no-flambda; (* the output will be slightly different under Flambda *)
    not tsan; (* TSan modifies the generated code *)
-   script = "sh ${test_source_directory}/check-reserved-bits.sh";
-   script;
+   not has_reserved_header_bits;
 
    setup-ocamlopt.byte-build-env;
    flags = "-c -dcmm -dno-locations -dno-unique-ids";


### PR DESCRIPTION
Harden a shell script against the absence of the `ocamlopt` bytecode executable at the root. This can happen when building with `--disable-native-compiler`, but also when doing a partial build, for instance running only `make world` to save time.

Reported by @gasche in https://github.com/ocaml/ocaml/pull/14678#issuecomment-4138080427.