### PR TITLE
Testsuite tweaks

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -850,8 +850,12 @@ let run_expect_twice input_file log env =
   end else (result1, env1)
 
 let run_expect log env =
-  let input_file = Actions_helpers.testfile env in
-  run_expect_twice input_file log env
+  if Environments.is_variable_defined Ocaml_variables.libraries env then
+    let reason = "include is not supported with expect tests" in
+    (Test_result.fail_with_reason reason, env)
+  else
+    let input_file = Actions_helpers.testfile env in
+    run_expect_twice input_file log env
 
 let run_expect =
   Actions.make ~name:"run-expect" ~description:"Run expect test" run_expect

--- a/testsuite/tests/afl-instrumentation/afl-fuzz-test.run
+++ b/testsuite/tests/afl-instrumentation/afl-fuzz-test.run
@@ -5,8 +5,13 @@ exec > ${output} 2>&1
 
 mkdir readline-input
 echo a > readline-input/testcase
-export AFL_SKIP_CPUFREQ=1 AFL_FAST_CAL=1 AFL_NO_UI=1 AFL_BENCH_UNTIL_CRASH=1
-timeout 10s afl-fuzz -m none -i readline-input -o readline-output ./readline > afl-output
+export AFL_SKIP_CPUFREQ=1 \
+       AFL_FAST_CAL=1 \
+       AFL_NO_UI=1 \
+       AFL_BENCH_UNTIL_CRASH=1 \
+       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+timeout 10s afl-fuzz -m none -i readline-input -o readline-output ./readline \
+  > afl-output
 
 if [ `grep "unique_crashes" readline-output/fuzzer_stats | cut -d ':' -f 2` -gt 0 ];
 then

--- a/testsuite/tests/compiler-libs/test_longident.ml
+++ b/testsuite/tests/compiler-libs/test_longident.ml
@@ -1,6 +1,5 @@
 (* TEST
  flags = "-I ${ocamlsrcdir}/parsing -I ${ocamlsrcdir}/toplevel";
- include ocamltoplevel;
  expect;
 *)
 [@@@alert "-deprecated"]

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -1,6 +1,5 @@
 (* TEST
  flags = "-I ${ocamlsrcdir}/typing -I ${ocamlsrcdir}/parsing";
- include ocamlcommon;
  expect;
 *)
 

--- a/testsuite/tests/lib-lazy/test-mutexed.ml
+++ b/testsuite/tests/lib-lazy/test-mutexed.ml
@@ -2,7 +2,8 @@
  shared-libraries;
  hassysthreads;
  flags = "-I ${ocamlsrcdir}/otherlibs/unix -I ${ocamlsrcdir}/otherlibs/systhreads";
- include systhreads;
+ ld_library_path += " ${ocamlsrcdir}/otherlibs/unix";
+ ld_library_path += " ${ocamlsrcdir}/otherlibs/systhreads";
  expect;
 *)
 

--- a/testsuite/tests/parsing/reloc.ml
+++ b/testsuite/tests/parsing/reloc.ml
@@ -1,6 +1,5 @@
 (* TEST
- flags = "-I ${ocamlsrcdir}/parsing -I ${ocamlsrcdir}/toplevel";
- include ocamlcommon;
+ flags = "-I ${ocamlsrcdir}/parsing";
  expect;
 *)
 

--- a/testsuite/tests/unicode/utf8_lexeme.ml
+++ b/testsuite/tests/unicode/utf8_lexeme.ml
@@ -1,6 +1,5 @@
 (* TEST
  flags = "-I ${ocamlsrcdir}/utils";
- include ocamlcommon;
  expect;
 *)
 


### PR DESCRIPTION
Two testsuite tweaks, related only inasmuch as I hit them both at the same time.

Expect tests don't support including libraries - this is something we've changed over in OxCaml-land (https://github.com/oxcaml/oxcaml/pull/2558), and it would be worth upstreaming that some day, but in the meantime I've hardened ocamltest to fail a test which uses `include` and `expect` and fixed the tests which were trying to rely on it.

The AFL tweak simply adds `AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1` to the list of various tweaks, which causes a configuration warning (and consequential unnecessary test failure) to be ignored on the box I'm on.