### PR TITLE
manpage: synchronize ocamlrunparam with the manual

### DIFF
--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -133,7 +133,7 @@ and an optional multiplier. If the letter is followed by anything
 else, the corresponding option is set to 1. Unknown letters
 are ignored.
 The options are documented below; the options
-.BR a , i , l , m , M , n , o , O , s , v , w
+.BR l , m , M , n , o , s , v
 correspond to the fields of the
 .B control
 record documented in
@@ -151,6 +151,15 @@ This option takes no argument.
 (cleanup_on_exit) Shut the runtime down gracefully on exit. The option
 also enables pooling (as in caml_startup_pooled). This mode can be used
 to detect leaks with a third-party memory debugger.
+.TP
+.B d " (max_domains)"
+Maximum number of domains that can be active concurrently. Defaults to
+128 on 64-bit platforms and 16 on 32-bit platforms.
+.TP
+.B e " (runtime_events_log_wsize)"
+Size of the per-domain runtime events ring buffers in log powers of
+two words. Defaults to 16, giving 64k word or 512kb buffers on 64-bit
+systems.
 .TP
 .BR l " (stack_limit)"
 The limit (in words) of the stack size.
@@ -258,6 +267,10 @@ GC debugging messages.
 .BR 0x1000
 Address space reservation changes.
 
+.TP
+.BR V
+(verify_heap) Runs an integrity check on the heap just after the
+completion of a major GC cycle.
 .TP
 .BR W
 Print runtime warnings to stderr (such as Channel opened on file dies without

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -175,12 +175,7 @@ The following environment variables are also consulted:
         the pushdown automaton that executes the parsers prints a
         trace of its actions.  This option takes no argument.
   \item[R] (randomize) Turn on randomization of all hash tables by default
-        (see
-\ifouthtml
-  \ahref{libref/Hashtbl.html}{Module \texttt{Hashtbl}}).
-\else
-  section~\ref{Hashtbl}).
-\fi
+        (see \stdmoduleref{Hashtbl}).
         This option takes no argument.
   \item[s] ("minor_heap_size")  Size of the minor heap. (in words)
   \item[t] Set the trace level for the debug runtime (ignored by the standard runtime).

--- a/manual/src/refman/extensions/indexops.etex
+++ b/manual/src/refman/extensions/indexops.etex
@@ -4,7 +4,6 @@
 (Introduced in 4.06)
 
 \begin{syntax}
-
 dot-ext:
    | dot-operator-char { operator-char }
 ;

--- a/manual/src/refman/extensions/signaturesubstitution.etex
+++ b/manual/src/refman/extensions/signaturesubstitution.etex
@@ -70,9 +70,7 @@ specification:
         | 'type' type-subst { 'and' type-subst }
         | 'module' module-name ':=' extended-module-path
         | 'module' 'type' module-name ':=' module-type
-
 ;
-
 type-subst:
           [type-params] typeconstr-name ':=' typexpr { type-constraint }
 \end{syntax}

--- a/manual/tools/fix_index.sh
+++ b/manual/tools/fix_index.sh
@@ -40,6 +40,8 @@ case $# in
 esac
 
 sed < "$1" > "$1.new" \
+    -e 's/verb`("|hyperxindexformat{\\"}/verb`("|"|)`|hyperpage/' \
+    -e 's/verb`("|hyperxindexformat{\\>)`}/verb`("|>)`|hyperpage/' \
     -e 's/verb`("|hyperindexformat{\\"}/verb`("|"|)`|hyperpage/' \
     -e 's/verb`("|hyperindexformat{\\>)`}/verb`("|>)`|hyperpage/'
 


### PR DESCRIPTION
This PR is collection of small documentation fixes:

- The first commit in this PR synchronizes the manual and manpage version of OCAMLRUNPARAM by adding the missing `d`, `e` and `V` options and updating the list of GC related flags in the manpage version.

- The second commit simplifies the manual description of the `R` option by using the `stdmoduleref` macro to reference the `Hashtbl` module.

- The third and fourth commits are small fixes to make the manual compiles with texlive.2025.20260124 (by removing unneeded blank lines in grammar description and extending the rules for `|>` and `||` in the indexes).