### PR TITLE
Dynarray.unsafe_{get,set}

### DIFF
--- a/Changes
+++ b/Changes
@@ -191,6 +191,9 @@ Working version
   Ulugbek Abdullaev, Hezekiah M. Carty, Simon Cruanes, Daniel Bünzli, Yotam
   Barnoy, Michael Hendricks and Léo Andrès)
 
+- #????: add Dynarray.unsafe_{get,set}
+  (Gabriel Scherer, review by ?)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/Changes
+++ b/Changes
@@ -191,8 +191,8 @@ Working version
   Ulugbek Abdullaev, Hezekiah M. Carty, Simon Cruanes, Daniel Bünzli, Yotam
   Barnoy, Michael Hendricks and Léo Andrès)
 
-- #????: add Dynarray.unsafe_{get,set}
-  (Gabriel Scherer, review by ?)
+- #14864: add Dynarray.unsafe_{get,set}
+  (Gabriel Scherer, review by Basile Clément and ?)
 
 ### Other libraries:
 

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -1384,3 +1384,12 @@ let unsafe_to_iarray ~capacity (f : 'a t -> unit) =
     with Dummy.Array.Dummy_found i -> Error.missing_element ~i ~length
   in
   unsafe_iarray_of_array values
+
+
+(** {1. Unsafe operations} *)
+
+let[@inline] unsafe_get (type a) (Pack a : a t) i =
+  Dummy.unsafe_get (Array.unsafe_get a.arr i)
+
+let[@inline] unsafe_set (Pack a) i x =
+  Array.unsafe_set a.arr i (Dummy.of_val x)

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -631,12 +631,27 @@ val unsafe_get : 'a t -> int -> 'a
     if an unsynchronized concurrent update put the dynarray in
     an invalid state.
 
-    This operation is {b more unsafe} than [Array.unsafe_get a i],
-    whose precondition [0 <= i < Array.length a] can usually be
-    checked by local reasoning. For a dynarray, the length may change
-    concurrently if the program wrongly performs unsynchronized
-    concurrent accesses, and the absence of such a race typically
-    cannot be ensured by local reasoning.
+    {b: Safety warning.} This operation is {b more unsafe} than
+    [Array.unsafe_get a i], whose precondition
+    [0 <= i < Array.length a] can usually be checked by local
+    reasoning. For a dynarray, the length may change concurrently if
+    the program wrongly performs unsynchronized concurrent accesses,
+    and the absence of such a race typically cannot be ensured by
+    local reasoning. In more concrete terms:
+
+    - If you are the author of a library, and you use
+      [unsafe_{get,set}] on a dynarray input that is provided by the
+      user of the library, then your function "inherits" the unsafety of
+      [unsafe_{get,set}], because if the user shrinks the array
+      concurrently the program can blow up. You have to mark this very
+      clearly and it is probably not a good idea.
+
+    - If you can control all usages of a dynarray value, because it is
+      local to a function or module and never escapes, or because you
+      control the code of the whole program, then you may be able to
+      reason globally about the fact that it is never shrunk below the
+      index -- for example, if you have the property that the dynarray
+      always grows, never shrinks. Then using this function is safe.
 *)
 
 val unsafe_set : 'a t -> int -> 'a -> unit

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -621,12 +621,32 @@ val reset : 'a t -> unit
     It is equivalent to [set_capacity a 0] or [clear a; fit_capacity a].
 *)
 
-(** {2:noleaks No leaks: preservation of memory liveness}
+(** {1:unsafe Unsafe operations} *)
 
-    The user-provided values reachable from a dynamic array [a] are
-    exactly the elements in the indices [0] to [length a - 1]. In
-    particular, no user-provided values are "leaked" by being present
-    in the backing array at index [length a] or later.
+val unsafe_get : 'a t -> int -> 'a
+(** [unsafe_get a i] accesses the element at index [i] of [a]
+    without bound-checking: it breaks type- and memory-safety
+    if [i] is not a valid index for [a], as it may return an
+    arbitrary value. It may also return a type-unsafe value
+    if an unsynchronized concurrent update put the dynarray in
+    an invalid state.
+
+    This operation is {b more unsafe} than [Array.unsafe_get a i],
+    whose precondition [0 <= i < Array.length a] can usually be
+    checked by local reasoning. For a dynarray, the length may change
+    concurrently if the program wrongly performs unsynchronized
+    concurrent accesses, and the absence of such a race typically
+    cannot be ensured by local reasoning.
+*)
+
+val unsafe_set : 'a t -> int -> 'a -> unit
+(** [unsafe_set a i v] sets the element at index [i] of [a]
+    to [v] without bound-checking: it breaks type- and memory-safety
+    if [i] is not a valid index for [a], as it may mutate an arbitrary
+    value.
+
+    See {!unsafe_get} for commentary on why this is {b more unsafe}
+    than the corresponding [Array.unsafe_set].
 *)
 
 val unsafe_to_iarray : capacity:int -> ('a t -> unit) -> 'a iarray
@@ -645,6 +665,13 @@ val unsafe_to_iarray : capacity:int -> ('a t -> unit) -> 'a iarray
 
     @since 5.4 *)
 
+(** {2:noleaks No leaks: preservation of memory liveness}
+
+    The user-provided values reachable from a dynamic array [a] are
+    exactly the elements in the indices [0] to [length a - 1]. In
+    particular, no user-provided values are "leaked" by being present
+    in the backing array at index [length a] or later.
+*)
 
 (** {1:examples Code examples}
 


### PR DESCRIPTION
On a synthetic microbenchmark on my machine, I observed [unsafe_set] being about 1.40x faster than [set], and [unsafe_get] being about 2.5x faster than [get].

| Command      |   Mean [ms] |    Relative |
|:-------------|------------:|------------:|
| `get`        | 211.4 ± 3.8 | 2.56 ± 0.11 |
| `unsafe_get` |  82.7 ± 3.4 |        1.00 |

| Command      |    Mean [ms] |    Relative |
|:-------------|-------------:|------------:|
| `set`        | 334.5 ± 13.7 | 1.39 ± 0.06 |
| `unsafe_set` |  241.1 ± 2.0 |        1.00 |

Note: the motivation to implement this now came from reading [the documentation of the hector library](https://cambium.inria.fr/~fpottier/hector/doc/hector/) by @fpottier, which points out that Dynarray does not expose `Dynarray.unsafe_{get,set}`.

```ocaml
let size = int_of_string (Sys.getenv "SIZE")
let n_iters = int_of_string (Sys.getenv "NITERS")

let arr = Dynarray.init size Fun.id

let test_safe_get () =
  for _ = 1 to n_iters do
    for i = 0 to size - 1 do
      ignore (Sys.opaque_identity (Dynarray.get arr i))
    done
  done

let test_unsafe_get () =
  for _ = 1 to n_iters do
    for i = 0 to size - 1 do
      ignore (Sys.opaque_identity (Dynarray.unsafe_get arr i))
    done
  done

let test_safe_set () =
  for _ = 1 to n_iters do
    for i = 0 to size - 1 do
      Dynarray.set arr i (Sys.opaque_identity i)
    done
  done;
  ignore (Sys.opaque_identity arr)

let test_unsafe_set () =
  for _ = 1 to n_iters do
    for i = 0 to size - 1 do
      Dynarray.unsafe_set arr i (Sys.opaque_identity i)
    done
  done;
  ignore (Sys.opaque_identity arr)

let () =
  match Sys.argv.(1) with
  | "get" -> test_safe_get ()
  | "unsafe_get" -> test_unsafe_get ()
  | "set" -> test_safe_set ()
  | "unsafe_set" -> test_unsafe_set ()
  | _ | exception _ ->
      prerr_endline "Please set environment variables NITERS=<num>, \
                     SIZE=<num>, and pass a command-line argument in \
                     [get | unsafe_get | set | unsafe_set]";
      exit 2
```