### PR TITLE
typing: fix duplicated "the" in typecore.ml and errortrace_report.ml comments

### DIFF
--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -92,7 +92,7 @@ let prepare_any_trace printing_status tr =
 let prepare_trace f tr =
   prepare_any_trace printing_status (Errortrace.map f tr)
 
-(** Keep elements that are [Diff _ ] and split the the last element if it is
+(** Keep elements that are [Diff _ ] and split the last element if it is
     optionally elidable, require a prepared trace *)
 let rec filter_trace = function
   | [] -> [], None

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6825,7 +6825,7 @@ and map_half_typed_cases
           else
             ext_env
         in
-        (* Before handing off the cases to the callback, first set up the the
+        (* Before handing off the cases to the callback, first set up the
            branch environments by adding the variables (and module variables)
            from the patterns.
         *)


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in source comments:
- `typing/typecore.ml` — "first set up the the" → "first set up the"
- `typing/errortrace_report.ml` — "split the the last element" → "split the last element"

No code/behavior change.