### PR TITLE
Env: remove an unnecessary mutual recursion

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1786,7 +1786,266 @@ let module_declaration_address env id presence md =
   | Mp_present ->
       Lazy_backtrack.create_forced (Aident id)
 
-let rec components_of_module_maker
+(* Insertion of bindings by identifier + path *)
+
+let check_usage loc id uid warn tbl =
+  if not loc.Location.loc_ghost &&
+     Uid.for_actual_declaration uid &&
+     Warnings.is_active (warn "")
+  then begin
+    let name = Ident.name id in
+    if Types.Uid.Tbl.mem tbl uid then ()
+    else let used = ref false in
+    Types.Uid.Tbl.add tbl uid (fun () -> used := true);
+    if not (name = "" || name.[0] = '_' || name.[0] = '#')
+    then
+      !add_delayed_check_forward
+        (fun () -> if not !used then Location.prerr_warning loc (warn name))
+  end
+
+let check_value_name name loc =
+  (* Note: we could also check here general validity of the
+     identifier, to protect against bad identifiers forged by -pp or
+     -ppx preprocessors. *)
+  if String.length name > 0 && not
+       (Utf8_lexeme.starts_like_a_valid_identifier name) then
+    for i = 1 to String.length name - 1 do
+      if name.[i] = '#' then
+        error (Illegal_value_name(loc, name))
+    done
+
+let store_value ?check id addr decl shape env =
+  check_value_name (Ident.name id) decl.val_loc;
+  Builtin_attributes.mark_alerts_used decl.val_attributes;
+  Option.iter
+    (fun f -> check_usage decl.val_loc id decl.val_uid f !value_declarations)
+    check;
+  let vda =
+    { vda_description = decl;
+      vda_address = addr;
+      vda_shape = shape }
+  in
+  { env with
+    values = IdTbl.add id (Val_bound vda) env.values;
+    summary = Env_value(env.summary, id, decl) }
+
+let store_constructor ~check type_decl type_id cstr_id cstr env =
+  Builtin_attributes.warning_scope cstr.cstr_attributes (fun () ->
+  if check && not type_decl.type_loc.Location.loc_ghost
+     && Warnings.is_active (Warnings.Unused_constructor ("", Unused))
+  then begin
+    let ty_name = Ident.name type_id in
+    let name = cstr.cstr_name in
+    let loc = cstr.cstr_loc in
+    let k = cstr.cstr_uid in
+    let priv = type_decl.type_private in
+    if not (Types.Uid.Tbl.mem !used_constructors k) then begin
+      let used = constructor_usages () in
+      Types.Uid.Tbl.add !used_constructors k
+        (add_constructor_usage used);
+      if not (ty_name = "" || ty_name.[0] = '_')
+      then
+        !add_delayed_check_forward
+          (fun () ->
+            Option.iter
+              (fun complaint ->
+                 if not (is_in_signature env) then
+                   Location.prerr_warning loc
+                     (Warnings.Unused_constructor(name, complaint)))
+              (constructor_usage_complaint ~rebind:false priv used));
+    end;
+  end);
+  Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
+  Builtin_attributes.mark_warn_on_literal_pattern_used cstr.cstr_attributes;
+  let cda_shape = Shape.leaf cstr.cstr_uid in
+  { env with
+    constrs =
+      TycompTbl.add cstr_id
+        { cda_description = cstr; cda_address = None; cda_shape } env.constrs;
+  }
+
+let store_label ~check type_decl type_id lbl_id lbl env =
+  Builtin_attributes.warning_scope lbl.lbl_attributes (fun () ->
+  if check && not type_decl.type_loc.Location.loc_ghost
+     && Warnings.is_active (Warnings.Unused_field ("", Unused))
+  then begin
+    let ty_name = Ident.name type_id in
+    let priv = type_decl.type_private in
+    let name = lbl.lbl_name in
+    let loc = lbl.lbl_loc in
+    let mut = lbl.lbl_mut in
+    let k = lbl.lbl_uid in
+    if not (Types.Uid.Tbl.mem !used_labels k) then
+      let used = label_usages () in
+      Types.Uid.Tbl.add !used_labels k
+        (add_label_usage used);
+      if not (ty_name = "" || ty_name.[0] = '_' || name.[0] = '_')
+      then !add_delayed_check_forward
+          (fun () ->
+            Option.iter
+              (fun complaint ->
+                 if not (is_in_signature env) then
+                   Location.prerr_warning
+                     loc (Warnings.Unused_field(name, complaint)))
+              (label_usage_complaint priv mut used))
+  end);
+  Builtin_attributes.mark_alerts_used lbl.lbl_attributes;
+  if lbl.lbl_mut = Mutable then
+    Builtin_attributes.mark_deprecated_mutable_used lbl.lbl_attributes;
+  { env with
+    labels = TycompTbl.add lbl_id lbl env.labels;
+  }
+
+let store_type ~check id info shape env =
+  let loc = info.type_loc in
+  if check then
+    check_usage loc id info.type_uid
+      (fun s -> Warnings.Unused_type_declaration (s, Warnings.Declaration))
+      !type_declarations;
+  let descrs, env =
+    let path = Pident id in
+    match info.type_kind with
+    | Type_variant (_,repr) ->
+        let constructors = Datarepr.constructors_of_type path info
+                            ~current_unit:(get_current_unit ())
+        in
+        Type_variant (List.map snd constructors, repr),
+        List.fold_left
+          (fun env (cstr_id, cstr) ->
+            store_constructor ~check info id cstr_id cstr env)
+          env constructors
+    | Type_record (_, repr) ->
+        let labels = Datarepr.labels_of_type path info in
+        Type_record (List.map snd labels, repr),
+        List.fold_left
+          (fun env (lbl_id, lbl) ->
+            store_label ~check info id lbl_id lbl env)
+          env labels
+    | Type_abstract r -> Type_abstract r, env
+    | Type_open -> Type_open, env
+    | Type_external name -> Type_external name, env
+  in
+  let tda =
+    { tda_declaration = info;
+      tda_descriptions = descrs;
+      tda_shape = shape }
+  in
+  Builtin_attributes.mark_alerts_used info.type_attributes;
+  { env with
+    types = IdTbl.add id tda env.types;
+    summary = Env_type(env.summary, id, info) }
+
+let store_type_infos ~tda_shape id info env =
+  (* Simplified version of store_type that doesn't compute and store
+     constructor and label infos, but simply record the arity and
+     manifest-ness of the type.  Used in components_of_module to
+     keep track of type abbreviations (e.g. type t = float) in the
+     computation of label representations. *)
+  let tda =
+    {
+      tda_declaration = info;
+      tda_descriptions = Type_abstract (Btype.type_origin info);
+      tda_shape
+    }
+  in
+  { env with
+    types = IdTbl.add id tda env.types;
+    summary = Env_type(env.summary, id, info) }
+
+let store_extension ~check ~rebind id addr ext shape env =
+  let loc = ext.ext_loc in
+  let cstr =
+    Datarepr.extension_descr
+      ~current_unit:(get_current_unit ()) (Pident id) ext
+  in
+  let cda =
+    { cda_description = cstr;
+      cda_address = Some addr;
+      cda_shape = shape }
+  in
+  Builtin_attributes.mark_alerts_used ext.ext_attributes;
+  Builtin_attributes.mark_warn_on_literal_pattern_used ext.ext_attributes;
+  Builtin_attributes.warning_scope ext.ext_attributes (fun () ->
+  if check && not loc.Location.loc_ghost &&
+    Warnings.is_active (Warnings.Unused_extension ("", false, Unused))
+  then begin
+    let priv = ext.ext_private in
+    let is_exception = Path.same ext.ext_type_path Predef.path_exn in
+    let name = cstr.cstr_name in
+    let k = cstr.cstr_uid in
+    if not (Types.Uid.Tbl.mem !used_constructors k) then begin
+      let used = constructor_usages () in
+      Types.Uid.Tbl.add !used_constructors k
+        (add_constructor_usage used);
+      !add_delayed_check_forward
+         (fun () ->
+           Option.iter
+             (fun complaint ->
+                if not (is_in_signature env) then
+                  Location.prerr_warning loc
+                    (Warnings.Unused_extension
+                       (name, is_exception, complaint)))
+             (constructor_usage_complaint ~rebind priv used))
+    end;
+  end);
+  { env with
+    constrs = TycompTbl.add id cda env.constrs;
+    summary = Env_extension(env.summary, id, ext) }
+
+let store_module ?(update_summary=true) ~check
+                 id addr presence md shape env =
+  let open Subst.Lazy in
+  let loc = md.mdl_loc in
+  Option.iter
+    (fun f -> check_usage loc id md.mdl_uid f !module_declarations) check;
+  Builtin_attributes.mark_alerts_used md.mdl_attributes;
+  let alerts = Builtin_attributes.alerts_of_attrs md.mdl_attributes in
+  let comps =
+    components_of_module ~alerts ~uid:md.mdl_uid
+      env Subst.identity (Pident id) addr md.mdl_type shape
+  in
+  let mda =
+    { mda_declaration = md;
+      mda_components = comps;
+      mda_address = addr;
+      mda_shape = shape }
+  in
+  let summary =
+    if not update_summary then env.summary
+    else Env_module (env.summary, id, presence, force_module_decl md) in
+  { env with
+    modules = IdTbl.add id (Mod_local mda) env.modules;
+    summary }
+
+let store_modtype ?(update_summary=true) id info shape env =
+  Builtin_attributes.mark_alerts_used info.Subst.Lazy.mtdl_attributes;
+  let mtda = { mtda_declaration = info; mtda_shape = shape } in
+  let summary =
+    if not update_summary then env.summary
+    else Env_modtype (env.summary, id, Subst.Lazy.force_modtype_decl info) in
+  { env with
+    modtypes = IdTbl.add id mtda env.modtypes;
+    summary }
+
+let store_class id addr desc shape env =
+  Builtin_attributes.mark_alerts_used desc.cty_attributes;
+  let clda =
+    { clda_declaration = desc;
+      clda_address = addr;
+      clda_shape = shape; }
+  in
+  { env with
+    classes = IdTbl.add id clda env.classes;
+    summary = Env_class(env.summary, id, desc) }
+
+let store_cltype id desc shape env =
+  Builtin_attributes.mark_alerts_used desc.clty_attributes;
+  let cltda = { cltda_declaration = desc; cltda_shape = shape } in
+  { env with
+    cltypes = IdTbl.add id cltda env.cltypes;
+    summary = Env_cltype(env.summary, id, desc) }
+
+let components_of_module_maker
           {cm_env; cm_prefixing_subst;
            cm_path; cm_addr; cm_mty; cm_shape} : _ result =
   match scrape_alias cm_env cm_mty with
@@ -1970,265 +2229,6 @@ let rec components_of_module_maker
           fcomp_subst_cache = Hashtbl.create 17 })
   | MtyL_ident _ -> Error No_components_abstract
   | MtyL_alias p -> Error (No_components_alias p)
-
-(* Insertion of bindings by identifier + path *)
-
-and check_usage loc id uid warn tbl =
-  if not loc.Location.loc_ghost &&
-     Uid.for_actual_declaration uid &&
-     Warnings.is_active (warn "")
-  then begin
-    let name = Ident.name id in
-    if Types.Uid.Tbl.mem tbl uid then ()
-    else let used = ref false in
-    Types.Uid.Tbl.add tbl uid (fun () -> used := true);
-    if not (name = "" || name.[0] = '_' || name.[0] = '#')
-    then
-      !add_delayed_check_forward
-        (fun () -> if not !used then Location.prerr_warning loc (warn name))
-  end;
-
-and check_value_name name loc =
-  (* Note: we could also check here general validity of the
-     identifier, to protect against bad identifiers forged by -pp or
-     -ppx preprocessors. *)
-  if String.length name > 0 && not
-       (Utf8_lexeme.starts_like_a_valid_identifier name) then
-    for i = 1 to String.length name - 1 do
-      if name.[i] = '#' then
-        error (Illegal_value_name(loc, name))
-    done
-
-and store_value ?check id addr decl shape env =
-  check_value_name (Ident.name id) decl.val_loc;
-  Builtin_attributes.mark_alerts_used decl.val_attributes;
-  Option.iter
-    (fun f -> check_usage decl.val_loc id decl.val_uid f !value_declarations)
-    check;
-  let vda =
-    { vda_description = decl;
-      vda_address = addr;
-      vda_shape = shape }
-  in
-  { env with
-    values = IdTbl.add id (Val_bound vda) env.values;
-    summary = Env_value(env.summary, id, decl) }
-
-and store_constructor ~check type_decl type_id cstr_id cstr env =
-  Builtin_attributes.warning_scope cstr.cstr_attributes (fun () ->
-  if check && not type_decl.type_loc.Location.loc_ghost
-     && Warnings.is_active (Warnings.Unused_constructor ("", Unused))
-  then begin
-    let ty_name = Ident.name type_id in
-    let name = cstr.cstr_name in
-    let loc = cstr.cstr_loc in
-    let k = cstr.cstr_uid in
-    let priv = type_decl.type_private in
-    if not (Types.Uid.Tbl.mem !used_constructors k) then begin
-      let used = constructor_usages () in
-      Types.Uid.Tbl.add !used_constructors k
-        (add_constructor_usage used);
-      if not (ty_name = "" || ty_name.[0] = '_')
-      then
-        !add_delayed_check_forward
-          (fun () ->
-            Option.iter
-              (fun complaint ->
-                 if not (is_in_signature env) then
-                   Location.prerr_warning loc
-                     (Warnings.Unused_constructor(name, complaint)))
-              (constructor_usage_complaint ~rebind:false priv used));
-    end;
-  end);
-  Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
-  Builtin_attributes.mark_warn_on_literal_pattern_used cstr.cstr_attributes;
-  let cda_shape = Shape.leaf cstr.cstr_uid in
-  { env with
-    constrs =
-      TycompTbl.add cstr_id
-        { cda_description = cstr; cda_address = None; cda_shape } env.constrs;
-  }
-
-and store_label ~check type_decl type_id lbl_id lbl env =
-  Builtin_attributes.warning_scope lbl.lbl_attributes (fun () ->
-  if check && not type_decl.type_loc.Location.loc_ghost
-     && Warnings.is_active (Warnings.Unused_field ("", Unused))
-  then begin
-    let ty_name = Ident.name type_id in
-    let priv = type_decl.type_private in
-    let name = lbl.lbl_name in
-    let loc = lbl.lbl_loc in
-    let mut = lbl.lbl_mut in
-    let k = lbl.lbl_uid in
-    if not (Types.Uid.Tbl.mem !used_labels k) then
-      let used = label_usages () in
-      Types.Uid.Tbl.add !used_labels k
-        (add_label_usage used);
-      if not (ty_name = "" || ty_name.[0] = '_' || name.[0] = '_')
-      then !add_delayed_check_forward
-          (fun () ->
-            Option.iter
-              (fun complaint ->
-                 if not (is_in_signature env) then
-                   Location.prerr_warning
-                     loc (Warnings.Unused_field(name, complaint)))
-              (label_usage_complaint priv mut used))
-  end);
-  Builtin_attributes.mark_alerts_used lbl.lbl_attributes;
-  if lbl.lbl_mut = Mutable then
-    Builtin_attributes.mark_deprecated_mutable_used lbl.lbl_attributes;
-  { env with
-    labels = TycompTbl.add lbl_id lbl env.labels;
-  }
-
-and store_type ~check id info shape env =
-  let loc = info.type_loc in
-  if check then
-    check_usage loc id info.type_uid
-      (fun s -> Warnings.Unused_type_declaration (s, Warnings.Declaration))
-      !type_declarations;
-  let descrs, env =
-    let path = Pident id in
-    match info.type_kind with
-    | Type_variant (_,repr) ->
-        let constructors = Datarepr.constructors_of_type path info
-                            ~current_unit:(get_current_unit ())
-        in
-        Type_variant (List.map snd constructors, repr),
-        List.fold_left
-          (fun env (cstr_id, cstr) ->
-            store_constructor ~check info id cstr_id cstr env)
-          env constructors
-    | Type_record (_, repr) ->
-        let labels = Datarepr.labels_of_type path info in
-        Type_record (List.map snd labels, repr),
-        List.fold_left
-          (fun env (lbl_id, lbl) ->
-            store_label ~check info id lbl_id lbl env)
-          env labels
-    | Type_abstract r -> Type_abstract r, env
-    | Type_open -> Type_open, env
-    | Type_external name -> Type_external name, env
-  in
-  let tda =
-    { tda_declaration = info;
-      tda_descriptions = descrs;
-      tda_shape = shape }
-  in
-  Builtin_attributes.mark_alerts_used info.type_attributes;
-  { env with
-    types = IdTbl.add id tda env.types;
-    summary = Env_type(env.summary, id, info) }
-
-and store_type_infos ~tda_shape id info env =
-  (* Simplified version of store_type that doesn't compute and store
-     constructor and label infos, but simply record the arity and
-     manifest-ness of the type.  Used in components_of_module to
-     keep track of type abbreviations (e.g. type t = float) in the
-     computation of label representations. *)
-  let tda =
-    {
-      tda_declaration = info;
-      tda_descriptions = Type_abstract (Btype.type_origin info);
-      tda_shape
-    }
-  in
-  { env with
-    types = IdTbl.add id tda env.types;
-    summary = Env_type(env.summary, id, info) }
-
-and store_extension ~check ~rebind id addr ext shape env =
-  let loc = ext.ext_loc in
-  let cstr =
-    Datarepr.extension_descr
-      ~current_unit:(get_current_unit ()) (Pident id) ext
-  in
-  let cda =
-    { cda_description = cstr;
-      cda_address = Some addr;
-      cda_shape = shape }
-  in
-  Builtin_attributes.mark_alerts_used ext.ext_attributes;
-  Builtin_attributes.mark_warn_on_literal_pattern_used ext.ext_attributes;
-  Builtin_attributes.warning_scope ext.ext_attributes (fun () ->
-  if check && not loc.Location.loc_ghost &&
-    Warnings.is_active (Warnings.Unused_extension ("", false, Unused))
-  then begin
-    let priv = ext.ext_private in
-    let is_exception = Path.same ext.ext_type_path Predef.path_exn in
-    let name = cstr.cstr_name in
-    let k = cstr.cstr_uid in
-    if not (Types.Uid.Tbl.mem !used_constructors k) then begin
-      let used = constructor_usages () in
-      Types.Uid.Tbl.add !used_constructors k
-        (add_constructor_usage used);
-      !add_delayed_check_forward
-         (fun () ->
-           Option.iter
-             (fun complaint ->
-                if not (is_in_signature env) then
-                  Location.prerr_warning loc
-                    (Warnings.Unused_extension
-                       (name, is_exception, complaint)))
-             (constructor_usage_complaint ~rebind priv used))
-    end;
-  end);
-  { env with
-    constrs = TycompTbl.add id cda env.constrs;
-    summary = Env_extension(env.summary, id, ext) }
-
-and store_module ?(update_summary=true) ~check
-                 id addr presence md shape env =
-  let open Subst.Lazy in
-  let loc = md.mdl_loc in
-  Option.iter
-    (fun f -> check_usage loc id md.mdl_uid f !module_declarations) check;
-  Builtin_attributes.mark_alerts_used md.mdl_attributes;
-  let alerts = Builtin_attributes.alerts_of_attrs md.mdl_attributes in
-  let comps =
-    components_of_module ~alerts ~uid:md.mdl_uid
-      env Subst.identity (Pident id) addr md.mdl_type shape
-  in
-  let mda =
-    { mda_declaration = md;
-      mda_components = comps;
-      mda_address = addr;
-      mda_shape = shape }
-  in
-  let summary =
-    if not update_summary then env.summary
-    else Env_module (env.summary, id, presence, force_module_decl md) in
-  { env with
-    modules = IdTbl.add id (Mod_local mda) env.modules;
-    summary }
-
-and store_modtype ?(update_summary=true) id info shape env =
-  Builtin_attributes.mark_alerts_used info.Subst.Lazy.mtdl_attributes;
-  let mtda = { mtda_declaration = info; mtda_shape = shape } in
-  let summary =
-    if not update_summary then env.summary
-    else Env_modtype (env.summary, id, Subst.Lazy.force_modtype_decl info) in
-  { env with
-    modtypes = IdTbl.add id mtda env.modtypes;
-    summary }
-
-and store_class id addr desc shape env =
-  Builtin_attributes.mark_alerts_used desc.cty_attributes;
-  let clda =
-    { clda_declaration = desc;
-      clda_address = addr;
-      clda_shape = shape; }
-  in
-  { env with
-    classes = IdTbl.add id clda env.classes;
-    summary = Env_class(env.summary, id, desc) }
-
-and store_cltype id desc shape env =
-  Builtin_attributes.mark_alerts_used desc.clty_attributes;
-  let cltda = { cltda_declaration = desc; cltda_shape = shape } in
-  { env with
-    cltypes = IdTbl.add id cltda env.cltypes;
-    summary = Env_cltype(env.summary, id, desc) }
 
 let scrape_alias env mty = scrape_alias env mty
 


### PR DESCRIPTION
Since OCaml 4.00 there is no longer a cyclic dependency between the `Env.store_{type,value,...}` functions and the `Env.module_components` function.
 
This small PR thus proposes to split the corresponding mutually recursive definition into independent definitions.