### PR TITLE
#11922, typechecking: check scope escape for `build_as_type`

### DIFF
--- a/Changes
+++ b/Changes
@@ -271,6 +271,10 @@ Working version
   counter-example search space.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #11922, #14789: fix a missing scope escape error message when a pattern alias
+  captured local types from under an or-pattern.
+  (Florian Angeletti, report by Richard Eisenberg, review by Jacques Garrigue)
+
 OCaml 5.5.0
 -----------
 

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -768,3 +768,40 @@ Error: This pattern matches values of type "$a"
        The type constructor "$a" would escape its scope
        Hint: "$a" is an existential type bound by the constructor "A".
 |}]
+
+(* Test as-patterns capturing whole or-patterns *)
+
+type _ t = A : 'ca -> (char * 'ca) t
+
+let f (type abs): abs t option -> abs -> bool = function
+| Some A _ | None as x -> fun (c,_) -> c = '0'
+[%%expect {|
+type _ t = A : 'ca -> (char * 'ca) t
+Line 4, characters 2-17:
+4 | | Some A _ | None as x -> fun (c,_) -> c = '0'
+      ^^^^^^^^^^^^^^^
+Error: This pattern matches values of type "(char * $0) t option"
+       The type constructor "$0" would escape its scope
+|}]
+
+type _ t1 =
+  | A : 'a -> [> `A of 'a ] t1
+  | B : 'a -> [> `B of 'a ] t1
+
+let f1 (type a) (t : [ `A of a | `B of a ] t1) = assert false
+
+type t = T : _ t1 -> t
+
+let f (T x) =
+  match x with
+  | (A _ | B _) as x -> ignore (f1 x : _)
+[%%expect {|
+type _ t1 = A : 'a -> [> `A of 'a ] t1 | B : 'a -> [> `B of 'a ] t1
+val f1 : [ `A of 'a | `B of 'a ] t1 -> 'b = <fun>
+type t = T : 'a t1 -> t
+Line 11, characters 4-15:
+11 |   | (A _ | B _) as x -> ignore (f1 x : _)
+         ^^^^^^^^^^^
+Error: This pattern matches values of type "[> `A of $1 | `B of $1 ] t1"
+       The type constructor "$1" would escape its scope
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -222,6 +222,16 @@ let not_principal fmt =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
+let check_scope_escape loc env level ty =
+  try Ctype.check_scope_escape env level ty
+  with Escape esc ->
+    (* We don't expand the type here because if we do, we might expand to the
+       type that escaped, leading to confusing error messages. *)
+    let trace = Errortrace.[Escape (map_escape trivial_expansion esc)] in
+    raise (Error(loc,
+                 env,
+                 Pattern_type_clash(Errortrace.unification_error ~trace, None)))
+
 let error_of_filter_arrow_failure ~explanation ~first ty_fun
   : filter_arrow_failure -> _ = function
   | Unification_error unif_err ->
@@ -932,10 +942,15 @@ and build_as_type_aux (env : Env.t) p =
    We could also have used [generic_level] rather than [generic_level - 10],
    but this requires much care inside [build_as_type], in particular
    [instance_unshared] would have to be modified.
+   However, we recheck the scope of the final type to make sure it is
+   usable in the current scope.
  *)
 let solve_Ppat_alias env pat =
-  with_local_level_generalize (fun () ->
-    with_level ~level:(generic_level - 10) (fun () -> build_as_type env pat))
+  let ty = with_local_level_generalize (fun () ->
+      with_level ~level:(generic_level - 10) (fun () -> build_as_type env pat))
+  in
+  check_scope_escape pat.pat_loc env (get_current_level ()) ty;
+  ty
 
 (* Extracts the first element from a list matching a label. Roughly:
      pat <- List.assoc_opt label patl;
@@ -1792,17 +1807,6 @@ let rec has_literal_pattern p = match p.ppat_desc with
   | Ppat_effect (p, q)
   | Ppat_or (p, q) ->
      has_literal_pattern p || has_literal_pattern q
-
-let check_scope_escape loc env level ty =
-  try Ctype.check_scope_escape env level ty
-  with Escape esc ->
-    (* We don't expand the type here because if we do, we might expand to the
-       type that escaped, leading to confusing error messages. *)
-    let trace = Errortrace.[Escape (map_escape trivial_expansion esc)] in
-    raise (Error(loc,
-                 env,
-                 Pattern_type_clash(Errortrace.unification_error ~trace, None)))
-
 
 (** The typedtree has two distinct syntactic categories for patterns,
    "value" patterns, matching on values, and "computation" patterns


### PR DESCRIPTION
This PR proposes to fix the uncaught exception errors in #11922 by adding a scope escape check on the type 
build by `build_as_type` in `solve_Ppat_alias`.

As far as I can see, this specific issue requires that:

- a branch of an or-pattern adds an equation to the environment
- a wild pattern captures part of this equation
- the other branches of the or-patterns avoid the type introduced by the equation
- the whole or-pattern is captured by an `as`-alias.

For instance
```ocaml
type _ t = A : 'ca -> (char * 'ca) t

let f (type abs): abs t option -> unit = function
| (Some A _ | None) as x -> ()
```


When those four elements are aligned, the function `build_as_type` generates a type which contains an instance of the type of the wild pattern which has been reified to a local type with a scope limited to the or-pattern.
(For instance, the type of `x` in the example above is `(char * $0) t option` with the scope of $0 limited to the or-pattern.)

At this point, there is no scope escape error inside `build_as_type` because `build_as_type` temporarily disables 
the scope escape check in order to be able to handle existential types in branches of or-patterns. And this mismatched scope is thus only detected later on when the typechecker tries to enforce the level of pattern variables.

As a fix, this PR proposes to follow the simple path and checks that the type generated by `build_as_type` is valid in the current scope.

Fixes #11922 