### PR TITLE
runtime/typing: fix duplicated "the" in env.mli and lf_skiplist.c comments

### DIFF
--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -148,7 +148,7 @@ static int skiplist_find(struct lf_skiplist *sk, uintnat key,
 
 retry:
   while (1) {
-    /* start at the the head of the skiplist. This node has a key less than any
+    /* start at the head of the skiplist. This node has a key less than any
        key we could be searching for */
     pred = sk->head;
     /*

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -403,7 +403,7 @@ val enter_signature: ?mod_shape:Shape.t -> scope:int -> signature -> t ->
   signature * t
 
 (* Same as [enter_signature] but also extends the shape map ([parent_shape])
-   with all the the items from the signature, their shape being a projection
+   with all the items from the signature, their shape being a projection
    from the given shape. *)
 val enter_signature_and_shape: scope:int -> parent_shape:Shape.Map.t ->
   Shape.t -> signature -> t -> signature * Shape.Map.t * t


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in source comments:
- `typing/env.mli` — "with all the the items from the signature" → "with all the items from the signature"
- `runtime/lf_skiplist.c` — "start at the the head of the skiplist" → "start at the head of the skiplist"

No code/behavior change.