### PR TITLE
fix an inverted check in mark_header for lazy tags

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1464,7 +1464,7 @@ Caml_inline header_t mark_header(value block, header_t hd, status marked)
   header_t marked_hd;
 again:
   marked_hd = With_status_hd(hd, marked);
-  if (Tag_hd(hd) == Lazy_tag && Tag_hd(hd) == Forcing_tag) {
+  if (Tag_hd(hd) == Lazy_tag || Tag_hd(hd) == Forcing_tag) {
     /* To detect and mitigate a race against some other domain
      * short-circuiting alazy block, we compare-and-swap */
     if (!atomic_compare_exchange_strong(Hp_atomic_val(block), &hd, marked_hd)) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1466,7 +1466,7 @@ again:
   marked_hd = With_status_hd(hd, marked);
   if (Tag_hd(hd) == Lazy_tag || Tag_hd(hd) == Forcing_tag) {
     /* To detect and mitigate a race against some other domain
-     * short-circuiting alazy block, we compare-and-swap */
+     * short-circuiting a lazy block, we compare-and-swap */
     if (!atomic_compare_exchange_strong(Hp_atomic_val(block), &hd, marked_hd)) {
       hd = Hd_val(block);
       goto again;


### PR DESCRIPTION
Fixes a regression in #14816; see https://github.com/ocaml/ocaml/commit/462106c1b6410550b28ff75d9838464ecc73385f#diff-440e451c73705396986bb40ef403b17be94b67e9a27cf4f99133ed46c73f251bR1459-R1467 for the original check.

This was spotted in a regression sweep using Claude Fable 5, checked by @sadiqj and @kayceesrk, /cc @NickBarnes 