### PR TITLE
typechecker debugging: better unscoped printing

### DIFF
--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -683,8 +683,8 @@ module Digraph = struct
     | Types.Tarrow(l,t1,t2,_) ->
        mk "→%a" Pp.exponent_of_label l |> numbered [t1; t2]
     | Types.Tfunctor(l,us,{pack_path; pack_constraints},t2) ->
-        mk "→%a (%s : %a)" Pp.exponent_of_label l
-                    (Ident.Unscoped.name us)
+        mk "→%a (%a : %a)" Pp.exponent_of_label l
+                    Ident.Unscoped.print us
                     pp_path pack_path
           |> package_constraints params id pack_constraints
           |> numbered [t2]

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -43,6 +43,9 @@ module Unscoped = struct
     | Ulink u -> get_desc u
 
   let name us = (get_desc us).name
+  let print ppf us =
+    let d = get_desc us in
+    Format.fprintf ppf "%s/%d" d.name d.stamp
 
   let refresh us = create (get_desc us).name
 

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -83,6 +83,7 @@ module Unscoped : sig
    val refresh: t -> t
 
    val name: t -> string
+   val print: Format.formatter -> t -> unit
    val same: t -> t -> bool
 
    type change

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -88,8 +88,8 @@ and raw_type_desc ppf = function
         (string_of_label l) raw_type t1 raw_type t2
         (if is_commu_ok c then "Cok" else "Cunknown")
   | Tfunctor (l, id, {pack_path; pack_constraints}, t2) ->
-    fprintf ppf "@[<hov1>Tfunctor(\"%s\",@,%s,@,(%a,@,%a),@,%a)@]"
-      (string_of_label l) (Ident.Unscoped.name id)
+    fprintf ppf "@[<hov1>Tfunctor(\"%s\",@,%a,@,(%a,@,%a),@,%a)@]"
+      (string_of_label l) Ident.Unscoped.print id
       path pack_path raw_lid_type_list pack_constraints raw_type t2
   | Ttuple tl ->
       fprintf ppf "@[<1>Ttuple@,%a@]" labeled_type_list tl


### PR DESCRIPTION
This small PR improves debuggability of the typechecker by adding a printer function for unscoped identifiers and using it in the debugging modules  `Rawprinttyp` and `Gprinttyp`.