### PR TITLE
Help `ocamldep` identify the proper `Str` module in `Typing_recovery_state`

### DIFF
--- a/.depend
+++ b/.depend
@@ -2350,7 +2350,6 @@ typing/typing_recovery.cmi : \
 typing/typing_recovery_state.cmo : \
     typing/typing_recovery.cmi \
     typing/typedtree.cmi \
-    otherlibs/str/str.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     parsing/location.cmi \
@@ -2362,7 +2361,6 @@ typing/typing_recovery_state.cmo : \
 typing/typing_recovery_state.cmx : \
     typing/typing_recovery.cmx \
     typing/typedtree.cmx \
-    otherlibs/str/str.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     parsing/location.cmx \

--- a/typing/typing_recovery_state.ml
+++ b/typing/typing_recovery_state.ml
@@ -71,7 +71,9 @@ let flush_saved_types () =
     let open Ast_helper in
     let pconst_desc = Saved_parts.store parts in
     let pexp = Exp.constant { pconst_desc; pconst_loc = !default_loc } in
-    let pstr = Str.eval pexp in
+    (* Explicit Ast_helper.Str here so that ocamldep doesn't read that as
+       otherlibs' Str *)
+    let pstr = Ast_helper.Str.eval pexp in
     [ Attr.mk Saved_parts.attribute (Parsetree.PStr [ pstr ]) ]
 
 let incorrect_attribute =


### PR DESCRIPTION
I noticed yesterday (following on from #14833) that Cross CI is broken since #14241: `.depend` contains since then an unnecessary dependency to `otherlibs/str` because `ocamlc -depend` doesn’t correctly identify `Str` as `Ast_helper.Str` in the new `Typing_recovery_state` module. This patch works around the issue by making sure the proper `Str` is seen also when computing dependencies.

No change entry needed, running the cross compilation CI could be useful even though I tried on my fork first.