### PR TITLE
dynarray: suggest alternate wording in docs re concurrency

### DIFF
--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -45,15 +45,18 @@
 (** {b Unsynchronized accesses} *)
 
 [@@@alert unsynchronized_access
-    "Unsynchronized accesses to dynamic arrays are a programming error."
+    "Unsynchronized mutations to dynamic arrays are a programming error."
 ]
 
 (**
-   Concurrent accesses to dynamic arrays must be synchronized
-   (for instance with a {!Mutex.t}). Unsynchronized accesses to
-   a dynamic array are a programming error that may lead to an invalid
-   dynamic array state, on which some operations would fail with an
-   [Invalid_argument] exception.
+   Concurrent accesses to dynamic arrays, where one or more such access may
+   change the number of elements in the array, must be synchronized (for
+   instance with a {!Mutex.t}). Failing to synchronise such mutations is a
+   programming error that may lead to an invalid dynamic array state, on which
+   some operations would fail with an [Invalid_argument] exception.
+
+   Concurrent reads to elements or dynarray state, or concurrent [set]s to
+   disjoint elements of a dynarray, are safe.
 *)
 
 (** {1:dynarrays Dynamic arrays} *)


### PR DESCRIPTION
Dear OCaml maintainers,

This afternoon I was reading the documentation for `Dynarray` and was surprised to see mention that _any_ concurrent access to the data structure was forbidden; I was anticipating disjoint `put`s to be valid, as well as certainly concurrent `get`s.  Thinking maybe some implementation detail (say, fixups on `get` or a lazy resize on a `set` or something) might explain this, I went splunking in the code (and enjoyed discovering the use of GADTs in the `'stamp` type parameter), but couldn't find any.

I thought perhaps this notice to users could be reworded, so this patch proposes a more precise (but hopefully still accurate) constraint on what's allowed on `Dynarray`s across domains.

I don't feel strongly about this change so I understand if you'd prefer to leave the original overapproximation of the safety contract.

Cheers,
Nathan