### PR TITLE
testsuite: add a test that fragments the sizeclass pools

### DIFF
--- a/testsuite/tests/misc/pool_fragment.ml
+++ b/testsuite/tests/misc/pool_fragment.ml
@@ -1,0 +1,123 @@
+(* TEST *)
+type t = unit array
+
+let empty = [||]
+
+let alloc words : t =
+  assert (words > 1) ;
+  let n = words - 1 in
+  Array.make n ()
+
+let pool_wsize = 4096
+
+let pool_header_wsize = 4
+
+let minor_heap_size = Gc.(get ()).minor_heap_size
+
+let pools_per_minor_heap = minor_heap_size / (pool_wsize - pool_header_wsize)
+
+let sizeclasses =
+  [ 2
+  ; 3
+  ; 4
+  ; 5
+  ; 6
+  ; 7
+  ; 8
+  ; 10
+  ; 12
+  ; 14
+  ; 16
+  ; 17
+  ; 19
+  ; 22
+  ; 25
+  ; 28
+  ; 32
+  ; 33
+  ; 37
+  ; 42
+  ; 47
+  ; 53
+  ; 59
+  ; 65
+  ; 73
+  ; 81
+  ; 89
+  ; 99
+  ; 108
+  ; 118
+  ; 128 ]
+
+let repeat = 40
+
+let keep =
+  Array.init repeat (fun _ ->
+      Array.make_matrix List.(length sizeclasses) pools_per_minor_heap empty )
+
+let fragment_sizeclasses () =
+  let fragment_sizeclass j sizeclass_idx sizeclass =
+    let n = minor_heap_size / sizeclass in
+    let pool_entries = (pool_wsize - pool_header_wsize) / sizeclass in
+    (* this will trigger an implicit minor GC when n > 256 *)
+    let all = Array.init n (fun _ -> alloc sizeclass) in
+    for i = 1 to pools_per_minor_heap do
+      keep.(j).(sizeclass_idx).(i - 1) <- all.((i * pool_entries) - 1)
+    done
+    (* [all] becomes freeable here *)
+  in
+  let fragment_sizeclass sizeclass_idx sizeclass =
+    for j = 0 to repeat - 1 do
+      fragment_sizeclass j sizeclass_idx sizeclass
+    done
+  in
+  sizeclasses |> List.iteri fragment_sizeclass
+
+let print_delta gc0 gc1 reachable_words =
+  let delta_top_heap_words = gc1.Gc.top_heap_words - gc0.Gc.top_heap_words in
+  let delta_heap_words = gc1.Gc.heap_words - gc0.Gc.heap_words in
+  let delta_frag_words = gc1.Gc.fragments - gc0.Gc.fragments in
+  Printf.printf
+    "+top_heap_words: %d, +heap_words: %d, +reachable_words: %d, +frag_words: \
+     %d, ratio: %.2f\n"
+    delta_top_heap_words delta_heap_words reachable_words delta_frag_words
+    (float_of_int delta_heap_words /. float_of_int reachable_words)
+
+(* for easier comparison with OCaml 4 turn off deprecation alerts on Gc.stat.
+   Gc.quick_stat on OCaml 4 would set live_words to 0, so it cannot be used.
+ *)
+[@@@alert "-deprecated"]
+
+let full_major_and_top_ratio () =
+  Gc.full_major () ;
+  Gc.full_major () ;
+  let gc = Gc.stat () in
+  (* we're interested in the top memory usage here, since this can lead to OOM *)
+  float_of_int gc.top_heap_words /. float_of_int gc.live_words
+
+let compact_and_ratio () =
+  Gc.compact () ;
+  Gc.compact () ;
+  let gc = Gc.stat () in
+  (* compaction can't decrease top_heap_words, just heap_words *)
+  float_of_int gc.heap_words /. float_of_int gc.live_words
+
+let () =
+  (* disable automatic compaction for a fairer comparison with OCaml 4 *)
+  Gc.(set {(get ()) with max_overhead= 1000000}) ;
+  fragment_sizeclasses () ;
+  let ratio = full_major_and_top_ratio () in
+  if ratio > 16. then begin
+    Gc.print_stat stdout ;
+    Printf.printf "\n[!] Top heap size to live words ratio is too high: %.2f\n"
+      ratio
+  end
+  else print_endline "top_heap_words/live_words: OK" ;
+  let ratio = compact_and_ratio () in
+  if ratio > 3. then begin
+    Gc.print_stat stdout ;
+    Printf.printf
+      "\n[!] Heap size after compaction to live words ratio is too high: %.2f\n"
+      ratio
+  end
+  else print_endline "\ncompact: OK"

--- a/testsuite/tests/misc/pool_fragment.ml
+++ b/testsuite/tests/misc/pool_fragment.ml
@@ -49,7 +49,7 @@ let sizeclasses =
   ; 118
   ; 128 ]
 
-let repeat = 40
+let repeat = 20
 
 let keep =
   Array.init repeat (fun _ ->
@@ -113,7 +113,7 @@ let () =
   let ratio = full_major_and_top_ratio () in
   (* if you've changed the GC and confirmed that the higher ratio is
      an expected and acceptable trade-off then tweak this constant *)
-  if ratio > 16. then begin
+  if ratio > 25. then begin
     Gc.print_stat stdout ;
     Printf.printf "\n[!] Top heap size to live words ratio is too high: %.2f.\n"
       ratio;

--- a/testsuite/tests/misc/pool_fragment.ml
+++ b/testsuite/tests/misc/pool_fragment.ml
@@ -102,22 +102,33 @@ let compact_and_ratio () =
   (* compaction can't decrease top_heap_words, just heap_words *)
   float_of_int gc.heap_words /. float_of_int gc.live_words
 
+(* See c89bff11ab944e868413f446e1444577e7f6cdbb *)
+let triage_msg = "Have you changed the GC?"
+let triage_msg_compact = "Have you changed the GC compactor?"
+
 let () =
   (* disable automatic compaction for a fairer comparison with OCaml 4 *)
   Gc.(set {(get ()) with max_overhead= 1000000}) ;
   fragment_sizeclasses () ;
   let ratio = full_major_and_top_ratio () in
+  (* if you've changed the GC and confirmed that the higher ratio is
+     an expected and acceptable trade-off then tweak this constant *)
   if ratio > 16. then begin
     Gc.print_stat stdout ;
-    Printf.printf "\n[!] Top heap size to live words ratio is too high: %.2f\n"
-      ratio
+    Printf.printf "\n[!] Top heap size to live words ratio is too high: %.2f.\n"
+      ratio;
+    print_endline triage_msg
   end
   else print_endline "top_heap_words/live_words: OK" ;
   let ratio = compact_and_ratio () in
+  (* This is expected to be around 1, so this is not expected to fail.
+     There is some memory that cannot freed, so it isn't exactly 1.
+   *)
   if ratio > 3. then begin
     Gc.print_stat stdout ;
     Printf.printf
       "\n[!] Heap size after compaction to live words ratio is too high: %.2f\n"
-      ratio
+      ratio;
+    print_endline triage_msg_compact
   end
   else print_endline "\ncompact: OK"

--- a/testsuite/tests/misc/pool_fragment.reference
+++ b/testsuite/tests/misc/pool_fragment.reference
@@ -1,0 +1,3 @@
+top_heap_words/live_words: OK
+
+compact: OK


### PR DESCRIPTION
On OCaml 4.14.3, OCaml 5.5 (beta) and trunk this test passes. On OCaml 5.4.1 the test fails.

I tracked down the fix to the following:
c89bff11ab ("This is a rebase of the following patch by @stedolan: Major GC work accounting fixes (oxcaml#3618)")

It mentions that:
> the amount of free blocks in in-use pools tends to
> be low, but it makes the code closer to the theory

This adds a testcase so it is not theoretical anymore.

This is a simplified form of a test I've been writing that tries to trigger worst-case memory consumption in the GC, and was crashing with OOM on 5.4, and passing on 4.14. The test is modified to check the ratio without OOMing.

It runs successfully within 512MiB (note that d=1 is required when using ulimit, otherwise it fails due to 128 minor heaps)
```
ulimit -v 524288; OCAMLRUNPARAM=d=1 boot/ocamlrun testsuite/tests/misc/pool_fragment
```

I see there are a few branches/PRs with further tweaks to the GC, so I thought'd it'd be useful to add this testcase to avoid it regressing again.

I checked that with https://github.com/ocaml/ocaml/pull/14796 this testcase still passes.

# Background

I was writing a test that tries to trigger worst case total to live memory usage from the GC. 
For non-moving allocators a theoretical bound is known (https://sqlite.org/malloc.html#_mathematical_guarantees_against_memory_allocation_failures), together with an algorithm that can achieve the theoretical bound, and an allocation pattern that can trigger the worst case in that algorithm.
For allocators that can move, or incremental GCs I'm not aware of such theoretical bounds (if you compact you can achieve a 1:1 ratio, much better than for non-moving allocators), although steady-state assumptions in pacing complicates this.

The initial test for fragmentation based on https://doi.org/10.1109/TC.2009.154 and https://doi.org/10.1145/321832.321846 worked well, however slight tweaks have shown very large changes in memory usage, and even crashes due to OOM.

I observed that inserting a `Gc.minor ()` call (or equivalently a sufficiently large `Array.make` which triggers it implicitly) can really upset the GC and prevent it from reaching a steady state.
Initially I was worried that this would be because of the lack of compaction, or due to issues with reusing the sizeclass pools. 
Those assumptions both turned out to be false: explicitly disabling compaction on OCaml 4 shows that it still maintains good memory usage, and the max ratio achieved is ~90 (if pools weren't reused then an ~1983 ratio would've been achievable).

Although 3 observations remained valid:
* this is related to how the GC treats small allocations (that fit within its sizeclass pools). Increasing the allocations beyond 128 makes the issue go away.
* this is related to the GC's speed/pace. Insert Gc.minor changes it. Inserting `Gc.major_slice 0` didn't, but inserting `Gc.major_slice >0` did.
* once a sizeclass pool is fragmented enough, if we weren't quick enough to sweep it in time, then even running `Gc.full_major ()` later won't bring memory usage down. Only `Gc.compact` will, but AFAIK there is no automatic compaction yet.

Once I had a testcase, I simplified it until I got one small enough to run (with several false paths, where during simplification the problem went away as it was able to reach steady state again).

<details>
<summary>
Then I used `git bisect` to find the commit that fixed it by inverting bad and good:
</summary>

```
git bisect start '--term-old=oom' '--term-new=works' '--' 'runtime/'
# status: waiting for both good and bad commits
# oom: [152d7ca5dd2c67ecfece73f91aea5697f95178a5] release 5.4.1
git bisect oom 152d7ca5dd2c67ecfece73f91aea5697f95178a5
# status: waiting for bad commit, 1 good commit known
# works: [2b61aa9b612ae60296edfcdffcb4bd3a61f6d3da] fix pprintast of package_type to pp attributes. (#14797)
git bisect works 2b61aa9b612ae60296edfcdffcb4bd3a61f6d3da
# oom: [bec870ad15a89acb898327e2d5ca5c105e67b9b0] last commit before branching 5.4
git bisect oom bec870ad15a89acb898327e2d5ca5c105e67b9b0
# oom: [94d408c9c94b2756bf57838ec04a327f861eaeef] Merge pull request #14189 from tmcgilchrist/patch-1
git bisect oom 94d408c9c94b2756bf57838ec04a327f861eaeef
# works: [8a8eb71a9537d0203e802c083449810e0e1e5a07] Load ld.conf from all possible places
git bisect works 8a8eb71a9537d0203e802c083449810e0e1e5a07
# oom: [d55bbc9de328f54c35f9750b1f022175eeef7e89] Avoid TLS in st_stubs.c
git bisect oom d55bbc9de328f54c35f9750b1f022175eeef7e89
# works: [d197927a89e08d84cbd030ae3112295b31de3f18] Merge pull request #14337 from TheNumbat/callback-use-cont
git bisect works d197927a89e08d84cbd030ae3112295b31de3f18
# oom: [14980901e121ea58bfac2574a8ac1ffc0ced0fc8] late fix for #14304
git bisect oom 14980901e121ea58bfac2574a8ac1ffc0ced0fc8
# works: [1a7c3888a52f5283a7762db13281d8702490e7fd] Merge pull request #14329 from damiendoligez/gc-pacing-ephe-accounting
git bisect works 1a7c3888a52f5283a7762db13281d8702490e7fd
# oom: [66ecd758c28761d4f97bda38b494a90e374abe5f] [minor] fix a TSan report in shared_heap.c
git bisect oom 66ecd758c28761d4f97bda38b494a90e374abe5f
# works: [c89bff11ab944e868413f446e1444577e7f6cdbb] This is a rebase of the following patch by @stedolan:
git bisect works c89bff11ab944e868413f446e1444577e7f6cdbb
# first works commit: [c89bff11ab944e868413f446e1444577e7f6cdbb] This is a rebase of the following patch by @stedolan:
```
</details>

The commit that I found had a good explanation for exactly the problem that I was seeing (issues with how free blocks in pools are accounted for).