### PR TITLE
Make Seq.cycle create a cyclic sequence

### DIFF
--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -296,23 +296,25 @@ let forever f =
 
 (* This preliminary definition of [cycle] requires the sequence [xs]
    to be nonempty. Applying it to an empty sequence would produce a
-   sequence that diverges when it is forced.
-   The tail is defined recursively for reuse on every cycle.  *)
-
-let cycle_nonempty xs () =
-  let rec tl () = append xs tl () in tl ()
+   sequence that diverges when it is forced.  *)
 
 (* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
-   sequence. Otherwise, [cycle xs] produces one copy of [xs] followed
-   with the infinite sequence [cycle_nonempty xs]. Thus, the nonemptiness
-   check is performed just once. *)
+   sequence. Otherwise, [cycle xs] produces one copy of [xs] whose
+   final Cons points back to the initial element. *)
 
+let lazy_to_fun l () = Lazy.force l
+
+let rec loop init xs =
+  match xs () with
+  | Nil -> Lazy.force init
+  | Cons (x, xs') -> Cons (x, lazy_to_fun (lazy (loop init xs')))
+                   
 let cycle xs () =
-  match xs() with
-  | Nil ->
-      Nil
-  | Cons (x, xs') ->
-      Cons (x, append xs' (cycle_nonempty xs))
+  match xs () with
+  | Nil -> Nil
+  | Cons (x, xs') -> let rec lseq = lazy (Cons (x, lazy_to_fun ltail))
+                         and ltail = lazy (loop lseq xs') in
+                      Lazy.force lseq
 
 (* [iterate1 f x] is the sequence [f x, f (f x), ...].
    It is equivalent to [tail (iterate f x)].

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -294,28 +294,6 @@ let repeat x =
 let forever f =
   let rec tl () = Cons (f(), tl) in tl
 
-(* This preliminary definition of [cycle] requires the sequence [xs]
-   to be nonempty. Applying it to an empty sequence would produce a
-   sequence that diverges when it is forced.  *)
-
-(* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
-   sequence. Otherwise, [cycle xs] produces one copy of [xs] whose
-   final Cons points back to the initial element. *)
-
-let lazy_to_fun l () = Lazy.force l
-
-let rec loop init xs =
-  match xs () with
-  | Nil -> Lazy.force init
-  | Cons (x, xs') -> Cons (x, lazy_to_fun (lazy (loop init xs')))
-                   
-let cycle xs () =
-  match xs () with
-  | Nil -> Nil
-  | Cons (x, xs') -> let rec lseq = lazy (Cons (x, lazy_to_fun ltail))
-                         and ltail = lazy (loop lseq xs') in
-                      Lazy.force lseq
-
 (* [iterate1 f x] is the sequence [f x, f (f x), ...].
    It is equivalent to [tail (iterate f x)].
    [iterate1] is used as a building block in the definition of [iterate]. *)
@@ -490,6 +468,24 @@ let rec once xs =
     | Cons (x, xs) ->
         Cons (x, once xs)
   )
+
+(* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
+   sequence. Otherwise, [cycle xs] produces one copy of [xs] whose
+   final Cons points back to the initial element. *)
+let rec loop hd tl =
+  Suspension.memoize (fun () ->
+    match tl () with
+    | Nil -> Lazy.force hd
+    | Cons (x, xs) -> Cons (x, loop hd xs)
+  )
+
+
+let cycle xs () =
+  match xs () with
+  | Nil -> Nil
+  | Cons (x, xs) ->
+      let rec hd = lazy (Cons (x, loop hd xs)) in
+      Lazy.force hd
 
 
 let rec zip xs ys () =

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -413,7 +413,7 @@ val forever : (unit -> 'a) -> 'a t
     @since 4.14 *)
 
 val cycle : 'a t -> 'a t
-(** [cycle xs] is the infinite sequence that consists of an infinite
+(** [cycle xs] is the cyclic sequence that consists of an infinite
     number of repetitions of the sequence [xs].
 
     If [xs] is an empty sequence,

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -413,15 +413,19 @@ val forever : (unit -> 'a) -> 'a t
     @since 4.14 *)
 
 val cycle : 'a t -> 'a t
-(** [cycle xs] is the cyclic sequence that consists of an infinite
-    number of repetitions of the sequence [xs].
+(** [cycle xs] is the cyclic sequence that encodes an infinite number
+    of repetitions of the sequence [xs].
 
     If [xs] is an empty sequence,
     then [cycle xs] is empty as well.
 
-    Consuming (a prefix of) the sequence [cycle xs] once
-    can cause the sequence [xs] to be consumed more than once.
-    Therefore, [xs] must be persistent.
+    If [xs] is an ephemeral sequence,
+    then [cycle xs] will not query the elements of [xs] more than once.
+
+    Querying elements from [cycle xs] is not thread-safe.
+    See {!memoize}.
+
+    [cycle xs] is equivalent to [append (memoize xs) (cycle xs)]
 
     @since 4.14 *)
 

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -74,6 +74,14 @@ let () =
   let xs = Seq.(take 7 (cycle !?[1;2;3])) in
   assert (!!xs = [1;2;3;1;2;3;1])
 
+(* [cycle] doesn't repeat computations *)
+let () =
+  let forces = ref 0 in
+  let counts = (fun _ -> incr forces; !forces) in
+  let xs = Seq.(take 4 (cycle (init 3 counts))) in
+  assert (!!xs = [1;2;3;1]);
+  assert (!forces = 3)
+
 (* [iterate] *)
 let () =
   let f x = x + 7 in

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -74,13 +74,6 @@ let () =
   let xs = Seq.(take 7 (cycle !?[1;2;3])) in
   assert (!!xs = [1;2;3;1;2;3;1])
 
-(* [cycle] doesn't repeat or cache computations *)
-let () =
-  let forces = ref 0 in
-  let xs () = incr forces; Seq.return 1 () in
-  let length = Seq.(length (take 3 (cycle xs))) in
-  assert (length = !forces)
-
 (* [iterate] *)
 let () =
   let f x = x + 7 in


### PR DESCRIPTION
Make `Seq.cycle` create a cyclic sequence rather than an infinite sequence.

Using @hyphenrf's benchmarks from https://github.com/ocaml/ocaml/pull/14781 shows the space improvement:

```
cycle-old		n=1	words=41	words/elem=41.00
cycle-new		n=1	words=40	words/elem=40.00
cycle-cyclic	n=1	words=38	words/elem=38.00

cycle-old		n=2	words=58	words/elem=29.00
cycle-new		n=2	words=52	words/elem=26.00
cycle-cyclic	n=2	words=38	words/elem=19.00

cycle-old		n=10	words=194	words/elem=19.40
cycle-new		n=10	words=148	words/elem=14.80
cycle-cyclic	n=10	words=38	words/elem=3.80

cycle-old		n=100	words=1724	words/elem=17.24
cycle-new		n=100	words=1228	words/elem=12.28
cycle-cyclic	n=100	words=38	words/elem=0.38

cycle-old		n=1000	words=17024		words/elem=17.02
cycle-new		n=1000	words=12028		words/elem=12.03
cycle-cyclic	n=1000	words=38		words/elem=0.04

cycle-old		n=10000	words=170024	words/elem=17.00
cycle-new		n=10000	words=120028	words/elem=12.00
cycle-cyclic	n=10000	words=38		words/elem=0.00
```

Here `cycle-old` is the pre-https://github.com/ocaml/ocaml/pull/14781 implementation, `cycle-new` is the https://github.com/ocaml/ocaml/pull/14781, and `cycle-cyclic` is the implementation in this PR.

I've removed the test that checks that "[cycle] doesn't repeat or cache computations" because the new implementation of `cycle` does avoid unnecessary recomputation.  The new behaviour seems in line with the existing documentation string, which says

>  Consuming (a prefix of) the sequence [cycle xs] once can cause the sequence [xs] to be consumed more than once. Therefore, [xs] must be persistent.
