### PR TITLE
docs: fix "an unit"/"an complete" grammar in comments and docstrings

### DIFF
--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -211,7 +211,7 @@ let get_global_info global_ident = (
             (* Linking to a compilation unit expected to go into a
                pack (ui_for_pack = Some ...) is possible only from
                inside the same pack, but it is perfectly ok to link to
-               an unit outside of the pack. *)
+               a unit outside of the pack. *)
             (match ui.ui_for_pack, current_unit.ui_for_pack with
              | None, _ -> ()
              | Some p1, Some p2 when

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -588,10 +588,10 @@ module User : sig
 
   type 'value t
   (** The type for a user event. User events describe their tag, carried data
-      type and an unique string-based name. *)
+      type and a unique string-based name. *)
 
   val register : string -> tag -> 'value Type.t -> 'value t
-  (** [register name tag ty] registers a new event with an unique [name],
+  (** [register name tag ty] registers a new event with a unique [name],
       carrying a [tag] and values of type [ty]. *)
 
   val write : 'value t -> 'value -> unit

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -126,7 +126,7 @@ let parse_and_expand_argv_dynamic_aux allow_expand current argv speclist anonfun
   let convert_error error =
     (* convert an internal error to a Bad/Help exception
        *or* add the program name as a prefix and the usage message as a suffix
-       to an user-raised Bad exception.
+       to a user-raised Bad exception.
     *)
     let b = Buffer.create 200 in
     let progname =

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -419,7 +419,7 @@ let bprint_iconv_flag buf iconv = match iconv with
       buffer_add_char buf '#'
   | Int_d | Int_i | Int_x | Int_X | Int_o | Int_u -> ()
 
-(* Print an complete int format in a buffer (ex: "%3.*d"). *)
+(* Print a complete int format in a buffer (ex: "%3.*d"). *)
 let bprint_int_fmt buf ign_flag iconv pad prec =
   buffer_add_char buf '%';
   bprint_ignored_flag buf ign_flag;

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -54,7 +54,7 @@ module Error = struct
     | Unit
     | Empty_struct
      (** For backward compatibility's sake, an empty struct can be implicitly
-         converted to an unit module  *)
+         converted to a unit module  *)
 
   type ('a,'b) diff = {got:'a; expected:'a; symptom:'b}
   type 'a core_diff =('a,unit) diff

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -33,7 +33,7 @@ module Error: sig
     | Unit
     | Empty_struct
      (** For backward compatibility's sake, an empty struct can be implicitly
-         converted to an unit module. *)
+         converted to a unit module. *)
 
   type core_sigitem_symptom =
     | Value_descriptions of


### PR DESCRIPTION

**Repo:** ocaml/ocaml (⭐ 5300)
**Type:** docs
**Files changed:** 6
**Lines:** +7/-7

## What
Corrects six occurrences of the indefinite article "an" used before
consonant-sound words ("unit", "user", "unique", "complete") in source
comments and `.mli` docstrings. The affected files are `stdlib/arg.ml`,
`stdlib/camlinternalFormat.ml`, `middle_end/compilenv.ml`,
`typing/includemod.ml`, `typing/includemod.mli`, and
`otherlibs/runtime_events/runtime_events.mli`.

## Why
Two of the changes (`runtime_events.mli`) are in user-facing odoc
documentation that is rendered in the OCaml manual and shown by IDEs on
hover, so the grammar fix improves what readers see. The remaining four
are minor in-source comment polish in the same spirit. No code or API
behaviour changes.

## Testing
Comment-only and docstring-only edits — no compilation or test impact.
Verified via `git diff` that only comment/docstring text changed.

## Risk
Low — comments and docstrings only, no executable code touched.
