### PR TITLE
typechecker, moregen: missing wrap_trace_gadts_instance

### DIFF
--- a/Changes
+++ b/Changes
@@ -65,7 +65,7 @@ Working version
 
 ### Type system:
 
-* #11648, #14766, #14768: Keep expansion and new well-foundedness check
+* #11648, #14766, #14768, #14776: Keep expansion and new well-foundedness check
   implementation.
   Do expansion in place during unification, rather than only memoizing it
   in a temporary cache. This fixes a number of non-terminations and crashes

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4833,8 +4833,8 @@ and moregen_row type_pairs env row1 row2 =
 
 (* Must empty univar_pairs first *)
 let moregen type_pairs env patt subj =
-  with_univar_pairs [] (fun () ->
-    moregen type_pairs env patt subj)
+  with_univar_pairs [] @@ wrap_trace_gadt_instances env @@ fun () ->
+    moregen type_pairs env patt subj
 
 (*
    Non-generic variable can be instantiated only if [inst_nongen] is


### PR DESCRIPTION
When `Ctype.moregen` is called on first-class module (to check inclusion between the module and module types), for instance in
```ocaml
let f = fun (type a) (x: a t): (module S) -> match x with A -> (module M)
```
it may be called with an environment which contains local constraints. In order to handle correctly unification in this case, we need to set up the tracing of GADTs instances at the start of moregen: this is what this PR is doing. 

Without this setup, it is the inner calls to the `unify_var'` function within moregen that will detect the local constraints, call `trace_gadts_instance` and delete the abbreviations computed up to this point by moregen at the end of the call of `unify_var'`. This deletion then invalidates the equality context used by moregen which registers equalities between expanded types and is thus dependent on the expansion of the same type nodes being stable. 

Currently, this issue is not visible because `moregen` is using `expand_head ~link:true` which keeps the expansion visible in the type graph itself. However, if we replace `expand_head` by `expand_head_nolink` in `moregen`, we get an infinite loop in
```ocaml
type a = [ `Foo of a list ]
type b = [ `Foo of b list ]
module type S = sig val x: a end
module M = struct let x: b = `Foo [] end

type _ t = A: int t
let f = fun (type a) (x: a t): (module S) -> match x with A -> (module M)
```
when checking that `(module M :> (module S))` because we end up creating fresh type nodes whenever we expand `type a` or `type b` making no progress in the analysis.

Consequently, this PR proposes to add the missing call to `wrap_trace_gadt_instances` at the top of `moregen` to avoid the problematic behavior of `unify_var'`, even if it only matters in the abstract.

Note that I am pondering if we might want `moregen` to modify type graphs as little as possible (only instantiating non-generic type variables) by using `expand_head_nolink`, but I believe that this should be a separate PR.