### PR TITLE
GHA: fix the cygwin-packages download directory

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: |
-            C:\cygwin-packages
+            D:\cygwin-packages
           key: cygwin-packages
 
       - name: Install Cygwin
@@ -118,7 +118,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: |
-            C:\cygwin-packages
+            D:\cygwin-packages
           key: cygwin-packages
 
       - name: Set up MSVC


### PR DESCRIPTION
cygwin-install-action has a [`work-vol`][1] setting:

> The Windows volume to which the installer and packages are downloaded.
> The default value is `D:` for performance reasons.

[1]: https://github.com/cygwin/cygwin-install-action#work-vol

We're not customizing it, but we were giving `C:\cygwin-packages` to the cache restore/save actions, leading to cache miss. This saves around 20 seconds… See https://github.com/cygwin/cygwin-install-action/blob/781ea34f8c7c28e794b807fb7120e93bfdac3089/src/install.ps1#L54.