### PR TITLE
Harden the C++ test when building for musl

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -667,6 +667,11 @@ AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #error "No C++11 support"
+/* This extra test is added to ignore C++ support when compiling with musl
+   (where the -xc++ flag will get passed through to gcc, but the headers are
+   not available). */
+#elif defined(__has_include) && !__has_include(<atomic>)
+#error "Missing <atomic> header"
 #endif
 #include <iostream>
           ]])],

--- a/configure
+++ b/configure
@@ -23988,6 +23988,11 @@ fi
 
 #if !defined(__cplusplus) || __cplusplus < 201103L
 #error "No C++11 support"
+/* This extra test is added to ignore C++ support when compiling with musl
+   (where the -xc++ flag will get passed through to gcc, but the headers are
+   not available). */
+#elif defined(__has_include) && !__has_include(<atomic>)
+#error "Missing <atomic> header"
 #endif
 #include <iostream>
 


### PR DESCRIPTION
The C++ testing we do following #14421 / #14498 gets slightly confused when musl libc is being targeted. C++ doesn't make sense at this point, but because musl wraps GCC, the detection of `-xc++` still works and so the build continues up until it tries to `#include <atomic>` which at that point won't be found.

There aren't detection macros which can be used here because `<atomic>` is a mandatory header in C++ mode. The alternative would be just to try doing `#include <atomic>`, but I wrote it using using `__has_include` instead.

Tested in https://github.com/oxcaml/oxcaml/pull/6138, where just the musl build now correctly skips C++. The C++ testing isn't in 5.5, and this is low-risk as none of it activates for release builds anyway.