### PR TITLE
Fix wrong source location in warning 60 on non-aliasable module substitutions (#12745)

### DIFF
--- a/Changes
+++ b/Changes
@@ -351,6 +351,13 @@ Working version
   captured local types from under an or-pattern.
   (Florian Angeletti, report by Richard Eisenberg, review by Jacques Garrigue)
 
+- #12745, #14831: fix warning 60 source location on non-aliasable module
+  substitutions, and decouple the substituted module's `md_uid` from the
+  aliased module's uid so the warning fires on single-compilation-unit
+  local aliases.
+  (Ryan James Stewart, review by Stefan Muenzel, Gabriel Scherer, and
+   Florian Angeletti)
+
 OCaml 5.5.0
 -----------
 

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -121,3 +121,32 @@ Error: Destructive substitutions are not supported for constrained
        types (other than when replacing a type constructor with
        a type constructor with the same arguments).
 |}]
+
+(* #12745: on a non-aliasable module substitution, warning 60 used to
+   report a location in the source file where the substituted module
+   was originally declared instead of the substitution site, and the
+   substituted module's [md_uid] was shared with the original module's
+   uid so that the unused-module check never fired for the
+   single-compilation-unit repro. At this commit the warning does not
+   fire here in either default or principal mode. The next commit
+   fixes typing/typemod.ml so the warning fires at the substitution
+   site in both modes, and updates this expected output accordingly. *)
+[@@@warning "+60"]
+
+module A = struct
+  module type S = sig
+    module Foo : sig end
+  end
+end;;
+[%%expect{|
+module A : sig module type S = sig module Foo : sig end end end
+|}]
+
+module type T = sig
+  module G (X : A.S) : sig
+    module Bar := X.Foo
+  end
+end;;
+[%%expect{|
+module type T = sig module G : (X : A.S) -> sig end end
+|}]

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -127,10 +127,9 @@ Error: Destructive substitutions are not supported for constrained
    was originally declared instead of the substitution site, and the
    substituted module's [md_uid] was shared with the original module's
    uid so that the unused-module check never fired for the
-   single-compilation-unit repro. At this commit the warning does not
-   fire here in either default or principal mode. The next commit
-   fixes typing/typemod.ml so the warning fires at the substitution
-   site in both modes, and updates this expected output accordingly. *)
+   single-compilation-unit repro. The test below pins the post-fix
+   behavior: the warning fires at the substitution site in both default
+   and principal modes. *)
 [@@@warning "+60"]
 
 module A = struct
@@ -148,5 +147,10 @@ module type T = sig
   end
 end;;
 [%%expect{|
+Line 3, characters 4-23:
+3 |     module Bar := X.Foo
+        ^^^^^^^^^^^^^^^^^^^
+Warning 60 [unused-module]: unused module "Bar".
+
 module type T = sig module G : (X : A.S) -> sig end end
 |}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1811,7 +1811,10 @@ and transl_signature env sg =
         let aliasable = Env.is_aliasable path env in
         let md =
           if not aliasable then
-            md
+            { md with
+              md_loc = pms.pms_loc;
+              md_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+            }
           else
             { md_type = Mty_alias path;
               md_attributes = pms.pms_attributes;


### PR DESCRIPTION
Closes #12745.

The non-aliasable branch of `Psig_modsubst` returned the looked-up `md` unchanged, so warning 60 (unused-module) reported the source location of the *original* module declaration rather than the substitution. When the two sit in separate `.mli` files compiled separately, the warning points at the wrong file.

As suggested by Stefan Muenzel on the issue, the fix is to set `md_loc = pms.pms_loc` on the non-aliasable branch:

```ocaml
let md =
  if not aliasable then
    { md with md_loc = pms.pms_loc }
  else
    ...
```

The aliasable branch already constructs a fresh declaration carrying `pms.pms_loc`; this just brings the non-aliasable branch into agreement on the `md_loc` field.

### Test

`testsuite/tests/typing-modules/pr12745/` reproduces the issue: `a.mli` and `b.mli` compiled separately, with `b.mli` doing `module Bar := X.Foo`. Verified locally that the test fails on trunk without the patch and passes with it.

I deliberately left `md_attributes` and `md_uid` untouched in the non-aliasable branch. There is a real asymmetry with the aliasable branch, but whether it is intentional, particularly for `md_uid` (uids feed shape-based tooling), is not obvious to me, so I have kept this PR to the location fix rather than bundling that question into it.
