### PR TITLE
Add `Weak.{iter, iteri, foldi_left}`

### DIFF
--- a/Changes
+++ b/Changes
@@ -149,6 +149,15 @@ Working version
 - #14553: Add Array.fold_{left,right}2
   (Clément Pottier, review by Nicolás Ojeda Bär and Vincent Laviron)
 
+- #14792: Add `Weak.iter`, `Weak.iteri` and `Weak.foldi_left` for
+  zero-allocation iteration over weak arrays. All three are built on a
+  single C primitive `caml_weak_foldi_left` that passes each live element
+  directly to the callback without wrapping it in `option`. Also export
+  `caml_ephe_try_get_field`, a C function that retrieves an ephemeron key
+  without allocating, equivalent to `caml_ephemeron_get_key` available in
+  OCaml 4.14.x.
+  (Romain Beauxis)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -108,6 +108,13 @@ void caml_ephe_list_append_inplace(value e, value *li);
 
 value caml_ephe_list_pop(value *li);
 
+CAMLextern int caml_ephe_try_get_field(value eph, mlsize_t offset, value *key);
+/** Return 1 if the key in the ephemeron at the given offset is set.
+    Otherwise 0. When returning 1, set [*key] to the pointed value.
+
+    The value [eph] must be an ephemeron and [offset] a valid key
+    offset.
+*/
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "caml/alloc.h"
+#include "caml/callback.h"
 #include "caml/domain.h"
 #include "caml/fail.h"
 #include "caml/major_gc.h"
@@ -286,19 +287,34 @@ CAMLprim value caml_ephe_unset_data (value e)
   return caml_ephe_set_data(e, caml_ephe_none);
 }
 
+static bool ephe_try_get_field(value e, mlsize_t offset, value *dst)
+{
+  clean_field(e, offset);
+  value elt = Field(e, offset);
+
+  if (elt == caml_ephe_none)
+    return 0;
+
+  if (caml_marking_started())
+    caml_darken (Caml_state, elt, 0);
+
+  *dst = elt;
+  return 1;
+}
+
+CAMLexport int caml_ephe_try_get_field(value e, mlsize_t offset, value *dst)
+{
+  return ephe_try_get_field(e, offset, dst);
+}
+
 static value ephe_get_field (value e, mlsize_t offset)
 {
   CAMLparam1(e);
   CAMLlocal2 (res, elt);
 
-  clean_field(e, offset);
-  elt = Field(e, offset);
-
-  if (elt == caml_ephe_none) {
+  if (!ephe_try_get_field(e, offset, &elt)) {
     res = Val_none;
   } else {
-    if (caml_marking_started())
-      caml_darken (Caml_state, elt, 0);
     res = caml_alloc_small (1, Tag_some);
     Field(res, 0) = elt;
   }
@@ -467,6 +483,20 @@ CAMLprim value caml_ephe_check_key (value e, value n)
 CAMLprim value caml_weak_check (value e, value n)
 {
   return caml_ephe_check_key(e,n);
+}
+
+CAMLprim value caml_weak_foldi_left(value f, value init, value ar)
+{
+  CAMLparam3(f, init, ar);
+  CAMLlocal2(acc, elt);
+  mlsize_t sz = Wosize_val(ar);
+
+  acc = init;
+  for (mlsize_t i = CAML_EPHE_FIRST_KEY; i < sz; i++) {
+    if (!ephe_try_get_field(ar, i, &elt)) continue;
+    acc = caml_callback3(f, Val_long(i - CAML_EPHE_FIRST_KEY), acc, elt);
+  }
+  CAMLreturn(acc);
 }
 
 CAMLprim value caml_ephe_check_data (value e)

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -77,6 +77,19 @@ let fill ar ofs len x =
     done
   end
 
+external foldi_left : (int -> 'a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+  = "caml_weak_foldi_left"
+
+let iter =
+  let h _ g v = g v; g in
+  fun f t -> ignore (foldi_left h f t)
+[@@warning "-5"]
+
+let iteri =
+  let h i g v = g i v; g in
+  fun f t -> ignore (foldi_left h f t)
+[@@warning "-5"]
+
 
 (** Weak hash tables *)
 

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -98,6 +98,22 @@ val blit : 'a t -> int -> 'a t -> int -> int -> unit
    not designate a valid subarray of [ar1], or if [off2] and [len]
    do not designate a valid subarray of [ar2].*)
 
+val foldi_left : (int -> 'a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+(** [Weak.foldi_left f init ar] computes
+   [f n (... (f 1 (f 0 init x0) x1) ...) xn]
+   where [x0, ..., xn] are the full cells of [ar] and the integer
+   arguments are their indices.  Empty cells are skipped. *)
+
+val iteri : (int -> 'a -> unit) -> 'a t -> unit
+(** [Weak.iteri f ar] applies [f] to each full cell of [ar], passing
+   the index and the element.  Empty cells are skipped.
+   Does not allocate. *)
+
+val iter : ('a -> unit) -> 'a t -> unit
+(** [Weak.iter f ar] applies [f] to each full cell of [ar], in index
+   order.  Empty cells are skipped.
+   Does not allocate. *)
+
 
 (** {1 Weak hash sets} *)
 

--- a/testsuite/tests/weak-ephe-final/weak_iter_fold.ml
+++ b/testsuite/tests/weak-ephe-final/weak_iter_fold.ml
@@ -1,0 +1,68 @@
+(* TEST *)
+
+let check test b =
+  Printf.printf "%s: %s\n" test (if b then "OK" else "FAIL")
+
+(* --- iter --- *)
+
+let test_iter_empty () =
+  let w : int ref Weak.t = Weak.create 5 in
+  let count = ref 0 in
+  Weak.iter (fun _ -> incr count) w;
+  check "iter_empty" (!count = 0)
+let () = (test_iter_empty [@inlined never]) ()
+
+let test_iter_partial () =
+  let w = Weak.create 5 in
+  let v0 = ref 0 and v2 = ref 2 and v4 = ref 4 in
+  Weak.set w 0 (Some v0);
+  Weak.set w 2 (Some v2);
+  Weak.set w 4 (Some v4);
+  let seen = ref [] in
+  Weak.iter (fun v -> seen := !v :: !seen) w;
+  check "iter_partial" (List.rev !seen = [0; 2; 4]);
+  ignore (Sys.opaque_identity (v0, v2, v4))
+let () = (test_iter_partial [@inlined never]) ()
+
+(* --- iteri --- *)
+
+let test_iteri () =
+  let w = Weak.create 5 in
+  let v1 = ref 10 and v3 = ref 30 in
+  Weak.set w 1 (Some v1);
+  Weak.set w 3 (Some v3);
+  let seen = ref [] in
+  Weak.iteri (fun i v -> seen := (i, !v) :: !seen) w;
+  check "iteri" (List.rev !seen = [(1, 10); (3, 30)]);
+  ignore (Sys.opaque_identity (v1, v3))
+let () = (test_iteri [@inlined never]) ()
+
+(* --- foldi_left --- *)
+
+let test_foldi_left () =
+  let w = Weak.create 5 in
+  let v0 = ref 1 and v2 = ref 2 and v4 = ref 4 in
+  Weak.set w 0 (Some v0);
+  Weak.set w 2 (Some v2);
+  Weak.set w 4 (Some v4);
+  let sum = Weak.foldi_left (fun _ acc v -> acc + !v) 0 w in
+  check "foldi_left_sum" (sum = 7);
+  let pairs = Weak.foldi_left (fun i acc v -> acc @ [(i, !v)]) [] w in
+  check "foldi_left_indices" (pairs = [(0, 1); (2, 2); (4, 4)]);
+  ignore (Sys.opaque_identity (v0, v2, v4))
+let () = (test_foldi_left [@inlined never]) ()
+
+(* --- GC erasure --- *)
+
+let test_gc_erasure () =
+  let w = Weak.create 3 in
+  let v0 = ref 0 and v2 = ref 2 in
+  Weak.set w 0 (Some v0);
+  Weak.set w 1 (Some (ref 99)); (* no other strong reference *)
+  Weak.set w 2 (Some v2);
+  Gc.full_major ();
+  let seen = ref [] in
+  Weak.iter (fun v -> seen := !v :: !seen) w;
+  check "gc_erasure" (List.rev !seen = [0; 2]);
+  ignore (Sys.opaque_identity (v0, v2))
+let () = (test_gc_erasure [@inlined never]) ()

--- a/testsuite/tests/weak-ephe-final/weak_iter_fold.reference
+++ b/testsuite/tests/weak-ephe-final/weak_iter_fold.reference
@@ -1,0 +1,6 @@
+iter_empty: OK
+iter_partial: OK
+iteri: OK
+foldi_left_sum: OK
+foldi_left_indices: OK
+gc_erasure: OK


### PR DESCRIPTION
`Weak.foldi_left` is a C primitive that iterates over live slots in a weak array and passes each element directly to the callback without wrapping it in option, avoiding one heap allocation per live element.

`Weak.iter` and `Weak.iteri` are built on top of `Weak.foldi_left`.