### PR TITLE
Fix #14766

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,7 +61,8 @@ Working version
 
 ### Type system:
 
-* #11648: Keep expansion and new well-foundedness check implementation.
+* #11648, #14766, #14768: Keep expansion and new well-foundedness check
+  implementation.
   Do expansion in place during unification, rather than only memoizing it
   in a temporary cache. This fixes a number of non-terminations and crashes
   (#9314, #13230, #13881, #14036) and losses of principality (#14307 among
@@ -73,7 +74,9 @@ Working version
   implementation strives to follow the specification, some unspecified
   behaviors may change: stricter behavior of the well-foundedness check in
   some cases, or expansions kept in cmis in rare cases.
-  (Jacques Garrigue and Stefan Muenzel, cross reviewed)
+  (Jacques Garrigue and Stefan Muenzel, cross reviewed, temporary regression
+   reported by Jeremy Yallop, fix reviewed by Samuel Vivien and
+   Florian Angeletti)
 
 - #14512: Improve check for warning 16 (unerasable-optional-argument)
   (Alistair O'Brien, review by Florian Angeletti, Gabriel Scherer)

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -1437,6 +1437,69 @@ val u : ((module M : T) -> ([> M.v ] as 'a) -> 'a) -> (module T) -> 'a -> 'a =
   <fun>
 |}]
 
+(* Test shadowing of an include that could cause an error due to a module
+   not matching an inferred signature. *)
+
+module U = struct
+  type t = unit = ()
+end
+module M = struct
+  include U
+  type t = float
+  module type S = sig type t end
+  let f : (module X:S) -> X.t -> int = fun (module X:S)     _  -> 3
+end
+
+[%%expect{|
+module U : sig type t = unit = () end
+Lines 4-9, characters 11-3:
+4 | ...........struct
+5 |   include U
+6 |   type t = float
+7 |   module type S = sig type t end
+8 |   let f : (module X:S) -> X.t -> int = fun (module X:S)     _  -> 3
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = unit = ()
+           type t = float
+           module type S = sig type t end
+           val f : (module X : S) -> X.t -> int
+         end
+       is not included in
+         sig
+           type t = float
+           module type S = sig type t end
+           val f : (module X : S) -> X.t -> int
+         end
+       Values do not match:
+         val f : (module X : S) -> X.t -> int
+       is not included in
+         val f : (module X : S) -> X.t -> int
+       The type "(module X : S) -> X.t -> int" is not compatible with the type
+         "(module X : S) -> X.t -> int"
+       Type "X.t" is not compatible with type "X.t"
+|}]
+
+module type T = sig
+  type t
+end
+
+module F (X : T) = struct
+  type t = (module Y : T) -> Y.t -> X.t
+end
+
+module M = F(struct type t = float end)
+
+[%%expect{|
+module type T = sig type t end
+module F : (X : T) -> sig type t = (module Y : T) -> Y.t -> X.t end
+>> Fatal error: nondep_supertype not included in original module type
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
 (** Warnings *)
 
 module type Iter = sig

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -1452,34 +1452,12 @@ end
 
 [%%expect{|
 module U : sig type t = unit = () end
-Lines 4-9, characters 11-3:
-4 | ...........struct
-5 |   include U
-6 |   type t = float
-7 |   module type S = sig type t end
-8 |   let f : (module X:S) -> X.t -> int = fun (module X:S)     _  -> 3
-9 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           type t = unit = ()
-           type t = float
-           module type S = sig type t end
-           val f : (module X : S) -> X.t -> int
-         end
-       is not included in
-         sig
-           type t = float
-           module type S = sig type t end
-           val f : (module X : S) -> X.t -> int
-         end
-       Values do not match:
-         val f : (module X : S) -> X.t -> int
-       is not included in
-         val f : (module X : S) -> X.t -> int
-       The type "(module X : S) -> X.t -> int" is not compatible with the type
-         "(module X : S) -> X.t -> int"
-       Type "X.t" is not compatible with type "X.t"
+module M :
+  sig
+    type t = float
+    module type S = sig type t end
+    val f : (module X : S) -> X.t -> int
+  end
 |}]
 
 module type T = sig
@@ -1495,9 +1473,7 @@ module M = F(struct type t = float end)
 [%%expect{|
 module type T = sig type t end
 module F : (X : T) -> sig type t = (module Y : T) -> Y.t -> X.t end
->> Fatal error: nondep_supertype not included in original module type
-Uncaught exception: Misc.Fatal_error
-
+module M : sig type t = (module Y : T) -> Y.t -> float end
 |}]
 
 (** Warnings *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6480,7 +6480,7 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
                 Tvariant (set_row_name row (Some (Path.subst id_map p, tl)))
             | _ -> Tvariant row
           end
-      | desc -> copy_type_desc (nondep_type_rec env ids) desc
+      | desc -> copy_type_desc nondep_trec desc
     with
     | desc' ->
       Transient_expr.set_stub_desc ty' desc';
@@ -6489,7 +6489,7 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
       TypeHash.remove nondep_hash ty;
       raise e
 
-and nondep_type_rec ?expand_private env id ty =
+let nondep_type_rec ?expand_private env id ty =
   nondep_type_rec_aux ?expand_private env [] id ty
 
 let nondep_type env id ty =

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -287,7 +287,7 @@ let print ~with_scope ppf =
         pp_stamped (name, stamp)
   | Unscoped us ->
       let Unscoped.{ name; stamp } = Unscoped.get_desc us in
-      fprintf ppf "U%a"
+      fprintf ppf "U:%a"
         pp_stamped (name, stamp)
   | Scoped { name; stamp; scope } ->
       fprintf ppf "%a%s"


### PR DESCRIPTION
In #11648 , a recursive call to `nondep_type_rec_aux` did not include the `id_map`, resulting in the module path of a `Tfunctor` not being properly substituted, resulting in #14766