### PR TITLE
Fix `-Wwrite-strings` error on Cygwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,8 +47,8 @@ Working version
 - #14482: Add DWARF CFI support to POWER backend.
   (Tim McGilchrist, review by Xavier Leroy)
 
-- #14666: Give C string constants the type `const char[N]` instead of `char[N]`
-  with the C compiler `-Wwrite-strings` flag.
+- #14666, #14751: Give C string constants the type `const char[N]` instead of
+  `char[N]` with the C compiler `-Wwrite-strings` flag.
   (Antonin Décimo, review by Xavier Leroy and Olivier Nicole)
 
 - #14717: assign 'unique_id' early during domain creation to help debugging

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -174,10 +174,11 @@ static int cygwin_file_exists(const char * name)
   return ret == 0 && S_ISREG(st.st_mode);
 }
 
-static caml_stat_string cygwin_search_exe_in_path(struct ext_table * path,
+static caml_stat_string cygwin_search_exe_in_path(const struct ext_table * path,
                                                   const char * name)
 {
-  char * dir, * fullname;
+  const char * dir;
+  char * fullname;
   for (const char *p = name; *p != 0; p++) {
     if (*p == '/' || *p == '\\') goto not_found;
   }


### PR DESCRIPTION
> There is a build error on Cygwin (which is not exercised by the Github CI):
>
> ```
> runtime/unix.c: In function 'cygwin_search_exe_in_path':
> runtime/unix.c:186:26: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
>  186 |     if (dir[0] == 0) dir = ".";  /* empty path component = current dir */
>      |  
> ```

_Originally posted by @OlivierNicole in https://github.com/ocaml/ocaml/issues/14666#issuecomment-4258909951_
            