### PR TITLE
[fix(docs)] correct link to `ocamltest/OCAMLTEST.adoc`

### DIFF
--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -12,7 +12,7 @@ a specific sub-directory.
 
 There are many kind of tests already, so the easiest way to start is
 to extend or copy an existing test. To learn how to write new tests
-using ocamltest, read link:../ocamltest/OCAMLTEST.org[].
+using ocamltest, read link:../ocamltest/OCAMLTEST.adoc[].
 
 == Sorts of tests
 

--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -12,7 +12,7 @@ a specific sub-directory.
 
 There are many kind of tests already, so the easiest way to start is
 to extend or copy an existing test. To learn how to write new tests
-using ocamltest, read link:../ocamltest/OCAMLTEST.adoc[].
+using ocamltest, read xref:../ocamltest/OCAMLTEST.adoc[].
 
 == Sorts of tests
 


### PR DESCRIPTION
The ext name of `ocamltest/OCAMLTEST.org` has been changed to `ocamltest/OCAMLTEST.adoc`, but the link in `testsuite/HACKING.adoc` hasn't been aligned. 