### PR TITLE
stdlib/option: fix typo in is_some documentation

### DIFF
--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -90,7 +90,7 @@ val is_none : 'a option -> bool
 (** [is_none o] is [true] if and only if [o] is [None]. *)
 
 val is_some : 'a option -> bool
-(** [is_some o] is [true] if and only if [o] is [Some o]. *)
+(** [is_some o] is [true] if and only if [o] is [Some _]. *)
 
 val equal : ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
 (** [equal eq o0 o1] is [true] if and only if [o0] and [o1] are both [None]


### PR DESCRIPTION
The documentation comment for is_some contained a typo: it read [Some o] where o is the option value itself, making the description self-referential and incorrect. Changed to [Some _] to be consistent with the rest of the file.