### PR TITLE
add level to abbreviations in Texpand

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,7 +120,7 @@ Working version
 
 ### Type system:
 
-* #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and
+* #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and
   new well-foundedness check implementation.
   Do expansion in place during unification, rather than only memoizing it
   in a temporary cache. This fixes a number of non-terminations and crashes
@@ -133,9 +133,9 @@ Working version
   implementation strives to follow the specification, some unspecified
   behaviors may change: stricter behavior of the well-foundedness check in
   some cases, or expansions kept in cmis in rare cases.
-  (Jacques Garrigue and Stefan Muenzel, cross reviewed, temporary regression
-   reported by Jeremy Yallop, fix reviewed by Samuel Vivien and
-   Florian Angeletti)
+  (Jacques Garrigue and Stefan Muenzel, cross reviewed,
+   temporary regression reported by Jeremy Yallop, fix reviewed by Samuel
+   Vivien and Florian Angeletti, other regression reported by Florian Angeletti)
 
 - #14512: Improve check for warning 16 (unerasable-optional-argument)
   (Alistair O'Brien, review by Florian Angeletti, Gabriel Scherer)

--- a/testsuite/tests/typing-misc/conjunctive_types.ml
+++ b/testsuite/tests/typing-misc/conjunctive_types.ml
@@ -112,6 +112,137 @@ module type Vec =
        cross, 'c one)
       t -> ('dim, 'd one) t -> ('dim2, 'rank2) t
   end
-Uncaught exception: Stack overflow
-
+module F :
+  (V : Vec) ->
+    sig
+      val fn :
+        (([< `three of
+               'a *
+               ([< `one of
+                     'c z &
+                     [< `one of 'd * 'a * 'e & 'f one * 'g one * 'g one
+                      | `zero of 'd * 'e & 'f one * 'a ] &
+                     [< `one of 'd * 'a * 'e & 'f one * 'g one * 'g one
+                      | `zero of 'd * 'e & 'f one * 'a ]
+                 | `two of
+                     'c z &
+                     [< `two of 'd * 'a * 'e & 'f two * 'a * 'e
+                      | `zero of 'd * 'e & 'f two * 'a ] &
+                     [< `two of 'd * 'a * 'e & 'f two * 'a * 'e
+                      | `zero of 'd * 'e & 'f two * 'a ]
+                 | `zero of
+                     'c z &
+                     [< `one of 'd * 'e & 'f one * 'g one
+                      | `two of 'd * 'e & 'f two * 'g one
+                      | `zero of 'd * 'e & 'f z * 'h one ] &
+                     [< `one of 'd * 'e & 'f one * 'g one
+                      | `two of 'd * 'e & 'f two * 'g one
+                      | `zero of 'd * 'e & 'f z * 'h one ] ]
+                as 'b) &
+               'i three * 'j one
+           | `two of 'a * 'b & 'i * 'j z ]
+          as 'dim, 'a * 'b, 'j * 'i)
+         cross, 'k one)
+        t -> ('dim, 'l one) t -> ('e, 'd) t
+      val loop : ('a one, 'b z) t
+    end
+|}, Principal{|
+type k = float
+type 'a one = [ `one of 'a ]
+type 'a z = [ `zero of 'a ]
+type 'a two = [ `two of 'a ]
+type 'a three = [ `three of 'a ]
+type 'a four = [ `four of 'a ]
+type ('rank1, 'rank2, 'rank3, 'dim1, 'dim2, 'dim3, 'a) sum = 'rank1
+  constraint 'rank1 =
+    [< `one of
+         'rank2 &
+         [< `one of 'rank3 * 'dim1 * 'dim3 & 'p1 one * 'dim2 * 'dim2
+          | `zero of 'rank3 * 'dim3 & 'p1 one * 'dim1 ]
+     | `two of
+         'rank2 &
+         [< `two of 'rank3 * 'dim1 * 'dim3 & 'p1 two * 'dim1 * 'dim3
+          | `zero of 'rank3 * 'dim3 & 'p1 two * 'dim1 ]
+     | `zero of
+         'rank2 &
+         [< `one of 'rank3 * 'dim3 & 'p1 one * 'dim2
+          | `two of 'rank3 * 'dim3 & 'p1 two * 'dim2
+          | `zero of 'rank3 * 'dim3 & 'p1 z * 'p2 one ] ]
+  constraint 'a = 'p1 * 'p2 * 'p3
+type ('dim, 'res, 'a) cross = 'dim
+  constraint 'dim =
+    [< `three of 'res & 'p2 three * 'p1 one | `two of 'res & 'p2 * 'p1 z ]
+  constraint 'a = 'p1 * 'p2
+type (+'dim, +'rank) t
+type +'c scalar = ('a one, 'b z) t constraint 'c = 'a * 'b
+type +'c vec2 = ('a two, 'b one) t constraint 'c = 'a * 'b
+module type Vec =
+  sig
+    val scalar : k -> ('a * 'b) scalar
+    val vec2 : k -> k -> ('a * 'b) vec2
+    val ( + ) :
+      ('dim1,
+       ([< `one of
+             'rank2 &
+             [< `one of 'rank3 * 'dim1 * 'dim3 & 'a one * 'dim2 * 'dim2
+              | `zero of 'rank3 * 'dim3 & 'a one * 'dim1 ]
+         | `two of
+             'rank2 &
+             [< `two of 'rank3 * 'dim1 * 'dim3 & 'a two * 'dim1 * 'dim3
+              | `zero of 'rank3 * 'dim3 & 'a two * 'dim1 ]
+         | `zero of
+             'rank2 &
+             [< `one of 'rank3 * 'dim3 & 'a one * 'dim2
+              | `two of 'rank3 * 'dim3 & 'a two * 'dim2
+              | `zero of 'rank3 * 'dim3 & 'a z * 'b one ] ],
+        'rank2, 'rank3, 'dim1, 'dim2, 'dim3, 'a * 'b * 'c)
+       sum)
+      t -> ('dim2, 'rank2) t -> ('dim3, 'rank3) t
+    val cross :
+      (([< `three of 'dim2 * 'rank2 & 'a three * 'b one
+         | `two of 'dim2 * 'rank2 & 'a * 'b z ]
+        as 'dim, 'dim2 * 'rank2, 'b * 'a)
+       cross, 'c one)
+      t -> ('dim, 'd one) t -> ('dim2, 'rank2) t
+  end
+module F :
+  (V : Vec) ->
+    sig
+      val fn :
+        ([< `three of
+              'b *
+              ([< `one of
+                    'd z &
+                    [< `one of 'e * 'b * 'f & 'g one * 'h one * 'h one
+                     | `zero of 'e * 'f & 'g one * 'b ] &
+                    [< `one of 'e * 'b * 'f & 'g one * 'h one * 'h one
+                     | `zero of 'e * 'f & 'g one * 'b ] &
+                    [< `one of 'e * 'b * 'f & 'g one * 'h one * 'h one
+                     | `zero of 'e * 'f & 'g one * 'b ]
+                | `two of
+                    'd z &
+                    [< `two of 'e * 'b * 'f & 'g two * 'b * 'f
+                     | `zero of 'e * 'f & 'g two * 'b ] &
+                    [< `two of 'e * 'b * 'f & 'g two * 'b * 'f
+                     | `zero of 'e * 'f & 'g two * 'b ] &
+                    [< `two of 'e * 'b * 'f & 'g two * 'b * 'f
+                     | `zero of 'e * 'f & 'g two * 'b ]
+                | `zero of
+                    'd z &
+                    [< `one of 'e * 'f & 'g one * 'h one
+                     | `two of 'e * 'f & 'g two * 'h one
+                     | `zero of 'e * 'f & 'g z * 'i one ] &
+                    [< `one of 'e * 'f & 'g one * 'h one
+                     | `two of 'e * 'f & 'g two * 'h one
+                     | `zero of 'e * 'f & 'g z * 'i one ] &
+                    [< `one of 'e * 'f & 'g one * 'h one
+                     | `two of 'e * 'f & 'g two * 'h one
+                     | `zero of 'e * 'f & 'g z * 'i one ] ]
+               as 'c) &
+              'j three * 'k one
+          | `two of 'b * 'c & 'j * 'k z ]
+         as 'a, 'l one)
+        t -> ('a, 'm one) t -> ('f, 'e) t
+      val loop : ('a one, 'b z) t
+    end
 |}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -180,7 +180,7 @@ let dummy_method = "*dummy method*"
 
 let get_constr_desc ty =
   match get_abbrev ty with
-    Some (path, tyl) -> Tconstr (path, tyl, ref Mnil)
+    Some abbr -> Tconstr (abbr.abbr_path, abbr.abbr_args, ref Mnil)
   | None -> get_desc ty
 
                   (********************************)
@@ -858,7 +858,7 @@ let deep_occur_rec mark t0 =
       iter_type_desc occur ty'.desc;
       iter_abbrev occur_abbrev ty
     end
-  and occur_abbrev _p tyl = List.iter occur tyl
+  and occur_abbrev abbr = List.iter occur abbr.abbr_args
   in
   occur
 
@@ -887,7 +887,7 @@ let get_folded_desc ~keep_Tvar ty =
       (* Only re-instate an abbreviation if there is no risk to hide
          something *)
       match get_abbrev ty with
-      | Some (path, args) when not (Path.contains_unscoped_ident path ||
-                                    deep_occur_list ty args) ->
-          Tconstr (path, args, ref Mnil)
+      | Some abbr when not (Path.contains_unscoped_ident abbr.abbr_path ||
+                            deep_occur_list ty abbr.abbr_args) ->
+          Tconstr (abbr.abbr_path, abbr.abbr_args, ref Mnil)
       | _ -> desc

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -914,6 +914,8 @@ let needs_expand env level path args =
     (without this constraint, the type system would actually be unsound.)
 *)
 
+(* Check whether no internal level needs to be updated,
+   including abbreviations *)
 let rec check_level_type_rec visited level ty =
   get_level ty <= level &&
   match get_abbrev ty with
@@ -999,6 +1001,20 @@ let rec update_level env level expand ty =
   end
   else update_level_abbrev env level expand ty
 
+(* [update_level_abbrev] needs to be called to update levels in abbreviations
+   even if the level of the type itself (which is the level of the expanded
+   form) is already correct.
+   Namely, abbreviations are taken from nodes that are actually ancestors
+   to the expanded versions of the type. And, through unification, it may
+   be the case that the same expanded type node can be accessed through
+   different ancestors, holding different abbreviations.
+   We keep an abbreviation if its scope is valid and either all the levels it
+   contains are already low enough (check_level_type) or if we can succesfully
+   update the levels in its arguments. Otherwise, we forget it as invalid.
+   To avoid checking the same abbreviation repeatedly, we store the level
+   we have checked inside it. Since path compression can copy a Texpand to
+   an ancestor node, it would be inefficient to use the level of the node
+   containing the Texpand (the level would have to be copied too). *)
 and update_level_abbrev env level expand ty =
   iter_abbrev
     (function {abbr_path=p; abbr_args=args; abbr_level=l} as abbr ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -995,7 +995,7 @@ let rec update_level env level expand ty =
         raise_escape_exn Self
     | _ ->
         set_level ();
-        (* XXX what about abbreviations in Tconstr ? *)
+        (* XXX what about memoized abbreviations in Tconstr ? *)
         iter_type_expr (update_level env level expand) ty;
         update_level_abbrev env level expand ty
   end
@@ -1005,7 +1005,7 @@ let rec update_level env level expand ty =
    even if the level of the type itself (which is the level of the expanded
    form) is already correct.
    Namely, abbreviations are taken from nodes that are actually ancestors
-   to the expanded versions of the type. And, through unification, it may
+   to the expanded version of the type. And, through unification, it may
    be the case that the same expanded type node can be accessed through
    different ancestors, holding different abbreviations.
    We keep an abbreviation if its scope is valid and either all the levels it

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -917,11 +917,12 @@ let needs_expand env level path args =
 let rec check_level_type_rec visited level ty =
   get_level ty <= level &&
   match get_abbrev ty with
-    Some (path, args) ->
-      Path.scope path <= level &&
-      (args = [] || List.memq ty visited ||
+    Some abbr ->
+      abbr.abbr_level <= level ||
+      Path.scope abbr.abbr_path <= level &&
+      (abbr.abbr_args = [] || List.memq ty visited ||
       let visited = ty :: visited in
-      List.for_all (check_level_type_rec visited level) args)
+      List.for_all (check_level_type_rec visited level) abbr.abbr_args)
   | None -> true
 
 let check_level_type level ty = check_level_type_rec [] level ty
@@ -1000,11 +1001,16 @@ let rec update_level env level expand ty =
 
 and update_level_abbrev env level expand ty =
   iter_abbrev
-    (fun p args ->
+    (function {abbr_path=p; abbr_args=args; abbr_level=l} as abbr ->
+      if level >= l then () else
       if level < Path.scope p then forget_abbrev ty else
-      if List.for_all (check_level_type level) args then () else
-      if expand || needs_expand env level p args then forget_abbrev ty else
-      List.iter (update_level env level expand) args)
+      if List.for_all (check_level_type level) args then
+        set_abbrev_level abbr level
+      else if expand || needs_expand env level p args then forget_abbrev ty
+      else begin
+        set_abbrev_level abbr level;
+        List.iter (update_level env level expand) args
+      end)
     ty
 
 let try_update_level env level ty =
@@ -1488,11 +1494,12 @@ let rec copy ?partial ?keep_names ?scope ?(unscoped = empty_unscoped_mapping)
     in
     let desc' =
       match ty_expand with
-        Some (path, args) ->
-          let path = Path.subst unscoped.map path in
-          let args = List.map copy args in
+        Some abbr ->
+          let path = Path.subst unscoped.map abbr.abbr_path in
+          let args = List.map copy abbr.abbr_args in
           let t' = new_scoped_ty ty_scope desc' in
-          Texpand (t', path, args)
+          Texpand (t',
+                   {abbr with abbr_args = args; abbr_level = !current_level})
       | None ->
           desc'
     in
@@ -3482,10 +3489,11 @@ and unify3 uenv t1' t2' =
             without_assume_injective uenv (fun uenv -> unify_list uenv tl1 tl2)
           else if in_current_module p1 (* || in_pervasives p1 *)
                || List.exists
-                   (fun (p, _) -> expands_to_datatype (get_env uenv) p)
-                   (Option.to_list (get_abbrev t1') @
-                    Option.to_list (get_abbrev t2') @
-                    [p1, []])
+                   (expands_to_datatype (get_env uenv))
+                   (List.map (fun a -> a.abbr_path)
+                      (Option.to_list (get_abbrev t1') @
+                       Option.to_list (get_abbrev t2'))
+                    @ [p1])
           then
             unify_list uenv tl1 tl2
           else

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1231,8 +1231,8 @@ let rec inv_type hash pty ty =
   with Not_found ->
     let inv = { inv_type = ty; inv_parents = pty } in
     TypeHash.add hash ty inv;
-    iter_abbrev (fun _ args ->
-      List.iter (inv_type hash [inv]) args
+    iter_abbrev (fun {abbr_args} ->
+      List.iter (inv_type hash [inv]) abbr_args
     ) ty;
     iter_type_expr (inv_type hash [inv]) ty
 
@@ -1302,7 +1302,8 @@ let type_subexpressions_with_free_occurrences ids ty =
   in
   let occurrence_in_abbrev inv =
     iter_abbrev
-      (fun p _ -> if Path.exists_free ids p then add_all_parents ids inv)
+      (fun {abbr_path} ->
+        if Path.exists_free ids abbr_path then add_all_parents ids inv)
       inv.inv_type
   in
   TypeHash.iter (fun ty inv ->
@@ -1514,8 +1515,8 @@ let rec copy ?partial ?keep_names ?scope ?(unscoped = empty_unscoped_mapping)
           let path = Path.subst unscoped.map abbr.abbr_path in
           let args = List.map copy abbr.abbr_args in
           let t' = new_scoped_ty ty_scope desc' in
-          Texpand (t',
-                   {abbr with abbr_args = args; abbr_level = !current_level})
+          Texpand (t', {abbr_path = path; abbr_args = args;
+                        abbr_level = !current_level})
       | None ->
           desc'
     in

--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -725,7 +725,7 @@ module Digraph = struct
           ~color ~id ~desc
     | Types.Tnil -> mk "[Nil]"
     | Types.Tlink t -> add_tynode Decoration.(make [Style Dash]) |> std_edge t
-    | Types.Texpand (t, _, _) ->
+    | Types.Texpand (t, _) ->
         add_tynode Decoration.(make [Style Dash]) |> std_edge t
     | Types.Tsubst (t, o) ->
         let dg = add_tynode (labelr "[Subst]") |> std_edge t in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -2052,7 +2052,7 @@ let trees_of_type_expansion mode Errortrace.{ty = t; expanded = t'} =
   let manifest =
     match get_abbrev t with
     | None -> None
-    | Some (tconstr, params) ->
+    | Some {abbr_path=tconstr; abbr_args=params} ->
         let should_use_manifest =
           match printer_get_desc t with
           | Tconstr (p, tl, _) ->

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -112,9 +112,12 @@ and raw_type_desc ppf = function
   | Tsubst (t, None) -> fprintf ppf "@[<1>Tsubst@,(%a,None)@]" raw_type t
   | Tsubst (t, Some t') ->
       fprintf ppf "@[<1>Tsubst@,(%a,@ Some%a)@]" raw_type t raw_type t'
-  | Texpand (t, p, args) ->
-      fprintf ppf "@[<1>Texpand(@,%a,@,%a,@,%a)@]" raw_type t path p
-        raw_type_list args
+  | Texpand (t, a) ->
+      let abbrev ppf abbr =
+        fprintf ppf "@[<1>{abbr_path=%a;@,abbr_args=%a;@,abbr_level=%d}]"
+         path abbr.abbr_path raw_type_list abbr.abbr_args abbr.abbr_level
+      in
+      fprintf ppf "@[<1>Texpand(@,%a,@,%a)@]" raw_type t abbrev a
   | Tunivar name -> fprintf ppf "Tunivar %a" print_name name
   | Tpoly (t, tl) ->
       fprintf ppf "@[<hov1>Tpoly(@,%a,@,%a)@]"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -307,8 +307,10 @@ end = struct
         let id_map = (id, new_id) :: id_map in
         let package = deep_copy_package id_map copy_with_map package in
         Tfunctor (l, new_id, package, copy_with_map id_map type_expr)
-    | Texpand (t, p, tl) ->
-        Texpand (copy t, copy_path id_map p, List.map copy tl)
+    | Texpand (t, abbr) ->
+        Texpand (copy t, {abbr_path = copy_path id_map abbr.abbr_path;
+                          abbr_args = List.map copy abbr.abbr_args;
+                          abbr_level = abbr.abbr_level})
     | Tlink _ | Tsubst _ -> assert false
 
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -44,9 +44,14 @@ and type_desc =
   | Tpoly of type_expr * type_expr list
   | Tpackage of package
   | Tfunctor of arg_label * Ident.Unscoped.t * package * type_expr
-  | Texpand of type_expr * Path.t * type_expr list
+  | Texpand of type_expr * abbrev
   | Tlink of type_expr
   | Tsubst of type_expr * type_expr option
+
+and abbrev =
+    { abbr_path : Path.t;
+      abbr_args : type_expr list;
+      mutable abbr_level : int }
 
 and package =
     { pack_path : Path.t;
@@ -491,6 +496,7 @@ type change =
   | Ccommu of [`var] commutable_gen
   | Cuniv of type_expr option ref * type_expr option
   | Cuident of Ident.Unscoped.change
+  | Cabbr_level of abbrev * int
 
 type changes =
     Change of change * changes ref
@@ -545,22 +551,22 @@ let repr_update t_orig d =
   log_change (Ccompress (t_orig, t_orig.desc, d));
   t_orig.desc <- d
 
-let rec repr_expand update t_orig t path args =
+let rec repr_expand update t_orig t abbrev =
   match t.desc with
-  | Tlink t' | Texpand (t', _, _) ->
-      repr_expand true t_orig t' path args
+  | Tlink t' | Texpand (t', _) ->
+      repr_expand true t_orig t' abbrev
   | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
-      repr_expand true t_orig t' path args
+      repr_expand true t_orig t' abbrev
   | _ ->
-      if update then repr_update t_orig (Texpand (t, path, args));
+      if update then repr_update t_orig (Texpand (t, abbrev));
       t
 
 let rec repr_link update t_orig t =
   match t.desc with
   | Tlink t' ->
       repr_link true t_orig t'
-  | Texpand (t', path, args) ->
-      repr_expand true t_orig t' path args
+  | Texpand (t', abbrev) ->
+      repr_expand true t_orig t' abbrev
   | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
       repr_link true t_orig t'
   | _ ->
@@ -590,8 +596,8 @@ let repr_slow_path t =
   match t.desc with
   | Tlink t' ->
       repr_link false t t'
-  | Texpand (t', path, args) ->
-      repr_expand false t t' path args
+  | Texpand (t', abbrev) ->
+      repr_expand false t t' abbrev
   | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
       repr_link true t t'
   | _ -> t
@@ -659,11 +665,15 @@ let not_marked_node mark t =
 
 let get_abbrev t =
   ignore (repr t);
-  match t.desc with Texpand (_, path, args) -> Some (path, args) | _ -> None
+  match t.desc with Texpand (_, abbrev) -> Some abbrev | _ -> None
 
 let [@inline hint] iter_abbrev f t =
   ignore (repr t);
-  match t.desc with Texpand (_, path, args) -> f path args | _ -> ()
+  match t.desc with Texpand (_, abbrev) -> f abbrev | _ -> ()
+
+let set_abbrev_level abbrev level =
+  log_change (Cabbr_level (abbrev, abbrev.abbr_level));
+  abbrev.abbr_level <- level
 
 let ignore_abbrev ty = repr ty
 
@@ -857,6 +867,7 @@ let undo_change = function
   | Ccommu (Cvar r)  -> r.commu <- Cunknown
   | Cuniv  (r, v)    -> r := v
   | Cuident change    -> Ident.Unscoped.undo_change change
+  | Cabbr_level (a, l) -> a.abbr_level <- l
 
 type snapshot = changes ref * int
 let last_snapshot = Local_store.s_ref 0
@@ -871,13 +882,18 @@ let link_expand ty ty' =
   match ty.desc with
     Tconstr (path, args, _memo) ->
       log_type ty;
-      Transient_expr.set_desc ty (Texpand (ty', path, args))
+      let abbrev =
+        { abbr_path = path;
+          abbr_args = args;
+          abbr_level = ty'.level }
+      in
+      Transient_expr.set_desc ty (Texpand (ty', abbrev))
   | _ -> Misc.fatal_error "Types.link_expand"
 
 let forget_abbrev ty =
   ignore (repr ty);
   match ty.desc with
-    Texpand (ty', _, _) ->
+    Texpand (ty', _) ->
       log_type ty;
       ty.desc <- Tlink ty'
   | _ -> Misc.fatal_error "Types.forget_abbrev"

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -885,7 +885,7 @@ let link_expand ty ty' =
       let abbrev =
         { abbr_path = path;
           abbr_args = args;
-          abbr_level = ty'.level }
+          abbr_level = ty.level }
       in
       Transient_expr.set_desc ty (Texpand (ty', abbrev))
   | _ -> Misc.fatal_error "Types.link_expand"

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -129,9 +129,9 @@ type type_desc =
   | Tfunctor of arg_label * Ident.Unscoped.t * package * type_expr
   (** Type of a dependent arrow *)
 
-  | Texpand of type_expr * Path.t * type_expr list
+  | Texpand of type_expr * abbrev
   (** [Texpand] is like [Tlink] but the result of an expansion;
-      [Path.t] and [type_expr list] remember the original declaration. *)
+      [abbrev] remember the original declaration. *)
 
   | Tlink of type_expr
   (** Indirection used by unification engine. *)
@@ -144,6 +144,12 @@ type type_desc =
       The second is available only when the first is the row variable of
       a polymorphic variant.  It then contains a copy of the whole variant.
       This constructor should not appear outside of these cases. *)
+
+(** [abbrev] remembers information about an expanded type abbreviation *)
+and abbrev =
+    { abbr_path : Path.t;
+      abbr_args : type_expr list;
+      mutable abbr_level : int }
 
 (** [package] corresponds to the type of a first-class module *)
 and package =
@@ -267,10 +273,11 @@ val try_mark_node: type_mark -> type_expr -> bool
            Return false if it was already marked *)
 
 (** Handle kept abbreviations *)
-val get_abbrev: type_expr -> (Path.t * type_expr list) option
-val iter_abbrev: (Path.t -> type_expr list -> unit) -> type_expr -> unit
+val get_abbrev: type_expr -> abbrev option
+val iter_abbrev: (abbrev -> unit) -> type_expr -> unit
 val forget_abbrev: type_expr -> unit
 val ignore_abbrev: type_expr -> type_expr
+val set_abbrev_level: abbrev -> int -> unit
 
 (** Transient [type_expr].
     Should only be used immediately after [Transient_expr.repr] *)


### PR DESCRIPTION
This is an alternative fix to #14769.
We change slightly the representation of `Texpand` nodes, to keep track explicitly of the level at which abbreviations have been checked.
This should also avoid checking the same abbreviation over and over again (across separate calls to `update_level`).