### PR TITLE
Fix escaping in `Filename.quote_command` on Windows.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1186,6 +1186,9 @@ OCaml 5.5.0
   printing in surface syntax.
   (Chet Murthy, review by Nicolás Ojeda Bär)
 
+- #14853: fix quoting of filenames passed to Filename.quote_command on Windows.
+  (David Allsopp, report by Andrew Nesbitt, review by ???)
+
 OCaml 5.4.0 (9 October 2025)
 ----------------------------
 

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -207,7 +207,9 @@ Quoting commands for execution by cmd.exe is difficult.
     in
     if String.exists (function '\"' | '%' -> true | _ -> false) f then
       failwith ("Filename.quote_command: bad file name " ^ f)
-    else if String.contains f ' ' then
+    else if String.exists (function
+              | ' ' | '(' | ')' | '^' | '<' | '>' | '&' | '|' -> true
+              | _ -> false) f then
       String.concat "" ["\""; f; "\""]
     else
       f

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -172,13 +172,13 @@ Quoting commands for execution by cmd.exe is difficult.
    protect it against the processing performed by the C runtime system,
    then cmd.exe's special characters are escaped with '^', using
    the "quote_cmd" function below.  For more details, see
-   https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23
+   https://web.archive.org/web/20251122022701/https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
 2- The command and the redirection files, if any, must be double-quoted
-   in case they contain spaces.  This quoting is interpreted by cmd.exe,
-   not by the C runtime system, hence the "quote" function above
-   cannot be used.  The two characters we don't know how to quote
-   inside a double-quoted cmd.exe string are double-quote and percent.
-   We just fail if the command name or the redirection file names
+   if they contain any of the special characters which are valid in filenames.
+   This quoting is interpreted by cmd.exe, not by the C runtime system, hence
+   the "quote" function above cannot be used.  The two characters we don't know
+   how to quote inside a double-quoted cmd.exe string are double-quote and
+   percent.  We just fail if the command name or the redirection file names
    contain a double quote (not allowed in Windows file names, anyway)
    or a percent.  See function "quote_cmd_filename" below.
 3- The whole string passed to Sys.command is then enclosed in double
@@ -208,7 +208,7 @@ Quoting commands for execution by cmd.exe is difficult.
     if String.exists (function '\"' | '%' -> true | _ -> false) f then
       failwith ("Filename.quote_command: bad file name " ^ f)
     else if String.exists (function
-              | ' ' | '(' | ')' | '^' | '<' | '>' | '&' | '|' -> true
+              | ' ' | '(' | ')' | '!' | '^' | '&' -> true
               | _ -> false) f then
       String.concat "" ["\""; f; "\""]
     else

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -123,7 +123,7 @@ let _ =
     printf "-- %s\n" name;
     run prog ["per aspera"; "ad astra"];
     Sys.remove name)
-    ["my&echo.exe"; "my(echo).exe"; "my^echo.exe"]
+    ["my&echo.exe"; "my(echo).exe"; "my(echo.exe"; "my)echo.exe"; "my^echo.exe"; "my!echo.exe"]
 
 let _ =
   printf "-------- Redirection to names with metacharacters\n";
@@ -131,7 +131,7 @@ let _ =
     run echo_exe ~stdout:fn ["lux et veritas"];
     printf "-- %s:\n" fn;
     cat_and_rm_file fn)
-    ["out&put.tmp"; "out(put).tmp"; "out^put.tmp"; "a & b.tmp"]
+    ["out&put.tmp"; "out(put).tmp"; "out(put.tmp"; "out)put.tmp"; "out^put.tmp"; "out!put.tmp"; "a & b.tmp"]
 
 (* Arguments go through quote then quote_cmd.  Check that variable expansion is
    suppressed and that trailing backslashes survive the C-runtime quoting. *)

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -45,10 +45,14 @@ let copy_file src dst =
   close_in ic;
   close_out oc
 
-let cat_file f =
-  let ic = open_in f in
-  copy_channels ic stdout;
-  close_in ic
+let cat_and_rm_file f =
+  match open_in f with
+  | ic ->
+      copy_channels ic stdout;
+      close_in ic;
+      Sys.remove f
+  | exception Sys_error _ ->
+      printf "Could not open %S\n" f
 
 let myecho =
   Filename.concat Filename.current_dir_name "my echo.exe"
@@ -57,10 +61,8 @@ let run prog ?stdin ?stdout ?stderr args =
   flush Stdlib.stdout;
   let rc =
    Sys.command (Filename.quote_command prog ?stdin ?stdout ?stderr args) in
-  if rc > 0 then begin
-    printf "!!! %s failed\n" prog;
-    exit 2
-  end
+  if rc > 0 then
+    printf "!!! %s failed\n" prog
 
 let _ =
   let run = run myecho in
@@ -87,21 +89,71 @@ let _ =
               ["Exceptur sint"; "-err"; "occaecat"; "cupidatat";
                "-out"; "non proident"; "-err"; "sunt in culpa"];
   printf "-- stderr:\n";
-  cat_file "my 'file'.tmp";
-  Sys.remove "my 'file'.tmp";
+  cat_and_rm_file "my 'file'.tmp";
   printf "-------- Output and error redirections (different files)\n";
   run ~stdout:"my stdout.tmp" ~stderr:"my stderr.tmp"
               ["qui officia"; "-err"; "deserunt"; "mollit";
                "-out"; "anim id est"; "-err"; "laborum."];
-  printf "-- stdout:\n"; cat_file "my stdout.tmp"; Sys.remove "my stdout.tmp";
-  printf "-- stderr:\n"; cat_file "my stderr.tmp"; Sys.remove "my stderr.tmp";
+  printf "-- stdout:\n"; cat_and_rm_file "my stdout.tmp";
+  printf "-- stderr:\n"; cat_and_rm_file "my stderr.tmp";
   printf "-------- Output and error redirections (same file)\n";
   run ~stdout:"my file.tmp" ~stderr:"my file.tmp"
               ["Duis aute"; "irure dolor"; "-err"; "in reprehenderit";
                "in voluptate"; "-out"; "velit esse cillum"; "-err"; "dolore"];
-  cat_file "my file.tmp"; Sys.remove "my file.tmp";
+  cat_and_rm_file "my file.tmp";
   Sys.remove "my echo.exe"
 
 let _ =
   printf "-------- Forward slashes in program position\n";
   run "./myecho.exe" ["alea iacta est"]
+
+let echo_exe = "./myecho.exe"
+
+(* The program name and the redirection files go through quote_cmd_filename,
+   which must double-quote cmd.exe metacharacters that are legal in a Windows
+   file name (& ( ) ^), not just spaces.  These check the right program is
+   found and the right (literally named) file is written -- i.e. both that no
+   command is injected and that the result is correct. *)
+
+let _ =
+  printf "-------- Metacharacters in program name\n";
+  List.iter (fun name ->
+    let prog = Filename.concat Filename.current_dir_name name in
+    copy_file "myecho.exe" name;
+    printf "-- %s\n" name;
+    run prog ["per aspera"; "ad astra"];
+    Sys.remove name)
+    ["my&echo.exe"; "my(echo).exe"; "my^echo.exe"]
+
+let _ =
+  printf "-------- Redirection to names with metacharacters\n";
+  List.iter (fun fn ->
+    run echo_exe ~stdout:fn ["lux et veritas"];
+    printf "-- %s:\n" fn;
+    cat_and_rm_file fn)
+    ["out&put.tmp"; "out(put).tmp"; "out^put.tmp"; "a & b.tmp"]
+
+(* Arguments go through quote then quote_cmd.  Check that variable expansion is
+   suppressed and that trailing backslashes survive the C-runtime quoting. *)
+let _ =
+  printf "-------- Adversarial arguments\n";
+  run echo_exe ["%PATH%"; {|"&whoami&"|}; {|C:\Program Files\|};
+                {|a\|}; {|a\\|}; ""]
+
+(* The two characters quote_cmd_filename cannot quote (double-quote and %) must
+   be rejected with Failure, in the program name and in any redirection file. *)
+let check_raises descr f =
+  match f () with
+  | _ -> printf "%s: no exception (BUG)\n" descr
+  | exception Failure _ -> printf "%s: Failure (ok)\n" descr
+
+let _ =
+  printf "-------- Rejected (unquotable) characters\n";
+  check_raises "stdout %"
+    (fun () -> Filename.quote_command "true" ~stdout:"a%b" []);
+  check_raises {|stdout "|}
+    (fun () -> Filename.quote_command "true" ~stdout:{|a"b|} []);
+  check_raises "program %"
+    (fun () -> Filename.quote_command "a%b" []);
+  check_raises {|program "|}
+    (fun () -> Filename.quote_command {|a"b|} [])

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -143,9 +143,15 @@ let _ =
 (* The two characters quote_cmd_filename cannot quote (double-quote and %) must
    be rejected with Failure, in the program name and in any redirection file. *)
 let check_raises descr f =
-  match f () with
-  | _ -> printf "%s: no exception (BUG)\n" descr
-  | exception Failure _ -> printf "%s: Failure (ok)\n" descr
+  let raised_failure =
+    match f () with
+    | _ -> false
+    | exception Failure _ -> true
+  in
+  if raised_failure = Sys.win32 then
+    printf "%s: OK\n" descr
+  else
+    printf "%s: ERROR\n" descr
 
 let _ =
   printf "-------- Rejected (unquotable) characters\n";

--- a/testsuite/tests/lib-filename/quotecommand.reference
+++ b/testsuite/tests/lib-filename/quotecommand.reference
@@ -40,26 +40,21 @@ argv[9] = {|dolore|}
 argv[1] = {|alea iacta est|}
 -------- Metacharacters in program name
 -- my&echo.exe
-'.\my' is not recognized as an internal or external command,
-operable program or batch file.
-exe "per aspera" "ad astra"
+argv[1] = {|per aspera|}
+argv[2] = {|ad astra|}
 -- my(echo).exe
-'.\my' is not recognized as an internal or external command,
-operable program or batch file.
-!!! .\my(echo).exe failed
+argv[1] = {|per aspera|}
+argv[2] = {|ad astra|}
 -- my^echo.exe
 argv[1] = {|per aspera|}
 argv[2] = {|ad astra|}
 -------- Redirection to names with metacharacters
-'put.tmp' is not recognized as an internal or external command,
-operable program or batch file.
-!!! ./myecho.exe failed
 -- out&put.tmp:
-Could not open "out&put.tmp"
+argv[1] = {|lux et veritas|}
 -- out(put).tmp:
 argv[1] = {|lux et veritas|}
 -- out^put.tmp:
-Could not open "out^put.tmp"
+argv[1] = {|lux et veritas|}
 -- a & b.tmp:
 argv[1] = {|lux et veritas|}
 -------- Adversarial arguments

--- a/testsuite/tests/lib-filename/quotecommand.reference
+++ b/testsuite/tests/lib-filename/quotecommand.reference
@@ -65,7 +65,7 @@ argv[4] = {|a\|}
 argv[5] = {|a\\|}
 argv[6] = {||}
 -------- Rejected (unquotable) characters
-stdout %: Failure (ok)
-stdout ": Failure (ok)
-program %: Failure (ok)
-program ": Failure (ok)
+stdout %: OK
+stdout ": OK
+program %: OK
+program ": OK

--- a/testsuite/tests/lib-filename/quotecommand.reference
+++ b/testsuite/tests/lib-filename/quotecommand.reference
@@ -45,7 +45,16 @@ argv[2] = {|ad astra|}
 -- my(echo).exe
 argv[1] = {|per aspera|}
 argv[2] = {|ad astra|}
+-- my(echo.exe
+argv[1] = {|per aspera|}
+argv[2] = {|ad astra|}
+-- my)echo.exe
+argv[1] = {|per aspera|}
+argv[2] = {|ad astra|}
 -- my^echo.exe
+argv[1] = {|per aspera|}
+argv[2] = {|ad astra|}
+-- my!echo.exe
 argv[1] = {|per aspera|}
 argv[2] = {|ad astra|}
 -------- Redirection to names with metacharacters
@@ -53,7 +62,13 @@ argv[2] = {|ad astra|}
 argv[1] = {|lux et veritas|}
 -- out(put).tmp:
 argv[1] = {|lux et veritas|}
+-- out(put.tmp:
+argv[1] = {|lux et veritas|}
+-- out)put.tmp:
+argv[1] = {|lux et veritas|}
 -- out^put.tmp:
+argv[1] = {|lux et veritas|}
+-- out!put.tmp:
 argv[1] = {|lux et veritas|}
 -- a & b.tmp:
 argv[1] = {|lux et veritas|}

--- a/testsuite/tests/lib-filename/quotecommand.reference
+++ b/testsuite/tests/lib-filename/quotecommand.reference
@@ -38,3 +38,39 @@ argv[7] = {|velit esse cillum|}
 argv[9] = {|dolore|}
 -------- Forward slashes in program position
 argv[1] = {|alea iacta est|}
+-------- Metacharacters in program name
+-- my&echo.exe
+'.\my' is not recognized as an internal or external command,
+operable program or batch file.
+exe "per aspera" "ad astra"
+-- my(echo).exe
+'.\my' is not recognized as an internal or external command,
+operable program or batch file.
+!!! .\my(echo).exe failed
+-- my^echo.exe
+argv[1] = {|per aspera|}
+argv[2] = {|ad astra|}
+-------- Redirection to names with metacharacters
+'put.tmp' is not recognized as an internal or external command,
+operable program or batch file.
+!!! ./myecho.exe failed
+-- out&put.tmp:
+Could not open "out&put.tmp"
+-- out(put).tmp:
+argv[1] = {|lux et veritas|}
+-- out^put.tmp:
+Could not open "out^put.tmp"
+-- a & b.tmp:
+argv[1] = {|lux et veritas|}
+-------- Adversarial arguments
+argv[1] = {|%PATH%|}
+argv[2] = {|"&whoami&"|}
+argv[3] = {|C:\Program Files\|}
+argv[4] = {|a\|}
+argv[5] = {|a\\|}
+argv[6] = {||}
+-------- Rejected (unquotable) characters
+stdout %: Failure (ok)
+stdout ": Failure (ok)
+program %: Failure (ok)
+program ": Failure (ok)

--- a/testsuite/tests/lib-filename/windows.ml
+++ b/testsuite/tests/lib-filename/windows.ml
@@ -51,6 +51,8 @@ let () =
   run_probe "stdout &"  ~stdout:"out&false" ();
   run_probe "stdout &&" ~stdout:"out&&false" ();
   run_probe "stdout ()" ~stdout:"out(false)" ();
+  run_probe "stdout (" ~stdout:"out(false)" ();
+  run_probe "stdout )" ~stdout:"out(false)" ();
   run_probe "stderr &"  ~stderr:"err&false" ();
   print_string "==== Illegal file-name targets, must be quoted\n";
   show "stdout |" ~stdout:"out|false" ();

--- a/testsuite/tests/lib-filename/windows.ml
+++ b/testsuite/tests/lib-filename/windows.ml
@@ -1,0 +1,13 @@
+(* TEST
+ target-windows;
+ {
+   bytecode;
+ }{
+   native;
+ }
+*)
+
+let () =
+  let cmd = Filename.quote_command "true" ~stdout:"output&false" [] in
+  let result = Sys.command cmd in
+  Printf.printf "Command: %S\nResult: %d\n" cmd result

--- a/testsuite/tests/lib-filename/windows.ml
+++ b/testsuite/tests/lib-filename/windows.ml
@@ -7,7 +7,54 @@
  }
 *)
 
+(* Adversarial tests for Filename.quote_command: a hostile string supplied as
+   a redirection target or program name must not be able to smuggle an extra
+   command past cmd.exe.
+
+   The cmd.exe metacharacters split in two, according to whether they are legal
+   in a Windows file name:
+
+   - Legal in a file name (& ( ) ^): a correctly quoted target becomes a real
+     (oddly named) file, so we can actually run "true" with the redirection and
+     confirm it executes (Result 0) instead of the injected "false" (which
+     would give a non-zero code).  The payloads contain no spaces, so that the
+     pre-fix code -- which double-quoted only when a space was present -- does
+     not neutralise them by accident.
+
+   - Illegal in a file name (| < >): such a string can never name a real file,
+     so a correctly quoted target can only ever make cmd.exe fail, never
+     execute.  Running it would just compare cmd.exe's locale-dependent error
+     text, so instead we pin the constructed command line and check the target
+     is wrapped in double quotes.
+
+   true/false are the POSIX commands on the PATH (the testsuite runs under
+   Cygwin). *)
+
+let remove f = try Sys.remove f with Sys_error _ -> ()
+
+(* Run the redirection and report the exit code.  A correctly quoted target is
+   a real file, so "true" runs and the code is 0. *)
+let run_probe label ?stdin ?stdout ?stderr () =
+  let cmd = Filename.quote_command "true" ?stdin ?stdout ?stderr [] in
+  let rc = Sys.command cmd in
+  List.iter (function Some f -> remove f | None -> ()) [stdin; stdout; stderr];
+  Printf.printf "%s: %S -> %d\n" label cmd rc
+
+(* Just show the constructed command line, for targets that cannot name a file
+   and so cannot be executed cleanly. *)
+let show label ?stdin ?stdout ?stderr () =
+  Printf.printf "%s: %S\n" label
+    (Filename.quote_command "true" ?stdin ?stdout ?stderr [])
+
 let () =
-  let cmd = Filename.quote_command "true" ~stdout:"output&false" [] in
-  let result = Sys.command cmd in
-  Printf.printf "Command: %S\nResult: %d\n" cmd result
+  print_string "==== Executable (legal file name) targets, must not inject\n";
+  run_probe "stdout &"  ~stdout:"out&false" ();
+  run_probe "stdout &&" ~stdout:"out&&false" ();
+  run_probe "stdout ()" ~stdout:"out(false)" ();
+  run_probe "stderr &"  ~stderr:"err&false" ();
+  print_string "==== Illegal file-name targets, must be quoted\n";
+  show "stdout |" ~stdout:"out|false" ();
+  show "stdout <" ~stdout:"out<false" ();
+  show "stdout >" ~stdout:"out>false" ();
+  show "stdin  |" ~stdin:"in|false" ();
+  show "stderr |" ~stderr:"err|false" ()

--- a/testsuite/tests/lib-filename/windows.ml
+++ b/testsuite/tests/lib-filename/windows.ml
@@ -40,12 +40,6 @@ let run_probe label ?stdin ?stdout ?stderr () =
   List.iter (function Some f -> remove f | None -> ()) [stdin; stdout; stderr];
   Printf.printf "%s: %S -> %d\n" label cmd rc
 
-(* Just show the constructed command line, for targets that cannot name a file
-   and so cannot be executed cleanly. *)
-let show label ?stdin ?stdout ?stderr () =
-  Printf.printf "%s: %S\n" label
-    (Filename.quote_command "true" ?stdin ?stdout ?stderr [])
-
 let () =
   print_string "==== Executable (legal file name) targets, must not inject\n";
   run_probe "stdout &"  ~stdout:"out&false" ();
@@ -54,9 +48,3 @@ let () =
   run_probe "stdout (" ~stdout:"out(false)" ();
   run_probe "stdout )" ~stdout:"out(false)" ();
   run_probe "stderr &"  ~stderr:"err&false" ();
-  print_string "==== Illegal file-name targets, must be quoted\n";
-  show "stdout |" ~stdout:"out|false" ();
-  show "stdout <" ~stdout:"out<false" ();
-  show "stdout >" ~stdout:"out>false" ();
-  show "stdin  |" ~stdin:"in|false" ();
-  show "stderr |" ~stderr:"err|false" ()

--- a/testsuite/tests/lib-filename/windows.reference
+++ b/testsuite/tests/lib-filename/windows.reference
@@ -5,9 +5,3 @@ stdout (): "\"true  >\"out(false)\"\"" -> 0
 stdout (: "\"true  >\"out(false)\"\"" -> 0
 stdout ): "\"true  >\"out(false)\"\"" -> 0
 stderr &: "\"true  2>\"err&false\"\"" -> 0
-==== Illegal file-name targets, must be quoted
-stdout |: "\"true  >\"out|false\"\""
-stdout <: "\"true  >\"out<false\"\""
-stdout >: "\"true  >\"out>false\"\""
-stdin  |: "\"true  <\"in|false\"\""
-stderr |: "\"true  2>\"err|false\"\""

--- a/testsuite/tests/lib-filename/windows.reference
+++ b/testsuite/tests/lib-filename/windows.reference
@@ -1,11 +1,11 @@
 ==== Executable (legal file name) targets, must not inject
-stdout &: "\"true  >out&false\"" -> 1
-stdout &&: "\"true  >out&&false\"" -> 1
-stdout (): "\"true  >out(false)\"" -> 0
-stderr &: "\"true  2>err&false\"" -> 1
+stdout &: "\"true  >\"out&false\"\"" -> 0
+stdout &&: "\"true  >\"out&&false\"\"" -> 0
+stdout (): "\"true  >\"out(false)\"\"" -> 0
+stderr &: "\"true  2>\"err&false\"\"" -> 0
 ==== Illegal file-name targets, must be quoted
-stdout |: "\"true  >out|false\""
-stdout <: "\"true  >out<false\""
-stdout >: "\"true  >out>false\""
-stdin  |: "\"true  <in|false\""
-stderr |: "\"true  2>err|false\""
+stdout |: "\"true  >\"out|false\"\""
+stdout <: "\"true  >\"out<false\"\""
+stdout >: "\"true  >\"out>false\"\""
+stdin  |: "\"true  <\"in|false\"\""
+stderr |: "\"true  2>\"err|false\"\""

--- a/testsuite/tests/lib-filename/windows.reference
+++ b/testsuite/tests/lib-filename/windows.reference
@@ -1,2 +1,11 @@
-Command: "\"true  >output&false\""
-Result: 1
+==== Executable (legal file name) targets, must not inject
+stdout &: "\"true  >out&false\"" -> 1
+stdout &&: "\"true  >out&&false\"" -> 1
+stdout (): "\"true  >out(false)\"" -> 0
+stderr &: "\"true  2>err&false\"" -> 1
+==== Illegal file-name targets, must be quoted
+stdout |: "\"true  >out|false\""
+stdout <: "\"true  >out<false\""
+stdout >: "\"true  >out>false\""
+stdin  |: "\"true  <in|false\""
+stderr |: "\"true  2>err|false\""

--- a/testsuite/tests/lib-filename/windows.reference
+++ b/testsuite/tests/lib-filename/windows.reference
@@ -2,6 +2,8 @@
 stdout &: "\"true  >\"out&false\"\"" -> 0
 stdout &&: "\"true  >\"out&&false\"\"" -> 0
 stdout (): "\"true  >\"out(false)\"\"" -> 0
+stdout (: "\"true  >\"out(false)\"\"" -> 0
+stdout ): "\"true  >\"out(false)\"\"" -> 0
 stderr &: "\"true  2>\"err&false\"\"" -> 0
 ==== Illegal file-name targets, must be quoted
 stdout |: "\"true  >\"out|false\"\""

--- a/testsuite/tests/lib-filename/windows.reference
+++ b/testsuite/tests/lib-filename/windows.reference
@@ -1,0 +1,2 @@
+Command: "\"true  >output&false\""
+Result: 1


### PR DESCRIPTION
While #1492 goes to extreme lengths to get the escaping right for arguments in `Filename.quote_command`, it turns out we weren't quite as worried with the escaping for the redirection arguments for the standard handles as we needed to be, as this example subtly shows:

```console
$ ocaml
OCaml version 5.4.1
Enter #help;; for help.

# Sys.command (Filename.quote_command "true" ~stdout:"output&false" []);;
- : int = 1
```
The exit code comes from `false`. With this PR, we get the exit code from `true` instead (and the filename requested is actually created):

```console
$ make runtop
OCaml version 5.6.0+dev0-2026-01-26
Enter #help;; for help.

# Sys.command (Filename.quote_command "true" ~stdout:"output&false" []);;
- : int = 0
```

The first commit was hand-knitted by me based on a slightly different example from @mtelvers. The test cases in the second commit were produced by Claude as positive tests after the fix was made, but I then adapted quotecommand.ml to fail more gracefully so that the second commit shows all these tests failing. The third commit then fixes the bug and updates the reference files.

No security-conscious Windows program should be doing anything with `Sys.command` under any circumstances and no program on any platform should really be providing the user with control over the optional arguments being passed to `Filename.quote_command`, so I struggle to label this as much of a security issue, but it's a bug nonetheless, and the fix is relatively straightforward.