### PR TITLE
Add DragonFly BSD frame pointer support

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,7 +32,7 @@ Working version
 
 - #14840: Add DragonFly BSD frame pointers support for AMD64 and recognize
   DragonFly as BSD in ocamltest.
-  (Michael Neumann, review by ?)
+  (Michael Neumann, review by Nicolás Ojeda Bär)
 
 - #14486, #14530: Add FreeBSD frame pointers support for AMD64 and ARM64.
   Document the usage of pmcstat and dtrace for generating profiling

--- a/Changes
+++ b/Changes
@@ -30,6 +30,10 @@ Working version
   (KC Sivaramakrishnan, review by Olivier Nicole, Tim McGilchrist, Zane Hambly
   and Ali Caglayan)
 
+- #14840: Add DragonFly BSD frame pointers support for AMD64 and recognize
+  DragonFly as BSD in ocamltest.
+  (Michael Neumann, review by ?)
+
 - #14486, #14530: Add FreeBSD frame pointers support for AMD64 and ARM64.
   Document the usage of pmcstat and dtrace for generating profiling
   information.

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1019,7 +1019,8 @@ let begin_assembly() =
 
   emit_named_text_section (Compilenv.make_symbol (Some "code_begin"));
   emit_global_label "code_begin";
-  if system = S_macosx || system = S_freebsd then I.nop (); (* PR#4690 *)
+  if system = S_macosx || system = S_freebsd || system = S_dragonfly
+  then I.nop (); (* PR#4690 *)
   ()
 
 let end_assembly() =

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -27,6 +27,7 @@ type system =
   | S_freebsd
   | S_netbsd
   | S_openbsd
+  | S_dragonfly
 
   | S_unknown
 
@@ -43,6 +44,7 @@ let system = match Config.system with
   | "freebsd" -> S_freebsd
   | "netbsd" -> S_netbsd
   | "openbsd" -> S_openbsd
+  | "dragonfly" -> S_dragonfly
 
   | _ -> S_unknown
 

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -69,6 +69,7 @@ type system =
   | S_freebsd
   | S_netbsd
   | S_openbsd
+  | S_dragonfly
 
   | S_unknown
 

--- a/configure
+++ b/configure
@@ -23780,8 +23780,8 @@ fi
 if test x"$enable_frame_pointers" = "xyes"
 then :
   case $target in #(
-  x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|aarch64-*-linux*| \
-     aarch64-*-darwin*|aarch64-*-freebsd*) :
+  x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|x86_64-*-dragonfly*| \
+     aarch64-*-linux*|aarch64-*-darwin*|aarch64-*-freebsd*) :
     case $ocaml_cc_vendor in #(
   clang-*|gcc-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/configure.ac
+++ b/configure.ac
@@ -2812,8 +2812,8 @@ AS_IF([$native_compiler],
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
   [AS_CASE([$target],
-    [x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|aarch64-*-linux*| \
-     aarch64-*-darwin*|aarch64-*-freebsd*],
+    [x86_64-*-linux*|x86_64-*-darwin*|x86_64-*-freebsd*|x86_64-*-dragonfly*| \
+     aarch64-*-linux*|aarch64-*-darwin*|aarch64-*-freebsd*],
      [AS_CASE([$ocaml_cc_vendor],
         [clang-*|gcc-*],
          [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -155,7 +155,7 @@ let target_windows = make
 
 let is_bsd_system s =
   match s with
-  | "bsd_elf" | "netbsd" | "freebsd" | "openbsd" -> true
+  | "bsd_elf" | "netbsd" | "freebsd" | "openbsd" | "dragonfly" -> true
   | _ -> false
 
 let bsd = make

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -10,7 +10,7 @@
 
 #if defined(__APPLE__)
 #define RE_FUNC_NAME "^[[:digit:]]+[[:space:]]+[[:alnum:]_\\.]+[[:space:]]+0x[[:xdigit:]]+[[:space:]]([[:alnum:]_\\$]+).*$"
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 #define RE_FUNC_NAME  "^0x[[:xdigit:]]+ <(.+)\\+0x[[:xdigit:]]+>.*$"
 #else
 #define RE_FUNC_NAME  "^.*\\((.+)\\+0x[[:xdigit:]]+\\) \\[0x[[:xdigit:]]+\\]$"
@@ -31,7 +31,7 @@ typedef struct frame_info
  * or this on macOS:
  * 0   c_call.opt                          0x000000010e621079 camlC_call.entry + 57
  *
- * or this on FreeBSD:
+ * or this on FreeBSD (or DragonFly):
  * 0x22eea7 <camlModule.fn_123+0xb7> at ./path/to/binary
  */
 static const char* backtrace_symbol(const struct frame_info* fi)


### PR DESCRIPTION
In addition, recognize DragonFly BSD as a BSD in ocamltest.

When using DragonFly's standard compiler gcc 8.3 and binutils 2.34, the following tests fail when OCaml was built with --enable-frame-pointers:

List of failed tests:
    tests/asmgen/arith.cmm
    tests/asmgen/catch-float.cmm
    tests/asmgen/catch-multiple.cmm
    tests/asmgen/catch-rec-deadhandler.cmm
    tests/asmgen/catch-rec.cmm
    tests/asmgen/catch-try-float.cmm
    tests/asmgen/catch-try.cmm
    tests/asmgen/checkbound.cmm
    tests/asmgen/even-odd-spill-float.cmm
    tests/asmgen/even-odd-spill.cmm
    tests/asmgen/even-odd.cmm
    tests/asmgen/fib.cmm
    tests/asmgen/immediates.cmm
    tests/asmgen/pgcd.cmm
    tests/asmgen/quicksort.cmm
    tests/asmgen/quicksort2.cmm
    tests/asmgen/soli.cmm
    tests/asmgen/tagged-fib.cmm
    tests/asmgen/tagged-integr.cmm
    tests/asmgen/tagged-quicksort.cmm
    tests/asmgen/tagged-tak.cmm
    tests/asmgen/tak.cmm

Looking at one failed test, e.g. tak.cmm, reveals:

```
> Running C compiler to build tak.out
> Commandline: gcc -O2 -fno-strict-aliasing -fwrapv -g -fno-omit-frame-pointer -I$HOME/Dev/ocaml/runtime -o tak.out -DUNIT_INT -DFUN=takmain main.c tak.s $HOME/Dev/ocaml/testsuite/tools/asmgen_amd64.o
>   Redirecting stdout to $HOME/Dev/ocaml/testsuite/_ocamltest/tests/asmgen/tak/compiler-output
>   Redirecting stderr to $HOME/Dev/ocaml/testsuite/_ocamltest/tests/asmgen/tak/compiler-output
> ### begin stdout ###
> tak.s: Assembler messages:
> tak.s:22: Error: file number 1 already allocated
> ### end stdout ###
> Action 3/3 (cc) => failed (Running C compiler to build tak.out: command
> gcc -O2 -fno-strict-aliasing -fwrapv -g  -fno-omit-frame-pointer -I$HOME/Dev/ocaml/runtime -o tak.out -DUNIT_INT -DFUN=takmain main.c tak.s $HOME/Dev/ocaml/testsuite/tools/asmgen_amd64.o
> failed with exit code 1)
```

This seems to be an issue with gcc 8.3 and binutils 2.34 when debug symbols are generated and goes away when I use gcc14:

     env CC=gcc14 ./configure --enable-frame-pointers

It also goes away when I manually remove the ".file" assembler directive from "tak.s".