### PR TITLE
Fix detection of default arguments in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -1057,6 +1057,11 @@ OCaml 5.5.0
 - #14719, #14721: compute arity correctly for module-dependent function
   (Florian Angeletti, report by Jeremy Yallop, review by Stefan Muenzel)
 
+- #14760, #14802: Correct the detection of argument defaults in configure,
+  fixing an incorrect error message when installing OCaml through opam on
+  OpenSUSE with the site-config package installed.
+  (David Allsopp, report by Edwin Török, review by ???)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/configure
+++ b/configure
@@ -3349,6 +3349,28 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Configuring OCaml version 5.6.0+dev0-2026-01-26" >&5
 printf "%s\n" "$as_me: Configuring OCaml version 5.6.0+dev0-2026-01-26" >&6;}
 
+# It's important for the setting up of defaults and the checking of the
+# --with-relative-libdir option to know whether the user specified --libdir.
+# Unfortunately, autoconf doesn't provide an easy way to determine this, so we
+# simply repeat autoconf's argument parsing for the libdir and mandir options.
+# This is done early in the script to ensure that only autoconf and site-config
+# scripts have run.
+libdir_given=no
+mandir_given=no
+for ac_arg
+do
+  case $ac_arg in
+    -mandir=* | --mandir=* | --mandi=* | --mand=* | --man=* | --ma=* | --m=* | \
+    -mandir | --mandir | --mandi | --mand | --man | --ma | --m)
+      mandir_given=yes
+      break ;;
+    -libdir=* | --libdir=* | --libdi=* | --libd=* | \
+    -libdir   | --libdir   | --libdi   | --libd)
+      libdir_given=yes
+      break ;;
+  esac
+done
+
 # Configuration variables
 
 ## Command-line arguments passed to configure
@@ -24333,12 +24355,12 @@ esac
 
 
 
-if test x"$libdir" = x'${exec_prefix}/lib'
+if test x"$libdir_given" = 'xno'
 then :
   libdir="$libdir"/ocaml
 fi
 
-if test x"$mandir" = x'${datarootdir}/man'
+if test x"$mandir_given" = 'xno'
 then :
   mandir='${prefix}/man'
 fi
@@ -24415,7 +24437,7 @@ fi ;; #(
      ;;
 esac
 
-if test x"$libdir" = x'${exec_prefix}/lib/ocaml'
+if test x"$libdir_given" = 'xno'
 then :
   if test x"$bindir_to_libdir" != 'x'
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,28 @@ AC_INIT([OCaml],
 
 AC_MSG_NOTICE([Configuring OCaml version AC_PACKAGE_VERSION])
 
+# It's important for the setting up of defaults and the checking of the
+# --with-relative-libdir option to know whether the user specified --libdir.
+# Unfortunately, autoconf doesn't provide an easy way to determine this, so we
+# simply repeat autoconf's argument parsing for the libdir and mandir options.
+# This is done early in the script to ensure that only autoconf and site-config
+# scripts have run.
+libdir_given=no
+mandir_given=no
+for ac_arg
+do
+  case $ac_arg in
+    -mandir=* | --mandir=* | --mandi=* | --mand=* | --man=* | --ma=* | --m=* | \
+    -mandir | --mandir | --mandi | --mand | --man | --ma | --m)
+      mandir_given=yes
+      break ;;
+    -libdir=* | --libdir=* | --libdi=* | --libd=* | \
+    -libdir   | --libdir   | --libdi   | --libd)
+      libdir_given=yes
+      break ;;
+  esac
+done
+
 # Configuration variables
 
 ## Command-line arguments passed to configure
@@ -2997,10 +3019,10 @@ shlwapi.lib synchronization.lib"])
 
 AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 
-AS_IF([test x"$libdir" = x'${exec_prefix}/lib'],
+AS_IF([test x"$libdir_given" = 'xno'],
   [libdir="$libdir"/ocaml])
 
-AS_IF([test x"$mandir" = x'${datarootdir}/man'],
+AS_IF([test x"$mandir_given" = 'xno'],
   [mandir='${prefix}/man'])
 
 # Define default prefix correctly for the different Windows ports
@@ -3054,7 +3076,7 @@ AS_CASE([$cygwin_build_env,$host],
         [ocaml_libdir='${exec_prefix}\lib\ocaml'],
         [ocaml_libdir="$libdir"])])])
 
-AS_IF([test x"$libdir" = x'${exec_prefix}/lib/ocaml'],
+AS_IF([test x"$libdir_given" = 'xno'],
   [AS_IF([test x"$bindir_to_libdir" != 'x'],
     [ocaml_libdir="$bindir_to_libdir"
     target_libdir_is_relative=true


### PR DESCRIPTION
Alternate approach to #14761 for fixing #14760.

With OpenSUSE's site-config package installed, an autoconf mechanism is used which changes the default here:
https://github.com/ocaml/ocaml/blob/e451baeed3f31ae76af3116c84d76aa32a62a762/configure#L1158
to `'${exec_prefix}/lib64'` which has always thwarted the check here:
https://github.com/ocaml/ocaml/blob/e451baeed3f31ae76af3116c84d76aa32a62a762/configure.ac#L3000-L3001

You can see this before this PR:
```console
$ ./configure > /dev/null && grep ^LIBDIR Makefile.config
LIBDIR=${exec_prefix}/lib64
```

and, as in #14761, with this PR:

```console
$ ./configure > /dev/null && grep ^LIBDIR Makefile.config
LIBDIR=${exec_prefix}/lib64/ocaml
```

Rather than hard-coding a second value, the approach here instead scans the argument lists. The loop is mildly ugly, but is basically the one `configure` generates:
https://github.com/ocaml/ocaml/blob/e451baeed3f31ae76af3116c84d76aa32a62a762/configure#L1300-L1303

Given that the checking for `--with-relative-libdir` really does want to know if `--libdir` was specified, I think this approach is better. Technically, it actually thwarts the workaround in https://github.com/ocaml/ocaml/issues/14760#issuecomment-4282568625, but I think that's a good thing.