### PR TITLE
stdlib/list: clarify find_opt documentation

### DIFF
--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -339,7 +339,7 @@ val find : ('a -> bool) -> 'a list -> 'a
  *)
 
 val find_opt : ('a -> bool) -> 'a list -> 'a option
-(** [find f l] returns the first element of the list [l]
+(** [find_opt f l] returns the first element of the list [l]
    that satisfies the predicate [f].
    Returns [None] if there is no value that satisfies [f] in the
    list [l].

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -339,7 +339,7 @@ val find : f:('a -> bool) -> 'a list -> 'a
  *)
 
 val find_opt : f:('a -> bool) -> 'a list -> 'a option
-(** [find ~f l] returns the first element of the list [l]
+(** [find_opt ~f l] returns the first element of the list [l]
    that satisfies the predicate [f].
    Returns [None] if there is no value that satisfies [f] in the
    list [l].


### PR DESCRIPTION
This patch updates the documentation of `List.find_opt` and `ListLabels.find_opt`.

The previous documentation referred to `find` / `find ~f`, while nearby functions such as `find_index`, `find_map`, and `assoc_opt` refer to their own function names in documentation examples.

This change updates the examples to `find_opt` / `find_opt ~f` for consistency.
