### PR TITLE
Emit EV_DOMAIN_CONDITION_WAIT event only in instrumented runtime

### DIFF
--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -197,12 +197,18 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   sync_mutex mut = Mutex_val(wmut);
   sync_retcode retcode;
 
+  #ifdef CAML_INSTR
   CAML_EV_BEGIN(EV_DOMAIN_CONDITION_WAIT);
+  #else
+  #endif
   caml_enter_blocking_section();
   retcode = sync_condvar_wait(cond, mut);
   caml_leave_blocking_section();
   caml_check_error(retcode, "Condition.wait");
+  #ifdef CAML_INSTR
   CAML_EV_END(EV_DOMAIN_CONDITION_WAIT);
+  #else
+  #endif
 
   CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
EV_DOMAIN_CONDITION_WAIT is currently emitted too frequently in certain cases causing runtime events buffers to get filled up quickly. To avoid flooding while keeping it as an option when required, this runtime phase is now emitted only in the instrumented runtime

For example, using the runtime events consumer C api, I was able to probe how many of each kind were emitted while running the Infer tool (on 5.4.1). The drastic change for EV_DOMAIN_CONDITION_WAIT (42) causes the ring buffer to get flooded quickly and lose events, specifically in smaller job counts.

./infer analyze --multicore --no-report | -j 28 | -j 14
-- | -- | --
EV_MINOR_EPHE_CLEAN, // 49 | 0 | 0
EV_EMPTY_MINOR, // 48 | 762 | 620
EV_COMPACT_RELEASE, // 47 | 0 | 0
EV_COMPACT_FORWARD, // 46 | 0 | 0
EV_COMPACT_EVACUATE, // 45 | 0 | 0
EV_COMPACT, // 44 | 0 | 0
EV_DOMAIN_RESIZE_HEAP_RESERVATION, // 43 | 0 | 0
EV_DOMAIN_CONDITION_WAIT, // 42 | 53 | 46465
EV_MINOR_LOCAL_ROOTS_PROMOTE, // 41 | 19586 | 7714
EV_MINOR_REMEMBERED_SET_PROMOTE, // 40 | 19583 | 7714
EV_MINOR_REMEMBERED_SET, // 39 | 19581 | 7713
EV_MINOR_FINALIZERS_ADMIN, // 38 | 19594 | 7714
EV_MAJOR_MEMPROF_CLEAN, // 37 | 0 | 7
EV_MAJOR_FINISH_SWEEPING, // 36 | 0 | 0
EV_STW_LEADER, // 35 | 658 | 637
EV_STW_HANDLER, // 34 | 18920 | 8085
EV_STW_API_BARRIER, // 33 | 19577 | 7727
EV_MINOR_LEAVE_BARRIER, // 32 | 19587 | 7714
EV_MINOR_GLOBAL_ROOTS, // 31 | 651 | 89
EV_MINOR_FINALIZERS_OLDIFY, // 30 | 19581 | 7714
EV_MINOR_CLEAR, // 29 | 19595 | 7715
EV_MAJOR_FINISH_CYCLE, // 28 | 0 | 0
EV_MAJOR_SLICE, // 27 | 19378 | 8647
EV_MAJOR_MARK_OPPORTUNISTIC, // 26 | 0 | 0
EV_MAJOR_GC_STW, // 25 | 0 | 7
EV_MAJOR_GC_PHASE_CHANGE, // 24 | 0 | 14
EV_MAJOR_GC_CYCLE_DOMAINS, // 23 | 0 | 7
EV_MAJOR_FINISH_MARKING, // 22 | 0 | 4
EV_MAJOR_EPHE_SWEEP, // 21 | 0 | 0
EV_MAJOR_EPHE_MARK, // 20 | 0 | 0
EV_INTERRUPT_REMOTE, // 19 | 505 | 1526
EV_FINALISE_UPDATE_LAST, // 18 | 0 | 7
EV_FINALISE_UPDATE_FIRST, // 17 | 0 | 7
EV_EXPLICIT_GC_MAJOR_SLICE, // 16 | 0 | 0
EV_MINOR_FINALIZED, // 15 | 19589 | 7714
EV_MINOR_MEMPROF_CLEAN, // 14 | 19588 | 7714
EV_MINOR_MEMPROF_ROOTS, // 13 | 19581 | 7714
EV_MINOR_LOCAL_ROOTS, // 12 | 19585 | 7714
EV_MINOR, // 11 | 19580 | 7713
EV_MAJOR_MARK, // 10 | 0 | 0
EV_MAJOR_MEMPROF_ROOTS, // 9 | 0 | 7
EV_MAJOR_MARK_ROOTS, // 8 | 0 | 7
EV_MAJOR_SWEEP,  // 7 | 0 | 682
EV_MAJOR, // 6 | 19370 | 8642
EV_EXPLICIT_GC_COMPACT, // 5 | 0 | 0
EV_EXPLICIT_GC_FULL_MAJOR, // 4 | 0 | 0
EV_EXPLICIT_GC_MAJOR, // 3 | 0 | 0
EV_EXPLICIT_GC_MINOR, // 2 | 0 | 0
EV_EXPLICIT_GC_STAT, // 1 | 0 | 0
EV_EXPLICIT_GC_SET, // 0 | 0 | 0

