### PR TITLE
Fix #14753 by rechecking well-foundedness

### DIFF
--- a/Changes
+++ b/Changes
@@ -89,6 +89,11 @@ Working version
   inheritance in mutually recursive definition, immediate object inheritance.
   (Leo White, review by Florian Angeletti)
 
+- #14753, #14754: Prevent module constraints (`with type`) from introducing
+  cyclic types by re-checking well-foundedness when a module constraint is
+  used.
+  (Stefan Muenzel, report by Leo White, review by Jacques Garrigue)
+
 ### Code generation and optimizations:
 
 * #13919: optimize `lazy v` when `v` is a structured constant

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -262,8 +262,12 @@ module type T = S with type 'a t = 'b constraint 'a = < m : 'b >;;
 [%%expect{|
 module type S =
   sig type 'a t = 'a constraint 'a = < m : r > and r = < m : r > t end
-Uncaught exception: Stack overflow
-
+Line 7, characters 23-64:
+7 | module type T = S with type 'a t = 'b constraint 'a = < m : 'b >;;
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" contains a cycle:
+         "< m : r > t/2" = "r",
+         "r" = "< m : r > t/2"
 |}]
 
 (* Correct *)

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -60,6 +60,10 @@ val approx_type_decl:
     explanation:Types.type_origin -> Parsetree.type_declaration list ->
                                   (Ident.t * type_declaration) list
 
+val check_well_founded_decl:
+  abs_env:Env.t ->final_env:Env.t -> is_decl_path:(Path.t -> bool) ->
+  Location.t -> Path.t -> Types.type_declaration -> unit
+
 (** [check_recmod_typedecl ~abs_env env loc recmod_ids path decl]
    - [recmod_ids] is the list of recursively-defined module idents.
    - [path, decl] is the type declaration to be checked.

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -275,6 +275,11 @@ let check_type_decl env sg loc id row_id newdecl decl =
     let abs_ty = abstractify_type newdecl in
     Env.add_local_constraint path abs_ty env
   in
+  (* While any "with" constraints that could be used to create ill-founded
+     types in downstream definitions that depend on this one should be rejected
+     by the inclusion check below, we still need to ensure that the type
+     declarations input to the inclusion check are well-founded; otherwise
+     the inclusion check may loop on type declarations that it should reject. *)
   Typedecl.check_well_founded_decl
     ~abs_env ~final_env:env ~is_decl_path:(Path.same path) loc path
     newdecl;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -199,23 +199,23 @@ let type_module_type_of_fwd :
 (* Additional validity checks on type definitions arising from
    recursive modules *)
 
+let abstractify_type ty =
+  let arity = ty.type_arity in
+  { ty with
+    type_params =
+      List.map (fun _ -> Btype.newgenvar()) ty.type_params;
+    type_kind = Type_abstract Rec_check_regularity;
+    type_manifest = None;
+    type_variance = Variance.unknown_signature ~injective:false ~arity;
+    type_separability = Types.Separability.default_signature ~arity;
+    type_is_newtype = false;
+    type_expansion_scope = Btype.lowest_level;
+    type_immediate = Unknown;
+    type_unboxed_default = false;
+  }
+
 let check_recmod_typedecls env decls =
   let recmod_ids = List.map fst decls in
-  let abstractify_type ty =
-    let arity = ty.type_arity in
-    { ty with
-      type_params =
-        List.map (fun _ -> Btype.newgenvar()) ty.type_params;
-      type_kind = Type_abstract Rec_check_regularity;
-      type_manifest = None;
-      type_variance = Variance.unknown_signature ~injective:false ~arity;
-      type_separability = Types.Separability.default_signature ~arity;
-      type_is_newtype = false;
-      type_expansion_scope = Btype.lowest_level;
-      type_immediate = Unknown;
-      type_unboxed_default = false;
-    }
-  in
   let type_to_abstract =
     List.fold_left
       (fun acc (id, md) ->
@@ -271,6 +271,13 @@ let check_type_decl env sg loc id row_id newdecl decl =
     | Some fresh_row_id -> Env.add_type ~check:false fresh_row_id newdecl env
   in
   let env = Env.add_signature sg env in
+  let abs_env =
+    let abs_ty = abstractify_type newdecl in
+    Env.add_local_constraint path abs_ty env
+  in
+  Typedecl.check_well_founded_decl
+    ~abs_env ~final_env:env ~is_decl_path:(Path.same path) loc path
+    newdecl;
   Includemod.type_declarations ~mark:true ~loc env fresh_id newdecl decl;
   Typedecl.check_coherence env loc path newdecl
 


### PR DESCRIPTION
When we add `with type` module constraints, it is possible to introduce cyclic types, as seen in #14753.

Thus, we should re-check well-foundedness on the type definition after applying the constraints