### PR TITLE
Minor build fixes for cross-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,5 +329,6 @@ META
 /utils/domainstate.mli
 
 /yacc/ocamlyacc
+/yacc/ocamlyacc.opt
 /yacc/version.h
 /yacc/.gdb_history

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -253,7 +253,7 @@ let compile infile outfile =
   if masm then
     Ccomp.command (Config.asm ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
-                   (if !Clflags.verbose then "" else ">NUL"))
+                   (if !Clflags.verbose then "" else ">" ^ Filename.null))
   else
     Ccomp.command (Config.asm ^ " " ^
                    (String.concat " " (Misc.debug_prefix_map_flags ())) ^

--- a/configure
+++ b/configure
@@ -15030,7 +15030,7 @@ printf "%s\n" "$ocaml_cc_vendor" >&6; }
 
 
 DEP_CC_PREFIX=''
-case $host in #(
+case $target in #(
   sparc-sun-solaris*) :
     DEP_CC="false" ;; #(
   *-pc-windows) :

--- a/configure.ac
+++ b/configure.ac
@@ -847,7 +847,7 @@ OCAML_ASM_SIZE_TYPE_DIRECTIVES
 OCAML_CC_VENDOR
 
 DEP_CC_PREFIX=''
-AS_CASE([$host],
+AS_CASE([$target],
   [sparc-sun-solaris*],
     [DEP_CC="false"],
   [*-pc-windows],


### PR DESCRIPTION
Three (for now) minor build fixes for cross-compilation scenarios. These are so small and so self-contained that I'm submitting them independently. I'm hacking around cross-compiling with the `*-pc-windows` target, either with cl running in Wine or with clang-cl.

- [Git-ignore `/yacc/ocamlyacc.opt`](https://github.com/ocaml/ocaml/commit/abb3b13bdc8ec64384322908052626aacb683b6c)
  It is produced when building an OCaml cross-compiler, see the `installcross` rule in `/Makefile.cross`.

- [`asmcomp/x86_proc`: redirect masm output to `Filename.null`, not `NUL`](https://github.com/ocaml/ocaml/commit/642cc520ab90bda7e89f685cc192f7f2c244f38e)
  If the compilation target is `*-pc-windows`, then the output of masm will be redirected to the Windows null device (`NUL`). This doesn't work when the host is a true *nix, this will create `NUL` files. Instead, redirect the output to the host null device, portably given by `Filename.null`.

- [configure: use the target compiler for `DEP_CC`](https://github.com/ocaml/ocaml/commit/22777bffffd156e04f6c2c1e978ff83dcb77f43e)
  If the target is `*-pc-windows` and the host is a *nix, and `CC=cl` (cl can be run in Wine) then the code path rejecting cl is not taken as the host is a cc, and `DEP_CC` is set to cl. The dependency compiler should be decided based on the target, not the host.

no-change-entry-needed, configure-related.