### PR TITLE
Fix #14769 by checking for loops in update_level

### DIFF
--- a/testsuite/tests/typing-misc/conjunctive_types.ml
+++ b/testsuite/tests/typing-misc/conjunctive_types.ml
@@ -112,6 +112,137 @@ module type Vec =
        cross, 'c one)
       t -> ('dim, 'd one) t -> ('dim2, 'rank2) t
   end
-Uncaught exception: Stack overflow
-
+module F :
+  (V : Vec) ->
+    sig
+      val fn :
+        (([< `three of
+               'a *
+               ([< `one of
+                     'c z &
+                     [< `one of 'd * 'a * 'e & 'f one * 'g one * 'g one
+                      | `zero of 'd * 'e & 'f one * 'a ] &
+                     [< `one of 'd * 'a * 'e & 'f one * 'g one * 'g one
+                      | `zero of 'd * 'e & 'f one * 'a ]
+                 | `two of
+                     'c z &
+                     [< `two of 'd * 'a * 'e & 'f two * 'a * 'e
+                      | `zero of 'd * 'e & 'f two * 'a ] &
+                     [< `two of 'd * 'a * 'e & 'f two * 'a * 'e
+                      | `zero of 'd * 'e & 'f two * 'a ]
+                 | `zero of
+                     'c z &
+                     [< `one of 'd * 'e & 'f one * 'g one
+                      | `two of 'd * 'e & 'f two * 'g one
+                      | `zero of 'd * 'e & 'f z * 'h one ] &
+                     [< `one of 'd * 'e & 'f one * 'g one
+                      | `two of 'd * 'e & 'f two * 'g one
+                      | `zero of 'd * 'e & 'f z * 'h one ] ]
+                as 'b) &
+               'i three * 'j one
+           | `two of 'a * 'b & 'i * 'j z ]
+          as 'dim, 'a * 'b, 'j * 'i)
+         cross, 'k one)
+        t -> ('dim, 'l one) t -> ('e, 'd) t
+      val loop : ('a one, 'b z) t
+    end
+|}, Principal{|
+type k = float
+type 'a one = [ `one of 'a ]
+type 'a z = [ `zero of 'a ]
+type 'a two = [ `two of 'a ]
+type 'a three = [ `three of 'a ]
+type 'a four = [ `four of 'a ]
+type ('rank1, 'rank2, 'rank3, 'dim1, 'dim2, 'dim3, 'a) sum = 'rank1
+  constraint 'rank1 =
+    [< `one of
+         'rank2 &
+         [< `one of 'rank3 * 'dim1 * 'dim3 & 'p1 one * 'dim2 * 'dim2
+          | `zero of 'rank3 * 'dim3 & 'p1 one * 'dim1 ]
+     | `two of
+         'rank2 &
+         [< `two of 'rank3 * 'dim1 * 'dim3 & 'p1 two * 'dim1 * 'dim3
+          | `zero of 'rank3 * 'dim3 & 'p1 two * 'dim1 ]
+     | `zero of
+         'rank2 &
+         [< `one of 'rank3 * 'dim3 & 'p1 one * 'dim2
+          | `two of 'rank3 * 'dim3 & 'p1 two * 'dim2
+          | `zero of 'rank3 * 'dim3 & 'p1 z * 'p2 one ] ]
+  constraint 'a = 'p1 * 'p2 * 'p3
+type ('dim, 'res, 'a) cross = 'dim
+  constraint 'dim =
+    [< `three of 'res & 'p2 three * 'p1 one | `two of 'res & 'p2 * 'p1 z ]
+  constraint 'a = 'p1 * 'p2
+type (+'dim, +'rank) t
+type +'c scalar = ('a one, 'b z) t constraint 'c = 'a * 'b
+type +'c vec2 = ('a two, 'b one) t constraint 'c = 'a * 'b
+module type Vec =
+  sig
+    val scalar : k -> ('a * 'b) scalar
+    val vec2 : k -> k -> ('a * 'b) vec2
+    val ( + ) :
+      ('dim1,
+       ([< `one of
+             'rank2 &
+             [< `one of 'rank3 * 'dim1 * 'dim3 & 'a one * 'dim2 * 'dim2
+              | `zero of 'rank3 * 'dim3 & 'a one * 'dim1 ]
+         | `two of
+             'rank2 &
+             [< `two of 'rank3 * 'dim1 * 'dim3 & 'a two * 'dim1 * 'dim3
+              | `zero of 'rank3 * 'dim3 & 'a two * 'dim1 ]
+         | `zero of
+             'rank2 &
+             [< `one of 'rank3 * 'dim3 & 'a one * 'dim2
+              | `two of 'rank3 * 'dim3 & 'a two * 'dim2
+              | `zero of 'rank3 * 'dim3 & 'a z * 'b one ] ],
+        'rank2, 'rank3, 'dim1, 'dim2, 'dim3, 'a * 'b * 'c)
+       sum)
+      t -> ('dim2, 'rank2) t -> ('dim3, 'rank3) t
+    val cross :
+      (([< `three of 'dim2 * 'rank2 & 'a three * 'b one
+         | `two of 'dim2 * 'rank2 & 'a * 'b z ]
+        as 'dim, 'dim2 * 'rank2, 'b * 'a)
+       cross, 'c one)
+      t -> ('dim, 'd one) t -> ('dim2, 'rank2) t
+  end
+module F :
+  (V : Vec) ->
+    sig
+      val fn :
+        ([< `three of
+              'b *
+              ([< `one of
+                    'd z &
+                    [< `one of 'e * 'b * 'f & 'g one * 'h one * 'h one
+                     | `zero of 'e * 'f & 'g one * 'b ] &
+                    [< `one of 'e * 'b * 'f & 'g one * 'h one * 'h one
+                     | `zero of 'e * 'f & 'g one * 'b ] &
+                    [< `one of 'e * 'b * 'f & 'g one * 'h one * 'h one
+                     | `zero of 'e * 'f & 'g one * 'b ]
+                | `two of
+                    'd z &
+                    [< `two of 'e * 'b * 'f & 'g two * 'b * 'f
+                     | `zero of 'e * 'f & 'g two * 'b ] &
+                    [< `two of 'e * 'b * 'f & 'g two * 'b * 'f
+                     | `zero of 'e * 'f & 'g two * 'b ] &
+                    [< `two of 'e * 'b * 'f & 'g two * 'b * 'f
+                     | `zero of 'e * 'f & 'g two * 'b ]
+                | `zero of
+                    'd z &
+                    [< `one of 'e * 'f & 'g one * 'h one
+                     | `two of 'e * 'f & 'g two * 'h one
+                     | `zero of 'e * 'f & 'g z * 'i one ] &
+                    [< `one of 'e * 'f & 'g one * 'h one
+                     | `two of 'e * 'f & 'g two * 'h one
+                     | `zero of 'e * 'f & 'g z * 'i one ] &
+                    [< `one of 'e * 'f & 'g one * 'h one
+                     | `two of 'e * 'f & 'g two * 'h one
+                     | `zero of 'e * 'f & 'g z * 'i one ] ]
+               as 'c) &
+              'j three * 'k one
+          | `two of 'b * 'c & 'j * 'k z ]
+         as 'a, 'l one)
+        t -> ('a, 'm one) t -> ('f, 'e) t
+      val loop : ('a one, 'b z) t
+    end
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -926,7 +926,8 @@ let rec check_level_type_rec visited level ty =
 
 let check_level_type level ty = check_level_type_rec [] level ty
 
-let rec update_level env level expand ty =
+let rec update_level env level expand mark ty =
+  if try_mark_node mark ty then
   let ty_level = get_level ty in
   if ty_level > level then begin
     if level < get_scope ty then raise_scope_escape_exn ty;
@@ -942,7 +943,7 @@ let rec update_level env level expand ty =
         begin try
           let ty' = !forward_try_expand_safe env ty in
           link_type ty ty';
-          update_level env level expand ty
+          update_level env level expand mark ty
         with Cannot_expand ->
           raise_escape_exn (Constructor p)
         end
@@ -953,20 +954,20 @@ let rec update_level env level expand ty =
           if not needs_expand then raise Cannot_expand;
           let ty' = !forward_try_expand_safe env ty in
           link_type ty ty';
-          update_level env level expand ty
+          update_level env level expand mark ty
         with Cannot_expand ->
           set_level ();
-          iter_type_expr (update_level env level expand) ty;
-          update_level_abbrev env level expand ty
+          iter_type_expr (update_level env level expand mark) ty;
+          update_level_abbrev env level expand mark ty
         end
     | Tpackage pack when level < Path.scope pack.pack_path ->
         let pack_path = normalize_or_raise_escape env pack.pack_path in
         set_type_desc ty (Tpackage {pack with pack_path});
-        update_level env level expand ty
+        update_level env level expand mark ty
     | Tobject (_, ({contents=Some(p, _tl)} as nm))
       when level < Path.scope p ->
         set_name nm None;
-        update_level env level expand ty
+        update_level env level expand mark ty
     | Tvariant row ->
         begin match row_name row with
         | Some (p, _tl) when level < Path.scope p ->
@@ -974,38 +975,41 @@ let rec update_level env level expand ty =
         | _ -> ()
         end;
         set_level ();
-        iter_type_expr (update_level env level expand) ty;
-        update_level_abbrev env level expand ty
+        iter_type_expr (update_level env level expand mark) ty;
+        update_level_abbrev env level expand mark ty
     | Tfunctor (lbl, id, pack, t) when level < Path.scope pack.pack_path ->
         let pack_path = normalize_or_raise_escape env pack.pack_path in
         set_type_desc ty (Tfunctor (lbl, id, {pack with pack_path}, t));
-        update_level env level expand ty
+        update_level env level expand mark ty
     | Tfunctor (_, id, pack, t) ->
-        List.iter (fun (_, t) -> update_level env level expand t)
+        List.iter (fun (_, t) -> update_level env level expand mark t)
           pack.pack_constraints;
         let mty = modtype_of_package env Location.none pack in
         let env = Env.add_module (Ident.of_unscoped id) Mp_present mty env in
         set_level ();
-        update_level env level expand t
+        update_level env level expand mark t
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && level < get_scope ty1 ->
         raise_escape_exn Self
     | _ ->
         set_level ();
         (* XXX what about abbreviations in Tconstr ? *)
-        iter_type_expr (update_level env level expand) ty;
-        update_level_abbrev env level expand ty
+        iter_type_expr (update_level env level expand mark) ty;
+        update_level_abbrev env level expand mark ty
   end
-  else update_level_abbrev env level expand ty
+  else update_level_abbrev env level expand mark ty
 
-and update_level_abbrev env level expand ty =
+and update_level_abbrev env level expand mark ty =
   iter_abbrev
     (fun p args ->
       if level < Path.scope p then forget_abbrev ty else
       if List.for_all (check_level_type level) args then () else
       if expand || needs_expand env level p args then forget_abbrev ty else
-      List.iter (update_level env level expand) args)
+      List.iter (update_level env level expand mark) args)
     ty
+
+let update_level env level expand ty =
+  with_type_mark (fun mark -> update_level env level expand mark ty)
 
 let try_update_level env level ty =
   update_level env level false ty


### PR DESCRIPTION
The example in #14769 causes a loop in `update_level`:
the first argument to `sum` is the expanded type itself.
So when `update_level` is done, it sees that the type was expanded, and wants to update the abbreviation levels as well. `update_level_abbrev` updates the level of all the type arguments, and we end up at the first update level again.

I'm not sure that adding a simple "visited" check using type marks is the best approach here, or if there is another possibility, but I believe this approach is correct: any type we've already visited has its level updated, so we're okay skipping them. 