### PR TITLE
#14842: update expansion nodes containing tfunctor arguments

### DIFF
--- a/Changes
+++ b/Changes
@@ -89,8 +89,8 @@ Working version
 
 ### Type system:
 
-* #11648, #14766, #14768, #14776: Keep expansion and new well-foundedness check
-  implementation.
+* #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and
+  new well-foundedness check implementation.
   Do expansion in place during unification, rather than only memoizing it
   in a temporary cache. This fixes a number of non-terminations and crashes
   (#9314, #13230, #13881, #14036) and losses of principality (#14307 among

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -1222,8 +1222,8 @@ let fa1_applied = fa1 ()
 
 [%%expect{|
 module type M_arrow1 = sig type 'a t = int -> 'a end
-val fa1 : unit -> (module M_arrow1) -> int -> 'a = <fun>
-val fa1_applied : (module M_arrow1) -> int -> 'a = <fun>
+val fa1 : unit -> (module M : M_arrow1) -> int -> 'a = <fun>
+val fa1_applied : (module M : M_arrow1) -> int -> 'a = <fun>
 |}]
 
 module type M_arrow2 = sig
@@ -1236,8 +1236,8 @@ let fa2_applied = fa2 ()
 
 [%%expect{|
 module type M_arrow2 = sig type 'a t = 'a -> int end
-val fa2 : unit -> (module M_arrow2) -> 'a -> int = <fun>
-val fa2_applied : (module M_arrow2) -> '_weak4 -> int = <fun>
+val fa2 : unit -> (module M : M_arrow2) -> 'a -> int = <fun>
+val fa2_applied : (module M : M_arrow2) -> '_weak4 -> int = <fun>
 |}]
 
 module type Typ2 = sig
@@ -1519,4 +1519,15 @@ Line 1, characters 62-64:
 1 | let too_many_arg_bis = map (module Iarray) succ [| 0; 1; 2 |] ()
                                                                   ^^
   This extra argument is not expected.
+|}]
+
+module type S = sig type t type e val v : e -> t end
+let helper (type a) (module M : S with type t = a) _ : a = assert false
+let outer (type a) (type b) (module M : S with type e = a and type t = b) e =
+  helper (module M) (M.v e)
+[%%expect {|
+module type S = sig type t type e val v : e -> t end
+val helper : (module S with type t = 'a) -> 'b -> 'a = <fun>
+val outer : (module M : S with type e = 'a and type t = 'b) -> 'a -> M.t =
+  <fun>
 |}]

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -1222,8 +1222,8 @@ let fa1_applied = fa1 ()
 
 [%%expect{|
 module type M_arrow1 = sig type 'a t = int -> 'a end
-val fa1 : unit -> (module M : M_arrow1) -> int -> 'a = <fun>
-val fa1_applied : (module M : M_arrow1) -> int -> 'a = <fun>
+val fa1 : unit -> (module M : M_arrow1) -> 'a M.t = <fun>
+val fa1_applied : (module M : M_arrow1) -> 'a M.t = <fun>
 |}]
 
 module type M_arrow2 = sig
@@ -1236,8 +1236,8 @@ let fa2_applied = fa2 ()
 
 [%%expect{|
 module type M_arrow2 = sig type 'a t = 'a -> int end
-val fa2 : unit -> (module M : M_arrow2) -> 'a -> int = <fun>
-val fa2_applied : (module M : M_arrow2) -> '_weak4 -> int = <fun>
+val fa2 : unit -> (module M : M_arrow2) -> 'a M.t = <fun>
+val fa2_applied : (module M : M_arrow2) -> '_weak4 M.t = <fun>
 |}]
 
 module type Typ2 = sig
@@ -1528,6 +1528,6 @@ let outer (type a) (type b) (module M : S with type e = a and type t = b) e =
 [%%expect {|
 module type S = sig type t type e val v : e -> t end
 val helper : (module S with type t = 'a) -> 'b -> 'a = <fun>
-val outer : (module M : S with type e = 'a and type t = 'b) -> 'a -> M.t =
+val outer : (module M : S with type e = 'a and type t = 'b) -> M.e -> M.t =
   <fun>
 |}]

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -237,14 +237,14 @@ module Arrow : sig type ('a, 'b) t = 'a -> 'b end
 let f (module M:Arrow): ('a,'a) M.t = fun x -> x
 let ok x y = f (module Arrow) x y
 [%%expect {|
-val f : (module M : Arrow) -> 'a -> 'a = <fun>
+val f : (module M : Arrow) -> ('a, 'a) M.t = <fun>
 val ok : ('a -> 'b) -> 'a -> 'b = <fun>
 |}]
 
 let f (module M:Arrow): ('a,'b) M.t = fun _ -> assert false
 let ok_error x y = f (module Arrow) x y
 [%%expect {|
-val f : (module M : Arrow) -> 'a -> 'b = <fun>
+val f : (module M : Arrow) -> ('a, 'b) M.t = <fun>
 Line 2, characters 38-39:
 2 | let ok_error x y = f (module Arrow) x y
                                           ^

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -237,14 +237,14 @@ module Arrow : sig type ('a, 'b) t = 'a -> 'b end
 let f (module M:Arrow): ('a,'a) M.t = fun x -> x
 let ok x y = f (module Arrow) x y
 [%%expect {|
-val f : (module Arrow) -> 'a -> 'a = <fun>
+val f : (module M : Arrow) -> 'a -> 'a = <fun>
 val ok : ('a -> 'b) -> 'a -> 'b = <fun>
 |}]
 
 let f (module M:Arrow): ('a,'b) M.t = fun _ -> assert false
 let ok_error x y = f (module Arrow) x y
 [%%expect {|
-val f : (module Arrow) -> 'a -> 'b = <fun>
+val f : (module M : Arrow) -> 'a -> 'b = <fun>
 Line 2, characters 38-39:
 2 | let ok_error x y = f (module Arrow) x y
                                           ^

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1732,7 +1732,7 @@ let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) ~id_map sch =
       let t = newstub ~scope:(get_scope ty) in
       TypeHash.add visited ty t;
       let desc' =
-        match get_desc ty with
+        match get_folded_desc ~keep_Tvar:false ty with
         | Tvariant row ->
             let more = row_more row in
             (* We shall really check the level on the row variable *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1210,12 +1210,12 @@ let rec inv_type hash pty ty =
       (get_abbrev ty);
     inv.inv_parents <- pty @ inv.inv_parents
   with Not_found ->
-    let inv_paths = match get_abbrev ty with
-      | None -> []
-      | Some (p, _) -> [p]
-    in
-    let inv = { inv_type = ty; inv_paths; inv_parents = pty } in
+    let inv = { inv_type = ty; inv_paths=[]; inv_parents = pty } in
     TypeHash.add hash ty inv;
+    iter_abbrev (fun p args ->
+        inv.inv_paths <- [p];
+        List.iter (inv_type hash [inv]) args
+      ) ty;
     iter_type_expr (inv_type hash [inv]) ty
 
 let compute_univars ty =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1278,14 +1278,14 @@ let type_subexpressions_with_free_occurrences ids ty =
       end
     | _ -> false
   in
-  let occurrence_in_expansion inv =
+  let occurrence_in_abbrev inv =
     iter_abbrev
       (fun p _ -> if Path.exists_free ids p then add_all_parents ids inv)
       inv.inv_type
   in
   TypeHash.iter (fun ty inv ->
       if occurrence_in_desc inv ty then () else
-        occurrence_in_expansion inv
+        occurrence_in_abbrev inv
     ) inverted;
   !nodes
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1200,22 +1200,18 @@ let limited_generalize_class_type rv ~inside:cty =
 
 type inv_type_expr =
     { inv_type : type_expr;
-      mutable inv_parents : inv_type_expr list;
-      mutable inv_paths: Path.t list }
+      mutable inv_parents : inv_type_expr list }
 
 let rec inv_type hash pty ty =
   try
     let inv = TypeHash.find hash ty in
-    Option.iter (fun (p,_) -> inv.inv_paths <- p :: inv.inv_paths)
-      (get_abbrev ty);
     inv.inv_parents <- pty @ inv.inv_parents
   with Not_found ->
-    let inv = { inv_type = ty; inv_paths=[]; inv_parents = pty } in
+    let inv = { inv_type = ty; inv_parents = pty } in
     TypeHash.add hash ty inv;
-    iter_abbrev (fun p args ->
-        inv.inv_paths <- [p];
-        List.iter (inv_type hash [inv]) args
-      ) ty;
+    iter_abbrev (fun _ args ->
+      List.iter (inv_type hash [inv]) args
+    ) ty;
     iter_type_expr (inv_type hash [inv]) ty
 
 let compute_univars ty =
@@ -1283,8 +1279,9 @@ let type_subexpressions_with_free_occurrences ids ty =
     | _ -> false
   in
   let occurrence_in_expansion inv =
-    if List.exists (Path.exists_free ids) inv.inv_paths then
-      add_all_parents ids inv
+    iter_abbrev
+      (fun p _ -> if Path.exists_free ids p then add_all_parents ids inv)
+      inv.inv_type
   in
   TypeHash.iter (fun ty inv ->
       if occurrence_in_desc inv ty then () else

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1200,14 +1200,21 @@ let limited_generalize_class_type rv ~inside:cty =
 
 type inv_type_expr =
     { inv_type : type_expr;
-      mutable inv_parents : inv_type_expr list }
+      mutable inv_parents : inv_type_expr list;
+      mutable inv_paths: Path.t list }
 
 let rec inv_type hash pty ty =
   try
     let inv = TypeHash.find hash ty in
+    Option.iter (fun (p,_) -> inv.inv_paths <- p :: inv.inv_paths)
+      (get_abbrev ty);
     inv.inv_parents <- pty @ inv.inv_parents
   with Not_found ->
-    let inv = { inv_type = ty; inv_parents = pty } in
+    let inv_paths = match get_abbrev ty with
+      | None -> []
+      | Some (p, _) -> [p]
+    in
+    let inv = { inv_type = ty; inv_paths; inv_parents = pty } in
     TypeHash.add hash ty inv;
     iter_type_expr (inv_type hash [inv]) ty
 
@@ -1261,18 +1268,28 @@ let type_subexpressions_with_free_occurrences ids ty =
         nodes := TypeSet.add inv.inv_type !nodes;
         List.iter (add_all_parents ids) inv.inv_parents
   in
-  TypeHash.iter (fun ty inv ->
+  let occurrence_in_desc inv ty =
     match get_desc ty with
     | Tconstr (p, _, _) | Tobject (_, {contents = Some (p, _)})
     | Tfunctor (_, _, {pack_path = p}, _) | Tpackage {pack_path = p}
       when Path.exists_free ids p ->
-        add_all_parents ids inv
+        add_all_parents ids inv; true
     | Tvariant row ->
       begin match row_name row with
-      | Some (p, _) when Path.exists_free ids p -> add_all_parents ids inv
-      | _ -> ()
+      | Some (p, _) when Path.exists_free ids p ->
+          add_all_parents ids inv; true
+      | _ -> false
       end
-    | _ -> ()) inverted;
+    | _ -> false
+  in
+  let occurrence_in_expansion inv =
+    if List.exists (Path.exists_free ids) inv.inv_paths then
+      add_all_parents ids inv
+  in
+  TypeHash.iter (fun ty inv ->
+      if occurrence_in_desc inv ty then () else
+        occurrence_in_expansion inv
+    ) inverted;
   !nodes
 
 let fully_generic ty =
@@ -1475,6 +1492,7 @@ let rec copy ?partial ?keep_names ?scope ?(unscoped = empty_unscoped_mapping)
     let desc' =
       match ty_expand with
         Some (path, args) ->
+          let path = Path.subst unscoped.map path in
           let args = List.map copy args in
           let t' = new_scoped_ty ty_scope desc' in
           Texpand (t', path, args)


### PR DESCRIPTION
This PR fixes the uncaught exception reported in #14842 by making sure that we update expansion nodes containing `tfunctor` argument in `instance_tfunctor`.

This is done by tracking the path of expansion in the inverted type map which is used to detect which subexpression should be copied by the `copy_sep` function. This is enough to fix the bug from #14842 .

Going one step further, the second commit in this PR replaces the use of `get_desc` in `copy_sep` by `get_folded_desc` in order to restore type abbreviations that might involve user-written module-dependent types.

These two commits seem to be enough to also revert the changes to the modular explicit tests from `Keep expansion`.