### PR TITLE
Avoid collecting profile info when not profiling

### DIFF
--- a/.depend
+++ b/.depend
@@ -29,21 +29,18 @@ utils/ccomp.cmx : \
     utils/ccomp.cmi
 utils/ccomp.cmi :
 utils/clflags.cmo : \
-    utils/profile.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
     utils/config.cmi \
     utils/arg_helper.cmi \
     utils/clflags.cmi
 utils/clflags.cmx : \
-    utils/profile.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
     utils/config.cmx \
     utils/arg_helper.cmx \
     utils/clflags.cmi
 utils/clflags.cmi : \
-    utils/profile.cmi \
     utils/misc.cmi \
     utils/config.cmi
 utils/compression.cmo : \
@@ -182,11 +179,14 @@ utils/numbers.cmi : \
     utils/identifiable.cmi
 utils/profile.cmo : \
     utils/misc.cmi \
+    utils/clflags.cmi \
     utils/profile.cmi
 utils/profile.cmx : \
     utils/misc.cmx \
+    utils/clflags.cmx \
     utils/profile.cmi
-utils/profile.cmi :
+utils/profile.cmi : \
+    utils/clflags.cmi
 utils/stable_matching.cmo : \
     utils/stable_matching.cmi
 utils/stable_matching.cmx : \

--- a/Makefile
+++ b/Makefile
@@ -2500,7 +2500,6 @@ ocamlcp_ocamloptp_SOURCES = \
   build_path_prefix_map.mli build_path_prefix_map.ml \
   format_doc.mli format_doc.ml \
   misc.mli misc.ml \
-  profile.mli profile.ml \
   warnings.mli warnings.ml \
   identifiable.mli identifiable.ml \
   numbers.mli numbers.ml \
@@ -2508,6 +2507,7 @@ ocamlcp_ocamloptp_SOURCES = \
   local_store.mli local_store.ml \
   load_path.mli load_path.ml \
   clflags.mli clflags.ml \
+  profile.mli profile.ml \
   terminfo.mli terminfo.ml \
   location.mli location.ml \
   ccomp.mli ccomp.ml \

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -38,6 +38,8 @@ module Float_arg_helper = Arg_helper.Make (struct
   end
 end)
 
+type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
 let objfiles = ref ([] : string list)         (* .cmo and .cma files *)
 and ccobjs = ref ([] : string list)           (* .o, .a, .so and -cclib -lxxx *)
 and dllibs = ref ([] : (suffixed:bool * string) list)
@@ -153,7 +155,7 @@ let dump_reload = ref false             (* -dreload *)
 let dump_scheduling = ref false         (* -dscheduling *)
 let dump_linear = ref false             (* -dlinear *)
 let keep_startup_file = ref false       (* -dstartup *)
-let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
+let profile_columns : profile_column list ref = ref [] (* -dprofile/-dtimings *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -68,6 +68,8 @@ val o3_arguments : inlining_arguments
     The default is set if no round is provided. *)
 val use_inlining_arguments_set : ?round:int -> inlining_arguments -> unit
 
+type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
 val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : (suffixed:bool * string) list ref
@@ -207,7 +209,7 @@ val force_slash : bool ref
 val keep_docs : bool ref
 val keep_locs : bool ref
 val opaque : bool ref
-val profile_columns : Profile.column list ref
+val profile_columns : profile_column list ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/utils/profile.ml
+++ b/utils/profile.ml
@@ -72,6 +72,7 @@ let initial_measure = ref None
 let reset () = hierarchy := create (); initial_measure := None
 
 let record_call ?(accumulate = false) name f =
+  if !Clflags.profile_columns = [] then f () else
   let E prev_hierarchy = !hierarchy in
   let start_measure = Measure.create () in
   if !initial_measure = None then initial_measure := Some start_measure;
@@ -187,7 +188,6 @@ let compute_other_category (E table : hierarchy) (total : Measure_diff.t) =
   !r
 
 type row = R of string * (float * display) list * row list
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
 
 let rec rows_of_hierarchy ~nesting make_row name measure_diff hierarchy env =
   let rows =

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -31,15 +31,13 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)
 
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
-
-val print : Format.formatter -> column list -> unit
+val print : Format.formatter -> Clflags.profile_column list -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
 (** Command line flags *)
 
 val options_doc : string
-val all_columns : column list
+val all_columns : Clflags.profile_column list
 
 (** A few pass names that are needed in several places, and shared to
     avoid typos. *)


### PR DESCRIPTION
The profiling system used by -dprofile / -dcounters / -dtimings is surprisingly slow, particularly because the backend makes very many calls to Profile.record_call (one per function per phase).

Unfortunately, this overhead is always present, even if no profiling is in use. This patch avoids this overhead if profiling is not enabled.

On a microbenchmark (1000 copies of `let f a b c = a, b, c`) this cuts compile times by 30%. The effect will be smaller on programs with fewer tiny functions, though.

(This is oxcaml/oxcaml#6141)