### PR TITLE
Lambda: merge nested labelled applications 

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -183,6 +183,37 @@ let is_omitted = function
   | Arg _ -> false
   | Omitted () -> true
 
+module Arg_fusion = struct
+  (** Merge list of arguments in nested application [((f x1 x2) x3
+      ... xn)] in order to try to fill up omitted argument in the
+      inner applications with present arguments from the outer
+      applications. This can avoid creating intermediary closures for
+      omitted argument that are syntactically available. *)
+
+  let rec search_for_first_arg lbl apps = function
+    | [] -> (lbl, Omitted ()), List.rev apps
+    | [] :: app_args -> search_for_first_arg lbl apps app_args
+    | ((_, Omitted ()) :: app_args) :: other_app_args ->
+        search_for_first_arg lbl (app_args :: apps) other_app_args
+    | ((_, Arg _) as a :: app_args) :: other_app_args ->
+        a, List.rev_append (app_args :: apps) other_app_args
+
+  let rec coalesce sargs = match sargs with
+    | [] -> []
+    | [] :: sargs -> coalesce sargs
+    | ((_, Arg _) as a :: inner) :: sargs -> a :: coalesce (inner :: sargs)
+    | ((lbl, Omitted ()) :: inner) :: sargs ->
+        let arg, sargs = search_for_first_arg lbl [] sargs in
+        arg :: coalesce (inner::sargs)
+
+  let rec unnest sargs e = match e.exp_desc with
+    | Texp_apply (f,args) -> unnest(args::sargs) f
+    | _ -> e, coalesce sargs
+
+  let in_nested_apply e = unnest [] e
+
+end
+
 let rec transl_exp ~scopes e =
   transl_exp1 ~scopes ~in_new_scope:false e
 
@@ -244,10 +275,11 @@ and transl_exp0 ~in_new_scope ~scopes e =
           (transl_apply ~scopes ~tailcall ~inlined ~specialised
              lam extra_args (of_location ~scopes e.exp_loc))
       end
-  | Texp_apply(funct, oargs) ->
+  | Texp_apply(funct, _oargs) ->
       let tailcall = Translattribute.get_tailcall_attribute funct in
       let inlined = Translattribute.get_inlined_attribute funct in
       let specialised = Translattribute.get_specialised_attribute funct in
+      let funct, oargs = Arg_fusion.in_nested_apply e in
       let e = { e with exp_desc = Texp_apply(funct, oargs) } in
       event_after ~scopes e
         (transl_apply ~scopes ~tailcall ~inlined ~specialised

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -183,34 +183,96 @@ let is_omitted = function
   | Arg _ -> false
   | Omitted () -> true
 
-module Arg_fusion = struct
+module Apply_fusion = struct
   (** Merge list of arguments in nested application [((f x1 x2) x3
       ... xn)] in order to try to fill up omitted argument in the
       inner applications with present arguments from the outer
-      applications. This can avoid creating intermediary closures for
-      omitted argument that are syntactically available. *)
+      applications. This avoids creating intermediary closures for
+      argument that are in fact syntactically available. *)
 
-  let rec search_for_first_arg lbl apps = function
-    | [] -> (lbl, Omitted ()), List.rev apps
-    | [] :: app_args -> search_for_first_arg lbl apps app_args
-    | ((_, Omitted ()) :: app_args) :: other_app_args ->
-        search_for_first_arg lbl (app_args :: apps) other_app_args
-    | ((_, Arg _) as a :: app_args) :: other_app_args ->
-        a, List.rev_append (app_args :: apps) other_app_args
+  type 'a arg_list = {
+    args: (Asttypes.arg_label * ('a,unit) arg_or_omitted) list;
+    order_protected: bool
+  }
 
-  let rec coalesce sargs = match sargs with
-    | [] -> []
-    | [] :: sargs -> coalesce sargs
-    | ((_, Arg _) as a :: inner) :: sargs -> a :: coalesce (inner :: sargs)
-    | ((lbl, Omitted ()) :: inner) :: sargs ->
-        let arg, sargs = search_for_first_arg lbl [] sargs in
-        arg :: coalesce (inner::sargs)
+  let is_pure = function
+    | Lvar _ | Lconst _ -> true
+    | _ -> false
+
+  let effectful_arg = function
+    | Arg x -> if is_pure x then None else Some x
+    | Omitted () -> None
+
+  let alias () =
+    let id = Ident.create_local "arg" in
+    id, Lvar id
+
+  let rec protect_app_order defs args = function
+    | [] -> defs, List.rev args
+    | (lbl, a as larg) :: q ->
+        match effectful_arg a with
+        | None -> protect_app_order defs (larg::args) q
+        | Some a ->
+            (* Only move to [defs] the execution of effectful arguments.*)
+            let id, alias = alias () in
+            protect_app_order ((id,a)::defs) ((lbl, Arg alias)::args) q
+
+  (* Moving an argument to the left possibly delays its application
+     compared to other argument, to avoid this we move the execution
+     of all non-pure arguments to its right to a sequence of let
+     definition *)
+  let rec protect_order defs prev_apps = function
+    | [] -> defs, List.rev prev_apps
+    | a :: q ->
+        if a.order_protected then
+          defs, List.rev_append prev_apps (a::q)
+        else
+          let new_defs, args = protect_app_order [] [] a.args in
+          let defs = List.rev_append new_defs defs in
+          protect_order defs ({args; order_protected=true}::prev_apps) q
+
+  let rec first_present_arg lbl defs apps_before = function
+    | [] -> (lbl, Omitted ()), defs, List.rev apps_before
+    | app :: next_apps ->
+        match app.args with
+        | [] ->
+            (* an application cannot contain only omitted argument *)
+            assert false
+        | (_, Omitted ()) :: args ->
+            let app = { app with args } in
+            first_present_arg lbl defs (app :: apps_before) next_apps
+        | (lbl, Arg a) as arg :: args ->
+            let app = { app with args } in
+            (* we can move pure argument without changing execution order *)
+            if is_pure a then
+              arg, defs, List.rev_append (app :: apps_before) next_apps
+            else
+              let defs, apps = protect_order defs [] (app :: next_apps) in
+              let id, alias = alias () in
+              (lbl, Arg alias), (id,a) :: defs, List.rev_append apps_before apps
+
+  let rec coalesce defs unified_args sargs = match sargs with
+    | [] -> defs, List.rev unified_args
+    | a :: sargs ->
+        match a.args with
+        | [] -> coalesce defs unified_args sargs
+        | (_, Arg _) as arg :: args ->
+            coalesce defs (arg :: unified_args) ({ a with args }::sargs)
+        | (lbl, Omitted ()) :: args ->
+            let arg, defs, sargs = first_present_arg lbl defs [] sargs in
+            coalesce defs (arg :: unified_args) ({ a with args }::sargs)
 
   let rec unnest sargs e = match e.exp_desc with
-    | Texp_apply (f,args) -> unnest(args::sargs) f
-    | _ -> e, coalesce sargs
+    | Texp_apply (f,args) -> unnest (args::sargs) f
+    | _ -> e, sargs
 
-  let in_nested_apply e = unnest [] e
+  let map_args f l =
+    List.map (fun (lbl,x) -> lbl, Typedtree.map_apply_arg f x) l
+
+  let map f sargs =
+    List.map (fun x -> { order_protected = false; args = map_args f x}) sargs
+
+  let merge_args args = coalesce [] [] args
 
 end
 
@@ -272,18 +334,29 @@ and transl_exp0 ~in_new_scope ~scopes e =
         let specialised = Translattribute.get_specialised_attribute funct in
         let e = { e with exp_desc = Texp_apply(funct, oargs) } in
         event_after ~scopes e
-          (transl_apply ~scopes ~tailcall ~inlined ~specialised
-             lam extra_args (of_location ~scopes e.exp_loc))
+          (transl_apply_args ~tailcall ~inlined ~specialised lam
+             (Apply_fusion.map_args (transl_exp ~scopes) extra_args)
+             (of_location ~scopes e.exp_loc)
+          )
       end
-  | Texp_apply(funct, _oargs) ->
+  | Texp_apply(funct, oargs) ->
       let tailcall = Translattribute.get_tailcall_attribute funct in
       let inlined = Translattribute.get_inlined_attribute funct in
       let specialised = Translattribute.get_specialised_attribute funct in
-      let funct, oargs = Arg_fusion.in_nested_apply e in
       let e = { e with exp_desc = Texp_apply(funct, oargs) } in
       event_after ~scopes e
-        (transl_apply ~scopes ~tailcall ~inlined ~specialised
-           (transl_exp ~scopes funct) oargs (of_location ~scopes e.exp_loc))
+        (
+          let funct, sargs = Apply_fusion.unnest [] e in
+          let sargs = Apply_fusion.map (transl_exp ~scopes) sargs in
+          let defs, oargs = Apply_fusion.merge_args sargs in
+          let apply =
+            transl_apply_args ~tailcall ~inlined ~specialised
+              (transl_exp ~scopes funct) oargs (of_location ~scopes e.exp_loc)
+          in
+          List.fold_left
+            (fun body (id, lam) -> Llet(Strict, Pgenval, id, lam, body))
+            apply defs
+        )
   | Texp_match(arg, pat_expr_list, [], partial) ->
       transl_match ~scopes e arg pat_expr_list partial
   | Texp_match(arg, pat_expr_list, eff_pat_expr_list, partial) ->
@@ -656,7 +729,7 @@ and transl_tupled_cases ~scopes patl_expr_list =
   List.map (fun (patl, guard, expr) -> (patl, transl_guard ~scopes guard expr))
     patl_expr_list
 
-and transl_apply ~scopes
+and transl_apply_args
       ?(tailcall=Default_tailcall)
       ?(inlined = Default_inline)
       ?(specialised = Default_specialise)
@@ -750,12 +823,8 @@ and transl_apply ~scopes
     | [] ->
         lapply lam (List.rev_map fst args)
   in
-  let transl_arg arg = Typedtree.map_apply_arg (transl_exp ~scopes) arg in
-  (build_apply lam [] (List.map (fun (l, arg) ->
-                                   transl_arg arg,
-                                   Btype.is_optional l)
-                                sargs)
-     : Lambda.lambda)
+  let args = List.map (fun (l, arg) -> arg, Btype.is_optional l) sargs in
+  (build_apply lam [] args: Lambda.lambda)
 
 (* There are two cases in function translation:
     - [Tupled]. It takes a tupled argument, and we can flatten it.
@@ -1327,6 +1396,10 @@ and transl_letop ~scopes loc env let_ ands param case partial =
   }
 
 (* Wrapper for class compilation *)
+
+let transl_apply ~scopes ?tailcall ?inlined ?specialised lam sargs loc =
+  transl_apply_args ?tailcall ?inlined ?specialised lam
+    (Apply_fusion.map_args (transl_exp ~scopes) sargs) loc
 
 (*
 let transl_exp = transl_exp_wrap

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -195,12 +195,8 @@ module Apply_fusion = struct
     order_protected: bool
   }
 
-  let is_pure = function
-    | Lvar _ | Lconst _ -> true
-    | _ -> false
-
   let effectful_arg = function
-    | Arg x -> if is_pure x then None else Some x
+    | Arg x -> if Lambda.is_evaluated x then None else Some x
     | Omitted () -> None
 
   let alias () =
@@ -241,8 +237,8 @@ module Apply_fusion = struct
             first_present_arg lbl defs (app :: apps_before) next_apps
         | (lbl, Arg a) as arg :: args ->
             let app = { app with args } in
-            (* we can move pure argument without changing execution order *)
-            if is_pure a then
+            (* we can move value arguments without changing execution order *)
+            if Lambda.is_evaluated a then
               arg, defs, List.rev_append (app :: apps_before) next_apps
             else
               let defs, apps = protect_order defs [] (app :: next_apps) in
@@ -772,9 +768,8 @@ and transl_apply_args
         (* Out-of-order partial application; we will need to build a closure *)
         let defs = ref [] in
         let protect name lam =
-          match lam with
-            Lvar _ | Lconst _ -> lam
-          | _ ->
+          if Lambda.is_evaluated lam then lam
+          else
               let id = Ident.create_local name in
               defs := (id, lam) :: !defs;
               Lvar id

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -235,9 +235,7 @@ module Apply_fusion = struct
     | [] -> (lbl, Omitted ()), defs, List.rev apps_before
     | app :: next_apps ->
         match app.args with
-        | [] ->
-            (* an application cannot contain only omitted argument *)
-            assert false
+        | [] -> first_present_arg lbl defs apps_before next_apps
         | (_, Omitted ()) :: args ->
             let app = { app with args } in
             first_present_arg lbl defs (app :: apps_before) next_apps
@@ -263,7 +261,11 @@ module Apply_fusion = struct
             coalesce defs (arg :: unified_args) ({ a with args }::sargs)
 
   let rec unnest sargs e = match e.exp_desc with
-    | Texp_apply (f,args) -> unnest (args::sargs) f
+    | Texp_apply (f,args)
+      when List.exists (function (_, Omitted ()) -> true | _ -> false) args ->
+        (* Eager evaluation for inner applications with no omitted
+           arguments. *)
+          unnest (args::sargs) f
     | _ -> e, sargs
 
   let map_args f l =
@@ -346,7 +348,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
       let e = { e with exp_desc = Texp_apply(funct, oargs) } in
       event_after ~scopes e
         (
-          let funct, sargs = Apply_fusion.unnest [] e in
+          let funct, sargs = Apply_fusion.unnest [oargs] funct in
           let sargs = Apply_fusion.map (transl_exp ~scopes) sargs in
           let defs, oargs = Apply_fusion.merge_args sargs in
           let apply =

--- a/testsuite/tests/basic-more/labels_evaluation_order.ml
+++ b/testsuite/tests/basic-more/labels_evaluation_order.ml
@@ -21,8 +21,23 @@ let _ =
      ~c:(Printf.printf "C\n") ~b:(Printf.printf "B\n"))
   ~a:(Printf.printf "A\n") ~f:(Printf.printf "F\n")
 
-let delayed ?(x=()) =
+let () = Printf.printf "function eager\n"
+
+let eager ?(x=()) =
   Printf.printf "x argument\n";
   fun ?(y=()) ~a:() ~b:() -> ()
 
-let partial = (delayed ~x:()) ~b:()
+let _x = (eager ~x:()) ~b:()
+
+let () = Printf.printf "function delay\n"
+let delay =
+  fun ?(a=()) -> Printf.printf "param a\n";
+  fun ~b:() -> Printf.printf "param b\n";
+    fun ?(c=()) -> Printf.printf "param c\n";
+      fun ?(d=()) -> Printf.printf "param d\n";
+       fun () -> Printf.printf "end\n"
+
+let () = Printf.printf "function f\n"
+let f = (delay ~b:()) ~d:() ~a:()
+
+let g = Printf.printf "function g\n"; f ()

--- a/testsuite/tests/basic-more/labels_evaluation_order.ml
+++ b/testsuite/tests/basic-more/labels_evaluation_order.ml
@@ -14,3 +14,9 @@ let f = foo ~a:(print_endline "a argument") ~c:(print_endline "c argument")
 let _ = print_endline "f defined"
 
 let _ = f ~b:(print_endline "b argument")
+
+let f ~a ~b ~c ~d ~e ~f = ()
+let _ =
+  ((f ~e:(Printf.printf "E\n") ~d:(Printf.printf "D\n"))
+     ~c:(Printf.printf "C\n") ~b:(Printf.printf "B\n"))
+  ~a:(Printf.printf "A\n") ~f:(Printf.printf "F\n")

--- a/testsuite/tests/basic-more/labels_evaluation_order.ml
+++ b/testsuite/tests/basic-more/labels_evaluation_order.ml
@@ -20,3 +20,9 @@ let _ =
   ((f ~e:(Printf.printf "E\n") ~d:(Printf.printf "D\n"))
      ~c:(Printf.printf "C\n") ~b:(Printf.printf "B\n"))
   ~a:(Printf.printf "A\n") ~f:(Printf.printf "F\n")
+
+let delayed ?(x=()) =
+  Printf.printf "x argument\n";
+  fun ?(y=()) ~a:() ~b:() -> ()
+
+let partial = (delayed ~x:()) ~b:()

--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -11,4 +11,13 @@ C
 B
 E
 D
+function eager
 x argument
+function delay
+function f
+param a
+param b
+function g
+param c
+param d
+end

--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -11,3 +11,4 @@ C
 B
 E
 D
+x argument

--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -5,3 +5,9 @@ b argument
 a parameter
 b parameter
 c parameter
+F
+A
+C
+B
+E
+D


### PR DESCRIPTION
One of the stated motivation of #14286 was the creation of a spurious intermediary closure when writing 
```ocaml
let f ?(x=1) ~y z = x+y+z
let g () = (f ~y:1) 42
```
compared to the version written
```ocaml
let g () = f ~y:1 42
```

Taking a side step, this PR proposes to solve this issue by merging nested labelled applications in Lambda (which is already done for non-labelled applications) when there are omitted argument in the inner application.

For instance, an applications of the form
```ocaml
let f ?a ?b ~x ?c ?d ~y= ()
let g = (f ~x:0) ~y:1 ~c:'c' ~a:'a'
```
is represented after typechecking as
```ocaml
let g = (f ∅ ∅ ~x:0) ?a:'a' ∅ ?c:'c' ~y:1
```
where `∅` stands for omitted arguments and I am using `?a:'a'` as a short-hand for `?a:(Some 'a')`. This PR rewrites this nested applications by filling omitted arguments in the inner applications with the present arguments in the outer ones:

```ocaml
let g = f  ?a:'a' ∅ ~x:0  ?c:'c' ~y:1
```
which is equivalent to removing the parentheses in `(f ~x:0) ~y:1 ~c:'c' ~a:'a' `. In general, this avoid
the creation of closure in the inner application that are immediately applied in the outer one, with
```ocaml
let h = (((((f ~y:1) ?d:'d') ?c:'c) ~x:0) ?b:'b') ?a:'a'
```
>```ocaml
>      h/282 =[int]
>       (apply
>         (let
>           (func/304 =
>              (let
>                (func/301 =
>                   (let
>                     (func/297 =
>                        (let
>                          (func/291 =
>                             (function param/285 param/286 param/287 stub
>                               (let
>                                 (func/288 =
>                                    (apply f/274 param/285 param/286
>                                      param/287))
>                                 (function param/289 param/290 stub
>                                   (apply func/288 param/289 param/290 1)))))
>                          (function param/292 param/293 param/294 stub
>                            (let
>                              (func/295 =
>                                 (apply func/291 param/292 param/293
>                                   param/294))
>                              (function param/296 stub
>                                (apply func/295 param/296 [0: 'd']))))))
>                     (function param/298 param/299 param/300 stub
>                       (apply func/297 param/298 param/299 param/300
>                         [0: 'c']))))
>                (function param/302 param/303 stub
>                  (apply func/301 param/302 param/303 0))))
>           (function param/305 stub (apply func/304 param/305 [0: 'b'])))
>```
as a worst case which create a quadratic number of intermediary closures with the current compilation scheme, which is reduced to

> ```ocaml
>     h/282 =[int] (apply f/274 [0: 'a'] [0: 'b'] 0 [0: 'c'] [0: 'd'] 1))
>```
after this PR.

This optimisation is semantics preserving for all three semantics proposed in https://github.com/ocaml/ocaml/pull/10653#issuecomment-1815914118 :

- strict-eager: merging argument lists is equivalent to the unlabelled case
- maximal-delay: filling omitted arguments never extends the delay of optional arguments
- strict-unlabelled: the evaluation of optional parameters still happens at the latest on the following unlabelled parameter

However, the evaluation order is modified compared to the current implementation of strict-unlabelled whenever the inner application is joining together consecutive sequences of optional arguments (by providing as arguments the labelled arguments separating the two sequences). For instance, in
```ocaml
let g = (f ~x:0) ~y:1 ?c:'c' ?a:'a' ?b:'b' 
```
the inner application is joining the first group `?a ?b` of optional arguments with the second one, `?c ?d`. Consequently,
since the outer application is missing the `?d` argument, the evaluation of the optional parameters is delayed and
```ocaml
let f ?(a='%') = Printf.printf "param x=%c\n" a; fun ?b ~x ?c ?d ~y -> ()
let g = (f ~x:0) ~y:1 ~c:'c' ~a:'a' ~b:'b'
```
is not printing anything.

Contrarily in
```ocaml
let g = f ~x:0 ~y:1 ~c:'c' ~a:'a' ~b:'b' 
```
the first omitted argument appears after a first non-optional argument, and thus `f` is reduced up to this first omitted argument.

With this PR, the two form are equivalent to the flat application. 
This changes of behaviour could be fixed if necessary (by detecting it), but I am not sure if this is necessary?
