### PR TITLE
added instructions in a testsuite error message

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -18,7 +18,8 @@
 BASEDIR := $(shell pwd)
 ifneq "$(words |$(BASEDIR)|)" "1"
 $(error The Testsuite does not handle spaces\
-   in the ocaml working directory path: $(BASEDIR))
+   in the ocaml working directory path: $(BASEDIR).\
+   Delete all spaces, then configure and build again.)
 endif
 
 ROOTDIR = ..

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -19,7 +19,8 @@ BASEDIR := $(shell pwd)
 ifneq "$(words |$(BASEDIR)|)" "1"
 $(error The Testsuite does not handle spaces\
    in the ocaml working directory path: $(BASEDIR).\
-   Delete all spaces, then configure and build again.)
+   Rename the ocaml working directory path,\
+   then re-run configure and build again.)
 endif
 
 ROOTDIR = ..


### PR DESCRIPTION
In testsuite/Makefile, in the error message that appears when the working directory contains spaces : added instructions to delete those spaces, then configure and build again.