### PR TITLE
symtab.c: make_bucket: fully initialize to zero

### DIFF
--- a/Changes
+++ b/Changes
@@ -166,7 +166,8 @@ Working version
 
 - #14748: ocamlyacc: a data structure allocated with malloc was not being fully
   initialized, which could lead to incorrect line directives being generated.
-  (Nicolás Ojeda Bär, report by Igor Pikovets, review by Gabriel Scherer)
+  (Nicolás Ojeda Bär, report by Igor Pikovets, review by Gabriel Scherer and
+  Xavier Leroy)
 
 ### Manual and documentation:
 

--- a/Changes
+++ b/Changes
@@ -164,6 +164,10 @@ Working version
   that it would be okay to run only rarely.
   (Gabriel Scherer, review by Florian Angeletti)
 
+- #14748: ocamlyacc: a data structure allocated with malloc was not being fully
+  initialized, which could lead to incorrect line directives being generated.
+  (Nicolás Ojeda Bär, report by Igor Pikovets)
+
 ### Manual and documentation:
 
 - #14598: Add `@since` annotations to `Runtime_events`. (Raphaël Proust)

--- a/Changes
+++ b/Changes
@@ -166,7 +166,7 @@ Working version
 
 - #14748: ocamlyacc: a data structure allocated with malloc was not being fully
   initialized, which could lead to incorrect line directives being generated.
-  (Nicolás Ojeda Bär, report by Igor Pikovets)
+  (Nicolás Ojeda Bär, report by Igor Pikovets, review by Gabriel Scherer)
 
 ### Manual and documentation:
 

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -125,7 +125,7 @@
 
 #define CALLOC(k,n)      (calloc((unsigned)(k),(unsigned)(n)))
 #define FREE(x)          (free((char*)(x)))
-#define MALLOC(n)        (malloc((unsigned)(n)))
+#define MALLOC(n)        (CALLOC(n, 1))
 #define NEW(t)           ((t*)allocate(sizeof(t)))
 #define NEW2(n,t)        ((t*)allocate((unsigned)((n)*sizeof(t))))
 #define REALLOC(p,n)     (realloc((char*)(p),(unsigned)(n)))

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -125,7 +125,7 @@
 
 #define CALLOC(k,n)      (calloc((unsigned)(k),(unsigned)(n)))
 #define FREE(x)          (free((char*)(x)))
-#define MALLOC(n)        (CALLOC(n, 1))
+#define MALLOC(n)        (malloc((unsigned)(n)))
 #define NEW(t)           ((t*)allocate(sizeof(t)))
 #define NEW2(n,t)        ((t*)allocate((unsigned)((n)*sizeof(t))))
 #define REALLOC(p,n)     (realloc((char*)(p),(unsigned)(n)))

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -125,7 +125,7 @@
 
 #define CALLOC(k,n)      (calloc((unsigned)(k),(unsigned)(n)))
 #define FREE(x)          (free((char*)(x)))
-#define MALLOC(n)        (CALLOC(n, 1))
+#define MALLOC(n)        (CALLOC(n, 1)) /* Avoid undefined reads */
 #define NEW(t)           ((t*)allocate(sizeof(t)))
 #define NEW2(n,t)        ((t*)allocate((unsigned)((n)*sizeof(t))))
 #define REALLOC(p,n)     (realloc((char*)(p),(unsigned)(n)))

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -125,7 +125,7 @@
 
 #define CALLOC(k,n)      (calloc((unsigned)(k),(unsigned)(n)))
 #define FREE(x)          (free((char*)(x)))
-#define MALLOC(n)        (CALLOC(n, 1)) /* Avoid undefined reads */
+#define MALLOC(n)        (CALLOC(n, 1))
 #define NEW(t)           ((t*)allocate(sizeof(t)))
 #define NEW2(n,t)        ((t*)allocate((unsigned)((n)*sizeof(t))))
 #define REALLOC(p,n)     (realloc((char*)(p),(unsigned)(n)))

--- a/yacc/symtab.c
+++ b/yacc/symtab.c
@@ -63,7 +63,6 @@ make_bucket(const char *name)
     bp->lineno = 0;
     bp->column = 0;
 
-    if (bp->name == 0) no_space();
     strcpy(bp->name, name);
 
     return (bp);

--- a/yacc/symtab.c
+++ b/yacc/symtab.c
@@ -56,10 +56,12 @@ make_bucket(const char *name)
     bp->value = UNDEFINED;
     bp->index = 0;
     bp->prec = 0;
-    bp-> class = UNKNOWN;
+    bp->class = UNKNOWN;
     bp->assoc = TOKEN;
     bp->entry = 0;
     bp->true_token = 0;
+    bp->lineno = 0;
+    bp->column = 0;
 
     if (bp->name == 0) no_space();
     strcpy(bp->name, name);


### PR DESCRIPTION
Make sure to fully initialize the `bucket` data structure to zero after allocating it with `malloc`. Also, remove a duplicated check.

Fixes #14747