### PR TITLE
Disable "cold" tests in Github Actions CI

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -12,9 +12,11 @@ on:
       - 'trunk'
   pull_request:
 
-# env:
+env:
   # Fully print commands executed by Make
   # MAKEFLAGS: V=1
+  # Disable 'cold' tests
+  OCAMLTEST_COLD_TESTS: 0
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ env:
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
   # Fully print commands executed by Make
   # MAKEFLAGS: V=1
+  # Disable 'cold' tests
+  OCAMLTEST_COLD_TESTS: 0
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 # Concurrent workflows are grouped by the PR or branch that triggered them

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -8,6 +8,10 @@ on:
 # Restrict the GITHUB_TOKEN
 permissions: {}
 
+env:
+  # Disable 'cold' tests
+  OCAMLTEST_COLD_TESTS: 0
+
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 # Concurrent workflows are grouped by the PR or branch that triggered them
 # (github.ref) and the name of the workflow (github.workflow). The

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,8 @@ environment:
     BUILD_MODE: world.opt
     # Fully print commands executed by Make
     # MAKEFLAGS: V=1
+    # Disable cold tests
+    OCAMLTEST_COLD_TESTS: 0
   matrix:
     - PORT: mingw64
       BOOTSTRAP_FLEXDLL: true

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -197,8 +197,6 @@ case "$1" in
       sed -i '/native_/s/true/false/' \
              "$FULL_BUILD_PREFIX-$PORT/ocamltest/ocamltest_config.ml"
       $MAKE -C "$FULL_BUILD_PREFIX-$PORT" -j ocamltest ocamltest.opt
-      # Disable cold tests
-      export OCAMLTEST_COLD_TESTS=0
       # And run the entire testsuite, skipping all the native-code tests
       run "test $PORT" \
           make -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 all

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -197,6 +197,8 @@ case "$1" in
       sed -i '/native_/s/true/false/' \
              "$FULL_BUILD_PREFIX-$PORT/ocamltest/ocamltest_config.ml"
       $MAKE -C "$FULL_BUILD_PREFIX-$PORT" -j ocamltest ocamltest.opt
+      # Disable cold tests
+      export OCAMLTEST_COLD_TESTS=0
       # And run the entire testsuite, skipping all the native-code tests
       run "test $PORT" \
           make -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 all


### PR DESCRIPTION
This disables `cold` tests in the Github Actions CI (edit: and the AppVeyor one), as permitted by https://github.com/ocaml/ocaml/pull/14713.

(No actual tests are marked as cold yet, as far as I know.)

The extended, Inria CI runs everything for now. If useful, cold tests could be disabled there later also, with a periodic full run.