### PR TITLE
ephemerons: ensure that no orphaned ephemerons remain across GC cycles

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,7 @@ Working version
 - grouped fixes in the ephemeron runtime
   + #14734: fix ephemeron orphaning (a counterpart of #14722)
   + #14733: clarify the implementation of per-domain ephemeron work counters
+  + #14813: ensure that no orphaned ephemerons remain across GC cycles
   (Gabriel Scherer, review by Damien Doligez)
 
 ### Type system:

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -152,6 +152,14 @@ Caml_inline char caml_gc_phase_char(int may_access_gc_phase) {
   }
 }
 
+static bool is_complete_phase_sweep_and_mark_main (void);
+static bool is_complete_phase_mark_final (void);
+static bool is_complete_phase_sweep_ephe (void);
+
+static bool is_complete_last_phase (void) {
+  return is_complete_phase_sweep_ephe();
+}
+
 /*******************************************************************************
  * Prefetching
  ******************************************************************************/
@@ -1908,7 +1916,9 @@ struct cycle_callback_params {
   int force_compaction;
 };
 
-static void stw_cycle_all_domains(
+static atomic_bool can_cycle_all_domains;
+
+static void stw_try_cycle_all_domains(
   caml_domain_state* domain, void* args,
   int participating_count,
   caml_domain_state** participating)
@@ -1916,6 +1926,23 @@ static void stw_cycle_all_domains(
   /* We copy params because the stw leader may leave early. No barrier needed
      because there's one in the minor gc and after. */
   struct cycle_callback_params params = *((struct cycle_callback_params*)args);
+
+  /* It is possible that a domain invalidated the end-of-phase
+     condition while we were waiting for the STW section to start.
+     In this case we return immediately without actually ending the cycle. */
+  Caml_global_barrier_if_final(participating_count) {
+    /* We check [is_complete_last_phase] from within the STW section.
+       Otherwise a domain could make the last phase incomplete before joining
+       the STW section, invalidating the previous checks of other domains.
+
+       We check inside a barrier. Otherwise a domain could see an incomplete
+       phase, leave the STW section, and then make the last phase
+       complete. This would result in inconsistent behaviors with respects to
+       domains that have not reached the check yet -- some domains would exit
+       and some would stay and complete the cycle, which is incorrect. */
+    can_cycle_all_domains = is_complete_last_phase();
+  }
+  if (!can_cycle_all_domains) return;
 
   /* TODO: Not clear this memprof work is really part of the "cycle"
    * operation. It's more like ephemeron-cleaning really. An earlier
@@ -2334,23 +2361,29 @@ mark_again:
               sweep_work, mark_work,
               domain_state->stat_blocks_marked - blocks_marked_before);
 
-  if (mode != Slice_opportunistic && is_complete_phase_sweep_ephe()) {
+  if (mode != Slice_opportunistic && is_complete_last_phase()) {
     /* To handle the case where multiple domains try to finish the major cycle
        simultaneously, we loop until the current cycle has ended, ignoring
-       whether [caml_try_run_on_all_domains] succeeds. */
+       whether [caml_try_run_on_all_domains] succeeds.
+
+       If the phase becomes incomplete again (for example if a domain
+       adds orphaned work), we give up on finishing the cycle now. */
+
     saved_major_cycle = caml_major_cycles_completed;
 
     struct cycle_callback_params params;
     params.force_compaction = force_compaction;
 
-    while (saved_major_cycle == caml_major_cycles_completed) {
+    while (saved_major_cycle == caml_major_cycles_completed
+           && is_complete_last_phase())
+    {
       if (barrier_participants) {
-        stw_cycle_all_domains
+        stw_try_cycle_all_domains
               (domain_state, (void*)&params,
                 participant_count, barrier_participants);
       } else {
         caml_try_run_on_all_domains
-              (&stw_cycle_all_domains, (void*)&params, 0);
+              (&stw_try_cycle_all_domains, (void*)&params, 0);
       }
     }
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -2008,7 +2008,7 @@ static void stw_cycle_all_domains(
  * Major GC phases
  ******************************************************************************/
 
-static int is_complete_phase_sweep_and_mark_main (void)
+static bool is_complete_phase_sweep_and_mark_main (void)
 {
   return
     /* Marking is done */
@@ -2027,7 +2027,7 @@ static int is_complete_phase_sweep_and_mark_main (void)
     no_orphaned_work();
 }
 
-static int is_complete_phase_mark_final (void)
+static bool is_complete_phase_mark_final (void)
 {
   return
     /* updated finalise first values */
@@ -2045,7 +2045,7 @@ static int is_complete_phase_mark_final (void)
     no_orphaned_work();
 }
 
-static int is_complete_phase_sweep_ephe (void)
+static bool is_complete_phase_sweep_ephe (void)
 {
   return
     /* All domains have swept their ephemerons */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -756,14 +756,16 @@ static int no_orphaned_work (void)
     atomic_load_acquire(&orph_structs.final_info) == NULL;
 }
 
-static void adopt_orphaned_work (int expected_status)
+static void adopt_orphaned_work (void)
 {
   caml_domain_state* domain_state = Caml_state;
   value orph_ephe_list_live;
   struct caml_final_info *f, *myf, *temp;
 
 #ifdef DEBUG
-  orph_ephe_list_verify_status(expected_status);
+  /* We mark ephemerons before orphaning them,
+     and always re-adopt them during the same cycle. */
+  orph_ephe_list_verify_status(caml_global_heap_state.MARKED);
 #endif
 
   if (no_orphaned_work())
@@ -1772,18 +1774,8 @@ void caml_mark_roots_stw (int participant_count,
 
     latest_sweep_allocs = diffmod (work_counter, work_counter_at_sweep_start);
 
-    /* Adopt orphaned work from domains that were spawned and terminated in the
-       previous cycle. There must be no orphaned work remaining when this phase
-       change takes place because orphaned work contains roots.
-
-       [adopt_orphaned_work] also verifies that the ephemerons to be adopted
-       all have status [UNMARKED] in this cycle.
-
-       Note that ephemerons are not orphaned in [Phase_sweep_main]. When
-       orphaned, ephemerons and their data are [MARKED]. Any unadopted
-       ephemerons must come from last cycle. Due to the GC cycling, the
-       [MARKED] ephemerons must have status [UNMARKED] now. */
-    adopt_orphaned_work (caml_global_heap_state.UNMARKED);
+    /* Orphaned work may contain roots so we adopt them first. */
+    adopt_orphaned_work();
 
     global_prepare_for_ephe_marking(participant_count);
   }
@@ -2267,7 +2259,7 @@ mark_again:
     }
 
     if (!caml_domain_is_terminating()){
-      adopt_orphaned_work(caml_global_heap_state.MARKED);
+      adopt_orphaned_work();
     }
 
     /* Ephemerons */


### PR DESCRIPTION
This is the next PR in my current tree of ephemeron branches (described in https://github.com/ocaml/ocaml/discussions/14720#discussioncomment-16537367 ), after #14732 was merged.

This PR ensures that no orphaned ephemerons remain across GC cycles. Currently the major-GC code tries to ensure that phase changes do not occur when ephemerons are orphaned (which is good as it simplifies the orphaning and adoption logic), but it fails to prevent this correctly at the very end of the GC cycle.

The problem is that when a  domain observes that the last phase is complete it starts requesting a STW section to move to the next cycle, but in-between this request and the actual STW another domain may terminate and orphan ephemerons. The fix in the present PR is to start the next-cycle STW session with a barrier that checks that the phase-complete condition still holds, and set a global atomic flag that either has all participating domains continue or halts them all.

 ( cc @damiendoligez, with whom I discussed this work )

Note: it is possible to implement this without a barrier, because domains only enter the STW section when all domains have stopped mutator code, so the first domain to reach the check could check it correctly. But this would require a more complex synchronization mechanism; an earlier iteration of this PR had the common flag as part of the `cycle_params_callback` structure, with value among `{-1, true, false}`, and a possible race between checking domains. (Another option would be to add yet another kind of "leader_setup" callback that only runs after all domains are available.) The code with a barrier is much simpler, and this is not performance-sensitive as GC cycles are relatively rare events.