### PR TITLE
Implement Dynarray.sort

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,6 +255,9 @@ Working version
   the runtime's caml_hash_variant) to Obj.hash_variant.
   (David Allsopp, review by Léo Andrès and Nicolás Ojeda Bär)
 
+- #14848: Add Dynarray.stable_sort_sub, stable_sort and sort
+  (Jeanne Pottier, review by Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -48,7 +48,7 @@
    {2 Invariants and valid states}
 
    We enforce the invariant that [length >= 0] at all times.
-   we rely on this invariant for optimization.
+   We rely on this invariant for optimization.
 
    The following conditions define what we call a "valid" dynarray:
    - valid length: [length <= Array.length arr]

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -1239,6 +1239,73 @@ let compare cmp a1 a2 =
     r
   end
 
+(** {1:sorting Sorting}*)
+
+let cutoff = 5
+let unsafe_stable_sort_sub cmp a init_ofs init_len =
+  let merge src1ofs src1len src2 src2ofs src2len dst dstofs =
+    let src1r = src1ofs + src1len and src2r = src2ofs + src2len in
+    let rec loop i1 s1 i2 s2 d =
+      if cmp s1 s2 <= 0 then begin
+        set dst d s1;
+        let i1 = i1 + 1 in
+        if i1 < src1r then
+          loop i1 (get a i1) i2 s2 (d + 1)
+        else
+          blit ~src:src2 ~src_pos:i2 ~dst:dst ~dst_pos:(d + 1) ~len:(src2r - i2)
+      end else begin
+        set dst d s2;
+        let i2 = i2 + 1 in
+        if i2 < src2r then
+          loop i1 s1 i2 (get src2 i2) (d + 1)
+        else
+          blit ~src:a ~src_pos:i1 ~dst:dst ~dst_pos:(d + 1) ~len:(src1r - i1)
+      end
+    in loop src1ofs (get a src1ofs) src2ofs (get src2 src2ofs) dstofs;
+  in
+  let isortto srcofs dst dstofs len =
+    for i = 0 to len - 1 do
+      let e = (get a (srcofs + i)) in
+      let j = ref (dstofs + i - 1) in
+      while (!j >= dstofs && cmp (get dst !j) e > 0) do
+        set dst (!j + 1) (get dst !j);
+        decr j;
+      done;
+      set dst (!j + 1) e;
+    done;
+  in
+  let rec sortto srcofs dst dstofs len =
+    if len <= cutoff then isortto srcofs dst dstofs len else begin
+      let l1 = len / 2 in
+      let l2 = len - l1 in
+      sortto (srcofs + l1) dst (dstofs + l1) l2;
+      sortto srcofs a (srcofs + l2) l1;
+      merge (srcofs + l2) l1 dst (dstofs + l1) l2 dst dstofs;
+    end;
+  in
+  let base = init_ofs in
+  let l = init_len in
+  if l <= cutoff then isortto base a base l else begin
+    let l1 = l / 2 in
+    let l2 = l - l1 in
+    let t = make l2 (get a base) in
+    sortto (base + l1) t 0 l2;
+    sortto base a (base + l2) l1;
+    merge (base + l2) l1 t 0 l2 a base;
+  end
+
+let stable_sort_sub cmp a ofs len =
+  if ofs < 0 || len < 0 || ofs > length a - len
+  then invalid_arg Error.invalid_state_description
+  else unsafe_stable_sort_sub cmp a ofs len
+
+let stable_sort cmp a =
+  let Pack {arr; length = len; _} = a in begin
+  check_valid_length len arr;
+  unsafe_stable_sort_sub cmp a 0 (length a);
+  check_same_length "stable_sort" a ~length:len;
+  end
+
 (** {1:conversions Conversions to other data structures} *)
 
 (* The eager [to_*] conversion functions behave similarly to iterators

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -1306,6 +1306,7 @@ let stable_sort cmp a =
   check_same_length "stable_sort" a ~length:len;
   end
 
+let sort = stable_sort
 (** {1:conversions Conversions to other data structures} *)
 
 (* The eager [to_*] conversion functions behave similarly to iterators

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -1241,68 +1241,21 @@ let compare cmp a1 a2 =
 
 (** {1:sorting Sorting}*)
 
-let cutoff = 5
 let unsafe_stable_sort_sub cmp a init_ofs init_len =
   let Pack {arr = arr1; length = len1; dummy = dum1} = a in
   check_valid_length len1 arr1;
-  let merge src1ofs src1len src2 src2ofs src2len dst dstofs =
-    let Pack {arr = arr2; length = len2; dummy = dum2} = src2 in
-    check_valid_length len2 arr2;
-    let src1r = src1ofs + src1len and src2r = src2ofs + src2len in
-    let rec loop i1 s1 i2 s2 d =
-      if cmp s1 s2 <= 0 then begin
-        set dst d s1;
-        let i1 = i1 + 1 in
-        if i1 < src1r then
-          loop i1 (unsafe_get arr1 ~dummy:dum1 ~i:i1 ~length:len1) i2 s2 (d + 1)
-        else
-          blit ~src:src2 ~src_pos:i2 ~dst:dst ~dst_pos:(d + 1) ~len:(src2r - i2)
-      end else begin
-        set dst d s2;
-        let i2 = i2 + 1 in
-        if i2 < src2r then
-          loop i1 s1 i2 (unsafe_get arr2 ~dummy:dum2 ~i:i2 ~length:len2) (d + 1)
-        else
-          blit ~src:a ~src_pos:i1 ~dst:dst ~dst_pos:(d + 1) ~len:(src1r - i1)
-      end
-    in loop src1ofs (unsafe_get arr1 ~dummy:dum1 ~i:src1ofs ~length:len1)
-        src2ofs (unsafe_get arr2 ~dummy:dum2 ~i:src2ofs ~length:len2) dstofs;
-  in
-  let isortto srcofs dst dstofs len =
-    for i = 0 to len - 1 do
-      let e = (unsafe_get arr1 ~dummy:dum1 ~i:(srcofs + i) ~length:len1) in
-      let j = ref (dstofs + i - 1) in
-      while (!j >= dstofs && cmp (get dst !j) e > 0) do
-        set dst (!j + 1) (get dst !j);
-        decr j;
-      done;
-      set dst (!j + 1) e;
-    done;
-  in
-  let rec sortto srcofs dst dstofs len =
-    if len <= cutoff then isortto srcofs dst dstofs len else begin
-      let l1 = len / 2 in
-      let l2 = len - l1 in
-      sortto (srcofs + l1) dst (dstofs + l1) l2;
-      sortto srcofs a (srcofs + l2) l1;
-      merge (srcofs + l2) l1 dst (dstofs + l1) l2 dst dstofs;
-    end;
-  in
-  let base = init_ofs in
-  let l = init_len in
-  if l <= cutoff then isortto base a base l else begin
-    let l1 = l / 2 in
-    let l2 = l - l1 in
-    let t = make l2 (get a base) in
-    sortto (base + l1) t 0 l2;
-    sortto base a (base + l2) l1;
-    merge (base + l2) l1 t 0 l2 a base;
-  end
+  Array.stable_sort_sub
+    (fun x y ->
+     if Dummy.is_dummy x dum1 || Dummy.is_dummy y dum1
+     then invalid_arg Error.invalid_state_description
+     else cmp (Dummy.unsafe_get x) (Dummy.unsafe_get y))
+    arr1 init_ofs init_len;
+  check_same_length "unsafe_stable_sort_sub" a ~length:len1
 
-let stable_sort_sub cmp a ofs len =
-  if ofs < 0 || len < 0 || ofs > length a - len
+let stable_sort_sub cmp a ~pos ~len =
+  if pos < 0 || len < 0 || pos > length a - len
   then invalid_arg Error.invalid_state_description
-  else unsafe_stable_sort_sub cmp a ofs len
+  else unsafe_stable_sort_sub cmp a pos len
 
 let stable_sort cmp a =
   let Pack {arr; length = len; _} = a in begin

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -1243,29 +1243,34 @@ let compare cmp a1 a2 =
 
 let cutoff = 5
 let unsafe_stable_sort_sub cmp a init_ofs init_len =
+  let Pack {arr = arr1; length = len1; dummy = dum1} = a in
+  check_valid_length len1 arr1;
   let merge src1ofs src1len src2 src2ofs src2len dst dstofs =
+    let Pack {arr = arr2; length = len2; dummy = dum2} = src2 in
+    check_valid_length len2 arr2;
     let src1r = src1ofs + src1len and src2r = src2ofs + src2len in
     let rec loop i1 s1 i2 s2 d =
       if cmp s1 s2 <= 0 then begin
         set dst d s1;
         let i1 = i1 + 1 in
         if i1 < src1r then
-          loop i1 (get a i1) i2 s2 (d + 1)
+          loop i1 (unsafe_get arr1 ~dummy:dum1 ~i:i1 ~length:len1) i2 s2 (d + 1)
         else
           blit ~src:src2 ~src_pos:i2 ~dst:dst ~dst_pos:(d + 1) ~len:(src2r - i2)
       end else begin
         set dst d s2;
         let i2 = i2 + 1 in
         if i2 < src2r then
-          loop i1 s1 i2 (get src2 i2) (d + 1)
+          loop i1 s1 i2 (unsafe_get arr2 ~dummy:dum2 ~i:i2 ~length:len2) (d + 1)
         else
           blit ~src:a ~src_pos:i1 ~dst:dst ~dst_pos:(d + 1) ~len:(src1r - i1)
       end
-    in loop src1ofs (get a src1ofs) src2ofs (get src2 src2ofs) dstofs;
+    in loop src1ofs (unsafe_get arr1 ~dummy:dum1 ~i:src1ofs ~length:len1)
+        src2ofs (unsafe_get arr2 ~dummy:dum2 ~i:src2ofs ~length:len2) dstofs;
   in
   let isortto srcofs dst dstofs len =
     for i = 0 to len - 1 do
-      let e = (get a (srcofs + i)) in
+      let e = (unsafe_get arr1 ~dummy:dum1 ~i:(srcofs + i) ~length:len1) in
       let j = ref (dstofs + i - 1) in
       while (!j >= dstofs && cmp (get dst !j) e > 0) do
         set dst (!j + 1) (get dst !j);

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -435,8 +435,8 @@ val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
 
 (** {1:sorting Sorting}*)
 
-val stable_sort_sub : ('a -> 'a -> int) -> 'a t -> int -> int -> unit
-(**[stable_sort_sub cmp a pos len] sorts the subarray of the array [a]
+val stable_sort_sub : ('a -> 'a -> int) -> 'a t -> pos:int -> len:int -> unit
+(**[stable_sort_sub cmp a ~pos ~len] sorts the subarray of the array [a]
    delimited by the start position [pos] and by the length [len]. The data
    in this subarray is sorted in increasing order according to the comparison
    function [cmp]. The data outside of this subarray is unaffected. The
@@ -454,9 +454,9 @@ val stable_sort : ('a -> 'a -> int) -> 'a t -> unit
    The comparison function must return 0 if its arguments compare as equal,
    a positive integer if the first is greater, and a negative integer if the
    first is smaller. The algorithm is stable and sorts in place, using Merge
-   Sort if the array's length is greater than 5, and Insertion Sort 
+   Sort if the array's length is greater than 5, and Insertion Sort
    otherwise.
-   
+
    Changing the length of the array during the sort is considered to be a
    programming error and will result in the function failing. *)
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -460,6 +460,9 @@ val stable_sort : ('a -> 'a -> int) -> 'a t -> unit
    Changing the length of the array during the sort is considered to be a
    programming error and will result in the function failing. *)
 
+val sort : ('a -> 'a -> int) -> 'a t -> unit
+(** An alias for stable_sort. *)
+
 (** {1:conversions Conversions to other data structures}
 
     Note: the [of_*] functions raise [Invalid_argument] if the

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -17,7 +17,7 @@
 
 (** Dynamic arrays.
 
-    The {!Array} module provide arrays of fixed length. {!Dynarray}
+    The {!Array} module provides arrays of fixed length. {!Dynarray}
     provides arrays whose length can change over time, by adding or
     removing elements at the end of the array.
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -433,6 +433,32 @@ val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
     @since 5.3
 *)
 
+(** {1:sorting Sorting}*)
+
+val stable_sort_sub : ('a -> 'a -> int) -> 'a t -> int -> int -> unit
+(**[stable_sort_sub cmp a pos len] sorts the subarray of the array [a]
+   delimited by the start position [pos] and by the length [len]. The data
+   in this subarray is sorted in increasing order according to the comparison
+   function [cmp]. The data outside of this subarray is unaffected. The
+   sorting algorithm is stable; it is the same as in {!stable_sort}.
+
+   Changing the length of [a] during the sort is considered to be a programming
+   error and will result in the function failing.
+
+   @raise Invalid_argument if [pos] and [len] do not
+   designate a valid subarray of [a]; that is, if
+   [pos < 0], or [len < 0], or [pos + len > length a]. *)
+
+val stable_sort : ('a -> 'a -> int) -> 'a t -> unit
+(** Sorts an array in increasing order according to a comparison function.
+   The comparison function must return 0 if its arguments compare as equal,
+   a positive integer if the first is greater, and a negative integer if the
+   first is smaller. The algorithm is stable and sorts in place, using Merge
+   Sort if the array's length is greater than 5, and Insertion Sort 
+   otherwise.
+   
+   Changing the length of the array during the sort is considered to be a
+   programming error and will result in the function failing. *)
 
 (** {1:conversions Conversions to other data structures}
 

--- a/testsuite/tests/misc/sort_sub.ml
+++ b/testsuite/tests/misc/sort_sub.ml
@@ -98,7 +98,7 @@ module Small_Impl_Dynarray = struct
    let get = Dynarray.get
    let for_all2 = Dynarray.for_all2
    let sort = Dynarray.sort
-   let stable_sort_sub = Dynarray.stable_sort_sub
+   let stable_sort_sub cmp a pos len = Dynarray.stable_sort_sub cmp a ~pos ~len
    let copy = Dynarray.copy
 end
 

--- a/testsuite/tests/misc/sort_sub.ml
+++ b/testsuite/tests/misc/sort_sub.ml
@@ -3,67 +3,109 @@
 open Printf
 
 let () =
-  Random.init 42
+   Random.init 42
 
-(* [generate n] generates an array of length [n],
-   containing random integer data. *)
-let generate n =
-  Array.init n @@ fun i -> Random.int n
+module type SigArray = sig
+   type 'a t
+   val init : int -> (int -> 'a) -> 'a t
+   val length : 'a t -> int
+   val get : 'a t -> int -> 'a
+   val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+   val sort : ('a -> 'a -> int) -> 'a t -> unit
+   val stable_sort_sub : ('a -> 'a -> int) -> 'a t -> int -> int -> unit
+   val copy : 'a t -> 'a t
+end
 
-(* Our comparison function. *)
-let cmp =
-  Int.compare
+module Tests (A : SigArray) = struct
 
-(* Comparing the content of two arrays. *)
-let equal a1 a2 =
-  assert (Array.length a1 = Array.length a2);
-  Array.for_all2 (=) a1 a2
+   (* [generate n] generates an array of length [n],
+      containing random integer data. *)
+   let generate n =
+     A.init n @@ fun i -> Random.int n
 
-(* [test a ofs len] tests [Array.stable_sort_sub a ofs len].
-   [Array.sort] is used as a reference sorting algorithm. *)
-let test a ofs len =
-  let segment = Array.sub a ofs len in
-  Array.sort cmp segment;
-  let expected =
-    Array.concat [
-      Array.sub a 0 ofs;
-      segment;
-      Array.sub a (ofs+len) (Array.length a - (ofs+len))
-    ]
-  in
-  Array.stable_sort_sub cmp a ofs len;
-  if not (equal a expected) then
-    printf "Array.stable_sort_sub: FAILURE (array length %d, offset %d, segment length %d)\n%!"
-      (Array.length a) ofs len
+   (* Our comparison function. *)
+   let cmp =
+      Int.compare
 
-(* One set of tests, with random segments of a random array. *)
+   (* Comparing the content of two arrays. *)
+   let equal a1 a2 =
+     assert (A.length a1 = A.length a2);
+     A.for_all2 (=) a1 a2
 
-let number_of_tests = 1000
-let max_length = 128
+   (* [test a ofs len] tests [A.stable_sort_sub a ofs len].
+      [A.sort] is used as a reference sorting algorithm. *)
+   let test a ofs len =
+     let segment = A.init len (fun i -> A.get a (ofs + i)) in
+     A.sort cmp segment;
+     let expected = A.init (A.length a)
+      (fun i -> if i < ofs || i >= (ofs + len) then A.get a i
+                                              else A.get segment (i - ofs)) in
+     A.stable_sort_sub cmp a ofs len;
+     if not (equal a expected) then
+       printf "A.stable_sort_sub: FAILURE (array length %d, offset %d,
+           segment length %d)\n%!"
+         (A.length a) ofs len
+
+   (* One set of tests, with random segments of a random array. *)
+
+   let number_of_tests = 1000
+   let max_length = 128
+   let test1 () =
+     for _ = 1 to number_of_tests do
+       let n = Random.int (max_length+1) in
+       let a = generate n in
+       let ofs = Random.int (n+1) in
+       let len = Random.int (n+1-ofs) in
+       test a ofs len
+     done
+
+   (* A second set of tests, enumerating all segments of a short array. *)
+
+   let number_of_tests = 10
+   let length = 10
+   let test2 () =
+     for _ = 1 to number_of_tests do
+       let a = generate length in
+       for i = 0 to length do
+         for j = i to length do
+           test (A.copy a) i (j - i)
+         done
+       done
+     done
+
+   (* Done. *)
+
+   let run () =
+     test1 (); test2 ();
+
+end
+
+module Small_Impl_Array = struct
+   type 'a t = 'a Array.t
+   let init = Array.init
+   let length = Array.length
+   let get = Array.get
+   let for_all2 = Array.for_all2
+   let sort = Array.sort
+   let stable_sort_sub = Array.stable_sort_sub
+   let copy = Array.copy
+end
+
+module Small_Impl_Dynarray = struct
+   type 'a t = 'a Dynarray.t
+   let init = Dynarray.init
+   let length = Dynarray.length
+   let get = Dynarray.get
+   let for_all2 = Dynarray.for_all2
+   let sort = Dynarray.sort
+   let stable_sort_sub = Dynarray.stable_sort_sub
+   let copy = Dynarray.copy
+end
+
+module Array_Tests = Tests (Small_Impl_Array)
+module Dynarray_Tests = Tests (Small_Impl_Dynarray)
+
 let () =
-  for _ = 1 to number_of_tests do
-    let n = Random.int (max_length+1) in
-    let a = generate n in
-    let ofs = Random.int (n+1) in
-    let len = Random.int (n+1-ofs) in
-    test a ofs len
-  done
-
-(* A second set of tests, enumerating all segments of a short array. *)
-
-let number_of_tests = 10
-let length = 10
-let () =
-  for _ = 1 to number_of_tests do
-    let a = generate length in
-    for i = 0 to length do
-      for j = i to length do
-        test (Array.copy a) i (j - i)
-      done
-    done
-  done
-
-(* Done. *)
-
-let () =
-  printf "OK\n%!"
+   Array_Tests.run () ;
+   Dynarray_Tests.run ();
+   print_endline "OK"


### PR DESCRIPTION
This PR adds new standard library functions : `Dynarray.stable_sort_sub`, `Dynarray.stable_sort` and `Dynarray.sort`.
These functions were suggested here : https://github.com/ocaml/ocaml/pull/13343#issuecomment-3758575318 .
They use `Array.stable_sort_sub`, so the sorting algorithm is the same as in Array. They consider a change in length to be a programming error, and raise an exception when they detect one.

Note that `Dynarray.sort` is, in fact, an alias for `Dynarray.stable_sort` : I figured that a default sorting function was a good thing to have, and that it could be later replaced by an other algorithm if needed.

I have modified the tests in testsuite/tests/misc/sort_sub.ml so that they test both `Array.stable_sort_sub` and `Dynarray.stable_sort_sub`.

I came up with three versions in total, each committed separately :
  - version 1 : adapts the code in Array by using `Dynarray.get`, `Dynarray.set`, `Dynarray.blit` etc.
  - version 2 : adapts the code in Array by using `unsafe_get` on the backing arrays
  - version 3 : directly uses `Array.stable_sort_sub` on the backing array

My benchmarks show that the third one is the fastest, and it is also the shortest code-wise, so I only kept this one in the final commit. The benchmarks can be found on my [fork](https://github.com/Jeannalyse/jocaml) on the branch named benchmarks/dynarray-stable-sort-sub. Here are some results :

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./benchmarks.opt 1` | 1.509 ± 0.019 | 1.490 | 1.547 | 1.24 ± 0.03 |
| `./benchmarks.opt 2` | 1.359 ± 0.021 | 1.333 | 1.402 | 1.12 ± 0.03 |
| `./benchmarks.opt 3` | 1.213 ± 0.024 | 1.188 | 1.260 | 1.00|

Please don't hesitate to ask questions and suggest improvements.