### PR TITLE
mlvalues.h: caml_result_find_exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -129,6 +129,9 @@ Working version
   r31 stays allocatable when frame pointers are disabled
   (Tim McGilchrist, review by Zane Hambly and Olivier Nicole)
 
+- #14814: a `caml_result_find_exception` helper for the `caml_result` type
+  (Gabriel Scherer, review by Nicolás Ojeda Bär, request by Chris Vine)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -101,6 +101,7 @@ typedef struct caml_result_private caml_result;
    change in the future. Its public interface is formed of
    - Result_value, Result_exception
    - caml_result_is_exception
+   - caml_result_find_exception
    - caml_get_value_or_raise (in fail.h)
 */
 struct caml_result_private {
@@ -116,6 +117,12 @@ struct caml_result_private {
 Caml_inline int caml_result_is_exception(struct caml_result_private result)
 {
   return result.is_exception;
+}
+
+Caml_inline value *caml_result_find_exception(
+  struct caml_result_private *result)
+{
+  return (result->is_exception ? &result->data : NULL);
 }
 
 #define Result_unit Result_value(Val_unit)

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -107,9 +107,10 @@ static void run_pending_actions(struct compare_stack* stk,
   Begin_roots_block(roots_start, roots_length);
   result = caml_do_pending_actions_res();
   End_roots();
-  if (caml_result_is_exception(result)) {
+  value *exn = caml_result_find_exception(&result);
+  if (exn) {
     compare_free_stack(stk);
-    (void) caml_get_value_or_raise(result);;
+    caml_raise(*exn);
   }
 }
 


### PR DESCRIPTION
This is a proposal to solve #14016, following a proposal by @nojb in https://discuss.ocaml.org/t/using-ocaml-5-3s-caml-callback-res-function/16601/4.

This adds an inline function

```c
value *caml_result_find_exception(caml_result *);
```

which returns either NULL, if the result has no exception, or a pointer to the exception payload. Using it looks like it:

```c
  if (value *exn = caml_result_find_exception(&result)) {
    compare_free_stack(stk);
    caml_raise(*exn);
  }
```

Personally I find the use of pointers not very nice. I considered the following prototype instead

```c
value caml_result_find_exception(caml_result);
```

which returns either `0` (or `(value)NULL` for those who prefer) or a valid exception. But this is actually a bad idea as (1) it creates invalid values, which is what the `caml_result` API is trying to avoid, and (2) the returned value does not survive across allocations, while the pointer may survive if the `caml_result` has been registered as a root.

(I am not fully satisfied with this proposal, but then the solution of doing nothing is not an adequate way to address #14016 either.)