### PR TITLE
Remove incorrect breaks in configure.ac

### DIFF
--- a/Changes
+++ b/Changes
@@ -1166,10 +1166,10 @@ OCaml 5.5.0
 - #14719, #14721: compute arity correctly for module-dependent function
   (Florian Angeletti, report by Jeremy Yallop, review by Stefan Muenzel)
 
-- #14760, #14802: Correct the detection of argument defaults in configure,
-  fixing an incorrect error message when installing OCaml through opam on
-  OpenSUSE with the site-config package installed.
-  (David Allsopp, review by Edwin Török, report by Edwin Török)
+- #14760, #14802, #14846: Correct the detection of argument defaults in
+  configure, fixing an incorrect error message when installing OCaml through
+  opam on OpenSUSE with the site-config package installed.
+  (David Allsopp, report and review by Edwin Török)
 
 - #14797: avoid dropping attributes attached to package types when pretty
   printing in surface syntax.

--- a/configure
+++ b/configure
@@ -3362,12 +3362,10 @@ do
   case $ac_arg in
     -mandir=* | --mandir=* | --mandi=* | --mand=* | --man=* | --ma=* | --m=* | \
     -mandir | --mandir | --mandi | --mand | --man | --ma | --m)
-      mandir_given=yes
-      break ;;
+      mandir_given=yes;;
     -libdir=* | --libdir=* | --libdi=* | --libd=* | \
     -libdir   | --libdir   | --libdi   | --libd)
-      libdir_given=yes
-      break ;;
+      libdir_given=yes;;
   esac
 done
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,12 +38,10 @@ do
   case $ac_arg in
     -mandir=* | --mandir=* | --mandi=* | --mand=* | --man=* | --ma=* | --m=* | \
     -mandir | --mandir | --mandi | --mand | --man | --ma | --m)
-      mandir_given=yes
-      break ;;
+      mandir_given=yes;;
     -libdir=* | --libdir=* | --libdi=* | --libd=* | \
     -libdir   | --libdir   | --libdi   | --libd)
-      libdir_given=yes
-      break ;;
+      libdir_given=yes;;
   esac
 done
 


### PR DESCRIPTION
My fix in #14802 alas contained a somewhat daft logical error, noted in https://github.com/ocaml/ocaml/pull/14802#issuecomment-4600230547.