### PR TITLE
win32: map ERROR_DIRECTORY to ENOTDIR

### DIFF
--- a/Changes
+++ b/Changes
@@ -154,7 +154,8 @@ Working version
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to
   `ENOTDIR` instead of `EUNKNOWNERR(-267)` when raised by functions in the
   `Unix` module (eg `Unix.opendir`).
-  (Nicolás Ojeda Bär, report by Adrián Montesinos González)
+  (Nicolás Ojeda Bär, report by Adrián Montesinos González, review by Gabriel
+  Scherer)
 
 ### Tools:
 

--- a/Changes
+++ b/Changes
@@ -151,6 +151,11 @@ Working version
 
 ### Other libraries:
 
+* #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to
+  `ENOTDIR` instead of `EUNKNOWNERR(-267)` when raised by functions in the
+  `Unix` module (eg `Unix.opendir`).
+  (Nicolás Ojeda Bär, report by Adrián Montesinos González)
+
 ### Tools:
 
 - #14318, #14709, ocamldoc: use "Module_name (Library name)" rather than

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1264,6 +1264,7 @@ static const struct error_entry win_error_table[] = {
     ERROR_SHARING_BUFFER_EXCEEDED - ERROR_WRITE_PROTECT,
     EACCES },
   { ERROR_PRIVILEGE_NOT_HELD, 0, EPERM},
+  { ERROR_DIRECTORY, 0, ENOTDIR },
   { WSAEINVAL, 0, EINVAL },
   { WSAEACCES, 0, EACCES },
   { WSAEBADF, 0, EBADF },


### PR DESCRIPTION
Fixes #14767.

This is technically a breaking change.