### PR TITLE
Reduce closure allocation in `Seq.(cycle, repeat, forever)`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -139,8 +139,8 @@ Runhang Li <objmagic@github>
 Dmitrii Kosarev <Kakadu@github>
 Samuel Hym <shym@github>
 B. Szilvasy <eutro@github>
-Hazem Elmasry <hyphens@pm.me>
-Hazem Elmasry <hyphenrf@github>
+Hazem Elmasry <hazem-work@riseup.net> <hyphenrf@github>
+Hazem Elmasry <hazem-work@riseup.net> <zyptoskid@yahoo.com>
 T. Kinsart <hirrolot@gmail.com>
 
 # These contributors prefer to be referred to pseudonymously

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -288,11 +288,11 @@ let init n f =
   else
     init_aux f 0 n
 
-let rec repeat x () =
-  Cons (x, repeat x)
+let repeat x =
+  let rec tl () = Cons (x, tl) in tl
 
-let rec forever f () =
-  Cons (f(), forever f)
+let forever f =
+  let rec tl () = Cons (f(), tl) in tl
 
 (* This preliminary definition of [cycle] requires the sequence [xs]
    to be nonempty. Applying it to an empty sequence would produce a

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -298,8 +298,8 @@ let rec forever f () =
    to be nonempty. Applying it to an empty sequence would produce a
    sequence that diverges when it is forced. *)
 
-let rec cycle_nonempty xs () =
-  append xs (cycle_nonempty xs) ()
+let cycle_nonempty xs () =
+  let rec tl () = append xs tl () in tl ()
 
 (* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
    sequence. Otherwise, [cycle xs] produces one copy of [xs] followed

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -296,7 +296,8 @@ let forever f =
 
 (* This preliminary definition of [cycle] requires the sequence [xs]
    to be nonempty. Applying it to an empty sequence would produce a
-   sequence that diverges when it is forced. *)
+   sequence that diverges when it is forced.
+   The tail is defined recursively for reuse on every cycle.  *)
 
 let cycle_nonempty xs () =
   let rec tl () = append xs tl () in tl ()

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -148,6 +148,11 @@ let () =
   assert (Seq.length (Seq.take 1_000_000 seq) = 1_000_000);
   ()
 
+(* [forever] isn't too eager *)
+let () =
+  let f () = failwith "forever evaluated" in
+  ignore (Seq.forever f)
+
 (* [scan] must not invoke [f] too early. (An easy trap to fall into.)
    The function [f] does not tolerate being invoked 4 times. Indeed, in
    this example, it should be called 3 times only. *)

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -151,7 +151,7 @@ let () =
 (* [forever] isn't too eager *)
 let () =
   let f () = failwith "forever evaluated" in
-  ignore (Seq.forever f)
+  Fun.const () (Seq.forever f)
 
 (* [scan] must not invoke [f] too early. (An easy trap to fall into.)
    The function [f] does not tolerate being invoked 4 times. Indeed, in

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -74,6 +74,13 @@ let () =
   let xs = Seq.(take 7 (cycle !?[1;2;3])) in
   assert (!!xs = [1;2;3;1;2;3;1])
 
+(* [cycle] doesn't repeat or cache computations *)
+let () =
+  let forces = ref 0 in
+  let xs () = incr forces; Seq.return 1 () in
+  let length = Seq.(length (take 3 (cycle xs))) in
+  assert (length = !forces)
+
 (* [iterate] *)
 let () =
   let f x = x + 7 in


### PR DESCRIPTION
Hello, this is a minor performance improvement for the aforementioned functions. I've noticed that `cycle` needlessly allocated closures on the recursive calls, then noticed the same pattern is present in `forever` and `repeat`. Now I pass a reference to the tail wherever applicable. I've also added tests to ensure I'm not accidentally doing recomputations or skipping computations.

Benchmarks show consistent improvements for draining all sequences starting at 2 elements. taking just the head either allocates less or the same (unsure why the measurement is 1-word inconsistent with that one). Benchmark code is [here](https://gist.github.com/hyphenrf/67e1163a5abb5e6197aae8d62661214c) for scrutiny, and here are the results:
```
cycle-old	n=1	words=42	words/elem=42.00
cycle-new	n=1	words=41	words/elem=41.00
repeat-old	n=1	words=33	words/elem=33.00
repeat-new	n=1	words=28	words/elem=28.00
forever-old	n=1	words=33	words/elem=33.00
forever-new	n=1	words=28	words/elem=28.00

cycle-old	n=2	words=59	words/elem=29.50
cycle-new	n=2	words=53	words/elem=26.50
repeat-old	n=2	words=41	words/elem=20.50
repeat-new	n=2	words=31	words/elem=15.50
forever-old	n=2	words=41	words/elem=20.50
forever-new	n=2	words=31	words/elem=15.50

cycle-old	n=10	words=195	words/elem=19.50
cycle-new	n=10	words=149	words/elem=14.90
repeat-old	n=10	words=105	words/elem=10.50
repeat-new	n=10	words=55	words/elem=5.50
forever-old	n=10	words=105	words/elem=10.50
forever-new	n=10	words=55	words/elem=5.50

cycle-old	n=100	words=1725	words/elem=17.25
cycle-new	n=100	words=1229	words/elem=12.29
repeat-old	n=100	words=825	words/elem=8.25
repeat-new	n=100	words=325	words/elem=3.25
forever-old	n=100	words=825	words/elem=8.25
forever-new	n=100	words=325	words/elem=3.25

cycle-old	n=1000	words=17025	words/elem=17.02
cycle-new	n=1000	words=12029	words/elem=12.03
repeat-old	n=1000	words=8025	words/elem=8.03
repeat-new	n=1000	words=3025	words/elem=3.02
forever-old	n=1000	words=8025	words/elem=8.03
forever-new	n=1000	words=3025	words/elem=3.02

cycle-old	n=10000	words=170025	words/elem=17.00
cycle-new	n=10000	words=120029	words/elem=12.00
repeat-old	n=10000	words=80025	words/elem=8.00
repeat-new	n=10000	words=30025	words/elem=3.00
forever-old	n=10000	words=80025	words/elem=8.00
forever-new	n=10000	words=30025	words/elem=3.00
```
I believe `repeat` and `forever` are allocating their optimal minimum.

It's possible to review the changes in this PR all as one unit.

CC: @c-cube 