### PR TITLE
fix pprintast of package_type to pp attributes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -267,7 +267,7 @@ Working version
   counter-example search space.
   (Florian Angeletti, review by Gabriel Scherer)
 
-- #19962: fix pprintast of package_type to pp attributes.
+- #19962: avoid dropping attributes attached to package types when pretty printing in surface syntax.
   (Chet Murthy)
 
 OCaml 5.5.0

--- a/Changes
+++ b/Changes
@@ -267,7 +267,8 @@ Working version
   counter-example search space.
   (Florian Angeletti, review by Gabriel Scherer)
 
-- #19962: avoid dropping attributes attached to package types when pretty printing in surface syntax.
+- #19962: avoid dropping attributes attached to package types when pretty
+  printing in surface syntax.
   (Chet Murthy)
 
 OCaml 5.5.0

--- a/Changes
+++ b/Changes
@@ -267,6 +267,9 @@ Working version
   counter-example search space.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #19962: fix pprintast of package_type to pp attributes.
+  (Chet Murthy)
+
 OCaml 5.5.0
 -----------
 

--- a/Changes
+++ b/Changes
@@ -273,7 +273,7 @@ Working version
 
 - #19962: avoid dropping attributes attached to package types when pretty
   printing in surface syntax.
-  (Chet Murthy)
+  (Chet Murthy, review by Nicolás Ojeda Bär)
 
 OCaml 5.5.0
 -----------

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -544,7 +544,7 @@ and core_type1 ctxt f x =
     | (Ptyp_arrow _ | Ptyp_alias _ | Ptyp_poly _ | Ptyp_functor _) ->
        paren true (core_type ctxt) f x
 
-and package_type ctxt f ptyp =
+and package_type_aux ctxt f ptyp =
   let aux f (s, ct) =
     pp f "type %a@ =@ %a" (with_loc type_longident) s (core_type ctxt) ct
   in
@@ -554,6 +554,13 @@ and package_type ctxt f ptyp =
     pp f "%a@ with@ %a"
       (with_loc type_longident) ptyp.ppt_path
       (list aux ~sep:"@ and@ ") ptyp.ppt_constraints
+
+and package_type ctxt f ptyp =
+  match ptyp.ppt_attrs with
+    [] -> package_type_aux ctxt f ptyp
+  | __ ->
+     pp f "((%a)%a)" (package_type_aux ctxt) {ptyp with ppt_attrs=[]}
+      (attributes ctxt) ptyp.ppt_attrs
 
 (********************pattern********************)
 (* be cautious when use [pattern], [pattern1] is preferred *)

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7554,5 +7554,8 @@ let () =
   let%e[@foo] x = 12 in
   ()
 
+let f = function (module M : (A [@a])) -> ()
+let f = function (module M : (A with type t = int [@a])) -> ()
+
 (* 5.5 Features *)
 type t = external "foo"


### PR DESCRIPTION
Starting with 5.4.0,

let f = function (module M : (A [@a])) -> ()

would pretty-print without the attribute.  This little PR fixed that so it pretty-prints the attribute (allowing round-tripping).
Added a couple of simple tests to `testsuite/tests/parsetree/source.ml`