### PR TITLE
Remove the fake ocamlyacc.opt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,6 +329,5 @@ META
 /utils/domainstate.mli
 
 /yacc/ocamlyacc
-/yacc/ocamlyacc.opt
 /yacc/version.h
 /yacc/.gdb_history

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -117,6 +117,5 @@ installcross:
 	    $(foreach ext,cmi cmt cmti cmx, native/nat__dummy__.$(ext)) \
 	      all__dummy__.cmx topstart.o native/tophooks.cmi)
 	$(LN) `command -v ocamllex` lex/ocamllex.opt$(EXE)
-	$(LN) `command -v ocamlyacc` yacc/ocamlyacc.opt$(EXE)
 	# Real installation
 	$(MAKE) install $(INSTALL_OVERRIDES)


### PR DESCRIPTION
#14808 noticed that `Makefile.cross` creates an annoying `ocamlyacc.opt`. As it should never have been created in the first place (I can only apologize…), this tiny PR drops it.

No change entry needed.