### PR TITLE
New feature : configurable domain stack size

### DIFF
--- a/Changes
+++ b/Changes
@@ -102,6 +102,10 @@ Working version
   certain GC cycles longer due to ephemeron marking starting later.
   (Gabriel Scherer, review by B. Szilvasy and Damien Doligez)
 
+- #14195, #14860: new OCAMLRUNPARAM='S=3M' option to configure the system
+  stack size when creating a thread
+  (Jeanne Pottier, review by Antonin Décimo, request by Nathan Taylor)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -164,6 +164,11 @@ systems.
 .BR l " (stack_limit)"
 The limit (in words) of the stack size.
 .TP
+.B S " (thread_system_stack_size) "
+The minimum system stack size (in bytes) for new threads.
+This can be useful for threads that call FFI code that needs
+a larger system stack.
+.TP
 .BR m " (custom_minor_ratio)"
 Bound on floating garbage for out-of-heap memory
 held by custom values in the minor heap. A minor GC is triggered

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -147,6 +147,9 @@ The following environment variables are also consulted:
   \item[l] ("stack_limit") The limit (in words) of the stack size. This is
         relevant to both the byte-code runtime and the native code runtime:
         OCaml always uses its own stack and not the operating system's stack.
+  \item[S] ("thread_system_stack_size") The minimum system stack size (in bytes)
+        for new threads. This can be useful for threads that call FFI code
+        that needs a larger system stack.
   \item[m] ("custom_minor_ratio") Bound on floating garbage for
         out-of-heap memory
         held by custom values in the minor heap. A minor GC is triggered

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -37,7 +37,7 @@ static int st_thread_create(st_thread_id * res,
   int rc;
 
   pthread_attr_init(&attr);
-  if(caml_params->init_sys_stack_bsz != 0){
+  if (caml_params->init_sys_stack_bsz != 0) {
     pthread_attr_setstacksize(&attr, caml_params->init_sys_stack_bsz);
   }
   if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -37,6 +37,9 @@ static int st_thread_create(st_thread_id * res,
   int rc;
 
   pthread_attr_init(&attr);
+  if(caml_params->init_sys_stack_bsz != 0){
+    pthread_attr_setstacksize(&attr, caml_params->init_sys_stack_bsz);
+  }
   if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   rc = pthread_create(&thr, &attr, fn, arg);
   if (res != NULL) *res = thr;

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -48,7 +48,7 @@ static int st_thread_create(st_thread_id * res,
   st_thread_id thr;
   thr = (st_thread_id) _beginthreadex(
     NULL, /* security: handle can't be inherited */
-    0,    /* stack size */
+    caml_params->init_sys_stack_bsz, /* stack size */
     start_address,
     arg,
     0,    /* run immediately */

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -34,6 +34,10 @@ val create : ('a -> 'b) -> 'a -> t
    result of the application [funct arg] is discarded and not
    directly accessible to the parent thread.
 
+   Note that an option [S] can be passed to OCAMLRUNPARAM to configure
+   the minimum system stack size for new threads, which can be useful for
+   threads that call FFI code that needs a larger system stack.
+
    See also {!Domain.spawn} if you want parallel execution instead.
    *)
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -187,8 +187,8 @@ typedef uintptr_t uintnat;
 /* Default maximum size of the stack (words). */
 /* (1 Gib for 64-bit platforms, 512 Mib for 32-bit platforms) */
 #define Max_stack_def (128 * 1024 * 1024)
-/* Default system stack size for new pthreads (bytes).
-   0 stands for the default system value. */
+/* Default system stack size for new pthreads (bytes). */
+/* 0 stands for the default system value. */
 #define Sys_stack_def (0)
 
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -187,6 +187,9 @@ typedef uintptr_t uintnat;
 /* Default maximum size of the stack (words). */
 /* (1 Gib for 64-bit platforms, 512 Mib for 32-bit platforms) */
 #define Max_stack_def (128 * 1024 * 1024)
+/* Default system stack size for new pthreads (bytes).
+   0 stands for the default system value. */
+#define Sys_stack_def (0)
 
 
 /* Maximum size of a block allocated in the young generation (words). */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -230,12 +230,17 @@ int caml_plat_thread_create(caml_plat_thread *restrict thread,
                             void *(*start_routine)(void *),
                             void *restrict arg)
 {
+  int res;
   pthread_attr_t attr;
   pthread_attr_init(&attr);
-  if(caml_params->init_sys_stack_bsz != 0){
-    pthread_attr_setstacksize(&attr, caml_params->init_sys_stack_bsz);
+  if (caml_params->init_sys_stack_bsz != 0) {
+    res = pthread_attr_setstacksize(&attr, caml_params->init_sys_stack_bsz);
+    if (res) {
+      pthread_attr_destroy(&attr);
+      return res;
+    }
   }
-  int res = pthread_create(thread, &attr, start_routine, arg);
+  res = pthread_create(thread, &attr, start_routine, arg);
   pthread_attr_destroy(&attr);
   return res;
 }

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -38,6 +38,7 @@
 #include "mlvalues.h"
 #include "sys.h"
 #include "osdeps.h"
+#include "startup_aux.h"
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
@@ -137,7 +138,7 @@ int caml_plat_thread_create(caml_plat_thread *restrict thread,
 {
   *thread = (caml_plat_thread) _beginthreadex(
     NULL, /* security: handle can't be inherited */
-    0,    /* stack size */
+    caml_params->init_sys_stack_bsz, /* stack size */
     start_address,
     arg,
     0,    /* run immediately */
@@ -229,7 +230,14 @@ int caml_plat_thread_create(caml_plat_thread *restrict thread,
                             void *(*start_routine)(void *),
                             void *restrict arg)
 {
-  return pthread_create(thread, 0, start_routine, arg);
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  if(caml_params->init_sys_stack_bsz != 0){
+    pthread_attr_setstacksize(&attr, caml_params->init_sys_stack_bsz);
+  }
+  int res = pthread_create(thread, &attr, start_routine, arg);
+  pthread_attr_destroy(&attr);
+  return res;
 }
 
 Caml_inline

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -132,11 +132,9 @@ typedef void * caml_plat_thread_attr;
 
 Caml_inline
 int caml_plat_thread_create(caml_plat_thread *restrict thread,
-                            const caml_plat_thread_attr *restrict attr,
                             unsigned ( WINAPI *start_address )( void * ),
                             void *restrict arg)
 {
-  (void) attr; /* unused */
   *thread = (caml_plat_thread) _beginthreadex(
     NULL, /* security: handle can't be inherited */
     0,    /* stack size */
@@ -228,11 +226,10 @@ typedef pthread_attr_t caml_plat_thread_attr;
 
 Caml_inline
 int caml_plat_thread_create(caml_plat_thread *restrict thread,
-                            const caml_plat_thread_attr *restrict attr,
                             void *(*start_routine)(void *),
                             void *restrict arg)
 {
-  return pthread_create(thread, attr, start_routine, arg);
+  return pthread_create(thread, 0, start_routine, arg);
 }
 
 Caml_inline

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -52,6 +52,7 @@ struct caml_params {
   uintnat init_custom_minor_ratio;
   uintnat init_custom_minor_max_bsz;
   uintnat init_max_stack_wsz;
+  uintnat init_sys_stack_bsz;
 
   uintnat backtrace_enabled;
   uintnat runtime_warnings;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1243,7 +1243,7 @@ static value install_backup_thread_exn (dom_internal* di)
 #endif
 
   atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
-  err = caml_plat_thread_create(&di->backup_thread, 0, backup_thread_func,
+  err = caml_plat_thread_create(&di->backup_thread, backup_thread_func,
                                 (void*)di);
 
 #ifndef _WIN32
@@ -1506,7 +1506,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
                                     sizeof(struct domain_ml_values));
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
-  err = caml_plat_thread_create(&th, 0, domain_thread_func, (void*)&p);
+  err = caml_plat_thread_create(&th, domain_thread_func, (void*)&p);
   if (err) {
     free_domain_ml_values(p.ml_values);
     caml_check_error(err, "failed to create domain thread: "

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -62,6 +62,7 @@ void caml_init_startup_params(struct caml_params *params)
   params->init_custom_minor_ratio = Custom_minor_ratio_def;
   params->init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
   params->init_max_stack_wsz = Max_stack_def;
+  params->init_sys_stack_bsz = Sys_stack_def;
   params->max_domains = Max_domains_def;
   params->runtime_events_log_wsize = Default_runtime_events_log_wsize;
 
@@ -107,6 +108,7 @@ void caml_parse_startup_params(struct caml_params *params, const char *opt)
     case 'd': scanmult (opt, &params->max_domains); break;
     case 'e': scanmult (opt, &params->runtime_events_log_wsize); break;
     case 'l': scanmult (opt, &params->init_max_stack_wsz); break;
+    case 'S': scanmult (opt, &params->init_sys_stack_bsz); break;
     case 'M': scanmult (opt, &params->init_custom_major_ratio); break;
     case 'm': scanmult (opt, &params->init_custom_minor_ratio); break;
     case 'n': scanmult (opt, &params->init_custom_minor_max_bsz); break;

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -35,7 +35,11 @@ val spawn : (unit -> 'a) -> 'a t
     current domain.
 
     @raise Failure if the program has insufficient resources to create another
-    domain. *)
+    domain.
+
+    Note that an option [S] can be passed to OCAMLRUNPARAM to configure
+    the minimum system stack size for new threads, which can be useful for
+    threads that call FFI code that needs a larger system stack. *)
 
 val join : 'a t -> 'a
 (** [join d] blocks until domain [d] runs to completion. If [d] results in a


### PR DESCRIPTION
This PR adds the possibility to configure the size of the stack when spawning a domain, via a new `S` setting in OCAMLRUNPARAM. This feature was asked for in issue #14195 .
I tested it using these ad hoc files :

```ocaml
external f : int -> int = "f"

let () = 
  Domain.spawn (fun () -> print_int (f 42); print_newline ();) |> Domain.join
```

```c
#include <caml/mlvalues.h>
#include <caml/memory.h>

#define LEN (1024 * 1024 * 10)

CAMLprim value f(value k){
    int tab[LEN];
    for(int i = 0; i < LEN; i++){
        tab[i] = i;
    }
    return Val_int(tab[Int_val(k)]);
}
```

Running these programs with default settings segfaults on my computer, but it works perfectly fine with `OCAMLRUNPARAM='S=50M'`.