### PR TITLE
Update GHA dependencies

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout OCaml
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Configure, build and install OCaml
@@ -60,7 +60,7 @@ jobs:
           cd "$HOME"
           tar caf /tmp/ocaml.tar.zst .local
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: non-cross-ocaml
           path: /tmp/ocaml.tar.zst
@@ -71,7 +71,7 @@ jobs:
     needs: non-cross
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: non-cross-ocaml
       - name: Install non-cross OCaml and set up environment
@@ -83,7 +83,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64-x86-64
       - name: Checkout OCaml
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
           persist-credentials: false
@@ -113,7 +113,7 @@ jobs:
           cat example.ml
           $HOME/cross/bin/ocamlopt.opt.exe -I $HOME/cross/lib/ocaml/compiler-libs/ ocamlcommon.cmxa ocamloptcomp.cmxa example.ml -o example.exe -verbose
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-executable
           path: example.exe
@@ -133,7 +133,7 @@ jobs:
     needs: cross-windows
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-executable
       - name: Run example program
@@ -145,7 +145,7 @@ jobs:
     needs: non-cross
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: non-cross-ocaml
       - name: Install non-cross OCaml and set up environment
@@ -157,7 +157,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-aarch64-linux-gnu qemu-user
       - name: Checkout OCaml
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
           persist-credentials: false
@@ -206,7 +206,7 @@ jobs:
       API_LEVEL: 21
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: non-cross-ocaml
       - name: Install non-cross OCaml
@@ -216,7 +216,7 @@ jobs:
           rm -f ocaml.tar.zst
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Restore the Android NDK from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: |
@@ -232,14 +232,14 @@ jobs:
           rm android-ndk-$NDK-linux.zip
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Save the Android NDK to cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             /home/runner/android
           key: android-ndk-${{ env.NDK }}
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Checkout OCaml
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Configure, build and install Linux-to-Android OCaml

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Compute matrix for the "build" job
         id: matrix
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // # Always test cl and clang-cl
@@ -65,7 +65,7 @@ jobs:
             return {os: ['windows-latest'], prefix: ['$PROGRAMFILES/Бактріан🐫'], opam: ['false'], config_arg: [''], arch: ['x86_64'], cc: compilers, libdir: libdir, include: include};
       - name: Determine if the testsuite should be skipped
         id: skip
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             let skip_testsuite = false;
@@ -95,25 +95,25 @@ jobs:
     steps:
 
       - name: Fetch OCaml
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Restore Cygwin cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             C:\cygwin-packages
           key: cygwin-packages
 
       - name: Install Cygwin
-        uses: cygwin/cygwin-install-action@v3
+        uses: cygwin/cygwin-install-action@v6
         with:
           packages: make,${{ matrix.cc != 'gcc' && 'mingw64-x86_64-' || 'gcc-g++,gcc-fortran,' }}gcc-core,rsync,unzip
           install-dir: 'D:\cygwin'
 
       - name: Save Cygwin cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             C:\cygwin-packages
@@ -140,7 +140,7 @@ jobs:
           echo "key=${{ env.HOST }}-${{ matrix.cc }}-${{ hashFiles('configure') }}" >> $GITHUB_OUTPUT
 
       - name: Restore Autoconf cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             config.cache
@@ -175,7 +175,7 @@ jobs:
           fi
 
       - name: Save Autoconf cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             config.cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Check for manual changes
@@ -66,7 +66,7 @@ jobs:
       - name: Prepare Artifact
         run: tar --zstd -cf /tmp/sources.tar.zstd .
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compiler
           path: /tmp/sources.tar.zstd
@@ -98,7 +98,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compiler
       - name: Unpack Artifact
@@ -169,7 +169,7 @@ jobs:
     steps:
       - name: Record if the build matrix is expanded
         id: full
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             let full_matrix = false;
@@ -182,7 +182,7 @@ jobs:
             return full_matrix;
       - name: Compute matrix for the "others" job
         id: jobs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // # Default jobs: Linux -O0, Linux arm64 & macOS
@@ -224,7 +224,7 @@ jobs:
             return jobs;
       - name: Determine if the testsuite should be skipped
         id: skip
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             let skip_testsuite = false;
@@ -246,7 +246,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: macOS Dependencies

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -28,7 +28,7 @@ jobs:
         # context variable.
         if: failure()
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
           persist-credentials: false

--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -25,7 +25,7 @@ jobs:
             ocamlrunparam: b,s=4096
     steps:
       - name: Checkout OCaml
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ocaml
           persist-credentials: false
@@ -33,21 +33,21 @@ jobs:
         run: |
           bash -xe ocaml/tools/ci/actions/multicoretests.sh ocaml
       - name: Checkout multicoretests
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ocaml-multicore/multicoretests
           ref: 0.11
           path: multicoretests
           persist-credentials: false
       - name: Checkout QCheck
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: c-cube/qcheck
           ref: v0.26
           path: multicoretests/qcheck
           persist-credentials: false
       - name: Checkout dune
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ocaml/dune
           ref: 3.18.2

--- a/.github/workflows/parsetree-change.yml
+++ b/.github/workflows/parsetree-change.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify ppxlib maintainers
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -28,7 +28,7 @@ jobs:
               body: 'CC @ocaml/ppxlib-dev'
             })
       - name: Label PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -29,7 +29,7 @@ jobs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Install libunwind
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare Artifact
         run: tar --zstd -cf /tmp/sources.tar.zstd .
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compiler
           path: /tmp/sources.tar.zstd
@@ -77,7 +77,7 @@ jobs:
             dependencies: libunwind-dev
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compiler
       - name: Unpack Artifact


### PR DESCRIPTION
Avoid warnings about outdated Node and whatsoever in CI runs. AFAICT we're not affected by any breaking or non-breaking change to these actions.  
no change entry needed