### PR TITLE
type recovery and modular explicits: freeze paths too

### DIFF
--- a/Changes
+++ b/Changes
@@ -257,7 +257,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #14241: Introduction of a typing recovery mechanism to collect more
+- #14241, #14824: Introduction of a typing recovery mechanism to collect more
   than one typing error, facilitating integration with editors that
   need to report more than one error.
   (Xavier Van de Woestyne, Ulysse Gerard, Thomas Refis and Frédéric

--- a/testsuite/tests/typing-recovery/modular_explicit_examples.compilers.reference
+++ b/testsuite/tests/typing-recovery/modular_explicit_examples.compilers.reference
@@ -127,3 +127,14 @@ File "modular_explicit_examples.ml", line 133, characters 26-28:
 133 | let last_error : string = 10
                                 ^^
   The constant 10 has type int but an expression was expected of type string
+File "modular_explicit_examples.ml", line 141, characters 3-4:
+141 |   (g: float),
+         ^
+  The value g has type (module X : Typ) -> X.t -> int
+  but an expression was expected of type float
+File "modular_explicit_examples.ml", line 142, characters 3-4:
+142 |   (f:'a)
+         ^
+  The value f has type (module X : Typ) -> X.t -> X.t
+  but an expression was expected of type (module X : Typ) -> X.t -> int
+  Type X.t is not compatible with type int

--- a/testsuite/tests/typing-recovery/modular_explicit_examples.compilers.reference
+++ b/testsuite/tests/typing-recovery/modular_explicit_examples.compilers.reference
@@ -130,7 +130,7 @@ File "modular_explicit_examples.ml", line 133, characters 26-28:
 File "modular_explicit_examples.ml", line 141, characters 3-4:
 141 |   (g: float),
          ^
-  The value g has type (module X : Typ) -> X.t -> int
+  The value g has type (module Name_A : Typ) -> Name_A.t -> int
   but an expression was expected of type float
 File "modular_explicit_examples.ml", line 142, characters 3-4:
 142 |   (f:'a)

--- a/testsuite/tests/typing-recovery/modular_explicit_examples.ml
+++ b/testsuite/tests/typing-recovery/modular_explicit_examples.ml
@@ -132,3 +132,11 @@ let restrict_signature_with_priv_to_add_dep =
 
 let last_error : string = 10
 let r = last_error ^ "foo"
+
+
+type t = (module X:Typ) -> X.t -> X.t
+let f: t= fun (module F_name) x -> x
+
+let err (f:t) (g: (module Name_A:Typ) -> Name_A.t -> int as 'a) =
+  (g: float),
+  (f:'a)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -241,18 +241,12 @@ end = struct
     | Path.Papply (f,x) -> Path.Papply (copy_path id_map f, copy_path id_map x)
     | Path.Pextra_ty (p,e) -> Path.Pextra_ty(copy_path id_map p, e)
     | Path.Pident id as p ->
-      match Ident.find_unscoped id with
-      | None -> p
-      | Some us ->
-          let us' =
-            begin match copy_unscoped us !id_map with
-            | None -> let us' = Ident.Unscoped.refresh us in
-                id_map := (us,us')::!id_map;
-                us'
-            | Some us' -> us'
-            end
-          in
-          Path.Pident (Ident.of_unscoped us')
+        match Ident.find_unscoped id with
+        | None -> p
+        | Some us ->
+            match copy_unscoped us id_map with
+            | None -> p
+            | Some us' -> Path.Pident (Ident.of_unscoped us')
 
   let copy_path id_map p =
     if Path.contains_unscoped_ident p then copy_path id_map p else p
@@ -260,7 +254,7 @@ end = struct
   let deep_copy_package id_map copy {pack_path; pack_constraints} =
     {pack_path = copy_path id_map pack_path;
      pack_constraints =
-       List.map (fun (l, tl) -> l, copy tl) pack_constraints}
+       List.map (fun (l, tl) -> l, copy id_map tl) pack_constraints}
 
   (* The goal of [deep_copy_desc/deep_copy] is to obtain a fully
      independent copy of a type, including all nested structure,
@@ -277,7 +271,9 @@ end = struct
      One could consider adapting [Btype.copy_type_desc] to avoid
      duplication. *)
 
-  let deep_copy_desc id_map copy = function
+  let deep_copy_desc id_map copy_with_map =
+    let copy x = copy_with_map id_map x in
+    function
     | Tvar _ | Tnil | Tunivar _ as desc -> desc
     | Tvariant _ as desc ->
         (* The row_desc does contain some type exprs, but:
@@ -301,12 +297,12 @@ end = struct
     | Tfield (s,fk,t1,t2) -> Tfield (s, fk, copy t1, copy t2)
     | Tpoly (t,tl) -> Tpoly (copy t, List.map copy tl)
     | Tpackage package ->
-        Tpackage (deep_copy_package id_map copy package)
+        Tpackage (deep_copy_package id_map copy_with_map package)
     | Tfunctor (l, id, package, type_expr) ->
         let new_id = Ident.Unscoped.refresh id in
-        id_map := (id,new_id) :: !id_map;
-        let package = deep_copy_package id_map copy package in
-        Tfunctor (l, new_id, package, copy type_expr)
+        let id_map = (id, new_id) :: id_map in
+        let package = deep_copy_package id_map copy_with_map package in
+        Tfunctor (l, new_id, package, copy_with_map id_map type_expr)
     | Texpand (t, p, tl) ->
         Texpand (copy t, copy_path id_map p, List.map copy tl)
     | Tlink _ | Tsubst _ -> assert false
@@ -316,8 +312,7 @@ end = struct
      backtracking *)
   let deep_copy () =
     let table = TypeHash.create 7 in
-    let id_map = ref [] in
-    let rec copy ty : type_expr =
+    let rec copy id_map ty : type_expr =
       try TypeHash.find table ty with
       | Not_found ->
           let ty' =
@@ -332,7 +327,7 @@ end = struct
           Transient_expr.(set_desc (repr ty') desc);
           ty'
     in
-    copy
+    copy []
 
   let trace_copy_raw ?(copy=deep_copy ())
         (trace : Errortrace.unification Errortrace.error) =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -249,7 +249,11 @@ end = struct
             | Some us' -> Path.Pident (Ident.of_unscoped us')
 
   let copy_path id_map p =
-    if Path.contains_unscoped_ident p then copy_path id_map p else p
+    match id_map with
+    | [] -> p
+    | _ ->
+        if Path.contains_unscoped_ident p then copy_path id_map p
+        else p
 
   let deep_copy_package id_map copy {pack_path; pack_constraints} =
     {pack_path = copy_path id_map pack_path;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -230,8 +230,35 @@ module Error : sig
 end = struct
   type exn += In_context of Location.t * Env.t * error
 
-  let deep_copy_package copy {pack_path; pack_constraints} =
-    {pack_path;
+  (** Copy unscoped part of paths to freeze them in error messages *)
+  let copy_unscoped us id_map =
+    List.find_map
+      (fun (i,x) -> if Ident.Unscoped.same i us then Some x else None)
+      id_map
+
+  let rec copy_path id_map = function
+    | Path.Pdot (p,s) -> Path.Pdot (copy_path id_map p, s)
+    | Path.Papply (f,x) -> Path.Papply (copy_path id_map f, copy_path id_map x)
+    | Path.Pextra_ty (p,e) -> Path.Pextra_ty(copy_path id_map p, e)
+    | Path.Pident id as p ->
+      match Ident.find_unscoped id with
+      | None -> p
+      | Some us ->
+          let us' =
+            begin match copy_unscoped us !id_map with
+            | None -> let us' = Ident.Unscoped.refresh us in
+                id_map := (us,us')::!id_map;
+                us'
+            | Some us' -> us'
+            end
+          in
+          Path.Pident (Ident.of_unscoped us')
+
+  let copy_path id_map p =
+    if Path.contains_unscoped_ident p then copy_path id_map p else p
+
+  let deep_copy_package id_map copy {pack_path; pack_constraints} =
+    {pack_path = copy_path id_map pack_path;
      pack_constraints =
        List.map (fun (l, tl) -> l, copy tl) pack_constraints}
 
@@ -250,7 +277,7 @@ end = struct
      One could consider adapting [Btype.copy_type_desc] to avoid
      duplication. *)
 
-  let deep_copy_desc copy = function
+  let deep_copy_desc id_map copy = function
     | Tvar _ | Tnil | Tunivar _ as desc -> desc
     | Tvariant _ as desc ->
         (* The row_desc does contain some type exprs, but:
@@ -263,23 +290,25 @@ end = struct
     | Tarrow (l,t1,t2,c) -> Tarrow (l, copy t1, copy t2, c)
     | Ttuple tl ->
         Ttuple (List.map (fun (lbl, t) -> lbl, copy t) tl)
-    | Tconstr (p, tl, _) -> Tconstr (p, List.map copy tl, ref Mnil)
+    | Tconstr (p, tl, _) ->
+        Tconstr (copy_path id_map p, List.map copy tl, ref Mnil)
     | Tobject (t1, r) ->
         let r = match !r with
           | None -> None
-          | Some (p,tl) -> Some (p, List.map copy tl)
+          | Some (p,tl) -> Some (copy_path id_map p, List.map copy tl)
         in
         Tobject (copy t1, ref r)
     | Tfield (s,fk,t1,t2) -> Tfield (s, fk, copy t1, copy t2)
     | Tpoly (t,tl) -> Tpoly (copy t, List.map copy tl)
     | Tpackage package ->
-        Tpackage (deep_copy_package copy package)
+        Tpackage (deep_copy_package id_map copy package)
     | Tfunctor (l, id, package, type_expr) ->
-        (* TODO: Unscoped idents should probably also be copied to freeze
-           module-dependent paths *)
-        Tfunctor (l, id, deep_copy_package copy package, copy type_expr)
+        let new_id = Ident.Unscoped.refresh id in
+        id_map := (id,new_id) :: !id_map;
+        let package = deep_copy_package id_map copy package in
+        Tfunctor (l, new_id, package, copy type_expr)
     | Texpand (t, p, tl) ->
-        Texpand (copy t, p, List.map copy tl)
+        Texpand (copy t, copy_path id_map p, List.map copy tl)
     | Tlink _ | Tsubst _ -> assert false
 
 
@@ -287,6 +316,7 @@ end = struct
      backtracking *)
   let deep_copy () =
     let table = TypeHash.create 7 in
+    let id_map = ref [] in
     let rec copy ty : type_expr =
       try TypeHash.find table ty with
       | Not_found ->
@@ -298,7 +328,7 @@ end = struct
             create_expr ~level ~id ~scope desc
           in
           let () = TypeHash.add table ty ty' in
-          let desc = deep_copy_desc copy (get_desc ty) in
+          let desc = deep_copy_desc id_map copy (get_desc ty) in
           Transient_expr.(set_desc (repr ty') desc);
           ty'
     in


### PR DESCRIPTION
This PR makes the type recovery mechanism copies paths when it is copying part of the type expressions graph in order to freeze in time error messages. Without this copy of path, later unification of unscoped identifiers might affect the module names used in earlier error messages. 

For instance, without type recovery, the error message for
```ocaml
type t = (module X:Typ) -> X.t -> X.t
let err (f:t) (g: (module Name_A:Typ) -> Name_A.t -> int as 'a) =
  (g: float),
  (f:'a)
```
is

>```
>3 |   (g: float),
>       ^
>Error: The value g has type (module Name_A : Typ) -> Name_A.t -> int
>       but an expression was expected of type float
>```

but activating type recovery transforms this error message into

>```
>3 |   (g: float),
>       ^
>Error: The value g has type (module X : Typ) -> X.t -> int
>       but an expression was expected of type float
>```

because by the time of the second error message 

>```
>  The value f has type (module X : Typ) -> X.t -> X.t
>  but an expression was expected of type (module X : Typ) -> X.t -> int
>  Type X.t is not compatible with type int
>```

we have unified the unscoped identifier `Name_A` with `X`.

This PR decouple those error messages by adding a `copy_path` pass to the deep copy function used by the type recovery mechanism.

