### PR TITLE
configure: fix build error on OpenSUSE

### DIFF
--- a/Changes
+++ b/Changes
@@ -246,6 +246,9 @@ Working version
   counter-example search space.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #14761: Fix configure when `libdir='${exec_prefix}/lib64'`.
+  (Edwin Török)
+
 OCaml 5.5.0
 -----------
 

--- a/configure
+++ b/configure
@@ -24332,7 +24332,8 @@ esac
 
 
 
-if test x"$libdir" = x'${exec_prefix}/lib'
+if test x"$libdir" = x'${exec_prefix}/lib' || \
+       test x"$libdir" = x'${exec_prefix}/lib64'
 then :
   libdir="$libdir"/ocaml
 fi
@@ -24414,7 +24415,8 @@ fi ;; #(
      ;;
 esac
 
-if test x"$libdir" = x'${exec_prefix}/lib/ocaml'
+if test x"$libdir" = x'${exec_prefix}/lib/ocaml' || \
+       test x"$libdir" = x'${exec_prefix}/lib64/ocaml'
 then :
   if test x"$bindir_to_libdir" != 'x'
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -2996,7 +2996,8 @@ shlwapi.lib synchronization.lib"])
 
 AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 
-AS_IF([test x"$libdir" = x'${exec_prefix}/lib'],
+AS_IF([test x"$libdir" = x'${exec_prefix}/lib' || \
+       test x"$libdir" = x'${exec_prefix}/lib64'],
   [libdir="$libdir"/ocaml])
 
 AS_IF([test x"$mandir" = x'${datarootdir}/man'],
@@ -3053,7 +3054,8 @@ AS_CASE([$cygwin_build_env,$host],
         [ocaml_libdir='${exec_prefix}\lib\ocaml'],
         [ocaml_libdir="$libdir"])])])
 
-AS_IF([test x"$libdir" = x'${exec_prefix}/lib/ocaml'],
+AS_IF([test x"$libdir" = x'${exec_prefix}/lib/ocaml' || \
+       test x"$libdir" = x'${exec_prefix}/lib64/ocaml' ],
   [AS_IF([test x"$bindir_to_libdir" != 'x'],
     [ocaml_libdir="$bindir_to_libdir"
     target_libdir_is_relative=true


### PR DESCRIPTION
OpenSUSE has `libdir=${exec_prefix}/lib64` by default, which causes the default `opam` switch installation to fail, because it thinks that both `--with-relative-libdir` and `--libdir` were specified explicitly.

Accept both `${exec_prefix}/lib64` and `${exec_prefix}/lib`.

Fixes https://github.com/ocaml/ocaml/issues/14760