### PR TITLE
Force use of the OCamlFDO names for caml_hot__code_{begin,end}.

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -246,11 +246,7 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
   let globals_map = make_globals_map units_list ~crc_interfaces in
   compile_phrase (Cmm_helpers.globals_map globals_map);
   compile_phrase(Cmm_helpers.data_segment_table ("_startup" :: name_list));
-  if !Clflags.function_sections then
-    compile_phrase
-      (Cmm_helpers.code_segment_table("_hot" :: "_startup" :: name_list))
-  else
-    compile_phrase(Cmm_helpers.code_segment_table("_startup" :: name_list));
+  compile_phrase(Cmm_helpers.code_segment_table("_startup" :: name_list));
   let all_names = "_startup" :: "_system" :: name_list in
   compile_phrase (Cmm_helpers.frame_table all_names);
   if !Clflags.output_complete_object then

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -407,12 +407,22 @@ G(name):
         .text
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(CAMLSEP(hot,code_begin))
+/* Two sections, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
+   functions, and are hard-wired in OCamlFDO, but must also be present
+   in mangled form to interact properly with code-segments
+   mechanisms. */
+
+        TEXT_SECTION(caml_hot__code_begin)
+        .globl  G(caml_hot__code_begin)
         .globl  G(CAMLSEP(hot,code_begin))
+G(caml_hot__code_begin):
 G(CAMLSEP(hot,code_begin)):
 
-        TEXT_SECTION(CAMLSEP(hot,code_end))
+        TEXT_SECTION(caml_hot__code_end)
+        .globl  G(caml_hot__code_end)
         .globl  G(CAMLSEP(hot,code_end))
+G(caml_hot__code_end):
 G(CAMLSEP(hot,code_end)):
 #endif
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -409,21 +409,15 @@ G(name):
 #if defined(FUNCTION_SECTIONS)
 /* Two sections, and matching symbols, caml_hot__code_begin and
    caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
-   functions, and are hard-wired in OCamlFDO, but must also be present
-   in mangled form to interact properly with code-segments
-   mechanisms. */
+   functions, and are hard-wired in OCamlFDO. */
 
         TEXT_SECTION(caml_hot__code_begin)
         .globl  G(caml_hot__code_begin)
-        .globl  G(CAMLSEP(hot,code_begin))
 G(caml_hot__code_begin):
-G(CAMLSEP(hot,code_begin)):
 
         TEXT_SECTION(caml_hot__code_end)
         .globl  G(caml_hot__code_end)
-        .globl  G(CAMLSEP(hot,code_end))
 G(caml_hot__code_end):
-G(CAMLSEP(hot,code_end)):
 #endif
 
 /******************************************************************************/

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -106,12 +106,22 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(CAMLSEP(hot,code_begin))
+/* Two sections, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
+   functions, and are hard-wired in OCamlFDO, but must also be present
+   in mangled form to interact properly with code-segments
+   mechanisms. */
+
+        TEXT_SECTION(caml_hot__code_begin)
+        .globl  G(caml_hot__code_begin)
         .globl  G(CAMLSEP(hot,code_begin))
+G(caml_hot__code_begin):
 G(CAMLSEP(hot,code_begin)):
 
-        TEXT_SECTION(CAMLSEP(hot,code_end))
+        TEXT_SECTION(caml_hot__code_end)
+        .globl  G(caml_hot__code_end)
         .globl  G(CAMLSEP(hot,code_end))
+G(caml_hot__code_end):
 G(CAMLSEP(hot,code_end)):
 #endif
 

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -108,21 +108,15 @@
 #if defined(FUNCTION_SECTIONS)
 /* Two sections, and matching symbols, caml_hot__code_begin and
    caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
-   functions, and are hard-wired in OCamlFDO, but must also be present
-   in mangled form to interact properly with code-segments
-   mechanisms. */
+   functions, and are hard-wired in OCamlFDO. */
 
         TEXT_SECTION(caml_hot__code_begin)
         .globl  G(caml_hot__code_begin)
-        .globl  G(CAMLSEP(hot,code_begin))
 G(caml_hot__code_begin):
-G(CAMLSEP(hot,code_begin)):
 
         TEXT_SECTION(caml_hot__code_end)
         .globl  G(caml_hot__code_end)
-        .globl  G(CAMLSEP(hot,code_end))
 G(caml_hot__code_end):
-G(CAMLSEP(hot,code_end)):
 #endif
 
 #if defined(SYS_macosx)

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -90,13 +90,18 @@
 .endm
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION caml_hot.code_begin
-        .globl caml_hot.code_begin
-caml_hot.code_begin:
+/* Two sections, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
+   functions and should not be mangled in the same way as OCaml
+   symbols: they are hard-wired in OCamlFDO. */
 
-        TEXT_SECTION caml_hot.code_end
-        .globl caml_hot.code_end
-caml_hot.code_end:
+        TEXT_SECTION caml_hot__code_begin
+        .globl caml_hot__code_begin
+caml_hot__code_begin:
+
+        TEXT_SECTION caml_hot__code_end
+        .globl caml_hot__code_end
+caml_hot__code_end:
 #endif
 
 .macro FUNCTION name

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -64,13 +64,18 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(caml_hot.code_begin)
-        .globl caml_hot.code_begin
-caml_hot.code_begin:
+/* Two sections, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
+   functions and should not be mangled in the same way as OCaml
+   symbols: they are hard-wired in OCamlFDO. */
 
-        TEXT_SECTION(caml_hot.code_end)
-        .globl caml_hot.code_end
-caml_hot.code_end:
+        TEXT_SECTION(caml_hot__code_begin)
+        .globl caml_hot__code_begin
+caml_hot__code_begin:
+
+        TEXT_SECTION(caml_hot__code_end)
+        .globl caml_hot__code_end
+caml_hot__code_end:
 #endif
 
 /* Globals and labels */

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -48,13 +48,18 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(caml_hot.code_begin)
-        .globl caml_hot.code_begin
-caml_hot.code_begin:
+/* Two sections, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end, are used by OCamlFDO. These names are not OCaml
+   functions and should not be mangled in the same way as OCaml
+   symbols: they are hard-wired in OCamlFDO. */
 
-        TEXT_SECTION(caml_hot.code_end)
-        .globl caml_hot.code_end
-caml_hot.code_end:
+        TEXT_SECTION(caml_hot__code_begin)
+        .globl caml_hot__code_begin
+caml_hot__code_begin:
+
+        TEXT_SECTION(caml_hot__code_end)
+        .globl caml_hot__code_end
+caml_hot__code_end:
 #endif
 
 #define FUNCTION(name) \

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -69,6 +69,13 @@ static void init_segments(void)
   caml_register_code_fragment(&caml_system__code_begin,
                               &caml_system__code_end,
                               DIGEST_IGNORE, NULL);
+#ifdef FUNCTION_SECTIONS
+  /* And the "hot" code for OcamlFDO */
+  extern char caml_hot__code_begin, caml_hot__code_end;
+  caml_register_code_fragment(&caml_hot__code_begin,
+                              &caml_hot__code_end,
+                              DIGEST_IGNORE, NULL);
+#endif /* FUNCTION_SECTIONS */
 }
 
 extern value caml_start_program (caml_domain_state*);


### PR DESCRIPTION
[OcamlFDO](https://github.com/gretay-js/ocamlfdo) hard-wires the names `caml_hot__code_begin` and `caml_hot__code_end`; these have shifted into versions with different punctuation; this PR restores those spellings.

[@lthls addresses the following point in PR conversation:]
This PR retains the `CAMLSEP` versions on AMD64 and ARM64, as they seem to be important for [something in `asmlink.ml`](https://github.com/ocaml/ocaml/blob/fbf6f4e9051f8bc2b330b10c0fdb9078d004c419/asmcomp/asmlink.ml#L251): I'd appreciate review from someone who understands this! (@tmcgilchrist ?)