### PR TITLE
[5.5]: backport #14832

### DIFF
--- a/.depend
+++ b/.depend
@@ -185,8 +185,7 @@ utils/profile.cmx : \
     utils/misc.cmx \
     utils/clflags.cmx \
     utils/profile.cmi
-utils/profile.cmi : \
-    utils/clflags.cmi
+utils/profile.cmi :
 utils/stable_matching.cmo : \
     utils/stable_matching.cmi
 utils/stable_matching.cmx : \

--- a/.depend
+++ b/.depend
@@ -29,21 +29,18 @@ utils/ccomp.cmx : \
     utils/ccomp.cmi
 utils/ccomp.cmi :
 utils/clflags.cmo : \
-    utils/profile.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
     utils/config.cmi \
     utils/arg_helper.cmi \
     utils/clflags.cmi
 utils/clflags.cmx : \
-    utils/profile.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
     utils/config.cmx \
     utils/arg_helper.cmx \
     utils/clflags.cmi
 utils/clflags.cmi : \
-    utils/profile.cmi \
     utils/misc.cmi \
     utils/config.cmi
 utils/compression.cmo : \
@@ -182,11 +179,14 @@ utils/numbers.cmi : \
     utils/identifiable.cmi
 utils/profile.cmo : \
     utils/misc.cmi \
+    utils/clflags.cmi \
     utils/profile.cmi
 utils/profile.cmx : \
     utils/misc.cmx \
+    utils/clflags.cmx \
     utils/profile.cmi
-utils/profile.cmi :
+utils/profile.cmi : \
+    utils/clflags.cmi
 utils/stable_matching.cmo : \
     utils/stable_matching.cmi
 utils/stable_matching.cmx : \

--- a/Makefile
+++ b/Makefile
@@ -2428,7 +2428,6 @@ ocamlcp_ocamloptp_SOURCES = \
   build_path_prefix_map.mli build_path_prefix_map.ml \
   format_doc.mli format_doc.ml \
   misc.mli misc.ml \
-  profile.mli profile.ml \
   warnings.mli warnings.ml \
   identifiable.mli identifiable.ml \
   numbers.mli numbers.ml \
@@ -2436,6 +2435,7 @@ ocamlcp_ocamloptp_SOURCES = \
   local_store.mli local_store.ml \
   load_path.mli load_path.ml \
   clflags.mli clflags.ml \
+  profile.mli profile.ml \
   terminfo.mli terminfo.ml \
   location.mli location.ml \
   ccomp.mli ccomp.ml \

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -38,6 +38,8 @@ module Float_arg_helper = Arg_helper.Make (struct
   end
 end)
 
+type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
 let objfiles = ref ([] : string list)         (* .cmo and .cma files *)
 and ccobjs = ref ([] : string list)           (* .o, .a, .so and -cclib -lxxx *)
 and dllibs = ref ([] : (suffixed:bool * string) list)
@@ -151,7 +153,7 @@ let dump_reload = ref false             (* -dreload *)
 let dump_scheduling = ref false         (* -dscheduling *)
 let dump_linear = ref false             (* -dlinear *)
 let keep_startup_file = ref false       (* -dstartup *)
-let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
+let profile_columns : profile_column list ref = ref [] (* -dprofile/-dtimings *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -68,6 +68,8 @@ val o3_arguments : inlining_arguments
     The default is set if no round is provided. *)
 val use_inlining_arguments_set : ?round:int -> inlining_arguments -> unit
 
+type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
 val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : (suffixed:bool * string) list ref
@@ -205,7 +207,7 @@ val force_slash : bool ref
 val keep_docs : bool ref
 val keep_locs : bool ref
 val opaque : bool ref
-val profile_columns : Profile.column list ref
+val profile_columns : profile_column list ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -68,8 +68,6 @@ val o3_arguments : inlining_arguments
     The default is set if no round is provided. *)
 val use_inlining_arguments_set : ?round:int -> inlining_arguments -> unit
 
-type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
-
 val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : (suffixed:bool * string) list ref
@@ -207,7 +205,7 @@ val force_slash : bool ref
 val keep_docs : bool ref
 val keep_locs : bool ref
 val opaque : bool ref
-val profile_columns : profile_column list ref
+val profile_columns : [ `Time | `Alloc | `Top_heap | `Abs_top_heap ] list ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/utils/profile.ml
+++ b/utils/profile.ml
@@ -188,6 +188,7 @@ let compute_other_category (E table : hierarchy) (total : Measure_diff.t) =
   !r
 
 type row = R of string * (float * display) list * row list
+type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
 
 let rec rows_of_hierarchy ~nesting make_row name measure_diff hierarchy env =
   let rows =

--- a/utils/profile.ml
+++ b/utils/profile.ml
@@ -72,6 +72,7 @@ let initial_measure = ref None
 let reset () = hierarchy := create (); initial_measure := None
 
 let record_call ?(accumulate = false) name f =
+  if !Clflags.profile_columns = [] then f () else
   let E prev_hierarchy = !hierarchy in
   let start_measure = Measure.create () in
   if !initial_measure = None then initial_measure := Some start_measure;
@@ -187,7 +188,6 @@ let compute_other_category (E table : hierarchy) (total : Measure_diff.t) =
   !r
 
 type row = R of string * (float * display) list * row list
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
 
 let rec rows_of_hierarchy ~nesting make_row name measure_diff hierarchy env =
   let rows =

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -31,13 +31,15 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)
 
-val print : Format.formatter -> Clflags.profile_column list -> unit
+type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
+val print : Format.formatter -> column list -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
 (** Command line flags *)
 
 val options_doc : string
-val all_columns : Clflags.profile_column list
+val all_columns : column list
 
 (** A few pass names that are needed in several places, and shared to
     avoid typos. *)

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -31,15 +31,13 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)
 
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
-
-val print : Format.formatter -> column list -> unit
+val print : Format.formatter -> Clflags.profile_column list -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
 (** Command line flags *)
 
 val options_doc : string
-val all_columns : column list
+val all_columns : Clflags.profile_column list
 
 (** A few pass names that are needed in several places, and shared to
     avoid typos. *)


### PR DESCRIPTION
This PR backport #14832 to 5.5 while keeping nearly exactly the same interfaces in the compiler library than in current 5.5.

Indeed, if the fix in #14832 is the kind of obvious bug fix that I would like to cherry-pick in 5.5, it does also introduces refactoring changes to the mli files that I would prefer to avoid at this stage of the 5.5 branch.

This PR thus cherry-picks #14832 to 5.5 but revert the changes to the mli files.

cc @stedolan @nojb .