### PR TITLE
add test for sensible and weird cases of OCAMLRUNPARAM parsing

### DIFF
--- a/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
@@ -81,7 +81,7 @@ void test_space_ignored(void)
   caml_init_startup_params(&params);
 
   // we check that the rightmost setting takes precedence
-  const char *opts = "R, t=2K";
+  const char *opts = "R, t=2";
   caml_parse_startup_params(&params, opts);
 
   printf("OCAMLRUNPARAM='%s' gives "

--- a/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
@@ -3,6 +3,7 @@
 #define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/startup_aux.h>
+#include <caml/gc_ctrl.h>
 
 void test_minor_heap_wsz(void)
 {
@@ -18,9 +19,85 @@ void test_minor_heap_wsz(void)
   );
 }
 
+/* Passing an option without a value sets it to 1, for example
+   OCAMLRUNPARAM=b is equivalent to OCAMLRUNPARAM='b=1' */
+void test_optionless(void)
+{
+  struct caml_params params;
+  caml_init_startup_params(&params);
+
+  // we check that the rightmost setting takes precedence
+  const char *opts = "b";
+  caml_parse_startup_params(&params, opts);
+
+  printf("OCAMLRUNPARAM='%s' gives b=%d\n", opts, params.backtrace_enabled);
+}
+
+/* Weird behavior we may not want to preserve: boolean options
+   can receive non-boolean values.*/
+void test_nonbool(void)
+{
+  struct caml_params params;
+  caml_init_startup_params(&params);
+
+  // we check that the rightmost setting takes precedence
+  const char *opts = "b=3";
+  caml_parse_startup_params(&params, opts);
+
+  printf("OCAMLRUNPARAM='%s' gives "
+         "b=%" CAML_PRIuNAT "\n",
+         opts,
+         params.backtrace_enabled);
+}
+
+/* Weird behavior we may not want to preserve: k, M, G are understood
+   as powers of two, even on parameters that are not typically counted
+   in binary units. */
+void test_weirdly_binary(void)
+{
+  struct caml_params params;
+  caml_init_startup_params(&params);
+
+  // we check that the rightmost setting takes precedence
+  const char *opts = "b=2k,d=3M,M=4G";
+  caml_parse_startup_params(&params, opts);
+
+  printf("OCAMLRUNPARAM='%s' gives "
+         "b=%" CAML_PRIuNAT ", "
+         "d=%" CAML_PRIuNAT ", "
+         "M=%" CAML_PRIuNAT "\n",
+         opts,
+         params.backtrace_enabled,
+         params.max_domains,
+         params.init_custom_major_ratio);
+}
+
+/* Weird behavior we may not want to preserve: options preceded
+   by a space are ignored. */
+void test_space_ignored(void)
+{
+  struct caml_params params;
+  caml_init_startup_params(&params);
+
+  // we check that the rightmost setting takes precedence
+  const char *opts = "R, t=2K";
+  caml_parse_startup_params(&params, opts);
+
+  printf("OCAMLRUNPARAM='%s' gives "
+         "R=%" CAML_PRIuNAT ", "
+         "t=%" CAML_PRIuNAT "\n",
+         opts,
+         caml_runtime_hashtbl_randomized,
+         params.trace_level);
+}
+
 value run_tests(value unit)
 {
   test_minor_heap_wsz();
+  test_optionless();
+  test_nonbool();
+  test_weirdly_binary();
+  test_space_ignored();
 
   return Val_unit;
 }

--- a/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
@@ -30,7 +30,8 @@ void test_optionless(void)
   const char *opts = "b";
   caml_parse_startup_params(&params, opts);
 
-  printf("OCAMLRUNPARAM='%s' gives b=%d\n", opts, params.backtrace_enabled);
+  printf("OCAMLRUNPARAM='%s' gives b=%" CAML_PRIuNAT "\n",
+         opts, params.backtrace_enabled);
 }
 
 /* Weird behavior we may not want to preserve: boolean options

--- a/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
@@ -60,7 +60,7 @@ void test_weirdly_binary(void)
   caml_init_startup_params(&params);
 
   // we check that the rightmost setting takes precedence
-  const char *opts = "b=2k,d=3M,M=4G";
+  const char *opts = "b=2k,d=3M,m=3G";
   caml_parse_startup_params(&params, opts);
 
   printf("OCAMLRUNPARAM='%s' gives "

--- a/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/stub.c
@@ -66,11 +66,11 @@ void test_weirdly_binary(void)
   printf("OCAMLRUNPARAM='%s' gives "
          "b=%" CAML_PRIuNAT ", "
          "d=%" CAML_PRIuNAT ", "
-         "M=%" CAML_PRIuNAT "\n",
+         "m=%" CAML_PRIuNAT "\n",
          opts,
          params.backtrace_enabled,
          params.max_domains,
-         params.init_custom_major_ratio);
+         params.init_custom_minor_ratio);
 }
 
 /* Weird behavior we may not want to preserve: options preceded

--- a/testsuite/tests/tool-OCAMLRUNPARAM/test.reference
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/test.reference
@@ -1,5 +1,5 @@
 minor_heap_wsz: ok
 OCAMLRUNPARAM='b' gives b=1
 OCAMLRUNPARAM='b=3' gives b=3
-OCAMLRUNPARAM='b=2k,d=3M,M=4G' gives b=2048, d=3145728, M=4294967296
+OCAMLRUNPARAM='b=2k,d=3M,m=3G' gives b=2048, d=3145728, m=3221225472
 OCAMLRUNPARAM='R, t=2K' gives R=1, t=0

--- a/testsuite/tests/tool-OCAMLRUNPARAM/test.reference
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/test.reference
@@ -2,4 +2,4 @@ minor_heap_wsz: ok
 OCAMLRUNPARAM='b' gives b=1
 OCAMLRUNPARAM='b=3' gives b=3
 OCAMLRUNPARAM='b=2k,d=3M,m=3G' gives b=2048, d=3145728, m=3221225472
-OCAMLRUNPARAM='R, t=2K' gives R=1, t=0
+OCAMLRUNPARAM='R, t=2' gives R=1, t=0

--- a/testsuite/tests/tool-OCAMLRUNPARAM/test.reference
+++ b/testsuite/tests/tool-OCAMLRUNPARAM/test.reference
@@ -1,1 +1,5 @@
 minor_heap_wsz: ok
+OCAMLRUNPARAM='b' gives b=1
+OCAMLRUNPARAM='b=3' gives b=3
+OCAMLRUNPARAM='b=2k,d=3M,M=4G' gives b=2048, d=3145728, M=4294967296
+OCAMLRUNPARAM='R, t=2K' gives R=1, t=0


### PR DESCRIPTION
I decided to bite the bullet and look at implementing #14757 myself. My first realization on this journey (the first I want to share with the world) is that the current OCAMLRUNPARAM parsing rules are kind of *weird*, they have some not-obviously-intended behaviour, some which we want to keep (`OCAMLRUNPARAM=b` is equivalent to `OCAMLRUNPARAM=b=1`, this is actually [documented in the manual](https://ocaml.org/manual/5.4/runtime.html) but the way it is implemented looks like an unspecified error path), some of which it would probably be acceptable to remove in the future.

The current PR contains test cases of these various behaviors, so that follow-up PRs can be clear about what is going on in these edge cases (and/or add more edge cases in the testsuite).