### PR TITLE
Allow aliases when checking for signature inclusion #14204

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,11 @@ Working version
   used.
   (Stefan Muenzel, report by Leo White, review by Jacques Garrigue)
 
+- #13872, #14736, #14746: Expand type abbreviations when checking that a type is
+  a re-export of a previous one (e.g `type t = u = A | B`)
+  (Stefan Muenzel, request by ygrek and Jacques Garrigue,
+   review by Florian Angeletti)
+
 ### Code generation and optimizations:
 
 - #14575: Emit direct assembly for `Atomic.fetch_and_add`

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -194,8 +194,8 @@ the defined type constructor. The type expression in the equation part
 must agree with the representation: it must be of the same kind
 (record or variant) and have exactly the same constructors or fields,
 in the same order, with the same arguments. Moreover, the new type
-constructor must have the same arity and the same type constraints as the
-original type constructor.
+constructor must have the same arity, the same type parameters in the
+same order, and the same type constraints as the original type constructor.
 \end{description}
 
 The type variables appearing as type parameters can optionally be prefixed by

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -9,7 +9,7 @@ Error: Type declarations do not match:
          type !'a x = private [> `x ] constraint 'a = [> `x ]
        is not included in
          type 'a x
-       Their parameters differ
+       Their parameters differ:
        The type "[> `x ] x" = "[> `x ]" is not equal to the type "'a"
 |}, Principal{|
 Line 1:
@@ -17,7 +17,7 @@ Error: Type declarations do not match:
          type !'a x = private 'a constraint 'a = [> `x ]
        is not included in
          type 'a x
-       Their parameters differ
+       Their parameters differ:
        The type "[> `x ]" is not equal to the type "'a"
 |}];;
 

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -85,6 +85,41 @@ Error: This variant or record definition does not match that of type "bar"
        The original is abstract, but this is an extensible variant.
 |}]
 
+type baz += Baz of int
+;;
+[%%expect {|
+type baz += Baz of int
+|}]
+
+type foo += Foo of int
+
+let f = function
+  | Baz i -> 2 * i
+  | Foo i -> 3 * i
+  | _ -> 0
+;;
+
+[%%expect {|
+type foo += Foo of int
+Line 5, characters 4-7:
+5 |   | Foo i -> 3 * i
+        ^^^
+Error: This variant pattern is expected to have type "baz" = "foo/2"
+       There is no constructor "Foo" within type "baz"
+|}]
+
+type bar'
+
+type baz = bar' = ..
+[%%expect {|
+type bar'
+Line 3, characters 0-20:
+3 | type baz = bar' = ..
+    ^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "bar'"
+       The original is abstract, but this is an extensible variant.
+|}]
+
 (* Abbreviations need to match parameters *)
 
 type 'a foo = ..
@@ -237,6 +272,16 @@ Error: Signature mismatch:
          type foo = M.foo = private ..
        is not included in
          type foo = ..
+       A private extensible variant would be revealed.
+|}]
+
+type m_foo = M.foo = ..
+
+[%%expect {|
+Line 1, characters 0-23:
+1 | type m_foo = M.foo = ..
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "M.foo"
        A private extensible variant would be revealed.
 |}]
 

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -117,7 +117,7 @@ Line 1, characters 0-37:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a, 'a) foo"
-       Their parameters differ
+       Their parameters differ:
        The type "'a" is not equal to the type "'b"
 |}]
 

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -78,11 +78,7 @@ Error: Type definition "bar" is not extensible
 type baz = bar = ..
 ;;
 [%%expect {|
-Line 1, characters 0-19:
-1 | type baz = bar = ..
-    ^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type "bar"
-       The original is abstract, but this is an extensible variant.
+type baz = bar = ..
 |}]
 
 type baz += Baz of int
@@ -101,11 +97,7 @@ let f = function
 
 [%%expect {|
 type foo += Foo of int
-Line 5, characters 4-7:
-5 |   | Foo i -> 3 * i
-        ^^^
-Error: This variant pattern is expected to have type "baz" = "foo/2"
-       There is no constructor "Foo" within type "baz"
+val f : baz -> int = <fun>
 |}]
 
 type bar'

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -197,7 +197,7 @@ Error: Signature mismatch:
          type 'b t = 'b M.t = A constraint 'b = < x : 'a. 'a -> 'a >
        is not included in
          type 'b t = A constraint 'b = < x : 'a. 'a -> x >
-       Their parameters differ
+       Their parameters differ:
        The type "< x : 'a. 'a -> 'a >" is not equal to the type
          "< x : 'a. 'a -> x >"
        Type "'a" is not equal to type "x" = "M.x"

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -207,7 +207,7 @@ Error: Signature mismatch:
          type !'a t = 'a t/3 constraint 'a = < b : 'b >
        is not included in
          type !'a t constraint 'a = < b : 'b; c : 'c >
-       Their parameters differ
+       Their parameters differ:
        The type "< b : 'a >" is not equal to the type "< b : 'b; c : 'c >"
        The first object type has no method "c"
 |}]

--- a/testsuite/tests/typing-misc/pr13872.ml
+++ b/testsuite/tests/typing-misc/pr13872.ml
@@ -11,11 +11,7 @@ type b=y=T
 type x = T
 type a = x = T
 type y = x
-Line 4, characters 0-10:
-4 | type b=y=T
-    ^^^^^^^^^^
-Error: This variant or record definition does not match that of type "y"
-       The original is abstract, but this is a variant.
+type b = y = T
 |}]
 
 type x' = private T
@@ -47,7 +43,7 @@ Line 2, characters 0-14:
 2 | type b = y = T
     ^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type "y"
-       The original is abstract, but this is a variant.
+       Private variant constructor(s) would be revealed.
 |}]
 
 type x_p = private x
@@ -86,7 +82,12 @@ Line 3, characters 0-52:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a, 'b) t_rev"
-       The original is abstract, but this is a variant.
+       The representation of "t" cannot be used in the definition of this type, because
+         "('a, 'b) q" is not an alias of "('b, 'a) t".  Their parameters differ:
+         The type "'a" is not equal to the type "'b"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]
 
 type ('a, 'b) t = A of 'a | B of 'b
@@ -117,7 +118,11 @@ Line 4, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a, 'b) q'"
-       The original is abstract, but this is a variant.
+       The representation of "t_eq" cannot be used in the definition of this type, because
+         "('a, 'b) q" is not an alias of "'a t_eq".  They have different arities.
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]
 
 (* Reverse the reverse, so this could work if we can be more sophisticated
@@ -155,7 +160,12 @@ Line 4, characters 0-62:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a3, 'b3) t_rev_rev"
-       The original is abstract, but this is a variant.
+       The representation of "t_rev" cannot be used in the definition of this type, because
+         "('a2, 'b2) q" is not an alias of "('b2, 'a2) t_rev".
+         Their parameters differ: The type "'a2" is not equal to the type "'b2"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]
 
 (* Add one more indirection *)
@@ -176,7 +186,12 @@ Line 5, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a, 'b) q'"
-       The original is abstract, but this is a variant.
+       The representation of "t_rev" cannot be used in the definition of this type, because
+         "('a, 'b) t_rev_rev" is not an alias of "('b, 'a) t_rev".
+         Their parameters differ: The type "'a" is not equal to the type "'b"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]
 
 type ('a, 'b) t = A of 'a | B of 'b
@@ -186,12 +201,7 @@ type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
 [%%expect{|
 type ('a, 'b) t = A of 'a | B of 'b
 type ('a, 'b) t_same = ('a, 'b) t
-Line 3, characters 0-53:
-3 | type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type
-         "('a, 'b) t_same"
-       The original is abstract, but this is a variant.
+type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
 |}]
 
 (* Extra constraints are rejected *)
@@ -208,7 +218,13 @@ Line 3, characters 0-53:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "(int, 'b) t_same"
-       The original is abstract, but this is a variant.
+       The representation of "t" cannot be used in the definition of this type, because
+         "(int, 'b) q" is not an alias of "(int, 'b) t".
+         "(int, 'b) t" is not an unmodified instantiation of "('a, 'b) t"
+         Their parameters differ: The type "'a" is not equal to the type "int"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]
 
 (* They are even rejected if they don't change the representation *)
@@ -225,7 +241,13 @@ Line 3, characters 0-61:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a, 'b, int) t_same"
-       The original is abstract, but this is a variant.
+       The representation of "t" cannot be used in the definition of this type, because
+         "('a, 'b, int) q" is not an alias of "('a, 'b, int) t".
+         "('a, 'b, int) t" is not an unmodified instantiation of "('a, 'b, 'c) t"
+         Their parameters differ: The type "'c" is not equal to the type "int"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]
 
 (* Of course, this works for records *)
@@ -242,5 +264,11 @@ Line 3, characters 0-62:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "('a, 'b, int) t_same"
-       The original is abstract, but this is a record.
+       The representation of "t" cannot be used in the definition of this type, because
+         "('a, 'b, int) q" is not an alias of "('a, 'b, int) t".
+         "('a, 'b, int) t" is not an unmodified instantiation of "('a, 'b, 'c) t"
+         Their parameters differ: The type "'c" is not equal to the type "int"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]

--- a/testsuite/tests/typing-misc/pr13872.ml
+++ b/testsuite/tests/typing-misc/pr13872.ml
@@ -1,0 +1,246 @@
+(* TEST
+ expect;
+*)
+
+type x=T
+type a=x=T
+type y=x
+type b=y=T
+
+[%%expect{|
+type x = T
+type a = x = T
+type y = x
+Line 4, characters 0-10:
+4 | type b=y=T
+    ^^^^^^^^^^
+Error: This variant or record definition does not match that of type "y"
+       The original is abstract, but this is a variant.
+|}]
+
+type x' = private T
+
+[%%expect{|
+type x' = private T
+|}]
+
+(* Privacy is preserved *)
+
+type a' = x' = T
+
+[%%expect{|
+Line 1, characters 0-16:
+1 | type a' = x' = T
+    ^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "x'"
+       Private variant constructor(s) would be revealed.
+|}]
+
+(* Even through aliases*)
+
+type y = x'
+type b = y = T
+
+[%%expect{|
+type y = x'
+Line 2, characters 0-14:
+2 | type b = y = T
+    ^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "y"
+       The original is abstract, but this is a variant.
+|}]
+
+type x_p = private x
+type b = x_p = private T
+
+[%%expect{|
+type x_p = private x
+Line 2, characters 0-24:
+2 | type b = x_p = private T
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "x_p"
+       The type "x" is not equal to the type "x_p"
+|}]
+
+type x_p = private x
+type b = x_p = T
+
+[%%expect{|
+type x_p = private x
+Line 2, characters 0-16:
+2 | type b = x_p = T
+    ^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "x_p"
+       The type "x" is not equal to the type "x_p"
+|}]
+
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_rev = ('b, 'a) t
+type ('a, 'b) q = ('a, 'b) t_rev = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_rev = ('b, 'a) t
+Line 3, characters 0-52:
+3 | type ('a, 'b) q = ('a, 'b) t_rev = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a, 'b) t_rev"
+       The original is abstract, but this is a variant.
+|}]
+
+type ('a, 'b) t = A of 'a | B of 'b
+type 'a t_eq = ('a, 'a) t
+type ('a, 'b) q = 'a t_eq = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b) t = A of 'a | B of 'b
+type 'a t_eq = ('a, 'a) t
+Line 3, characters 0-45:
+3 | type ('a, 'b) q = 'a t_eq = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "'a t_eq"
+       They have different arities.
+|}]
+
+type ('a, 'b) t = A of 'a | B of 'b
+type 'a t_eq = ('a, 'a) t
+type ('a, 'b) q' = 'a t_eq
+type ('a, 'b) q = ('a, 'b) q' = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b) t = A of 'a | B of 'b
+type 'a t_eq = ('a, 'a) t
+type ('a, 'b) q' = 'a t_eq
+Line 4, characters 0-49:
+4 | type ('a, 'b) q = ('a, 'b) q' = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a, 'b) q'"
+       The original is abstract, but this is a variant.
+|}]
+
+(* Reverse the reverse, so this could work if we can be more sophisticated
+   about expanding manifest types. *)
+
+type ('a0, 'b0) t = A of 'a0 | B of 'b0
+type ('a1, 'b1) t_rev = ('b1, 'a1) t
+type ('a2, 'b2) q = ('b2, 'a2) t_rev = A of 'a2 | B of 'b2
+
+[%%expect{|
+type ('a0, 'b0) t = A of 'a0 | B of 'b0
+type ('a1, 'b1) t_rev = ('b1, 'a1) t
+Line 3, characters 0-58:
+3 | type ('a2, 'b2) q = ('b2, 'a2) t_rev = A of 'a2 | B of 'b2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('b2, 'a2) t_rev"
+       Their parameters differ:
+       The type "'b2" is not equal to the type "'a2"
+|}]
+
+(* Reverse the reverse using a separate abbreviation *)
+
+type ('a0, 'b0) t = A of 'a0 | B of 'b0
+type ('a1, 'b1) t_rev = ('b1, 'a1) t
+type ('a2, 'b2) t_rev_rev = ('b2, 'a2) t_rev
+type ('a3, 'b3) q = ('a3, 'b3) t_rev_rev = A of 'a3 | B of 'b3
+
+[%%expect{|
+type ('a0, 'b0) t = A of 'a0 | B of 'b0
+type ('a1, 'b1) t_rev = ('b1, 'a1) t
+type ('a2, 'b2) t_rev_rev = ('b2, 'a2) t_rev
+Line 4, characters 0-62:
+4 | type ('a3, 'b3) q = ('a3, 'b3) t_rev_rev = A of 'a3 | B of 'b3
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a3, 'b3) t_rev_rev"
+       The original is abstract, but this is a variant.
+|}]
+
+(* Add one more indirection *)
+
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_rev = ('b, 'a) t
+type ('a, 'b) t_rev_rev = ('b, 'a) t_rev
+type ('a, 'b) q' = ('a, 'b) t_rev_rev
+type ('a, 'b) q = ('a, 'b) q' = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_rev = ('b, 'a) t
+type ('a, 'b) t_rev_rev = ('b, 'a) t_rev
+type ('a, 'b) q' = ('a, 'b) t_rev_rev
+Line 5, characters 0-49:
+5 | type ('a, 'b) q = ('a, 'b) q' = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a, 'b) q'"
+       The original is abstract, but this is a variant.
+|}]
+
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_same = ('a, 'b) t
+type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_same = ('a, 'b) t
+Line 3, characters 0-53:
+3 | type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a, 'b) t_same"
+       The original is abstract, but this is a variant.
+|}]
+
+(* Extra constraints are rejected *)
+
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_same = ('a, 'b) t constraint 'a = int
+type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b) t = A of 'a | B of 'b
+type ('a, 'b) t_same = ('a, 'b) t constraint 'a = int
+Line 3, characters 0-53:
+3 | type ('a, 'b) q = ('a, 'b) t_same = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "(int, 'b) t_same"
+       The original is abstract, but this is a variant.
+|}]
+
+(* They are even rejected if they don't change the representation *)
+
+type ('a, 'b, 'c) t = A of 'a | B of 'b
+type ('a, 'b, 'c) t_same = ('a, 'b, 'c) t constraint 'c = int
+type ('a, 'b, 'c) q = ('a, 'b, 'c) t_same = A of 'a | B of 'b
+
+[%%expect{|
+type ('a, 'b, 'c) t = A of 'a | B of 'b
+type ('a, 'b, 'c) t_same = ('a, 'b, 'c) t constraint 'c = int
+Line 3, characters 0-61:
+3 | type ('a, 'b, 'c) q = ('a, 'b, 'c) t_same = A of 'a | B of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a, 'b, int) t_same"
+       The original is abstract, but this is a variant.
+|}]
+
+(* Of course, this works for records *)
+
+type ('a, 'b, 'c) t = { a : 'a; b : 'b }
+type ('a, 'b, 'c) t_same = ('a, 'b, 'c) t constraint 'c = int
+type ('a, 'b, 'c) q = ('a, 'b, 'c) t_same = { a : 'a; b : 'b }
+
+[%%expect{|
+type ('a, 'b, 'c) t = { a : 'a; b : 'b; }
+type ('a, 'b, 'c) t_same = ('a, 'b, 'c) t constraint 'c = int
+Line 3, characters 0-62:
+3 | type ('a, 'b, 'c) q = ('a, 'b, 'c) t_same = { a : 'a; b : 'b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('a, 'b, int) t_same"
+       The original is abstract, but this is a record.
+|}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -196,7 +196,7 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "(int, [> `A ]) def"
-       Their parameters differ
+       Their parameters differ:
        The type "int" is not equal to the type "'a"
 |}]
 

--- a/testsuite/tests/typing-misc/type_external.ml
+++ b/testsuite/tests/typing-misc/type_external.ml
@@ -293,20 +293,7 @@ module Q(P : P) : P with type t = P.t = struct
 end;;
 [%%expect{|
 module type P = sig type t = external "p" end
-Lines 4-6, characters 40-3:
-4 | ........................................struct
-5 |   type t = P.t
-6 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = P.t end
-       is not included in
-         sig type t = external "p" end
-       Type declarations do not match:
-         type t = P.t
-       is not included in
-         type t = external "p"
-       The first is abstract, but the second is external "p".
+module Q : (P : P) -> sig type t = external "p" end
 |}]
 
 module type P1 = sig
@@ -317,20 +304,7 @@ module Q(P1 : P1) : P1 with type 'a t = 'a P1.t = struct
 end;;
 [%%expect{|
 module type P1 = sig type !'b t = external "p" end
-Lines 4-6, characters 50-3:
-4 | ..................................................struct
-5 |   type 'a t = 'a P1.t
-6 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig type !'a t = 'a P1.t end
-       is not included in
-         sig type !'a t = external "p" end
-       Type declarations do not match:
-         type !'a t = 'a P1.t
-       is not included in
-         type !'a t = external "p"
-       The first is abstract, but the second is external "p".
+module Q : (P1 : P1) -> sig type !'a t = external "p" end
 |}]
 
 module type P1 = sig
@@ -341,18 +315,5 @@ module Q(P1 : P1) : P1 with type 'a t = 'a P1.t = struct
 end;;
 [%%expect{|
 module type P1 = sig type +!'b t = external "p" end
-Lines 4-6, characters 50-3:
-4 | ..................................................struct
-5 |   type 'a t = 'a P1.t
-6 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig type +!'a t = 'a P1.t end
-       is not included in
-         sig type +!'a t = external "p" end
-       Type declarations do not match:
-         type +!'a t = 'a P1.t
-       is not included in
-         type +!'a t = external "p"
-       The first is abstract, but the second is external "p".
+module Q : (P1 : P1) -> sig type +!'a t = external "p" end
 |}]

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -66,7 +66,7 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          "(int, [> `A ]) def"
-       Their parameters differ
+       Their parameters differ:
        The type "int" is not equal to the type "'a"
 |}]
 

--- a/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
@@ -7,6 +7,6 @@ Error: In this with constraint, the new definition of t
          type t = int
        is not included in
          type t = { a : int; b : int; }
-       The first is abstract, but the second is a record.
+       The first is external "int", but the second is a record.
        File "pr6293_bad.ml", line 9, characters 20-50: Expected declaration
        File "pr6293_bad.ml", line 10, characters 18-37: Actual declaration

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1557,7 +1557,7 @@ Error: This application of the functor "F" is ill-typed.
             type t = int
           is not included in
             type t = Y of X.t
-          The first is abstract, but the second is a variant.
+          The first is external "int", but the second is a variant.
        3. Modules do not match:
             Y : sig type t = Y.t = Y of int end
           is not included in

--- a/testsuite/tests/typing-modules/pr14204.ml
+++ b/testsuite/tests/typing-modules/pr14204.ml
@@ -8,19 +8,7 @@ module M : sig type u = T end = struct type u = t end
 
 [%%expect{|
 type t = T
-Line 2, characters 32-53:
-2 | module M : sig type u = T end = struct type u = t end
-                                    ^^^^^^^^^^^^^^^^^^^^^
-Error: Signature mismatch:
-       Modules do not match:
-         sig type u = t end
-       is not included in
-         sig type u = T end
-       Type declarations do not match:
-         type u = t
-       is not included in
-         type u = T
-       The first is abstract, but the second is a variant.
+module M : sig type u = T end
 |}]
 
 (* Check all permutations of privacy *)
@@ -42,7 +30,7 @@ Error: Signature mismatch:
          type u = private t
        is not included in
          type u = T
-       The first is abstract, but the second is a variant.
+       Private variant constructor(s) would be revealed.
 |}]
 
 type t = private T
@@ -62,7 +50,7 @@ Error: Signature mismatch:
          type u = t
        is not included in
          type u = T
-       The first is abstract, but the second is a variant.
+       Private variant constructor(s) would be revealed.
 |}]
 
 type t = private T
@@ -82,7 +70,7 @@ Error: Signature mismatch:
          type u = private t
        is not included in
          type u = T
-       The first is abstract, but the second is a variant.
+       Private variant constructor(s) would be revealed.
 |}]
 
 type t = T
@@ -102,7 +90,7 @@ Error: Signature mismatch:
          type u = t'
        is not included in
          type u = T
-       The first is abstract, but the second is a variant.
+       Private variant constructor(s) would be revealed.
 |}]
 
 
@@ -119,16 +107,7 @@ module type S = sig type 'a t end
 module Id : (S : S) -> sig type 'a t = 'a S.t end
 module type Sp = sig type 'a t = A of 'a list end
 module L : sig type 'a t = A of 'a list end
-Line 5, characters 16-21:
-5 | module M : Sp = Id(L)
-                    ^^^^^
-Error: Signature mismatch:
-       Modules do not match: sig type 'a t = 'a L.t end is not included in Sp
-       Type declarations do not match:
-         type 'a t = 'a L.t
-       is not included in
-         type 'a t = A of 'a list
-       The first is abstract, but the second is a variant.
+module M : Sp
 |}]
 
 
@@ -166,5 +145,10 @@ Error: Signature mismatch:
          type ('a, 'b) q = ('a, 'b) t_rev
        is not included in
          type ('a, 'b) q = A of 'a | B of 'b
-       The first is abstract, but the second is a variant.
+       The representation of "t" cannot be used in the declaration of the second type, because
+         "('a, 'b) t_rev" is not an alias of "('b, 'a) t".
+         Their parameters differ: The type "'a" is not equal to the type "'b"
+       When re-exporting a type representation, each type equation leading to
+       the original representation must be an alias defining a type
+       with the same parameters, in the same order, with the same constraints.
 |}]

--- a/testsuite/tests/typing-modules/pr14204.ml
+++ b/testsuite/tests/typing-modules/pr14204.ml
@@ -152,3 +152,30 @@ Error: Signature mismatch:
        the original representation must be an alias defining a type
        with the same parameters, in the same order, with the same constraints.
 |}]
+
+module X : sig
+  type t = external "x"
+end = struct
+  type x = external "x"
+  type t' = private x
+  type t = t'
+end ;;
+
+[%%expect{|
+Lines 3-7, characters 6-3:
+3 | ......struct
+4 |   type x = external "x"
+5 |   type t' = private x
+6 |   type t = t'
+7 | end...
+Error: Signature mismatch:
+       Modules do not match:
+         sig type x = external "x" type t' = private x type t = t' end
+       is not included in
+         sig type t = external "x" end
+       Type declarations do not match:
+         type t = t'
+       is not included in
+         type t = external "x"
+       A private external type would be revealed.
+|}]

--- a/testsuite/tests/typing-modules/pr14204.ml
+++ b/testsuite/tests/typing-modules/pr14204.ml
@@ -1,0 +1,170 @@
+(* TEST
+ expect;
+*)
+
+(* alias to a variant *)
+type t = T
+module M : sig type u = T end = struct type u = t end
+
+[%%expect{|
+type t = T
+Line 2, characters 32-53:
+2 | module M : sig type u = T end = struct type u = t end
+                                    ^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type u = t end
+       is not included in
+         sig type u = T end
+       Type declarations do not match:
+         type u = t
+       is not included in
+         type u = T
+       The first is abstract, but the second is a variant.
+|}]
+
+(* Check all permutations of privacy *)
+
+type t = T
+module M : sig type u = T end = struct type u = private t end
+
+[%%expect{|
+type t = T
+Line 2, characters 32-61:
+2 | module M : sig type u = T end = struct type u = private t end
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type u = private t end
+       is not included in
+         sig type u = T end
+       Type declarations do not match:
+         type u = private t
+       is not included in
+         type u = T
+       The first is abstract, but the second is a variant.
+|}]
+
+type t = private T
+module M : sig type u = T end = struct type u = t end
+
+[%%expect{|
+type t = private T
+Line 2, characters 32-53:
+2 | module M : sig type u = T end = struct type u = t end
+                                    ^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type u = t end
+       is not included in
+         sig type u = T end
+       Type declarations do not match:
+         type u = t
+       is not included in
+         type u = T
+       The first is abstract, but the second is a variant.
+|}]
+
+type t = private T
+module M : sig type u = T end = struct type u = private t end
+
+[%%expect{|
+type t = private T
+Line 2, characters 32-61:
+2 | module M : sig type u = T end = struct type u = private t end
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type u = private t end
+       is not included in
+         sig type u = T end
+       Type declarations do not match:
+         type u = private t
+       is not included in
+         type u = T
+       The first is abstract, but the second is a variant.
+|}]
+
+type t = T
+module M : sig type u = T end = struct type t' = private t type u = t' end
+
+[%%expect{|
+type t = T
+Line 2, characters 32-74:
+2 | module M : sig type u = T end = struct type t' = private t type u = t' end
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t' = private t type u = t' end
+       is not included in
+         sig type u = T end
+       Type declarations do not match:
+         type u = t'
+       is not included in
+         type u = T
+       The first is abstract, but the second is a variant.
+|}]
+
+
+(* more complicated example from garrigue *)
+
+module type S = sig type 'a t end
+module Id (S : S) = S
+module type Sp = sig type 'a t = A of 'a list end
+module L = struct type 'a t = A of 'a list end
+module M : Sp = Id(L)
+
+[%%expect{|
+module type S = sig type 'a t end
+module Id : (S : S) -> sig type 'a t = 'a S.t end
+module type Sp = sig type 'a t = A of 'a list end
+module L : sig type 'a t = A of 'a list end
+Line 5, characters 16-21:
+5 | module M : Sp = Id(L)
+                    ^^^^^
+Error: Signature mismatch:
+       Modules do not match: sig type 'a t = 'a L.t end is not included in Sp
+       Type declarations do not match:
+         type 'a t = 'a L.t
+       is not included in
+         type 'a t = A of 'a list
+       The first is abstract, but the second is a variant.
+|}]
+
+
+module M : sig
+  type ('a, 'b) t = A of 'a | B of 'b
+  type ('a, 'b) t_rev = ('b, 'a) t
+  type ('a, 'b) q = A of 'a | B of 'b
+end = struct
+  type ('a, 'b) t = A of 'a | B of 'b
+  type ('a, 'b) t_rev = ('b, 'a) t
+  type ('a, 'b) q = ('a, 'b) t_rev
+end
+
+[%%expect{|
+Lines 5-9, characters 6-3:
+5 | ......struct
+6 |   type ('a, 'b) t = A of 'a | B of 'b
+7 |   type ('a, 'b) t_rev = ('b, 'a) t
+8 |   type ('a, 'b) q = ('a, 'b) t_rev
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type ('a, 'b) t = A of 'a | B of 'b
+           type ('a, 'b) t_rev = ('b, 'a) t
+           type ('a, 'b) q = ('a, 'b) t_rev
+         end
+       is not included in
+         sig
+           type ('a, 'b) t = A of 'a | B of 'b
+           type ('a, 'b) t_rev = ('b, 'a) t
+           type ('a, 'b) q = A of 'a | B of 'b
+         end
+       Type declarations do not match:
+         type ('a, 'b) q = ('a, 'b) t_rev
+       is not included in
+         type ('a, 'b) q = A of 'a | B of 'b
+       The first is abstract, but the second is a variant.
+|}]

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -122,7 +122,7 @@ Error: Type declarations do not match:
          type !'a t = private 'a constraint 'a = < x : int; .. >
        is not included in
          type 'a t
-       Their parameters differ
+       Their parameters differ:
        The type < x : int; .. > is not equal to the type 'a
 type 'a t = private 'a constraint 'a = < x : int; .. >
 type t = [ `Closed ]

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -122,7 +122,7 @@ Error: Type declarations do not match:
          type !'a t = private < x : int; .. > constraint 'a = < x : int; .. >
        is not included in
          type 'a t
-       Their parameters differ
+       Their parameters differ:
        The type < x : int; .. > t = < x : int; .. > is not equal to the type
          'a
 type 'a t = private 'a constraint 'a = < x : int; .. >

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -192,6 +192,10 @@ type private_object_mismatch =
   | Missing of string
   | Types of Errortrace.equality_error
 
+type alias_mismatch_kind =
+  | Instantiation of type_expr
+  | Manifest
+
 type variant_change =
   (Types.constructor_declaration as 'l, 'l, constructor_mismatch)
     Diffing_with_keys.change
@@ -209,6 +213,14 @@ type type_mismatch =
   | Variant_mismatch of variant_change list
   | Unboxed_representation of position
   | Immediate of Type_immediacy.Violation.t
+  | Not_an_alias of alias_mismatch
+and alias_mismatch =
+  { kind : alias_mismatch_kind;
+    path1 : Path.t;
+    ty1 : type_expr;
+    path2 : Path.t;
+    ty2 : type_expr;
+    inner : type_mismatch }
 
 module Style = Misc.Style
 module Fmt = Format_doc
@@ -439,7 +451,7 @@ let report_kind_mismatch first second ppf (kind1, kind2) =
     second
     (kind_to_string kind2)
 
-let report_type_mismatch first second decl env ppf err =
+let rec report_type_mismatch first second decl env ppf err =
   let pr fmt = Fmt.fprintf ppf fmt in
   match err with
   | Arity ->
@@ -472,12 +484,39 @@ let report_type_mismatch first second decl env ppf err =
          "uses unboxed representation"
   | Immediate violation ->
       let first = StringLabels.capitalize_ascii first in
-      match violation with
+      begin match violation with
       | Type_immediacy.Violation.Not_always_immediate ->
           pr "%s is not an immediate type." first
       | Type_immediacy.Violation.Not_always_immediate_on_64bits ->
           pr "%s is not a type that is always immediate on 64 bit platforms."
             first
+      end
+  | Not_an_alias { ty1; path2; ty2; inner; kind } ->
+      let kind =
+        match kind with
+        | Manifest ->
+            Fmt.dprintf ""
+        | Instantiation ty2_def ->
+            Fmt.dprintf "%a is not an unmodified instantiation of %a"
+              (Style.as_inline_code Printtyp.type_expr) ty2
+              (Style.as_inline_code Printtyp.type_expr) ty2_def
+      in
+      let p2 = Path.name path2 in
+      pr "@[<hov2>The representation of %a cannot be used \
+          in the %s of %s type, because@ \
+          %a is not an alias of %a.@ %t@ %a@]@ \
+          When re-exporting a type representation, each type equation \
+          leading to@ the original representation must be an alias defining \
+          a type@ with the same parameters, in the same order, with the same \
+          constraints."
+        Style.inline_code p2
+        decl
+        second
+        (Style.as_inline_code Printtyp.type_expr) ty1
+        (Style.as_inline_code Printtyp.type_expr) ty2
+        kind
+        (report_type_mismatch "the first" "the second" "definition" env)
+        inner
 
 module Record_diffing = struct
 
@@ -938,6 +977,11 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
       | () -> None
     end
 
+let type_declarations_privacy_mismatch env decl1 decl2 =
+  match privacy_mismatch env decl1 decl2 with
+  | Some err -> Some (Privacy err)
+  | None -> None
+
 (* A type declarations [td1] is consistent with the type declaration [td2] if
    there is a context E such E |- td1 <: td2 for the ordinary subtyping. For
    types, this is the case as soon as the two type declarations share the same
@@ -945,9 +989,67 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
    context E where all type constructors are equal). *)
 let type_declarations_consistency env decl1 decl2 =
   if decl1.type_arity <> decl2.type_arity then Some Arity
-  else match privacy_mismatch env decl1 decl2 with
-    | Some err -> Some (Privacy err)
-    | None -> None
+  else type_declarations_privacy_mismatch env decl1 decl2
+
+type decl_path =
+  | Not_via_alias of type_mismatch
+  | Via_alias
+
+let rec extract_concrete_typedecl_via_alias env ty1 path1 decl1 =
+  let exception Found_error of (decl_path * Types.type_declaration) in
+  match decl1.type_kind, decl1.type_manifest with
+  | Type_open, _
+  | Type_external _, _
+  | Type_record _, _
+  | Type_variant _, _ -> Some (Via_alias, decl1)
+  | Type_abstract _, None -> None
+  | Type_abstract _, Some ty2 ->
+      match Btype.get_constr_desc ty2 with
+      | Tconstr (path2, params2, _) ->
+          begin try
+            let decl2 = Env.find_type path2 env in
+            match extract_concrete_typedecl_via_alias env ty2 path2 decl2 with
+            | None -> None
+            | Some (deep_via, deep_decl) ->
+                let deep_via =
+                  match
+                    type_declarations_privacy_mismatch env deep_decl decl2
+                  with
+                  | None -> deep_via
+                  | Some err -> Not_via_alias err
+                in
+                let deep_decl =
+                  match decl1.type_private with
+                  | Private -> { deep_decl with type_private = Private }
+                  | _ -> deep_decl
+                in
+                let found_error err kind =
+                  raise
+                    (Found_error
+                       (Not_via_alias
+                          (Not_an_alias
+                             { kind; path1; ty1; path2; ty2; inner = err })
+                       , deep_decl))
+                in
+                if decl1.type_arity <> decl2.type_arity then
+                  found_error Arity Manifest;
+                begin try Ctype.equal env true decl2.type_params params2
+                with Ctype.Equality err ->
+                  found_error (Constraint err)
+                    (Instantiation
+                       (Btype.newgenty
+                          (Tconstr(path2, decl2.type_params, ref Mnil))))
+                end;
+                begin try Ctype.equal env false decl1.type_params params2
+                with Ctype.Equality err ->
+                  found_error (Constraint err) Manifest
+                end;
+                Some (deep_via, deep_decl)
+          with
+          | Not_found -> None
+          | Found_error err -> Some err
+          end
+      | _ -> None
 
 let type_declarations ?(equality = false) ~loc env ~mark name
       decl1 path decl2 =
@@ -981,9 +1083,33 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           | () -> None
   in
   if err <> None then err else
-  let err = match (decl1.type_kind, decl2.type_kind) with
-      (_, Type_abstract _) -> None
-    | (Type_variant (cstrs1, rep1), Type_variant (cstrs2, rep2)) ->
+  let decl1', err, expand_error =
+    match decl1.type_kind, decl1.type_manifest, decl2.type_kind with
+    | (_,_, Type_abstract _) -> decl1, None, None
+    | (Type_abstract _, Some _, _) ->
+        let check_decl_privacy decl =
+          type_declarations_privacy_mismatch env decl decl2
+        in
+        let ty1 =
+          Btype.newgenty (Tconstr(path, decl1.type_params, ref Mnil))
+        in
+        begin match
+          extract_concrete_typedecl_via_alias env ty1 path decl1
+        with
+        | None ->
+            decl1, None, None
+        | Some (Via_alias, found_decl) ->
+            found_decl, check_decl_privacy found_decl, None
+        | Some (Not_via_alias err, found_decl) ->
+            (* Prefer privacy error over alias error. *)
+            decl1, check_decl_privacy found_decl, Some err
+        end
+    | _ -> decl1, None, None
+  in
+  if err <> None then err else
+  let err = match (decl1'.type_kind, decl2.type_kind, expand_error) with
+      (_, Type_abstract _, _) -> None
+    | (Type_variant (cstrs1, rep1), Type_variant (cstrs2, rep2), _) ->
         if mark then begin
           let mark usage cstrs =
             List.iter (fun cstr ->
@@ -998,13 +1124,13 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           if equality then mark Env.Exported cstrs2
         end;
         Variant_diffing.compare_with_representation ~loc env
-          decl1.type_params
+          decl1'.type_params
           decl2.type_params
           cstrs1
           cstrs2
           rep1
           rep2
-    | (Type_record(labels1,rep1), Type_record(labels2,rep2)) ->
+    | (Type_record(labels1,rep1), Type_record(labels2,rep2), _) ->
         if mark then begin
           let mark usage lbls =
             List.iter (fun lbl ->
@@ -1019,12 +1145,14 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           if equality then mark Env.Exported labels2
         end;
         Record_diffing.compare_with_representation ~loc env
-          decl1.type_params decl2.type_params
+          decl1'.type_params decl2.type_params
           labels1 labels2
           rep1 rep2
-    | (Type_open, Type_open) -> None
-    | (Type_external n1, Type_external n2) when n1 = n2 -> None
-    | (_, _) -> Some (Kind (of_kind decl1.type_kind, of_kind decl2.type_kind))
+    | (Type_open, Type_open, _) -> None
+    | (Type_external n1, Type_external n2, _) when n1 = n2 -> None
+    | (Type_abstract _, _, (Some _ as err)) -> err
+    | (_, _, _) ->
+        Some (Kind (of_kind decl1'.type_kind, of_kind decl2.type_kind))
   in
   if err <> None then err else
   let abstr = Btype.type_kind_is_abstract decl2 && decl2.type_manifest = None in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -452,7 +452,7 @@ let report_type_mismatch first second decl env ppf err =
       (* This error can come from implicit parameter disagreement or from
          explicit `constraint`s.  Both affect the parameters, hence this choice
          of explanatory text *)
-      pr "Their parameters differ@,";
+      pr "Their parameters differ:@ ";
       report_type_inequality env ppf err
   | Manifest err ->
       report_type_inequality env ppf err

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -137,6 +137,7 @@ type privacy_mismatch =
   | Private_record_type
   | Private_extensible_variant
   | Private_row_type
+  | Private_external_type
 
 type type_kind =
   | Kind_abstract
@@ -275,6 +276,7 @@ let report_privacy_mismatch ppf err =
     | Private_record_type        -> true,  "record constructor"
     | Private_extensible_variant -> true,  "extensible variant"
     | Private_row_type           -> true,  "row type"
+    | Private_external_type      -> true,  "external type"
   in Format_doc.fprintf ppf "%s %s would be revealed."
        (if singular then "A private" else "Private")
        item
@@ -817,6 +819,7 @@ let privacy_mismatch env decl1 decl2 =
       | Type_record  _, Type_record  _ -> Some Private_record_type
       | Type_variant _, Type_variant _ -> Some Private_variant_type
       | Type_open,      Type_open      -> Some Private_extensible_variant
+      | Type_external _, Type_external _ -> Some Private_external_type
       | Type_abstract _, Type_abstract _
         when Option.is_some decl2.type_manifest -> begin
           match decl1.type_manifest with

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -42,6 +42,7 @@ type privacy_mismatch =
   | Private_record_type
   | Private_extensible_variant
   | Private_row_type
+  | Private_external_type
 
 type type_kind =
   | Kind_abstract

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -92,6 +92,10 @@ type private_object_mismatch =
   | Missing of string
   | Types of Errortrace.equality_error
 
+type alias_mismatch_kind =
+  | Instantiation of type_expr
+  | Manifest
+
 type type_mismatch =
   | Arity
   | Privacy of privacy_mismatch
@@ -105,6 +109,14 @@ type type_mismatch =
   | Variant_mismatch of variant_change list
   | Unboxed_representation of position
   | Immediate of Type_immediacy.Violation.t
+  | Not_an_alias of alias_mismatch
+and alias_mismatch =
+  { kind : alias_mismatch_kind;
+    path1 : Path.t;
+    ty1 : type_expr;
+    path2 : Path.t;
+    ty2 : type_expr;
+    inner : type_mismatch }
 
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->


### PR DESCRIPTION
When checking the re-exportation of a type in the type declaration inclusion check, allow the following of aliases to the original representation.

This allows code such as
```ocaml
type t = T;;
module M : sig type u = T end = struct type u = t end
```
where we need to follow `u=t` to find that `u = T`

or 
```ocaml
type x=T
type a=x=T
type y=x
type b=y=T
```
where we need to follow type abbreviations when looking for a type declaration for `y`



Original discussion wrt. modules here: https://github.com/ocaml/ocaml/discussions/14204

Previous (incorrect) PR for the second case here: https://github.com/ocaml/ocaml/pull/14736


There are several issues to consider that make this PR non-trivial:
- `Ctype.extract_concrete_typedecl` performs expansions on the way to the concrete typedecl without tracking what is being expanded, which means just using this function, we are unable to detect the cases that make using the unmodified type declaration invalid, such as the re-ordering of parameters
- We need to be careful not to expose private types

In addition, we expand the error message to provide a more detailed explanation to the user about exactly why the definition could not be traced back.