### PR TITLE
documentation: fix Patterns.deconstruct comment

### DIFF
--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -97,9 +97,7 @@ module Head : sig
 
   val arity : t -> int
 
-  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
-
-      @raise [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns.*)
   val deconstruct : Simple.pattern -> t * pattern list
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)


### PR DESCRIPTION
This documentation fixes updates the documentation of `Patterns.deconstruct` to reflect that the function is total and does not raise an exception.

cc @gasche 