### PR TITLE
Testsuite: weak pointers and ephemerons repro cases for #14349

### DIFF
--- a/Changes
+++ b/Changes
@@ -83,6 +83,7 @@ Working version
   (Gabriel Scherer, review by Olivier Nicole)
 
 - grouped fixes in the ephemeron runtime
+  + #14745: testsuite examples inspired from Jan Midtgaard's repro cases
   + #14734: fix ephemeron orphaning (a counterpart of #14722)
   + #14733: clarify the implementation of per-domain ephemeron work counters
   + #14813: ensure that no orphaned ephemerons remain across GC cycles

--- a/testsuite/tests/weak-ephe-final/ephetest_par_2.ml
+++ b/testsuite/tests/weak-ephe-final/ephetest_par_2.ml
@@ -1,0 +1,16 @@
+(* TEST *)
+
+let go () =
+  for _ = 1 to 256 do
+    let stack = ref [] in
+    for _ = 1 to 256 do
+      stack := Ephemeron.K1.make (1, 2) (3, 4) :: !stack;
+    done;
+    ignore (Sys.opaque_identity !stack)
+  done
+
+let () =
+  for _ = 1 to 10 do
+    Array.init 4 (fun _ -> Domain.spawn go)
+    |> Array.iter Domain.join
+  done

--- a/testsuite/tests/weak-ephe-final/weak_array_par_2.ml
+++ b/testsuite/tests/weak-ephe-final/weak_array_par_2.ml
@@ -1,0 +1,23 @@
+(* TEST *)
+
+(* This test reliably exercises the bugs from Jan Midtgaard's repro case in #14349.
+
+   On a developer machine, out of 10 on OCaml 5.4, it was observed to:
+   - terminate in about 0.3s when it works correctly
+   - segfault 3 times
+   - loop indefinitely 2 times
+*)
+let go () =
+  for _ = 1 to 256 do
+    let stack = ref [] in
+    for _ = 1 to 256 do
+      stack := Weak.create 64 :: !stack;
+    done;
+    ignore (Sys.opaque_identity !stack)
+  done
+
+let () =
+  for _ = 1 to 4 do
+    Array.init 4 (fun _ -> Domain.spawn go)
+    |> Array.iter Domain.join
+  done


### PR DESCRIPTION
#14349 contains bug reports and bug hunting discussion about a failure found by @jmid's comprehensive [multicoretests](https://github.com/ocaml-multicore/multicoretests/) randomized harness. The present PRs contains two new tests for the compiler testsuite, which are simplified repro cases for the failures of the randomized test of #14349.

There are two tests:
- a test with weak pointers, which fails on 5.4 but works correctly on trunk, not because of a fix but because a pessimization in trunk makes the bug go away
- a test with ephemerons, which also fails on trunk (more precisely, it reliably raises assertion failures under the debug runtime)

Both tests take about 0.5s on my machine, and fail in about half their runs.

I believe that having those tests around in the testsuite would be helpful to ensure that ephemeron changes are correct (or, in this case, that the current ephemeron code gets fixed). Of course, merging this right now would have the, ahem, slight downside of breaking the CI on trunk -- because we haven't reviewed and merged trunk fixes for these bugs yet.