### PR TITLE
Prevent infinite stub inlining with flambda. fix for #14828

### DIFF
--- a/Changes
+++ b/Changes
@@ -364,7 +364,7 @@ Working version
 
 - #14828, #14839: fix infinite recursive inlining of stub function with flambda
   (Pierre Chambart, report by Nathanaëlle Courant and
-   Vincent Laviron review by ???)
+   Vincent Laviron review by Vincent Laviron)
 
 OCaml 5.5.0
 -----------

--- a/Changes
+++ b/Changes
@@ -362,6 +362,10 @@ Working version
   (Ryan James Stewart, review by Stefan Muenzel, Gabriel Scherer, and
    Florian Angeletti)
 
+- #14828, #14839: fix infinite recursive inlining of stub function with flambda
+  (Pierre Chambart, report by Nathanaëlle Courant and
+   Vincent Laviron review by ???)
+
 OCaml 5.5.0
 -----------
 

--- a/middle_end/flambda/inline_and_simplify_aux.ml
+++ b/middle_end/flambda/inline_and_simplify_aux.ml
@@ -40,6 +40,9 @@ module Env = struct
     never_inline_outside_closures : bool;
     unroll_counts : int Set_of_closures_origin.Map.t;
     inlining_counts : int Closure_origin.Map.t;
+    (* Set of stubs in the current inlining stack.
+       It is cleared as soon as non-stub inlining occur *)
+    inlined_stub : Set_of_closures_origin.Set.t;
     actively_unrolling : int Set_of_closures_origin.Map.t;
     closure_depth : int;
     inlining_stats_closure_stack : Inlining_stats.Closure_stack.t;
@@ -63,6 +66,7 @@ module Env = struct
       never_inline_outside_closures = false;
       unroll_counts = Set_of_closures_origin.Map.empty;
       inlining_counts = Closure_origin.Map.empty;
+      inlined_stub = Set_of_closures_origin.Set.empty;
       actively_unrolling = Set_of_closures_origin.Map.empty;
       closure_depth = 0;
       inlining_stats_closure_stack =
@@ -326,7 +330,7 @@ module Env = struct
       Set_of_closures_origin.Map.add
         origin (unroll_count - 1) t.unroll_counts
     in
-    { t with unroll_counts }
+    { t with unroll_counts; inlined_stub = Set_of_closures_origin.Set.empty }
 
   let inlining_allowed t id =
     let inlining_count =
@@ -337,6 +341,9 @@ module Env = struct
                  ~key:t.round !Clflags.inline_max_unroll)
     in
     inlining_count > 0
+
+  let stub_inlining_allowed t id =
+    not (Set_of_closures_origin.Set.mem id t.inlined_stub)
 
   let inside_inlined_function t id =
     let inlining_count =
@@ -349,7 +356,13 @@ module Env = struct
     let inlining_counts =
       Closure_origin.Map.add id (inlining_count - 1) t.inlining_counts
     in
-    { t with inlining_counts }
+    (* inlining_stubs prevents recursive stub inlining.
+       But as soon as we inline another kind of function,
+       we can reactivate stub inlining. *)
+    { t with inlining_counts; inlined_stub = Set_of_closures_origin.Set.empty }
+
+  let inside_inlined_stub_function t id =
+    { t with inlined_stub = Set_of_closures_origin.Set.add id t.inlined_stub }
 
   let inlining_level t = t.inlining_level
   let freshening t = t.freshening

--- a/middle_end/flambda/inline_and_simplify_aux.mli
+++ b/middle_end/flambda/inline_and_simplify_aux.mli
@@ -192,7 +192,7 @@ module Env : sig
       in the given environment. *)
   val unrolling_allowed : t -> Set_of_closures_origin.t -> bool
 
-  (** Whether the given environment is currently being used to rewrite the
+  (** Mark the environment as currently being used to rewrite the
       body of an unrolled recursive function. *)
   val inside_unrolled_function : t -> Set_of_closures_origin.t -> t
 
@@ -200,7 +200,7 @@ module Env : sig
       environment. *)
   val inlining_allowed : t -> Closure_origin.t -> bool
 
-  (** Whether the given environment is currently being used to rewrite the
+  (** Mark the environment as currently being used to rewrite the
       body of an inlined function. *)
   val inside_inlined_function : t -> Closure_origin.t -> t
 
@@ -212,7 +212,7 @@ module Env : sig
       stub inlining. *)
   val stub_inlining_allowed : t -> Set_of_closures_origin.t -> bool
 
-  (** Whether the given environment is currently being used to rewrite the
+  (** Mark the environment as  currently being used to rewrite the
       body of an inlined stub function. *)
   val inside_inlined_stub_function : t -> Set_of_closures_origin.t -> t
 

--- a/middle_end/flambda/inline_and_simplify_aux.mli
+++ b/middle_end/flambda/inline_and_simplify_aux.mli
@@ -204,6 +204,18 @@ module Env : sig
       body of an inlined function. *)
   val inside_inlined_function : t -> Closure_origin.t -> t
 
+  (** Whether it is permissible to inline a call to a stub function in the
+      given environment.
+      Stub function are always allowed by default. But to prevent infinite
+      inlining, recursive stub inlining is not allowed.
+      If there is any other kind of inlining, it is not considered recursive
+      stub inlining. *)
+  val stub_inlining_allowed : t -> Set_of_closures_origin.t -> bool
+
+  (** Whether the given environment is currently being used to rewrite the
+      body of an inlined stub function. *)
+  val inside_inlined_stub_function : t -> Set_of_closures_origin.t -> t
+
   (** If collecting inlining statistics, record that the inliner is about to
       descend into [closure_id].  This information enables us to produce a
       stack of closures that form a kind of context around an inlining

--- a/middle_end/flambda/inlining_decision.ml
+++ b/middle_end/flambda/inlining_decision.ml
@@ -513,7 +513,9 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
   match function_decl.function_body with
   | None -> original, original_r
   | Some { stub; _ } ->
-    if stub then begin
+    if stub
+    then if E.stub_inlining_allowed env function_decls.set_of_closures_origin then begin
+      let env = E.inside_inlined_stub_function env function_decls.set_of_closures_origin in
       let fun_vars = Variable.Map.keys function_decls.funs in
       let function_body = get_function_body function_decl in
       let body, r =
@@ -523,7 +525,13 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
           ~function_decl ~function_body ~args ~dbg ~simplify
       in
       simplify env r body
-    end else if E.never_inline env then
+    end else
+      (* It is extremely uncommon for stub inlining to be disalowed, but in that case
+         we want to prevent any kind of inlining.
+         The only known case is through recursive calls inside default argument stubs
+         let rec f ?(x = f ()) () = x + 1 *)
+      original, original_r
+    else if E.never_inline env then
       (* This case only occurs when examining the body of a stub function
          but not in the context of inlining said function.  As such, there
          is nothing to do here (and no decision to report). *)

--- a/middle_end/flambda/inlining_decision.ml
+++ b/middle_end/flambda/inlining_decision.ml
@@ -530,7 +530,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
         in
         simplify env r body
       end else
-        (* It is extremely uncommon for stub inlining to be disalowed, but in
+        (* It is extremely uncommon for stub inlining to be disallowed, but in
            that case we want to prevent any kind of inlining.
            The only known case is through recursive calls inside default
            argument stubs

--- a/middle_end/flambda/inlining_decision.ml
+++ b/middle_end/flambda/inlining_decision.ml
@@ -514,23 +514,28 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
   | None -> original, original_r
   | Some { stub; _ } ->
     if stub
-    then if E.stub_inlining_allowed env function_decls.set_of_closures_origin then begin
-      let env = E.inside_inlined_stub_function env function_decls.set_of_closures_origin in
-      let fun_vars = Variable.Map.keys function_decls.funs in
-      let function_body = get_function_body function_decl in
-      let body, r =
-        Inlining_transforms.inline_by_copying_function_body ~env
-          ~r ~fun_vars ~lhs_of_application
-          ~closure_id_being_applied ~specialise_requested ~inline_requested
-          ~function_decl ~function_body ~args ~dbg ~simplify
-      in
-      simplify env r body
-    end else
-      (* It is extremely uncommon for stub inlining to be disalowed, but in that case
-         we want to prevent any kind of inlining.
-         The only known case is through recursive calls inside default argument stubs
-         let rec f ?(x = f ()) () = x + 1 *)
-      original, original_r
+    then if E.stub_inlining_allowed env function_decls.set_of_closures_origin
+      then begin
+        let env =
+          E.inside_inlined_stub_function env
+            function_decls.set_of_closures_origin
+        in
+        let fun_vars = Variable.Map.keys function_decls.funs in
+        let function_body = get_function_body function_decl in
+        let body, r =
+          Inlining_transforms.inline_by_copying_function_body ~env
+            ~r ~fun_vars ~lhs_of_application
+            ~closure_id_being_applied ~specialise_requested ~inline_requested
+            ~function_decl ~function_body ~args ~dbg ~simplify
+        in
+        simplify env r body
+      end else
+        (* It is extremely uncommon for stub inlining to be disalowed, but in
+           that case we want to prevent any kind of inlining.
+           The only known case is through recursive calls inside default
+           argument stubs
+           let rec f ?(x = f ()) () = x + 1 *)
+        original, original_r
     else if E.never_inline env then
       (* This case only occurs when examining the body of a stub function
          but not in the context of inlining said function.  As such, there

--- a/testsuite/tests/flambda/non_recursive_stub_inlining.ml
+++ b/testsuite/tests/flambda/non_recursive_stub_inlining.ml
@@ -1,0 +1,31 @@
+(* TEST
+ flambda;
+ ocamlopt_flags += " -O3 ";
+ native;
+*)
+
+(* Test that the fix for Issue #14828 didn't degrade inlining.
+   In 'result' there is a call that might look recursive but isn't.
+   It should still be inlined.
+
+   This is asserted by verifying that the result of calls to 'result' is known.
+*)
+
+let f (g, x) = g x
+let id x = x
+let result n = f (f, (id, n))
+
+let[@inline never][@local never] g () =
+  let r = result 42 in
+  (* If the result is known, this is statically allocated, otherwise this is
+     a runtime allocation.
+     g is preventing from being inlined to avoid this being lifted and removing
+     the allocation by another mean. *)
+  (r, r)
+
+let _ =
+  let x0 = Gc.allocated_bytes () in
+  let x1 = Gc.allocated_bytes () in
+  let _ = (Sys.opaque_identity g) () in
+  let x2 = Gc.allocated_bytes () in
+  assert (x1 -. x0 = x2 -. x1)

--- a/testsuite/tests/flambda/recursive_stubs.ml
+++ b/testsuite/tests/flambda/recursive_stubs.ml
@@ -21,3 +21,12 @@ let caller () =
   let _ = (g[@unroll 1]) () in
   let _ = (i[@unroll 1]) () in
   ()
+
+type 'a self_rec = Self of ('a self_rec -> 'a) [@@unboxed]
+
+let g
+    (Self self : (?x:int -> unit -> int) self_rec)
+    ?(x = self (Self self) ()) () =
+  x + 1
+
+let b = g (Self g) ()

--- a/testsuite/tests/flambda/recursive_stubs.ml
+++ b/testsuite/tests/flambda/recursive_stubs.ml
@@ -29,4 +29,8 @@ let g
     ?(x = self (Self self) ()) () =
   x + 1
 
-let b = g (Self g) ()
+let _ =
+  if Sys.opaque_identity false then
+    g (Self g) ()
+  else
+    0

--- a/testsuite/tests/flambda/recursive_stubs.ml
+++ b/testsuite/tests/flambda/recursive_stubs.ml
@@ -1,0 +1,23 @@
+(* TEST
+ flambda;
+ ocamlopt_flags += " -O3 ";
+ native;
+*)
+
+(* Regression test for Issue #14828:
+   Ensure that inlining recursive stubs terminates. *)
+
+let rec f ?(x = f ()) () = x + 1
+
+let rec g ?(x = h ()) () = x + 1
+and h ?(y = g ()) () = y + 2
+
+let rec i ?(x = j ()) () = x + 1
+and j ?(y = k ()) () = y + 2
+and k ?(z = i ()) () = z + 3
+
+let caller () =
+  let _ = (f[@unroll 1]) () in
+  let _ = (g[@unroll 1]) () in
+  let _ = (i[@unroll 1]) () in
+  ()


### PR DESCRIPTION
In flambda, stub functions are always inlined. The point of stub function is to kind of change a function ABI, so it is always a good idea. But it is, possible to have recursive stub functions.

It is extremely contrived and probably very unlikely to have it appear in the wild (as it almost always lead to non terminating programs anyway), but thanks to @Ekdohibs it is now known to be possible (see #14828).
```ocaml
let rec f ?(x = f ()) () = x + 1
```
I've reviewed the other places where stubs are created, and I think that there are no other cases.

This patch prevents recursive inlining of stubs. but we don't want to prevent inlining of things like:
```ocaml
let f (g, x) = g x
let id x = x
let result n = f (f, (id, n))
```
The stub for the tupled version of f would be present twice in the 'inline stack', but this is not recursive. Hence the inline stub stack is cleaned at each non stub inlining.

I think that regular code is not going to be affected and the additional book-keeping is probably small enough