### PR TITLE
Nicer fonts for PDF manual

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         include:
           - id: normal
             name: normal
-            dependencies: texlive-latex-extra texlive-fonts-recommended texlive-luatex hevea sass gdb lldb
+            dependencies: texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra hevea sass gdb lldb
           - id: opam
             name: opam installation
           - id: debug

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -56,7 +56,7 @@ $(DIRS):
 
 pdf: files latex_files | texstuff
 	cd texstuff \
-	  && TEXINPUTS=$(TEXINPUTS) lualatex manual.tex
+	  && TEXINPUTS=$(TEXINPUTS) pdflatex manual.tex
 
 index: | texstuff
 	cd texstuff \

--- a/manual/src/macros.tex
+++ b/manual/src/macros.tex
@@ -36,6 +36,9 @@
 
 \newcommand{\lparagraph}[2]{\paragraph{\label{#1}#2}}
 
+% Use sans-serif font for chapter and section titles
+\allsectionsfont{\sffamily}
+
 % Numerotation
 \setcounter{secnumdepth}{2}     % Pour numeroter les \subsection
 \setcounter{tocdepth}{1}        % Pour ne pas mettre les \subsection

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -1,8 +1,13 @@
 \documentclass[11pt]{book}
+\usepackage{lmodern}% for T1 encoding and support of bold ttfamily
 
-% HEVEA\usepackage[utf8]{inputenc}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 \usepackage{microtype}
-\usepackage{fontspec}
+% HEVEA\@def@charset{UTF-8}%
+% Unicode character declarations
+\DeclareUnicodeCharacter{207A}{{}^{+}}
+\DeclareUnicodeCharacter{2014}{---}
 
 \usepackage{fullpage}
 \usepackage{syntaxdef}

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -1,9 +1,9 @@
 \documentclass[11pt]{book}
 \usepackage{lmodern}% for T1 encoding and support of bold ttfamily
-\usepackage{fourier}
-\usepackage{cabin}
+\usepackage{fourier}% Utopia font for serif and maths
+\usepackage{cabin}  % Cabin font for sans-serif
 \usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
+%\usepackage[T1]{fontenc}% included by 'fourier'
 \usepackage{microtype}
 % HEVEA\@def@charset{UTF-8}%
 % Unicode character declarations
@@ -18,6 +18,7 @@
 \usepackage{ocamldoc}
 \usepackage{xspace}
 \usepackage{color}
+\usepackage{sectsty}
 
 % Package for code examples:
 \usepackage{listings}

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -1,6 +1,7 @@
 \documentclass[11pt]{book}
 \usepackage{lmodern}% for T1 encoding and support of bold ttfamily
-
+\usepackage{fourier}
+\usepackage{cabin}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage{microtype}


### PR DESCRIPTION
Following the discussion at #13871, this PR changes the fonts used for the PDF version of the manual to Utopia and Cabin.
    
Utopia's metrics are close to that of Computer Modern Roman, so the page  layout doesn't change much.  Plus, it has nearly perfect math mode support. Utopia was the preferred choice among three in the little poll at #13871.

Cabin is one of many nice sans-serif fonts that work well for titles.

Typewriter font is still Computer Modern.

The `fourier` package that supports Utopia and math mode doesn't work well with lualatex, so this PR reverts to using pdflatex.

Fixes: #13871
