### PR TITLE
Cyclic Seq.cycle: second attempt (with memoization)

### DIFF
--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -296,23 +296,20 @@ let forever f =
 
 (* This preliminary definition of [cycle] requires the sequence [xs]
    to be nonempty. Applying it to an empty sequence would produce a
-   sequence that diverges when it is forced.
-   The tail is defined recursively for reuse on every cycle.  *)
-
-let cycle_nonempty xs () =
-  let rec tl () = append xs tl () in tl ()
+   sequence that diverges when it is forced.  *)
 
 (* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
-   sequence. Otherwise, [cycle xs] produces one copy of [xs] followed
-   with the infinite sequence [cycle_nonempty xs]. Thus, the nonemptiness
-   check is performed just once. *)
+   sequence. Otherwise, [cycle xs] produces one copy of [xs] whose
+   final Cons points back to the initial element. *)
+let rec loop init xs =
+  match xs () with
+  | Nil -> init
+  | Cons (x, xs') -> Cons (x, fun () -> loop init xs')
 
 let cycle xs () =
-  match xs() with
-  | Nil ->
-      Nil
-  | Cons (x, xs') ->
-      Cons (x, append xs' (cycle_nonempty xs))
+  match xs () with
+  | Nil -> Nil
+  | Cons (x, xs') -> let rec init = Cons (x, fun () -> loop init xs') in init
 
 (* [iterate1 f x] is the sequence [f x, f (f x), ...].
    It is equivalent to [tail (iterate f x)].

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -294,23 +294,6 @@ let repeat x =
 let forever f =
   let rec tl () = Cons (f(), tl) in tl
 
-(* This preliminary definition of [cycle] requires the sequence [xs]
-   to be nonempty. Applying it to an empty sequence would produce a
-   sequence that diverges when it is forced.  *)
-
-(* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
-   sequence. Otherwise, [cycle xs] produces one copy of [xs] whose
-   final Cons points back to the initial element. *)
-let rec loop init xs =
-  match xs () with
-  | Nil -> init
-  | Cons (x, xs') -> Cons (x, fun () -> loop init xs')
-
-let cycle xs () =
-  match xs () with
-  | Nil -> Nil
-  | Cons (x, xs') -> let rec init = Cons (x, fun () -> loop init xs') in init
-
 (* [iterate1 f x] is the sequence [f x, f (f x), ...].
    It is equivalent to [tail (iterate f x)].
    [iterate1] is used as a building block in the definition of [iterate]. *)
@@ -485,6 +468,26 @@ let rec once xs =
     | Cons (x, xs) ->
         Cons (x, once xs)
   )
+
+(* This preliminary definition for [cycle] passes the head [hd] through to be
+   tied back at the tail of the sequence [tl]. *)
+
+let rec loop hd tl =
+  Suspension.memoize (fun () ->
+    match tl () with
+    | Nil -> Lazy.force hd
+    | Cons (x, xs) -> Cons (x, loop hd xs)
+  )
+
+(* [cycle xs] produces one memoized and cyclical copy of [xs]. [hd] must be
+   guarded so as to not raise [Lazy.Undefined]. *)
+
+let cycle xs () =
+  match xs () with
+  | Nil -> Nil
+  | Cons (x, xs) ->
+      let rec hd = lazy (Cons (x, loop hd xs)) in
+      Lazy.force hd
 
 
 let rec zip xs ys () =

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -413,7 +413,7 @@ val forever : (unit -> 'a) -> 'a t
     @since 4.14 *)
 
 val cycle : 'a t -> 'a t
-(** [cycle xs] is the infinite sequence that consists of an infinite
+(** [cycle xs] is the cyclic sequence that consists of an infinite
     number of repetitions of the sequence [xs].
 
     If [xs] is an empty sequence,

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -413,15 +413,19 @@ val forever : (unit -> 'a) -> 'a t
     @since 4.14 *)
 
 val cycle : 'a t -> 'a t
-(** [cycle xs] is the cyclic sequence that consists of an infinite
-    number of repetitions of the sequence [xs].
+(** [cycle xs] is the cyclic sequence that encodes an infinite number
+    of repetitions of the sequence [xs].
 
     If [xs] is an empty sequence,
     then [cycle xs] is empty as well.
 
-    Consuming (a prefix of) the sequence [cycle xs] once
-    can cause the sequence [xs] to be consumed more than once.
-    Therefore, [xs] must be persistent.
+    If [xs] is an ephemeral sequence,
+    then [cycle xs] will not query the elements of [xs] more than once.
+
+    Querying elements from [cycle xs] is not thread-safe.
+    See {!memoize}.
+
+    [cycle xs] is equivalent to [append (memoize xs) (cycle xs)]
 
     @since 4.14 *)
 

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -74,6 +74,14 @@ let () =
   let xs = Seq.(take 7 (cycle !?[1;2;3])) in
   assert (!!xs = [1;2;3;1;2;3;1])
 
+(* [cycle] doesn't repeat computations *)
+let () =
+  let forces = ref 0 in
+  let counts = (fun _ -> incr forces; !forces) in
+  let xs = Seq.(take 4 (cycle (init 3 counts))) in
+  assert (!!xs = [1;2;3;1]);
+  assert (!forces = 3)
+
 (* [iterate] *)
 let () =
   let f x = x + 7 in

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -74,13 +74,6 @@ let () =
   let xs = Seq.(take 7 (cycle !?[1;2;3])) in
   assert (!!xs = [1;2;3;1;2;3;1])
 
-(* [cycle] doesn't repeat or cache computations *)
-let () =
-  let forces = ref 0 in
-  let xs () = incr forces; Seq.return 1 () in
-  let length = Seq.(length (take 3 (cycle xs))) in
-  assert (length = !forces)
-
 (* [iterate] *)
 let () =
   let f x = x + 7 in


### PR DESCRIPTION
building on @yallop 's implementation, the arguments I made in https://github.com/ocaml/ocaml/pull/14784#issuecomment-4363308820, and the comment @lthls made https://github.com/ocaml/ocaml/pull/14784#issuecomment-4363472753 regarding inconsistency, this is an attempt to make `Seq.cycle` both cyclical and consistent in behaviour.

Benchmarks were edited to allocate `m` number of items instead of a singleton, and to remove the polluting `Gc.stat` object allocations. New version is on the same gist [here](https://gist.github.com/hyphenrf/67e1163a5abb5e6197aae8d62661214c), and `cycle-old` is the current trunk's implementation from #14781.

```
original seq contains 10 elements

n = 0
drain-id	words=05	words/elem=inf
cycle-old	words=05	words/elem=inf
cycle-mem	words=16	words/elem=inf
cycle-cyc	words=05	words/elem=inf

n = 5
drain-id	words=60	words/elem=12.00
cycle-old	words=70	words/elem=14.00
cycle-mem	words=151	words/elem=30.20
cycle-cyc	words=106	words/elem=21.20

n = 10
drain-id	words=115	words/elem=11.50
cycle-old	words=130	words/elem=13.00
cycle-mem	words=281	words/elem=28.10
cycle-cyc	words=196	words/elem=19.60

n = 15
drain-id	words=115	words/elem=7.67
cycle-old	words=195	words/elem=13.00
cycle-mem	words=331	words/elem=22.07
cycle-cyc	words=196	words/elem=13.07

n = 100
drain-id	words=115	words/elem=1.15
cycle-old	words=1215	words/elem=12.15
cycle-mem	words=1096	words/elem=10.96
cycle-cyc	words=196	words/elem=1.96

n = 1000
drain-id	words=115	words/elem=0.12
cycle-old	words=12015	words/elem=12.02
cycle-mem	words=9196	words/elem=9.20
cycle-cyc	words=196	words/elem=0.20

n = 10000
drain-id	words=115	words/elem=0.01
cycle-old	words=120015	words/elem=12.00
cycle-mem	words=90196	words/elem=9.02
cycle-cyc	words=196	words/elem=0.02
```
1-elem for direct comparison with #14781
```
original seq contains 1 elements

n = 10000
drain-id	words=16	words/elem=0.00
cycle-old	words=120015	words/elem=12.00
cycle-mem	words=90043	words/elem=9.00
cycle-cyc	words=34	words/elem=0.00
```
Notice that the noise from calls to `Gc.stat` is removed here

Test was updated to reflect the change (note that originally the test was counting the number of rounds, now it needed to count the number of evaluated elements), so was the docstring (the equivalence relies on the nil case being specificed directly)

As can be seen above, it is some 50% heavier because of memoization on the first run, then afterwards it hits the desired amortized O(1) allocation. Cycle would make little sense when applied to a sequence then only demanded a prefix of that sequence, because demanding a prefix would never hit a cycle, so it could be said that this is an overall improvement for cycle in all cases it is properly used, and most visibly so for small sequences demanded a large amount.