### PR TITLE
modular explicits: update ocamldoc `is_function`

### DIFF
--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -118,7 +118,7 @@ let dummy_parameter_list typ =
 let is_function v =
   let rec f t =
     match Types.get_desc t with
-      Types.Tarrow _ ->
+      Types.Tarrow _ | Types.Tfunctor _ ->
         true
     | Types.Tlink t ->
         f t


### PR DESCRIPTION
This updates `ocamldoc` to consider module-dependent functions as function ... in the family of `module{_type,}_{functions,simple_values}` functions which is never used in ocamldoc (thus it is hard to know what was the intended specification of those functions).