### PR TITLE
Allow using constructors as builder functions

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -391,6 +391,11 @@ let is_iarray_type env ty =
 let protect_expansion env ty =
   if Env.has_local_constraints env then generic_instance ty else ty
 
+let is_arrow_type env ty =
+  match get_desc (expand_head_opt env (protect_expansion env ty)) with
+  | Tarrow _ -> true
+  | _ -> false
+
 type record_extraction_result =
   | Record_type of Path.t * Path.t * Types.label_declaration list
   | Not_a_record_type
@@ -4574,6 +4579,24 @@ and type_expect_
         exp_type = newty (Ttuple (List.map (fun (l, e) -> l, e.exp_type) expl));
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
+  | Pexp_construct(lid, None) when is_arrow_type env ty_expected ->
+      let var_name = "*auto_eta*" in
+      let var_loc = { loc with Location.loc_ghost = true } in
+      let pat = Ast_helper.Pat.var ~loc:var_loc { txt = var_name; loc = var_loc } in
+      let var_exp =
+        Ast_helper.Exp.ident ~loc:var_loc
+          { txt = Longident.Lident var_name; loc = var_loc }
+      in
+      let body = Ast_helper.Exp.construct ~loc:var_loc lid (Some var_exp) in
+      let param =
+        { pparam_loc = var_loc;
+          pparam_desc = Pparam_val (Nolabel, None, pat) }
+      in
+      let new_sexp =
+        Ast_helper.Exp.function_ ~loc ~attrs:sexp.pexp_attributes
+          [param] None (Pfunction_body body)
+      in
+      type_expect_ ~recarg env new_sexp ty_expected_explained
   | Pexp_construct(lid, sarg) ->
       type_construct env ~sexp lid sarg ty_expected_explained
   | Pexp_variant(l, sarg) ->


### PR DESCRIPTION
This is a very preliminary PR, **for discussion** (no test, etc).

When type-checking an argument-less constructor expression in a context expecting a function type, automatically eta-expand it into 'fun x -> Foo x'. For instance, this PR allows writing `List.map Some [1;2;3]`. Contrary to #9005, no new syntax is introduced here.

This "convenience" proposal is particularly useful when using libraries like vdom, where one needs to create many "wrapper" functions. For instance, here is a typical diff made possible by this PR:
 ```diff
   let controls =
     Flex.row ~wrap:`yes ~gap:`_2 [
-      checkbox "Hide initial" (fun b -> User_toggle_hide_initial b) ~checked:model.hide_initial;
-      checkbox "Hide deprecated" (fun b -> User_toggle_hide_deprecated b) ~checked:model.hide_deprecated;
-      checkbox "Show tags" (fun b -> User_toggle_show_tags b) ~checked:model.show_tags;
+      checkbox "Hide initial" User_toggle_hide_initial ~checked:model.hide_initial;
+      checkbox "Hide deprecated" User_toggle_hide_deprecated ~checked:model.hide_deprecated;
+      checkbox "Show tags" User_toggle_show_tags ~checked:model.show_tags;
     ]
   in
   let search_input =
````

Side-note : this PR does not do anything special about n-ary constructors. It would interact well with another possible extension : allowing `C e` when `C` resolves to a n-ary constructor (with the "eta" expansion `let (x1,..,xn) = e in C (x1,...,xn)`), but if people don't agree with the fact that this would be the right thing to do (i.e. they would prefer `C` to be turned into a curried function instead of a tupled one, despite what the OCaml syntax suggests), then one could restrict this PR to work only on unary constructors to avoid having deciding anything about n-ary constructors now.