### PR TITLE
Expose `caml_ba_compare` et al

### DIFF
--- a/Changes
+++ b/Changes
@@ -114,6 +114,10 @@ Working version
 - #14506: Add frame pointers support for RISC-V Linux.
   (Miod Vallat and Tim McGilchrist, review by Zane Hambly)
 
+- #14804: Expose caml_ba_compare, etc. publicly, removing the need to define
+  CAML_INTERNALS when allocating custom bigarrays.
+  (David Allsopp, review by ???)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -141,12 +141,6 @@ CAMLextern value caml_ba_alloc_dims(int flags, int num_dims, void * data,
 CAMLextern uintnat caml_ba_byte_size(struct caml_ba_array * b);
 CAMLextern uintnat caml_ba_num_elts(struct caml_ba_array * b);
 
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef CAML_INTERNALS
-
 CAMLextern const int caml_ba_element_size[];
 CAMLextern void caml_ba_finalize(value v);
 CAMLextern int caml_ba_compare(value v1, value v2);
@@ -154,6 +148,8 @@ CAMLextern intnat caml_ba_hash(value v);
 CAMLextern void caml_ba_serialize(value, uintnat *, uintnat *);
 CAMLextern uintnat caml_ba_deserialize(void * dst);
 
-#endif  /* CAML_INTERNALS */
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CAML_BIGARRAY_H */


### PR DESCRIPTION
Currently the functions needed to construct the `struct custom_operations` for a bigarray are guarded in bigarray.h:
https://github.com/ocaml/ocaml/blob/5a1adc03a3f957c62e12faee0a2fa7141f8618ef/runtime/caml/bigarray.h#L148-L157

There are a few libraries which define `CAML_INTERNALS` solely in order to access these functions, typically, though not exclusively, to change or chain some aspect of the finalisation behaviour. Given that these function pointers can be trivially obtained using `Custom_ops_val` (which is publicly declared in custom.h) and given that `caml_ba_element_size` is nicely `const`ified since #13470, it seems that we could reasonably make these "public".