### PR TITLE
Documentation of permissions for `Sys.mkdir`

### DIFF
--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -113,7 +113,9 @@ external chdir : string -> unit = "caml_sys_chdir"
 (** Change the current working directory of the process. *)
 
 external mkdir : string -> int -> unit = "caml_sys_mkdir"
-(** Create a directory with the given permissions.
+(** Create a directory with the given permissions (for instance [0o755]).
+   Only the 9 first binary bits of the integer are considered, representing
+   the read/write/execute permissions for the owner/group/other.
 
     @since 4.12
 *)


### PR DESCRIPTION
Hi,
This is a minor documentation suggestion. Given how `chmod` usually takes a decimal number (e.g. 755) and considers each of its decimal digits, one might assume (I did) that is was how permissions are meant to be interpreted for `Sys.mkdir`… but it's not the case.
Have a nice day,
Martin.