### PR TITLE
ctype: localize nondep traversal state in Nondep_scope

### DIFF
--- a/Changes
+++ b/Changes
@@ -247,6 +247,10 @@ Working version
   when mixing self types, local modules and first class modules.
   (Samuel Vivien, review by Florian Angeletti, Jacques Garrigue)
 
+- #14800: localise `nondep_type_rec` memoisation state in a new
+  `Nondep_scope` module (`typing/ctype.ml`).
+  (Matthew Marques, review by Stefan Muenzel)
+
 ### Build system:
 
 - #14676: Security fix: prevent shell injection in Github Actions workflows

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6365,12 +6365,41 @@ let arrow_labels env ty =
    expand_abbrev.
 *)
 
-let nondep_hash     = TypeHash.create 47
-let nondep_variants = TypeHash.create 17
-let clear_hash ()   =
-  TypeHash.clear nondep_hash; TypeHash.clear nondep_variants
+module Nondep_scope : sig
+  type t
 
-let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
+  val create : unit -> t
+  val reset : t -> unit
+
+  val find_copied_type : t -> type_expr -> type_expr
+  val find_copied_variant : t -> row:type_expr -> type_expr
+
+  val add_copied_type : t -> type_expr -> type_expr -> unit
+  val add_copied_variant : t -> row:type_expr -> type_expr -> unit
+
+  val remove_copied_type : t -> type_expr -> unit
+end = struct
+  type t = {
+    copied_types : type_expr TypeHash.t;
+    copied_variants : type_expr TypeHash.t
+  }
+
+  let create () =
+    { copied_types = TypeHash.create 47; copied_variants = TypeHash.create 17 }
+  let reset scope =
+    TypeHash.clear scope.copied_types; TypeHash.clear scope.copied_variants
+
+  let find_copied_type t key = TypeHash.find t.copied_types key
+  let find_copied_variant t ~row = TypeHash.find t.copied_variants row
+
+  let add_copied_type t key value = TypeHash.add t.copied_types key value
+  let add_copied_variant t ~row value = TypeHash.add t.copied_variants row value
+
+  let remove_copied_type t key = TypeHash.remove t.copied_types key
+end
+
+let rec nondep_type_rec_aux ?(expand_private=false) env
+    (scope : Nondep_scope.t) id_map ids ty =
   let try_expand env t =
     if expand_private then try_expand_safe_opt env t
     else try_expand_safe_no_link env t
@@ -6378,12 +6407,12 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
   let desc = get_folded_desc ~keep_Tvar:true ty in
   match desc with
     Tvar _ | Tunivar _ -> ty
-  | _ -> try TypeHash.find nondep_hash ty
+  | _ -> try Nondep_scope.find_copied_type scope ty
   with Not_found ->
     let ty' = newgenstub ~scope:(get_scope ty) in
-    TypeHash.add nondep_hash ty ty';
+    Nondep_scope.add_copied_type scope ty ty';
     let nondep_trec ?expand_private ty =
-      nondep_type_rec_aux ?expand_private env id_map ids ty
+      nondep_type_rec_aux ?expand_private env scope id_map ids ty
     in
     match
       match desc with
@@ -6399,7 +6428,7 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
           with (Nondep_cannot_erase _) as exn ->
             (* If that doesn't work, try expanding abbrevs *)
             if desc != get_desc ty then begin
-              TypeHash.remove nondep_hash ty;
+              Nondep_scope.remove_copied_type scope ty;
               Tlink (nondep_trec ~expand_private (ignore_abbrev ty))
             end else try
               Tlink (nondep_trec ~expand_private
@@ -6444,7 +6473,7 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
             assert (List.for_all (fun i -> not (Ident.same i id_us)) ids);
             let mty = modtype_of_package env Location.none pack in
             let env' = Env.add_module id_us Mp_present mty env in
-            let t' = nondep_type_rec_aux env' id_map ids t in
+            let t' = nondep_type_rec_aux env' scope id_map ids t in
             Tfunctor (l, us', pack', t')
           end
       | Tobject (t1, name) ->
@@ -6459,13 +6488,13 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
           let more = row_more row in
           (* We must keep sharing according to the row variable *)
           begin try
-            let ty2 = TypeHash.find nondep_variants more in
+            let ty2 = Nondep_scope.find_copied_variant scope ~row:more in
             (* This variant type has been already copied *)
-            TypeHash.add nondep_hash ty ty2;
+            Nondep_scope.add_copied_type scope ty ty2;
             Tlink ty2
           with Not_found ->
             (* Register new type first for recursion *)
-            TypeHash.add nondep_variants more ty';
+            Nondep_scope.add_copied_variant scope ~row:more ty';
             let static = static_row row in
             let more' =
               if static then newgenty Tnil else nondep_trec more
@@ -6486,166 +6515,148 @@ let rec nondep_type_rec_aux ?(expand_private=false) env id_map ids ty =
       Transient_expr.set_stub_desc ty' desc';
       ty'
     | exception e ->
-      TypeHash.remove nondep_hash ty;
+      Nondep_scope.remove_copied_type scope ty;
       raise e
 
-let nondep_type_rec ?expand_private env id ty =
-  nondep_type_rec_aux ?expand_private env [] id ty
+let nondep_type_rec ?expand_private env scope id ty =
+  nondep_type_rec_aux ?expand_private env scope [] id ty
 
 let nondep_type env id ty =
-  try
-    let ty' = nondep_type_rec env id ty in
-    clear_hash ();
-    ty'
-  with Nondep_cannot_erase _ as exn ->
-    clear_hash ();
-    raise exn
+  let scope = Nondep_scope.create () in
+  nondep_type_rec env scope id ty
 
 let () = nondep_type' := nondep_type
 
 (* Preserve sharing inside type declarations. *)
 let nondep_type_decl env mid is_covariant decl =
-  try
-    let params = List.map (nondep_type_rec env mid) decl.type_params in
-    let tk =
-      try map_kind (nondep_type_rec env mid) decl.type_kind
-      with Nondep_cannot_erase _ when is_covariant -> Type_abstract Definition
-    and tm, priv =
-      match decl.type_manifest with
-      | None -> None, decl.type_private
-      | Some ty ->
-          try Some (nondep_type_rec env mid ty), decl.type_private
-          with Nondep_cannot_erase _ when is_covariant ->
-            clear_hash ();
-            try Some (nondep_type_rec ~expand_private:true env mid ty),
-                Private
-            with Nondep_cannot_erase _ ->
-              None, decl.type_private
-    in
-    clear_hash ();
-    let priv =
-      match tm with
-      | Some ty when Btype.has_constr_row ty -> Private
-      | _ -> priv
-    in
-    { type_params = params;
-      type_arity = decl.type_arity;
-      type_kind = tk;
-      type_manifest = tm;
-      type_private = priv;
-      type_variance = decl.type_variance;
-      type_separability = decl.type_separability;
-      type_is_newtype = false;
-      type_expansion_scope = Btype.lowest_level;
-      type_loc = decl.type_loc;
-      type_attributes = decl.type_attributes;
-      type_immediate = decl.type_immediate;
-      type_unboxed_default = decl.type_unboxed_default;
-      type_uid = decl.type_uid;
-    }
-  with Nondep_cannot_erase _ as exn ->
-    clear_hash ();
-    raise exn
+  let scope = Nondep_scope.create () in
+  let params = List.map (nondep_type_rec env scope mid) decl.type_params in
+  let tk =
+    try map_kind (nondep_type_rec env scope mid) decl.type_kind
+    with Nondep_cannot_erase _ when is_covariant -> Type_abstract Definition
+  and tm, priv =
+    match decl.type_manifest with
+    | None -> None, decl.type_private
+    | Some ty ->
+        try Some (nondep_type_rec env scope mid ty), decl.type_private
+        with Nondep_cannot_erase _ when is_covariant ->
+          Nondep_scope.reset scope;
+          try Some (nondep_type_rec ~expand_private:true env scope mid ty),
+              Private
+          with Nondep_cannot_erase _ ->
+            None, decl.type_private
+  in
+  let priv =
+    match tm with
+    | Some ty when Btype.has_constr_row ty -> Private
+    | _ -> priv
+  in
+  { type_params = params;
+    type_arity = decl.type_arity;
+    type_kind = tk;
+    type_manifest = tm;
+    type_private = priv;
+    type_variance = decl.type_variance;
+    type_separability = decl.type_separability;
+    type_is_newtype = false;
+    type_expansion_scope = Btype.lowest_level;
+    type_loc = decl.type_loc;
+    type_attributes = decl.type_attributes;
+    type_immediate = decl.type_immediate;
+    type_unboxed_default = decl.type_unboxed_default;
+    type_uid = decl.type_uid;
+  }
 
 (* Preserve sharing inside extension constructors. *)
 let nondep_extension_constructor env ids ext =
-  try
-    let type_path, type_params =
-      match Path.find_free_opt ids ext.ext_type_path with
-      | Some id ->
-        begin
-          let ty =
-            newgenty (Tconstr(ext.ext_type_path, ext.ext_type_params, ref Mnil))
-          in
-          let ty' = nondep_type_rec env ids ty in
-            match get_desc ty' with
-                Tconstr(p, tl, _) -> p, tl
-              | _ -> raise (Nondep_cannot_erase id)
-        end
-      | None ->
-        let type_params =
-          List.map (nondep_type_rec env ids) ext.ext_type_params
+  let scope = Nondep_scope.create () in
+  let type_path, type_params =
+    match Path.find_free_opt ids ext.ext_type_path with
+    | Some id ->
+      begin
+        let ty =
+          newgenty (Tconstr(ext.ext_type_path, ext.ext_type_params, ref Mnil))
         in
-          ext.ext_type_path, type_params
-    in
-    let args = map_type_expr_cstr_args (nondep_type_rec env ids) ext.ext_args
-    in
-    let ret_type = Option.map (nondep_type_rec env ids) ext.ext_ret_type in
-      clear_hash ();
-      { ext_type_path = type_path;
-        ext_type_params = type_params;
-        ext_args = args;
-        ext_ret_type = ret_type;
-        ext_private = ext.ext_private;
-        ext_attributes = ext.ext_attributes;
-        ext_loc = ext.ext_loc;
-        ext_uid = ext.ext_uid;
-      }
-  with Nondep_cannot_erase _ as exn ->
-    clear_hash ();
-    raise exn
+        let ty' = nondep_type_rec env scope ids ty in
+          match get_desc ty' with
+              Tconstr(p, tl, _) -> p, tl
+            | _ -> raise (Nondep_cannot_erase id)
+      end
+    | None ->
+      let type_params =
+        List.map (nondep_type_rec env scope ids) ext.ext_type_params
+      in
+        ext.ext_type_path, type_params
+  in
+  let args =
+    map_type_expr_cstr_args (nondep_type_rec env scope ids) ext.ext_args
+  in
+  let ret_type = Option.map (nondep_type_rec env scope ids) ext.ext_ret_type in
+  { ext_type_path = type_path;
+    ext_type_params = type_params;
+    ext_args = args;
+    ext_ret_type = ret_type;
+    ext_private = ext.ext_private;
+    ext_attributes = ext.ext_attributes;
+    ext_loc = ext.ext_loc;
+    ext_uid = ext.ext_uid;
+  }
 
 
 (* Preserve sharing inside class types. *)
-let nondep_class_signature env id sign =
-  { csig_self = nondep_type_rec env id sign.csig_self;
-    csig_self_row = nondep_type_rec env id sign.csig_self_row;
+let nondep_class_signature env scope id sign =
+  { csig_self = nondep_type_rec env scope id sign.csig_self;
+    csig_self_row = nondep_type_rec env scope id sign.csig_self_row;
     csig_dummy_method = field_kind_internal_repr sign.csig_dummy_method;
     csig_vars =
-      Vars.map (function (m, v, t) -> (m, v, nondep_type_rec env id t))
+      Vars.map (function (m, v, t) -> (m, v, nondep_type_rec env scope id t))
         sign.csig_vars;
     csig_meths =
-      Meths.map (function (p, v, t) -> (p, v, nondep_type_rec env id t))
+      Meths.map (function (p, v, t) -> (p, v, nondep_type_rec env scope id t))
         sign.csig_meths }
 
-let rec nondep_class_type env ids =
+let rec nondep_class_type env scope ids =
   function
     Cty_constr (p, _, cty) when Path.exists_free ids p ->
-      nondep_class_type env ids cty
+      nondep_class_type env scope ids cty
   | Cty_constr (p, tyl, cty) ->
-      Cty_constr (p, List.map (nondep_type_rec env ids) tyl,
-                   nondep_class_type env ids cty)
+      Cty_constr (p, List.map (nondep_type_rec env scope ids) tyl,
+                   nondep_class_type env scope ids cty)
   | Cty_signature sign ->
-      Cty_signature (nondep_class_signature env ids sign)
+      Cty_signature (nondep_class_signature env scope ids sign)
   | Cty_arrow (l, ty, cty) ->
-      Cty_arrow (l, nondep_type_rec env ids ty,
-                 nondep_class_type env ids cty)
+      Cty_arrow (l, nondep_type_rec env scope ids ty,
+                 nondep_class_type env scope ids cty)
 
 let nondep_class_declaration env ids decl =
   assert (not (Path.exists_free ids decl.cty_path));
-  let decl =
-    { cty_params = List.map (nondep_type_rec env ids) decl.cty_params;
-      cty_variance = decl.cty_variance;
-      cty_type = nondep_class_type env ids decl.cty_type;
-      cty_path = decl.cty_path;
-      cty_new =
-        begin match decl.cty_new with
-          None    -> None
-        | Some ty -> Some (nondep_type_rec env ids ty)
-        end;
-      cty_loc = decl.cty_loc;
-      cty_attributes = decl.cty_attributes;
-      cty_uid = decl.cty_uid;
-    }
-  in
-  clear_hash ();
-  decl
+  let scope = Nondep_scope.create () in
+  { cty_params = List.map (nondep_type_rec env scope ids) decl.cty_params;
+    cty_variance = decl.cty_variance;
+    cty_type = nondep_class_type env scope ids decl.cty_type;
+    cty_path = decl.cty_path;
+    cty_new =
+      begin match decl.cty_new with
+        None    -> None
+      | Some ty -> Some (nondep_type_rec env scope ids ty)
+      end;
+    cty_loc = decl.cty_loc;
+    cty_attributes = decl.cty_attributes;
+    cty_uid = decl.cty_uid;
+  }
 
 let nondep_cltype_declaration env ids decl =
   assert (not (Path.exists_free ids decl.clty_path));
-  let decl =
-    { clty_params = List.map (nondep_type_rec env ids) decl.clty_params;
-      clty_variance = decl.clty_variance;
-      clty_type = nondep_class_type env ids decl.clty_type;
-      clty_path = decl.clty_path;
-      clty_hash_type = nondep_type_decl env ids false decl.clty_hash_type ;
-      clty_loc = decl.clty_loc;
-      clty_attributes = decl.clty_attributes;
-      clty_uid = decl.clty_uid;
-    }
-  in
-  clear_hash ();
-  decl
+  let scope = Nondep_scope.create () in
+  { clty_params = List.map (nondep_type_rec env scope ids) decl.clty_params;
+    clty_variance = decl.clty_variance;
+    clty_type = nondep_class_type env scope ids decl.clty_type;
+    clty_path = decl.clty_path;
+    clty_hash_type = nondep_type_decl env ids false decl.clty_hash_type ;
+    clty_loc = decl.clty_loc;
+    clty_attributes = decl.clty_attributes;
+    clty_uid = decl.clty_uid;
+  }
 
 (* collapse conjunctive types in class parameters *)
 let rec collapse_conj env visited ty =


### PR DESCRIPTION
  Replace the module-global `nondep_hash` / `nondep_variants` / `clear_hash` machinery in `Ctype` with a sealed `Nondep_scope` module, instances of which are created per top-level entry and threaded through the recursion. Inspired by `Btype.For_copy`.

  No semantic change intended. Public signatures (`.mli`) unchanged.

  Refs #14366