### PR TITLE
Fix #13335 hang from runtime events larger than the ring buffer

### DIFF
--- a/Changes
+++ b/Changes
@@ -318,6 +318,13 @@ Working version
 
 ### Bug fixes:
 
+- #13335: Fix infinite loop in runtime_events.c's write_to_ring when an
+  event is larger than the configured ring buffer. Only really comes up
+  if you run the instrumented runtime with a small OCAMLRUNPARAM=e= setting
+  (like e=4) during the first major GC inside caml_ev_alloc_flush.
+  Now the runtime reports it as a fatal error instead.
+  (Michael Bacarella, review by Gabriel Scherer)
+
 - #13777, #14347, #14348, #14421, #14498, #14526: Test that C++
   compilers can link with the OCaml runtime and include its headers.
   (Antonin Décimo, review by David Allsopp and Gabriel Scherer)

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -529,9 +529,9 @@ static void write_to_ring(ev_category category, ev_message_type type,
     int min_e = 0;
     while ((1ULL << min_e) < length_with_header_ts) min_e++;
     caml_fatal_error(
-        "runtime_events: event of %" PRIu64 " words exceeds the ring "
-        "buffer (%d words, from OCAMLRUNPARAM=e=%" CAML_PRIuNAT
-        "). Use OCAMLRUNPARAM=e=%d or higher.",
+        "runtime_events: event of %" PRIu64 " words exceeds the ring buffer "
+        "(%d words, from OCAMLRUNPARAM=e=%" CAML_PRIuNAT "). "
+        "Use OCAMLRUNPARAM=e=%d or higher.",
         length_with_header_ts, ring_size_words,
         caml_params->runtime_events_log_wsize, min_e);
   }

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -520,6 +520,22 @@ static void write_to_ring(ev_category category, ev_message_type type,
   /* account for header and timestamp (which are both uint64) */
   uint64_t length_with_header_ts = event_length + 2;
 
+  /* We must fatal error if the event is larger than the ring buffer.
+     Otherwise the loop below loops forever. In practice only the
+     alloc event can hit this, which is emitted by the instrumented
+     runtime. But users can also create arbitrarily sized events.
+     Closes #13335. */
+  if (length_with_header_ts > ring_size_words) {
+    int min_e = 0;
+    while ((1ULL << min_e) < length_with_header_ts) min_e++;
+    caml_fatal_error(
+        "runtime_events: event of %" PRIu64 " words exceeds the ring "
+        "buffer (%d words, from OCAMLRUNPARAM=e=%" CAML_PRIuNAT
+        "). Use OCAMLRUNPARAM=e=%d or higher.",
+        length_with_header_ts, ring_size_words,
+        caml_params->runtime_events_log_wsize, min_e);
+  }
+
   /* there is a ring buffer (made up of header and data) for each domain */
   struct runtime_events_buffer_header *domain_ring_header =
       get_ring_buffer_by_domain_id(Caml_state->id);

--- a/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
@@ -1,10 +1,12 @@
 (* TEST
  include runtime_events;
- ocamlrunparam += ",e=4";
+ ocamlrunparam += ",e=5";
 *)
 
 (* We set the ring buffer size smaller and witness that we do indeed
-   lose events. *)
+   lose events. (Was e=4, now e=5. Still small enough but makes the
+   test not fatal-error with the instrumented runtime's larger
+   messages.) *)
 open Runtime_events
 
 let lost_any_events = ref false


### PR DESCRIPTION
I was trolled by this infinite loop in `runtime_events.c` first reported in #13335 in 2024. 

This PR solves it by just ~~dropping the event and logging under verbose GC and~~ terminating with a fatal error. I went back and forth on louder reporting (re: @gasche's "fail clearly" comment) [on the issue](https://github.com/ocaml/ocaml/issues/13335#issuecomment-2255903525)~~, but went more minimal since stderr-on-drop breaks test output expectations.  Maybe it's better to change to `caml_fatal_error`. What say you, OCaml team?~~

EDIT: I thought about this some more. It makes more sense to terminate with fatal error when an event larger than the ring buffer is presented. The test isn't really trying to test that but it seems like an important invariant is failing and proceeding anyway (with or without error messages)  doesn't sit right with me.

Additionally, the test has an asymmetry in it that it behaves differently between the regular runtime (finishes quickly) and the instrumented one (hangs forever), because it sets `e=4`. But `e=5` is still sufficiently small to exercise the tested behavior and it eliminates the asymmetry. 

Finally, the linked issue mentions detecting a bad configuration and rejecting on startup but I think that leads to future maintenance burden as the set of messages is not closed. Users can send their own custom events of arbitrary size (see `Runtime_events.User.(register, write)`) and we really ought to fail reliably if they send one bigger than the ring buffer.

Repro
---
  - `USE_RUNTIME=i make -C  testsuite one TEST=tests/lib-runtime-events/test_caml_runparams.ml`
    (10-minute timeout).
  - With patch: same test passes in <1s.
  - With patch and change `e=5` to `e=4` at top of `test_caml_runparams.ml`. Aborts with this error:
  > Fatal error: runtime_events: event of 22 words exceeds the ring buffer (16 words, from OCAMLRUNPARAM=,e=4). Use OCAMLRUNPARAM=,e=5 or higher.
  - `./tools/check-typo`: clean

AI assistance
---
Claude Code running the Opus 4.7 model re-discovered this bug during the course of a frustrated experiment. It also noticed it had an existing issue. It proposed a few different fixes but they weren't quite cohesive enough so this PR ended up being artisinal human code. It's also fairly trivial.
