### PR TITLE
Ephemerons: wait on all domains to be done marking before asking for another round

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,6 +96,12 @@ Working version
   + #14813: ensure that no orphaned ephemerons remain across GC cycles
   (Gabriel Scherer, review by Damien Doligez)
 
+- #14774: wait for all domains to be done marking before asking for
+  another round of ephemeron marking. This can avoid un-necessary work
+  for multicore programs using ephemerons, but it could also make
+  certain GC cycles longer due to ephemeron marking starting later.
+  (Gabriel Scherer, review by B. Szilvasy and Damien Doligez)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -398,8 +398,8 @@ static bool has_completed_last_ephe_round (caml_domain_state *domain_state)
   return (domain_state->ephe_info->round == ephe_round_info.round);
 }
 
-/* Move to the next global ephemeron round. Called whenever any domain
- * finishes marking. */
+/* Move to the next global ephemeron round. Called when all domains
+ * are done marking. */
 static void ephe_next_round (void)
 {
   caml_plat_lock_blocking(&ephe_lock);
@@ -1714,9 +1714,34 @@ static intnat mark(intnat budget, enum mark_flag flag) {
       } else if (flag == MARK_NO_FINISH) {
         break;
       } else {
-        ephe_next_round ();
         domain_state->marking_done = 1;
-        (void)caml_atomic_counter_decr(&num_domains_to_mark);
+        /* If we are the last domain with marking work left,
+           it means that everyone is now done with marking,
+           and we should ask for a new round of ephemeron marking.
+
+           We must do this check _before_ decrementing
+           [num_domains_to_mark], otherwise other domains could
+           observe a state where all marking is done and the round has
+           not been incremented, and move to the next phase.
+        */
+        uintnat domains_still_marking =
+          caml_atomic_counter_value(&num_domains_to_mark);
+        do {
+          if (domains_still_marking == 1) {
+            /* We wait until all domains are done with their marking
+               work to ask for a new round of ephemeron marking, to
+               avoid useless rounds that would start with incomplete
+               marking information, and have to be followed by more runs
+               as more domains finish marking. */
+            ephe_next_round ();
+          }
+          /* [compare_exchange_strong] will succeed if
+             [num_domains_to_mark] is unchanged, and otherwise update
+             [domains_still_marking] to its new value. */
+        } while (!atomic_compare_exchange_strong(
+                   &num_domains_to_mark,
+                   &domains_still_marking,
+                   domains_still_marking - 1));
       }
     }
   }


### PR DESCRIPTION
Ephemeron marking must be done after normal marking, and may in turn reveal more normal marking work, which in turn requires a new round of ephemeron marking (marking all "TODO" ephemerons again to check if their keys have been marked), etc., until a fixpoint is reached as no additional normal-marking happens anymore.

On a single-domain system there is an obvious good strategy: wait until _all_ normal-marking work is done, and then do ephemeron marking, and repeat. On multi-domain systems we only know when we (the current domain) are done marking. The trunk code asks for a new ephemeron round (on all domains) whenever a domain is done marking; this can lead to useless repetition of ephemeron-marking work: if two domains finish marking one after the other, each will ask all domains to do a round of ephemeron-marking.

This PR changes the end-of-normal-marking logic to ensure that we ask for a new round of epehmeron marking when _all_ domains are done marking, rather than whenever the current domain is done marking.

@OlivierNicole and @damiendoligez reviewed an earlier version of this branch yesterday and we found a concurrency bug together. The new version uses a CAS loop to avoid concurrency issues, as we discussed.