### PR TITLE
Make Seq.repeat constant-space

### DIFF
--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -289,7 +289,7 @@ let init n f =
     init_aux f 0 n
 
 let repeat x =
-  let rec tl () = Cons (x, tl) in tl
+  let rec tl () = c and c = Cons (x, tl) in tl
 
 let forever f =
   let rec tl () = Cons (f(), tl) in tl


### PR DESCRIPTION
A single cycle of one closure and one cons cell is enough for `Seq.repeat`.  Using @hyphenrf's benchmarks from #14781 shows the space improvement:

```
repeat-old     	n=1	words=32	words/elem=32.00
repeat-new     	n=1	words=27	words/elem=27.00
repeat-constant	n=1	words=24	words/elem=24.00

repeat-old     	n=2	words=40	words/elem=20.00
repeat-new     	n=2	words=30	words/elem=15.00
repeat-constant	n=2	words=24	words/elem=12.00

repeat-old     	n=10	words=104	words/elem=10.40
repeat-new     	n=10	words=54	words/elem=5.40
repeat-constant	n=10	words=24	words/elem=2.40

repeat-old     	n=100	words=824	words/elem=8.24
repeat-new     	n=100	words=324	words/elem=3.24
repeat-constant	n=100	words=24	words/elem=0.24

repeat-old     	n=1000	words=8024	words/elem=8.02
repeat-new     	n=1000	words=3024	words/elem=3.02
repeat-constant	n=1000	words=24	words/elem=0.02

repeat-old     	n=10000	words=80024	words/elem=8.00
repeat-new     	n=10000	words=30024	words/elem=3.00
repeat-constant	n=10000	words=24	words/elem=0.00
```

Here `repeat-old` is the pre-#14781 implementation that allocates a closure and a cons cell for each element, `repeat-new` is the #14781 implementation that allocates a cons cell for each element, and `repeat-constant` is the implementation in this PR that allocates a single cons cell and a single closure for the whole (cyclic) sequence.