### PR TITLE
Small improvement to Value_rec_check

### DIFF
--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -435,7 +435,7 @@ sig
 
   val equal : t -> t -> bool
 end = struct
-  module M = Map.Make(Ident)
+  module M = Ident.Map
 
   (** A "t" maps each rec-bound variable to an access status *)
   type t = Mode.t M.t
@@ -448,10 +448,8 @@ end = struct
   let empty = M.empty
 
   let join (x: t) (y: t) =
-    M.fold
-      (fun (id: Ident.t) (v: Mode.t) (tbl: t) ->
-         let v' = find id tbl in
-         M.add id (Mode.join v v') tbl)
+    M.union
+      (fun _id v1 v2 -> Some (Mode.join v1 v2))
       x y
 
   let join_list li = List.fold_left join empty li


### PR DESCRIPTION
Tiny improvement to `Value_rec_check`:
- Use the standard `Ident.Map`
- For `join`, use `Map.union`, rather than repeated adds, which is more efficient

does not need a changes entry