### PR TITLE
remove some long-lost ocamlrun option from its manpage

### DIFF
--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -142,12 +142,6 @@ chapter "Standard Library", section "Gc".
 
 .RS 7
 .TP
-.BR a " (allocation_policy)"
-The policy used for allocating in the OCaml heap.  Possible values
-are 0 for the next-fit policy, 1 for the first-fit
-policy, and 2 for the best-fit policy. The default is 2.
-See the Gc module documentation for details.
-.TP
 .B b
 Trigger the printing of a stack backtrace
 when an uncaught exception aborts the program.
@@ -157,17 +151,6 @@ This option takes no argument.
 (cleanup_on_exit) Shut the runtime down gracefully on exit. The option
 also enables pooling (as in caml_startup_pooled). This mode can be used
 to detect leaks with a third-party memory debugger.
-.TP
-.BR h
-The initial size of the major heap (in words).
-.TP
-.BR H
-Allocate heap chunks by mmapping huge pages. Huge pages are locked into
-memory, and are not swapped.
-.TP
-.BR i " (major_heap_increment)"
-The default size increment for the major heap (in words if greater than 1000,
-else in percents of the heap size).
 .TP
 .BR l " (stack_limit)"
 The limit (in words) of the stack size.
@@ -210,9 +193,6 @@ Default: 8192 bytes.
 .TP
 .BR o " (space_overhead)"
 The main major GC speed setting.
-.TP
-.BR O " (max_overhead)"
-The heap compaction trigger setting.
 .TP
 .B p
 Turn on debugging support for
@@ -278,10 +258,6 @@ GC debugging messages.
 .BR 0x1000
 Address space reservation changes.
 
-.TP
-.BR w " (window_size)"
-Set size of the window used by major GC for smoothing out variations in
-its workload. This is an integer between 1 and 50. (Default: 1)
 .TP
 .BR W
 Print runtime warnings to stderr (such as Channel opened on file dies without


### PR DESCRIPTION
The PR #10890 removed OCAMLRUNPARAM parameters unused by the 5.x runtime (a, h, H, i, O, w) from the code of startup_aux and from the manual. The current commit removes them from the manpage as well.