### PR TITLE
Fix documentation comment for `Char.escaped`

### DIFF
--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -42,7 +42,7 @@ val escaped : char -> string
     with special characters escaped following the lexical conventions
     of OCaml.
     All characters outside the ASCII printable range \[[0x20];[0x7E]\] are
-    escaped, as well as backslash, double-quote, and single-quote. *)
+    escaped, as well as backslash and single-quote. *)
 
 (** {1:predicates Predicates and comparisons}
 


### PR DESCRIPTION
The patch applied in #6521 contained an incorrect statement about `Char.escaped`; it has always been `Char.escaped '"' = "\""`. And to think we say RTFM...