### PR TITLE
debugger: breakpoint on tfunctor

### DIFF
--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -628,7 +628,7 @@ let instr_break ppf lexbuf =
         begin try
           let (v, ty) = Eval.expression !selected_event env expr in
           match get_desc ty with
-          | Tarrow _ ->
+          | Tarrow _ | Tfunctor _ ->
               add_breakpoint_after_pc (Remote_value.closure_code v)
           | _ ->
               eprintf "Not a function.@.";

--- a/testsuite/tests/tool-debugger/fns/debuggee.ml
+++ b/testsuite/tests/tool-debugger/fns/debuggee.ml
@@ -1,0 +1,20 @@
+(* TEST
+ flags += " -g ";
+ debugger_script = "${test_source_directory}/input_script";
+ debugger;
+ shared-libraries;
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+ ocamldebug;
+ check-program-output;
+*)
+
+let f (z:int) = z, 2 * z + 1
+module type T = sig type t end
+let g (module M:T) (x:M.t) y = x, 1 + y
+
+let stop = f (1 + 1)
+
+let a = f 1
+let b = g (module String) "x" 100

--- a/testsuite/tests/tool-debugger/fns/debuggee.reference
+++ b/testsuite/tests/tool-debugger/fns/debuggee.reference
@@ -1,0 +1,9 @@
+Loading program... done.
+Breakpoint: 1
+17 let stop = f (1 + 1)<|a|>
+Breakpoint: 2
+13 let f (z:int) = <|b|>z, 2 * z + 1
+z: int = 1
+Breakpoint: 3
+15 let g (module M:T) (x:M.t) y = <|b|>x, 1 + y
+y: int = 100

--- a/testsuite/tests/tool-debugger/fns/input_script
+++ b/testsuite/tests/tool-debugger/fns/input_script
@@ -1,0 +1,9 @@
+break @ Debuggee 17
+run
+break f
+break g
+run
+print z
+run
+print y
+quit


### PR DESCRIPTION
This small PR makes it possible to set a breakpoint on a module-dependent function.