### PR TITLE
fix a typo in ocamlc/opt manpage

### DIFF
--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -795,7 +795,7 @@ This is the default.
 .TP
 .B \-typing\-recovery
 Experimental: let the compiler progress past the first type error,
-in order to try to report multiple errors type errors at the same time.
+in order to try to report multiple type errors at the same time.
 .TP
 .B \-unboxed\-types
 When a type is unboxable (i.e. a record with a single argument or a

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -691,7 +691,7 @@ This is the default.
 .TP
 .B \-typing\-recovery
 Experimental: let the compiler progress past the first type error,
-in order to try to report multiple errors type errors at the same time.
+in order to try to report multiple type errors at the same time.
 .TP
 .B \-unsafe
 Turn bound checking off for array and string accesses (the


### PR DESCRIPTION
This small PR fixes a typo in the ocamlc and ocamlopt manpage in the type recovery entry.
