### PR TITLE
More (cross-)compilation fixes for Windows

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -66,7 +66,7 @@ jobs:
           path: /tmp/ocaml.tar.zst
           retention-days: 1
 
-  cross-windows:
+  cross-x86_64-w64-mingw32:
     runs-on: ubuntu-latest
     needs: non-cross
     steps:
@@ -115,7 +115,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: windows-executable
+          name: x86_64-w64-mingw32-executable
           path: example.exe
           retention-days: 1
       - name: Test cross sak
@@ -128,19 +128,19 @@ jobs:
           runtime/sak encode-C-utf8-literal "$TESTDIR" > utf8
           git diff --no-index utf8.ref utf8
 
-  run-windows:
+  run-x86_64-w64-mingw32:
     runs-on: windows-latest
-    needs: cross-windows
+    needs: cross-x86_64-w64-mingw32
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v8
         with:
-          name: windows-executable
+          name: x86_64-w64-mingw32-executable
       - name: Run example program
         run: |
           .\example.exe
 
-  cross-arm-linux:
+  cross-aarch64-linux-gnu:
     runs-on: ubuntu-latest
     needs: non-cross
     steps:
@@ -197,7 +197,7 @@ jobs:
           runtime/sak encode-C-utf8-literal "$TESTDIR" > utf8
           git diff --no-index utf8.ref utf8
 
-  cross-android:
+  cross-x86_64-linux-android21:
     runs-on: ubuntu-latest
     needs: non-cross
     env:

--- a/Makefile
+++ b/Makefile
@@ -645,16 +645,8 @@ FLEXLINK_BUILD_ENV = \
 ifneq ($(RC),)
 FLEXLINK_BUILD_ENV += RC=$(RC)
 endif
-ifeq ($(FLEXDLL_CHAIN),cygwin64)
-FLEXLINK_BUILD_ENV += CYG64CC=$(CC)
-else ifeq ($(FLEXDLL_CHAIN),mingw)
-FLEXLINK_BUILD_ENV += MINCC=$(CC)
-else ifeq ($(FLEXDLL_CHAIN),mingw64)
-FLEXLINK_BUILD_ENV += MIN64CC=$(CC)
-else ifeq ($(FLEXDLL_CHAIN),msvc)
-FLEXLINK_BUILD_ENV += MSVCC=$(CC)
-else ifeq ($(FLEXDLL_CHAIN),msvc64)
-FLEXLINK_BUILD_ENV += MSVCC64=$(CC)
+ifneq ($(FLEXDLL_CC_VAR),)
+FLEXLINK_BUILD_ENV += $(FLEXDLL_CC_VAR)=$(CC)
 endif
 FLEXDLL_SOURCES = \
   $(addprefix $(FLEXDLL_SOURCE_DIR)/, flexdll.c flexdll_initer.c flexdll.h) \

--- a/Makefile
+++ b/Makefile
@@ -643,10 +643,10 @@ FLEXLINK_BUILD_ENV = \
   MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
   CHAINS=$(FLEXDLL_CHAIN) ROOTDIR=..
 ifneq ($(RC),)
-FLEXLINK_BUILD_ENV += RC=$(RC)
+FLEXLINK_BUILD_ENV += RC="$(RC)"
 endif
 ifneq ($(FLEXDLL_CC_VAR),)
-FLEXLINK_BUILD_ENV += $(FLEXDLL_CC_VAR)=$(CC)
+FLEXLINK_BUILD_ENV += $(FLEXDLL_CC_VAR)="$(CC)"
 endif
 FLEXDLL_SOURCES = \
   $(addprefix $(FLEXDLL_SOURCE_DIR)/, flexdll.c flexdll_initer.c flexdll.h) \

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -156,6 +156,7 @@ DOCUMENTATION_TOOL_CMD=@documentation_tool_cmd@
 # Git submodule)
 FLEXDLL_SOURCE_DIR=@flexdll_source_dir@
 BOOTSTRAPPING_FLEXDLL=@bootstrapping_flexdll@
+FLEXDLL_CC_VAR=@flexdll_cc_var@
 
 ### Where to install documentation
 PACKAGE_TARNAME = @PACKAGE_TARNAME@

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -177,6 +177,11 @@ NATDYNLINKOPTS=@natdynlinkopts@
 SYSLIB=@syslib@
 MKLIB=@mklib@
 
+# Flags for building the mingw-w64 and MSVC versions of stdlib/tmpheader.exe.
+HEADER_CFLAGS=@header_cflags@
+HEADER_LDFLAGS=@header_ldflags@
+HEADER_LIBS=@header_libs@
+
 # The following variable defines flags to be passed to the C preprocessor
 # when compiling C files to be linked with native code. This includes
 # the native runtime itself and can also include the stub code around

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -112,7 +112,8 @@ INSTALL_OVERRIDES=build_ocamldoc=false WITH_DEBUGGER= OCAMLRUN=ocamlrun
 .PHONY: installcross
 installcross:
 	# Create placeholder files to keep `install` happy
-	touch toplevel/topstart.$(O)
+	touch $(addprefix driver/, main.$(O) optmain.$(O)) \
+          tools/profiling.$(O) toplevel/topstart.$(O)
 	cd lex && $(LN_S) `command -v ocamllex` ocamllex.opt$(EXE)
 	# Real installation
 	$(MAKE) install $(INSTALL_OVERRIDES)

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -111,11 +111,8 @@ INSTALL_OVERRIDES=build_ocamldoc=false WITH_DEBUGGER= OCAMLRUN=ocamlrun
 
 .PHONY: installcross
 installcross:
-	# Create dummy files to keep `install` happy
-	touch \
-	  $(addprefix toplevel/, \
-	    $(foreach ext,cmi cmt cmti cmx, native/nat__dummy__.$(ext)) \
-	      all__dummy__.cmx topstart.$(O) native/tophooks.cmi)
+	# Create placeholder files to keep `install` happy
+	touch toplevel/topstart.$(O)
 	cd lex && $(LN_S) `command -v ocamllex` ocamllex.opt$(EXE)
 	# Real installation
 	$(MAKE) install $(INSTALL_OVERRIDES)

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -115,7 +115,7 @@ installcross:
 	touch \
 	  $(addprefix toplevel/, \
 	    $(foreach ext,cmi cmt cmti cmx, native/nat__dummy__.$(ext)) \
-	      all__dummy__.cmx topstart.o native/tophooks.cmi)
+	      all__dummy__.cmx topstart.$(O) native/tophooks.cmi)
 	cd lex && $(LN_S) `command -v ocamllex` ocamllex.opt$(EXE)
 	# Real installation
 	$(MAKE) install $(INSTALL_OVERRIDES)

--- a/configure
+++ b/configure
@@ -821,6 +821,7 @@ ocaml_prefix
 compute_deps
 build_libraries_manpages
 PACKLD
+flexdll_cc_var
 flexdll_chain
 afl
 oc_native_compflags
@@ -3601,6 +3602,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L038
 
 
  # TODO: rename this variable
+
 
 
 
@@ -15839,18 +15841,23 @@ flexlink_flags=''
 case $target in #(
   x86_64-*-cygwin) :
     flexdll_chain='cygwin64'
+    flexdll_cc_var='CYG64CC'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   i686-w64-mingw32*) :
     flexdll_chain='mingw'
+    flexdll_cc_var='MINCC'
     flexlink_flags='-stack 16777216' ;; #(
   x86_64-w64-mingw32*) :
     flexdll_chain='mingw64'
+    flexdll_cc_var='MIN64CC'
     flexlink_flags='-stack 33554432' ;; #(
   i686-pc-windows) :
     flexdll_chain='msvc'
+    flexdll_cc_var='MSVCC'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   x86_64-pc-windows) :
     flexdll_chain='msvc64'
+    flexdll_cc_var='MSVCC64'
     flexlink_flags='-merge-manifest -stack 33554432' ;; #(
   *) :
     flexdll_chain='' ;;

--- a/configure
+++ b/configure
@@ -24371,7 +24371,17 @@ fi
     # line.  /GS- disables compilation of runtime security checks and
     # /NOCOFFGRPINFO is an undocumented linker flag which removes the debug
     # directory from the PE+ image.
+    # Prevent Clang 21 and later from synthesizing a call to wcslen when
+    # building header.obj by passing -fno-builtin-wcslen. As tmpheader.exe is
+    # solely linked with kernel32.lib but not with the CRT, wcslen isn't found
+    # and the linker errors.
     header_cflags='/GS- /Os'
+    case $ocaml_cc_vendor in #(
+  msvc-*-clang-*) :
+    header_cflags="$header_cflags -fno-builtin-wcslen" ;; #(
+  *) :
+     ;;
+esac
     header_ldflags='/NOCOFFGRPINFO /subsystem:console'
     header_libs='kernel32.lib' ;; #(
   *) :

--- a/configure
+++ b/configure
@@ -15837,9 +15837,6 @@ fi
 # Define flexlink chain and flags correctly for the different Windows ports
 flexlink_flags=''
 case $target in #(
-  i686-*-cygwin) :
-    flexdll_chain='cygwin'
-    flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   x86_64-*-cygwin) :
     flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
@@ -19024,8 +19021,6 @@ case $target in #(
     arch=i386; system=openbsd ;; #(
   i[3456]86-*-haiku*) :
     arch=i386; system=beos ;; #(
-  i[3456]86-*-cygwin) :
-    arch=i386; system=cygwin ;; #(
   i[3456]86-w64-mingw32*) :
     arch=i386; system=mingw ;; #(
   i[3456]86-*-gnu*) :

--- a/configure
+++ b/configure
@@ -800,6 +800,9 @@ build_os
 build_vendor
 build_cpu
 build
+header_libs
+header_ldflags
+header_cflags
 cxx_extra_warnings
 cc_extra_warnings
 runtime_search_target
@@ -3602,6 +3605,9 @@ LINEAR_MAGIC_NUMBER=Caml1999L038
 
 
  # TODO: rename this variable
+
+
+
 
 
 
@@ -24335,6 +24341,44 @@ if test "$ccomp_type" != "msvc"
 then :
   internal_cflags="-g $internal_cflags"
 fi
+
+# The mingw-w64 and MSVC versions of tmpheader.exe are linked with special flags
+# to reduce their size (considerably). In particular, the entry point is
+# overridden, which prevents the linking of crt0.
+case "$toolchain" in #(
+  mingw) :
+    # mingw-w64: optimise header.o for space and remove all unused sections
+    # during linking.
+    header_cflags='-Os'
+    if test "$system" = "mingw"
+then :
+  entrypoint='_wmainCRTStartup'
+else $as_nop
+  entrypoint='wmainCRTStartup'
+fi
+    # Certainly for GCC, -nostdlib automatically adds -nostartfiles (clang's
+    # documentation is not explicit on this point, but it would be unusual for
+    # clang and GCC to differ). --gc-sections removes unreferenced code and data
+    # sections.
+    header_ldflags=\
+"-nostdlib -nostartfiles -Wl,--gc-sections -Wl,-e,$entrypoint"
+    header_libs='-lkernel32' ;; #(
+  msvc) :
+    # MSVC: Optimise header.obj for space. cl doesn't have an equivalent of
+    # -nostdlib, however it also doesn't have default libraries in the same way
+    # as GCC - the equivalent of crt0.o is linked because it provides the entry
+    # point symbol, rather than by being explicitly added to the linking command
+    # line.  /GS- disables compilation of runtime security checks and
+    # /NOCOFFGRPINFO is an undocumented linker flag which removes the debug
+    # directory from the PE+ image.
+    header_cflags='/GS- /Os'
+    header_ldflags='/NOCOFFGRPINFO /subsystem:console'
+    header_libs='kernel32.lib' ;; #(
+  *) :
+    header_cflags=''
+  header_ldflags=''
+  header_libs='' ;;
+esac
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,7 @@ AC_SUBST([function_sections])
 AC_SUBST([oc_native_compflags])
 AC_SUBST([afl])
 AC_SUBST([flexdll_chain])
+AC_SUBST([flexdll_cc_var])
 AC_SUBST([PACKLD])
 AC_SUBST([build_libraries_manpages])
 AC_SUBST([compute_deps])
@@ -1216,18 +1217,23 @@ flexlink_flags=''
 AS_CASE([$target],
   [x86_64-*-cygwin],
     [flexdll_chain='cygwin64'
+    flexdll_cc_var='CYG64CC'
     flexlink_flags='-merge-manifest -stack 16777216'],
   [i686-w64-mingw32*],
     [flexdll_chain='mingw'
+    flexdll_cc_var='MINCC'
     flexlink_flags='-stack 16777216'],
   [x86_64-w64-mingw32*],
     [flexdll_chain='mingw64'
+    flexdll_cc_var='MIN64CC'
     flexlink_flags='-stack 33554432'],
   [i686-pc-windows],
     [flexdll_chain='msvc'
+    flexdll_cc_var='MSVCC'
     flexlink_flags='-merge-manifest -stack 16777216'],
   [x86_64-pc-windows],
     [flexdll_chain='msvc64'
+    flexdll_cc_var='MSVCC64'
     flexlink_flags='-merge-manifest -stack 33554432'],
   [flexdll_chain=''])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1214,9 +1214,6 @@ AS_IF([test x"$enable_shared" = "xno"],
 # Define flexlink chain and flags correctly for the different Windows ports
 flexlink_flags=''
 AS_CASE([$target],
-  [i686-*-cygwin],
-    [flexdll_chain='cygwin'
-    flexlink_flags='-merge-manifest -stack 16777216'],
   [x86_64-*-cygwin],
     [flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216'],
@@ -1672,8 +1669,6 @@ AS_CASE([$target],
     [arch=i386; system=openbsd],
   [[i[3456]86-*-haiku*]],
     [arch=i386; system=beos],
-  [[i[3456]86-*-cygwin]],
-    [arch=i386; system=cygwin],
   [[i[3456]86-w64-mingw32*]],
     [arch=i386; system=mingw],
   [[i[3456]86-*-gnu*]],

--- a/configure.ac
+++ b/configure.ac
@@ -312,6 +312,9 @@ AC_SUBST([runtime_search])
 AC_SUBST([runtime_search_target])
 AC_SUBST([cc_extra_warnings])
 AC_SUBST([cxx_extra_warnings])
+AC_SUBST([header_cflags])
+AC_SUBST([header_ldflags])
+AC_SUBST([header_libs])
 
 ## Generated files
 
@@ -2989,6 +2992,39 @@ AS_IF([test x"$with_afl" = "xyes"],
 # info for both C and OCaml
 AS_IF([test "$ccomp_type" != "msvc"],
   [internal_cflags="-g $internal_cflags"])
+
+# The mingw-w64 and MSVC versions of tmpheader.exe are linked with special flags
+# to reduce their size (considerably). In particular, the entry point is
+# overridden, which prevents the linking of crt0.
+AS_CASE(["$toolchain"],
+  [mingw],
+    [# mingw-w64: optimise header.o for space and remove all unused sections
+    # during linking.
+    header_cflags='-Os'
+    AS_IF([test "$system" = "mingw"],
+      [entrypoint='_wmainCRTStartup'],
+      [entrypoint='wmainCRTStartup'])
+    # Certainly for GCC, -nostdlib automatically adds -nostartfiles (clang's
+    # documentation is not explicit on this point, but it would be unusual for
+    # clang and GCC to differ). --gc-sections removes unreferenced code and data
+    # sections.
+    header_ldflags=\
+"-nostdlib -nostartfiles -Wl,--gc-sections -Wl,-e,$entrypoint"
+    header_libs='-lkernel32'],
+  [msvc],
+    [# MSVC: Optimise header.obj for space. cl doesn't have an equivalent of
+    # -nostdlib, however it also doesn't have default libraries in the same way
+    # as GCC - the equivalent of crt0.o is linked because it provides the entry
+    # point symbol, rather than by being explicitly added to the linking command
+    # line.  /GS- disables compilation of runtime security checks and
+    # /NOCOFFGRPINFO is an undocumented linker flag which removes the debug
+    # directory from the PE+ image.
+    header_cflags='/GS- /Os'
+    header_ldflags='/NOCOFFGRPINFO /subsystem:console'
+    header_libs='kernel32.lib'],
+  [header_cflags=''
+  header_ldflags=''
+  header_libs=''])
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"

--- a/configure.ac
+++ b/configure.ac
@@ -3019,7 +3019,14 @@ AS_CASE(["$toolchain"],
     # line.  /GS- disables compilation of runtime security checks and
     # /NOCOFFGRPINFO is an undocumented linker flag which removes the debug
     # directory from the PE+ image.
+    # Prevent Clang 21 and later from synthesizing a call to wcslen when
+    # building header.obj by passing -fno-builtin-wcslen. As tmpheader.exe is
+    # solely linked with kernel32.lib but not with the CRT, wcslen isn't found
+    # and the linker errors.
     header_cflags='/GS- /Os'
+    AS_CASE([$ocaml_cc_vendor],
+      [msvc-*-clang-*],
+        [header_cflags="$header_cflags -fno-builtin-wcslen"])
     header_ldflags='/NOCOFFGRPINFO /subsystem:console'
     header_libs='kernel32.lib'],
   [header_cflags=''

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -90,41 +90,11 @@ runtime-launch-info: tmpheader.exe
 	@{ printf '$(if $(MANGLING),$(ZINC_RUNTIME_ID),\000)'; \
 	   cat $^; } > $@
 
-# The mingw-w64 and MSVC versions of tmpheader.exe are linked with special flags
-# to reduce their size (considerably). In particular, the entry point is
-# overridden, which prevents the linking of crt0.
-ifeq "$(TOOLCHAIN)" "mingw"
-# mingw-w64: optimise header.o for space and remove all unused sections during
-# linking.
-header.o: OC_CFLAGS += -Os
-ifeq "$(SYSTEM)" "mingw"
-  ENTRYPOINT = _wmainCRTStartup
-else
-  ENTRYPOINT = wmainCRTStartup
-endif
-# Certainly for GCC, -nostdlib automatically adds -nostartfiles (clang's
-# documentation is not explicit on this point, but it would be unusual for clang
-# and GCC to differ). --gc-sections removes unreferenced code and data sections.
-tmpheader.exe: OC_LDFLAGS += \
-  -nostdlib -nostartfiles -Wl,--gc-sections -Wl,-e,$(ENTRYPOINT)
-HEADERLIBS = -lkernel32
-else ifeq "$(TOOLCHAIN)" "msvc"
-# MSVC: Optimise header.obj for space. cl doesn't have an equivalent of
-# -nostdlib, however it also doesn't have default libraries in the same way as
-# GCC - the equivalent of crt0.o is linked because it provides the entry point
-# symbol, rather than by being explicitly added to the linking command line.
-# /GS- disables compilation of runtime security checks and /NOCOFFGRPINFO is an
-# undocumented linker flag which removes the debug directory from the PE+ image.
-header.obj: OC_CFLAGS += /GS- /Os
-tmpheader.exe: OC_LDFLAGS += /NOCOFFGRPINFO /subsystem:console
-HEADERLIBS = kernel32.lib
-else
-HEADERLIBS =
-endif
-
+header.$(O): OC_CFLAGS += $(HEADER_CFLAGS)
 .INTERMEDIATE: tmpheader.exe
+tmpheader.exe: OC_LDFLAGS += $(HEADER_LDFLAGS)
 tmpheader.exe: header.$(O)
-	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^ $(HEADERLIBS))
+	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^ $(HEADER_LIBS))
 # Do not strip the header produced by cl
 ifneq "$(TOOLCHAIN)" "msvc"
 	$(STRIP) $@


### PR DESCRIPTION
- **Use correct object extension with dummy files in installcross**
  Add more dummy files to avoid this error when running `make installcross` with a `*-pc-windows` target on a unix build/host.
  
      install: cannot stat 'tools/profiling.obj': No such file or directory
      install: cannot stat 'driver/main.obj': No such file or directory
      install: cannot stat 'driver/optmain.obj': No such file or directory
      install: cannot stat 'toplevel/topstart.obj': No such file or directory

- **Quote the `CC` variable passed to `FLEXLINK_BUILD_ENV`**
  If the `CC` variable contains spaces, which happens if flags such as `--target` or `-fuse-ld` are passed, it would be split when calling flexdll's Makefile. Quote the variable to prevent splitting.

- **Prevent clang-cl from synthesizing a call to `wcslen` in `header.obj`**
  > A recent optimization change in LLVM [1] aims to transform certain loop idioms into calls to strlen() or wcslen().
  
  quote from [[PATCH] kbuild: Add '-fno-builtin-wcslen'][2].
  
  [1]: https://github.com/llvm/llvm-project/commit/9694844d7e36fd5e01011ab56b64f27b867aa72d
  [2]: https://patchew.org/linux/20250407-fno-builtin-wcslen-v1-1-6775ce759b15@kernel.org/
  
  Since LLVM 21, clang-cl synthesizes a call to `wcslen` when building `header.obj`. However, to reduce its size, `tmpheader.exe` is only linked with `kernel32.obj`, so the symbol can't be found when linking. Prevent this by passing `-fno-builtin-wcslen` when building with clang. GitHub Actions currently packages LLVM 19.
  
      header.obj : error LNK2019: unresolved external symbol wcslen referenced in function search_and_exec_runtime
      
  The way I detect clang is a bit hackish, I'm open to other suggestions.

- **GHA: rename cross jobs with the target triplet**
  because `*-pc-windows` and `*-w64-mingw32` are different targets ;)

cc @shym and @dra27


If you really want to reproduce this thing, I have cloned [`msvc-wine`](https://github.com/mstorsjo/msvc-wine) in `~/Projects/msvc-wine` and installed MSVC in `~/my_msvc`. This requires clang >= 21, clang-tools, lld (and Wine). It installs an ocaml compiler in `~/.local` and an ocaml cross-compiler in `~/.local/x86_64-pc-windows`. You may need to set `CC` to `clang-cl-nn` where _nn_ is your local LLVM version.

```sh
./configure --cache-file=../ocaml-default.cache --prefix="$HOME/.local" \
            --disable-warn-error --disable-ocamldoc --disable-ocamltest \
            --disable-stdlib-manpages --disable-instrumented-runtime \
            --disable-debug-runtime && \
make -j$(nproc) && make install
make distclean

TARGET='x86_64-pc-windows'
(export PATH="$HOME/.local/bin:$HOME/my_msvc/bin/x64:$PATH" && \
 BIN=~/my_msvc/bin/x64 . ~/Projects/msvc-wine/msvcenv-native.sh && \
 ./configure --cache-file=../ocaml-"$TARGET".cache --target="$TARGET" \
             --prefix="$HOME/.local/$TARGET" \
             CC='clang-cl -fuse-ld=lld-link' && \
 make crossopt -j$(nproc) && make installcross) && \
"$HOME/.local/$TARGET/bin/ocamlc.exe" -config
```

I'll create a new CI job when I'll have the linker and assembler stories sorted out.