### PR TITLE
Instance variable lifting

### DIFF
--- a/Changes
+++ b/Changes
@@ -140,6 +140,9 @@ Working version
   (Hugo heuzard, David Allsopp review by Nicolás Ojeda Bär, Vincent Laviron
   and Gabriel Scherer)
 
+- #14861, #14868: Lift immutable instance variable reads
+  (Vincent Laviron, report by Romain Beauxis, review by a very kind person)
+
 ### Standard library:
 
 - #10798: Atomic helper function

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -145,7 +145,7 @@ let preserve_tailcall_for_prim = function
   | Prunstack | Pperform | Presume | Preperform | Ppoll ->
       true
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Psetglobal _
-  | Pmakeblock _ | Pmakelazyblock _ | Pfield _ | Pfield_computed | Psetfield _
+  | Pmakeblock _ | Pmakelazyblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
   | Pccall _ | Praise _ | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
@@ -372,7 +372,7 @@ let comp_primitive stack_info p sz args =
   | Pcompare_floats -> Kccall("caml_float_compare", 2, None)
   | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
   | Pfield(n, _ptr, _mut) -> Kgetfield n
-  | Pfield_computed -> Kgetvectitem
+  | Pfield_computed _ -> Kgetvectitem
   | Psetfield(n, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem
   | Psetfloatfield (n, _init) -> Ksetfloatfield n

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -200,7 +200,7 @@ let iter_on_occurrences
             add_label exp_env lid label_descr
           | Overridden (lid, _) -> add_label exp_env lid label_descr
           | Kept _ -> ()) fields
-      | Texp_instvar  (_self_path, path, name) ->
+      | Texp_instvar  (_self_path, path, _mut, name) ->
           let lid = { name with txt = Longident.Lident name.txt } in
           f ~namespace:Value exp_env path lid
       | Texp_setinstvar  (_self_path, path, name, _) ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -59,7 +59,7 @@ type primitive =
   | Pmakeblock of int * mutable_flag * block_shape
   | Pmakelazyblock of lazy_block_tag
   | Pfield of int * immediate_or_pointer * mutable_flag
-  | Pfield_computed
+  | Pfield_computed of mutable_flag
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int
@@ -932,11 +932,7 @@ let duplicate_function =
      ~freshen_bound_variables:true
      Ident.Map.empty).subst_lfunction
 
-let map_lfunction f { kind; params; return; body; attr; loc } =
-  let body = f body in
-  { kind; params; return; body; attr; loc }
-
-let shallow_map f = function
+let shallow_map_gen ~map_lfunction f = function
   | Lvar _
   | Lmutvar _
   | Lconst _ as lam -> lam
@@ -1002,8 +998,21 @@ let shallow_map f = function
   | Lifused (v, e) ->
       Lifused (v, f e)
 
+let map_lfunction f { kind; params; return; body; attr; loc } =
+  let body = f body in
+  { kind; params; return; body; attr; loc }
+
+let shallow_map f lam = shallow_map_gen ~map_lfunction f lam
+
 let map f =
   let rec g lam = f (shallow_map g lam) in
+  g
+
+let map_functions lfun_map =
+  let map_lfunction f lfun =
+    map_lfunction f (lfun_map lfun)
+  in
+  let rec g lam = shallow_map_gen ~map_lfunction g lam in
   g
 
 (* To let-bind expressions to variables *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -63,7 +63,7 @@ type primitive =
   | Pmakeblock of int * mutable_flag * block_shape
   | Pmakelazyblock of lazy_block_tag
   | Pfield of int * immediate_or_pointer * mutable_flag
-  | Pfield_computed
+  | Pfield_computed of mutable_flag
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int
@@ -488,6 +488,10 @@ val map : (lambda -> lambda) -> lambda -> lambda
 
 val map_lfunction : (lambda -> lambda) -> lfunction -> lfunction
   (** Apply the given transformation on the function's body *)
+
+val map_functions : (lfunction -> lfunction) -> lambda -> lambda
+  (** Bottom-up rewriting, applying the parameter to all
+      nodes defining functions *)
 
 val shallow_map  : (lambda -> lambda) -> lambda -> lambda
   (** Rewrite each immediate sub-term with the function. *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -171,7 +171,8 @@ let primitive ppf = function
         | Pointer, Immutable -> "field_imm "
       in
       fprintf ppf "%s%i" instr n
-  | Pfield_computed -> fprintf ppf "field_computed"
+  | Pfield_computed Mutable -> fprintf ppf "field_computed_mut"
+  | Pfield_computed Immutable -> fprintf ppf "field_computed_imm"
   | Psetfield(n, ptr, init) ->
       let instr =
         match ptr with
@@ -374,7 +375,7 @@ let name_of_primitive = function
   | Pmakeblock _ -> "Pmakeblock"
   | Pmakelazyblock _ -> "Pmakelazyblock"
   | Pfield _ -> "Pfield"
-  | Pfield_computed -> "Pfield_computed"
+  | Pfield_computed _ -> "Pfield_computed"
   | Psetfield _ -> "Psetfield"
   | Psetfield_computed _ -> "Psetfield_computed"
   | Pfloatfield _ -> "Pfloatfield"

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -940,6 +940,68 @@ let simplify_local_functions lam =
   else
     rewrite lam
 
+(* Lifting immutable instance variable reads *)
+
+(* This function implements a transformation where instance
+   variable reads inside methods (and object initializers)
+   are lifted to the beginning of the method, when it is correct to do so
+   (i.e. when the variable is not mutable).
+
+   This is particularly relevant for class parameters and variables bound
+   in the class definition before the object, which are treated as
+   invisible instance variables, and it would be counter-intuitive for
+   a reference to such a variable to keep the object itself alive.
+*)
+let lift_self_projections lam =
+  let lift_lfunction (lfun : Lambda.lfunction) =
+    match lfun.params with
+    | [] -> lfun
+    | (param, _) :: _ ->
+      (* Methods and object initializers take self as their first parameter.
+         All these self parameters start with self-, which is not a valid
+         source name, so there is no risk of hitting unrelated code. *)
+      if not (String.starts_with ~prefix:"self-" (Ident.name param))
+      then lfun
+      else
+        (* Index variables are bound to the runtime offset of the
+           instance variable into the object.
+           Field variables are created by this transformation and
+           will be bound to the actual contents of the instance variable. *)
+        let index_var_to_field_var = ref Ident.Map.empty in
+        let get_field_var index_var =
+          match Ident.Map.find_opt index_var !index_var_to_field_var with
+          | Some var -> var
+          | None ->
+            let field_var = Ident.rename index_var in
+            index_var_to_field_var :=
+              Ident.Map.add index_var field_var !index_var_to_field_var;
+            field_var
+        in
+        let rewrite_projection lam =
+          match lam with
+          | Lprim (Pfield_computed Immutable, [Lvar block; Lvar index], _) ->
+            if not (Ident.same block param)
+            then lam
+            else
+              let field_var = get_field_var index in
+              Lvar field_var
+          | _ -> lam
+        in
+        let translate_body body =
+          let body = Lambda.map rewrite_projection body in
+          Ident.Map.fold (fun index_var field_var body ->
+              Llet (StrictOpt, Pgenval, field_var,
+                    Lprim (Pfield_computed Immutable,
+                           [Lvar param; Lvar index_var],
+                           Loc_unknown),
+                    body))
+            !index_var_to_field_var
+            body
+        in
+        Lambda.map_lfunction translate_body lfun
+  in
+  Lambda.map_functions lift_lfunction lam
+
 (* The entry point:
    simplification
    + rewriting of tail-modulo-cons calls
@@ -949,6 +1011,7 @@ let simplify_local_functions lam =
 let simplify_lambda lam =
   let lam =
     lam
+    |> lift_self_projections
     |> (if !Clflags.native_code || not !Clflags.debug
         then simplify_local_functions else Fun.id
        )

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -839,7 +839,7 @@ let rec choice ctx t =
     (* in common cases we just return *)
     | Pbytes_to_string | Pbytes_of_string
     | Pgetglobal _ | Psetglobal _
-    | Pfield _ | Pfield_computed
+    | Pfield _ | Pfield_computed _
     | Psetfield _ | Psetfield_computed _
     | Pfloatfield _ | Psetfloatfield _
     | Pccall _

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -1042,7 +1042,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           [lfunction ((self, Pgenval) :: args)
              (if not (Ident.Set.mem env (free_variables body')) then body' else
               Llet(Alias, Pgenval, env,
-                   Lprim(Pfield_computed,
+                   Lprim(Pfield_computed Mutable,
                          [Lvar self; Lvar env2],
                          Loc_unknown),
                    body'))]

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -488,11 +488,11 @@ and transl_exp0 ~in_new_scope ~scopes e =
         ap_inlined=Default_inline;
         ap_specialised=Default_specialise;
       }
-  | Texp_instvar(path_self, path, _) ->
+  | Texp_instvar(path_self, path, mut, _) ->
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
       let var = transl_value_path loc e.exp_env path in
-      Lprim(Pfield_computed, [self; var], loc)
+      Lprim(Pfield_computed mut, [self; var], loc)
   | Texp_setinstvar(path_self, path, _, expr) ->
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -964,7 +964,7 @@ let lambda_primitive_needs_event_after = function
   | Pbbswap _ | Ppoll -> true
 
   | Pbytes_to_string | Pbytes_of_string | Pignore | Psetglobal _
-  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _
+  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Praise _
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -311,7 +311,7 @@ let compute_static_size lam =
     | Pgetglobal _
     | Psetglobal _
     | Pfield _
-    | Pfield_computed
+    | Pfield_computed _
     | Pfloatfield _
     | Prunstack
     | Pperform

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -30,7 +30,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       Pmakelazyblock tag
   | Pfield (field, imm_or_pointer, mutability) ->
       Pfield (field, imm_or_pointer, mutability)
-  | Pfield_computed -> Pfield_computed
+  | Pfield_computed _ -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)
   | Psetfield_computed (imm_or_pointer, init_or_assign) ->

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -334,7 +334,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pmakeblock _ -> pmakeblock
   | Pmakelazyblock _ -> pmakelazyblock
   | Pfield _ -> pfield
-  | Pfield_computed -> pfield_computed
+  | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
   | Psetfield_computed _ -> psetfield_computed
   | Pfloatfield _ -> pfloatfield
@@ -447,7 +447,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pmakeblock _ -> pmakeblock_arg
   | Pmakelazyblock _ -> pmakelazyblock_arg
   | Pfield _ -> pfield_arg
-  | Pfield_computed -> pfield_computed_arg
+  | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg
   | Psetfield_computed _ -> psetfield_computed_arg
   | Pfloatfield _ -> pfloatfield_arg

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -227,11 +227,12 @@ let cmas_need what directories libraries =
   List.find_map loads_c_code (String.words libraries)
 
 let compile_program (compiler : Ocaml_compilers.compiler) log env =
-  let program_variable = compiler#program_variable in
+  let (module Compiler) = compiler in
+  let program_variable = Compiler.program_variable in
   let program_file = Environments.safe_lookup program_variable env in
   let all_modules =
     Actions_helpers.words_of_variable env Ocaml_variables.all_modules in
-  let output_variable = compiler#output_variable in
+  let output_variable = Compiler.output_variable in
   let prepare = prepare_module output_variable log env in
   let modules =
     List.concat_map prepare (List.map Ocaml_filetypes.filetype all_modules) in
@@ -239,9 +240,9 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
   let c_headers_flags =
     if has_c_file then Ocaml_flags.c_includes else "" in
   let expected_exit_status =
-    Ocaml_tools.expected_exit_status env (compiler :> Ocaml_tools.tool) in
+    Ocaml_tools.expected_exit_status env (module Compiler) in
   let module_names =
-    (binary_modules compiler#target env) ^ " " ^
+    (binary_modules Compiler.target env) ^ " " ^
     (String.concat " " (List.map Ocaml_filetypes.make_filename modules)) in
   let what = Printf.sprintf "Compiling program %s from modules %s"
     program_file module_names in
@@ -253,9 +254,9 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
     if compile_only then " -c " else ""
   in
   let output = if compile_only then "" else "-o " ^ program_file in
-  let libraries = libraries compiler#target env in
+  let libraries = libraries Compiler.target env in
   let cmas_need_custom_runtime =
-    if compiler#target = Ocaml_backends.Bytecode then
+    if Compiler.target = Ocaml_backends.Bytecode then
       cmas_need Custom_runtime (directories env) libraries
     else
       None
@@ -267,16 +268,16 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
       let lib_needs_custom = (cmas_need_custom_runtime = Some (Ok ())) in
       let commandline =
       [
-        compiler#name;
-        Ocaml_flags.runtime_flags env compiler#target
+        Compiler.name;
+        Ocaml_flags.runtime_flags env Compiler.target
                                   (has_c_file || lib_needs_custom);
         c_headers_flags;
         Ocaml_flags.stdlib;
         directory_flags env;
         libraries;
-        backend_default_flags env compiler#target;
+        backend_default_flags env Compiler.target;
         flags env;
-        backend_flags env compiler#target;
+        backend_flags env Compiler.target;
         compile_flags;
         output;
         (Environments.safe_lookup Ocaml_variables.ocaml_filetype_flag env);
@@ -287,8 +288,8 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
         Actions_helpers.run_cmd
           ~environment:default_ocaml_env
           ~stdin_variable: Ocaml_variables.compiler_stdin
-          ~stdout_variable:compiler#output_variable
-          ~stderr_variable:compiler#output_variable
+          ~stdout_variable:Compiler.output_variable
+          ~stderr_variable:Compiler.output_variable
           ~append:true
           log env commandline in
       if exit_status=expected_exit_status
@@ -301,8 +302,9 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
       end
 
 let compile_module compiler module_ log env =
+  let (module Compiler : Ocaml_compilers.Compiler) = compiler in
   let expected_exit_status =
-    Ocaml_tools.expected_exit_status env (compiler :> Ocaml_tools.tool) in
+    Ocaml_tools.expected_exit_status env (module Compiler) in
   let what = Printf.sprintf "Compiling module %s" module_ in
   Printf.fprintf log "%s\n%!" what;
   let module_with_filetype = Ocaml_filetypes.filetype module_ in
@@ -311,22 +313,22 @@ let compile_module compiler module_ log env =
     if is_c then Ocaml_flags.c_includes else "" in
   let commandline =
   [
-    compiler#name;
+    Compiler.name;
     Ocaml_flags.stdlib;
     c_headers_flags;
     directory_flags env;
-    libraries compiler#target env;
-    backend_default_flags env compiler#target;
+    libraries Compiler.target env;
+    backend_default_flags env Compiler.target;
     flags env;
-    backend_flags env compiler#target;
+    backend_flags env Compiler.target;
     "-c " ^ module_;
   ] in
   let exit_status =
     Actions_helpers.run_cmd
       ~environment:default_ocaml_env
       ~stdin_variable: Ocaml_variables.compiler_stdin
-      ~stdout_variable:compiler#output_variable
-      ~stderr_variable:compiler#output_variable
+      ~stdout_variable:Compiler.output_variable
+      ~stderr_variable:Compiler.output_variable
       ~append:true
       log env commandline in
   if exit_status=expected_exit_status
@@ -372,16 +374,16 @@ let find_source_modules log env =
     (String.concat " " (List.map Ocaml_filetypes.make_filename source_modules))
     env
 
-let setup_tool_build_env tool log env =
+let setup_tool_build_env (module Tool : Ocaml_tools.Tool) log env =
   let source_directory = Actions_helpers.test_source_directory env in
   let testfile = Actions_helpers.testfile env in
   let testfile_basename = Filename.chop_extension testfile in
   let tool_reference_variable =
-    tool#reference_variable in
+    Tool.reference_variable in
   let tool_reference_prefix =
     Filename.make_path [source_directory; testfile_basename] in
   let tool_reference_file =
-    tool#reference_file env tool_reference_prefix
+    Tool.reference_file env tool_reference_prefix
   in
   let env =
     Environments.add_if_undefined
@@ -393,14 +395,14 @@ let setup_tool_build_env tool log env =
   let tool_directory_suffix =
     Environments.safe_lookup Ocaml_variables.compiler_directory_suffix env in
   let tool_directory_name =
-    tool#directory ^ tool_directory_suffix in
+    Tool.directory ^ tool_directory_suffix in
   let build_dir = Filename.concat
     (Environments.safe_lookup
       Builtin_variables.test_build_directory_prefix env)
     tool_directory_name in
-  let tool_output_variable = tool#output_variable in
+  let tool_output_variable = Tool.output_variable in
   let tool_output_filename =
-    Filename.make_filename tool#directory "output" in
+    Filename.make_filename Tool.directory "output" in
   let tool_output_file =
     Filename.make_path [build_dir; tool_output_filename]
   in
@@ -415,12 +417,13 @@ let setup_tool_build_env tool log env =
   Actions_helpers.setup_build_env ~add_testfile:false source_modules log env
 
 let setup_compiler_build_env (compiler : Ocaml_compilers.compiler) log env =
-  let (r, env) = setup_tool_build_env compiler log env in
+  let (module Compiler) = compiler in
+  let (r, env) = setup_tool_build_env (module Compiler) log env in
   if Test_result.is_pass r then
   begin
-    let prog_var = compiler#program_variable in
-    let prog_output_var = compiler#program_output_variable in
-    let default_prog_file = get_program_file compiler#target env in
+    let prog_var = Compiler.program_variable in
+    let prog_output_var = Compiler.program_output_variable in
+    let default_prog_file = get_program_file Compiler.target env in
     let env = Environments.add_if_undefined prog_var default_prog_file env in
     let prog_file = Environments.safe_lookup prog_var env in
     let prog_output_file = prog_file ^ ".output" in
@@ -432,8 +435,8 @@ let setup_compiler_build_env (compiler : Ocaml_compilers.compiler) log env =
     (r, env)
   end else (r, env)
 
-let setup_toplevel_build_env (toplevel : Ocaml_toplevels.toplevel) log env =
-  setup_tool_build_env toplevel log env
+let setup_toplevel_build_env (module Toplevel : Ocaml_toplevels.Toplevel) log env =
+  setup_tool_build_env (module Toplevel) log env
 
 let mk_compiler_env_setup name (compiler : Ocaml_compilers.compiler) =
   Actions.make ~name ~description:(Printf.sprintf "Setup build env (%s)" name)
@@ -479,6 +482,7 @@ let setup_ocamlnat_build_env =
       Ocaml_toplevels.ocamlnat)
 
 let compile (compiler : Ocaml_compilers.compiler) log env =
+  let (module Compiler) = compiler in
   match Environments.lookup_nonempty Builtin_variables.commandline env with
   | None ->
     begin
@@ -488,16 +492,16 @@ let compile (compiler : Ocaml_compilers.compiler) log env =
     end
   | Some cmdline ->
     let expected_exit_status =
-      Ocaml_tools.expected_exit_status env (compiler :> Ocaml_tools.tool) in
+      Ocaml_tools.expected_exit_status env (module Compiler) in
     let what = Printf.sprintf "Compiling using commandline %s" cmdline in
     Printf.fprintf log "%s\n%!" what;
-    let commandline = [compiler#name; cmdline] in
+    let commandline = [Compiler.name; cmdline] in
     let exit_status =
       Actions_helpers.run_cmd
         ~environment:default_ocaml_env
         ~stdin_variable: Ocaml_variables.compiler_stdin
-        ~stdout_variable:compiler#output_variable
-        ~stderr_variable:compiler#output_variable
+        ~stdout_variable:Compiler.output_variable
+        ~stderr_variable:Compiler.output_variable
         ~append:true
         log env commandline in
     if exit_status=expected_exit_status
@@ -860,31 +864,31 @@ let run_expect log env =
 let run_expect =
   Actions.make ~name:"run-expect" ~description:"Run expect test" run_expect
 
-let make_check_tool_output name tool = Actions.make
+let make_check_tool_output name (module Tool : Ocaml_tools.Tool) = Actions.make
   ~name
   ~description:(Printf.sprintf "Check tool output (%s)" name)
   (Actions_helpers.check_output
-    tool#family
-    tool#output_variable
-    tool#reference_variable)
+    Tool.family
+    Tool.output_variable
+    Tool.reference_variable)
 
 let check_ocamlc_byte_output = make_check_tool_output
-  "check-ocamlc.byte-output" Ocaml_compilers.ocamlc_byte
+  "check-ocamlc.byte-output" (module (val Ocaml_compilers.ocamlc_byte))
 
 let check_ocamlc_opt_output =
   native_action
     (make_check_tool_output
-      "check-ocamlc.opt-output" Ocaml_compilers.ocamlc_opt)
+      "check-ocamlc.opt-output" (module (val Ocaml_compilers.ocamlc_opt)))
 
 let check_ocamlopt_byte_output =
   native_action
     (make_check_tool_output
-      "check-ocamlopt.byte-output" Ocaml_compilers.ocamlopt_byte)
+      "check-ocamlopt.byte-output" (module (val Ocaml_compilers.ocamlopt_byte)))
 
 let check_ocamlopt_opt_output =
   native_action
     (make_check_tool_output
-      "check-ocamlopt.opt-output" Ocaml_compilers.ocamlopt_opt)
+      "check-ocamlopt.opt-output" (module (val Ocaml_compilers.ocamlopt_opt)))
 
 let really_compare_programs backend comparison_tool log env =
   let program = Environments.safe_lookup Builtin_variables.program env in
@@ -948,11 +952,12 @@ let compare_binary_files =
 
 let compile_module compiler compilername compileroutput log env
   (module_basename, module_filetype) =
-  let backend = compiler#target in
+  let (module Compiler : Ocaml_compilers.Compiler) = compiler in
+  let backend = Compiler.target in
   let filename =
     Ocaml_filetypes.make_filename (module_basename, module_filetype) in
   let expected_exit_status =
-    Ocaml_tools.expected_exit_status env (compiler :> Ocaml_tools.tool) in
+    Ocaml_tools.expected_exit_status env (module Compiler) in
   let what = Printf.sprintf "%s for file %s (expected exit status: %d)"
     (Ocaml_filetypes.action_of_filetype module_filetype) filename
       (expected_exit_status) in
@@ -1027,7 +1032,8 @@ let compile_modules compiler compilername compileroutput
   compile_mods initial_env modules_with_filetypes
 
 let run_test_program_in_toplevel (toplevel : Ocaml_toplevels.toplevel) log env =
-  let backend = toplevel#backend in
+  let (module Toplevel) = toplevel in
+  let backend = Toplevel.backend in
   let libraries = libraries backend env in
   (* This is a sub-optimal check - skip the test if any libraries requiring
      C stubs are loaded. It would be better at this point to build a custom
@@ -1043,10 +1049,11 @@ let run_test_program_in_toplevel (toplevel : Ocaml_toplevels.toplevel) log env =
     | _ ->
       let testfile = Actions_helpers.testfile env in
       let expected_exit_status =
-        Ocaml_tools.expected_exit_status env (toplevel :> Ocaml_tools.tool) in
-      let compiler_output_variable = toplevel#output_variable in
-      let compiler = toplevel#compiler in
-      let compiler_name = compiler#name in
+        Ocaml_tools.expected_exit_status env (module Toplevel) in
+      let compiler_output_variable = Toplevel.output_variable in
+      let compiler = Toplevel.compiler in
+      let (module Compiler) = compiler in
+      let compiler_name = Compiler.name in
       let modules_with_filetypes =
         List.map Ocaml_filetypes.filetype (modules env) in
       let (result, env) = compile_modules
@@ -1060,7 +1067,7 @@ let run_test_program_in_toplevel (toplevel : Ocaml_toplevels.toplevel) log env =
           (Ocaml_backends.string_of_backend backend)
           expected_exit_status in
         Printf.fprintf log "%s\n%!" what;
-        let toplevel_name = toplevel#name in
+        let toplevel_name = Toplevel.name in
         let ocaml_script_as_argument =
           match
             Environments.lookup_as_bool
@@ -1073,7 +1080,7 @@ let run_test_program_in_toplevel (toplevel : Ocaml_toplevels.toplevel) log env =
         [
           toplevel_name;
           Ocaml_flags.toplevel_default_flags;
-          toplevel#flags;
+          Toplevel.flags;
           Ocaml_flags.stdlib;
           directory_flags env;
           Ocaml_flags.include_toplevel_directory;
@@ -1120,12 +1127,12 @@ let ocamlnat =
       (run_test_program_in_toplevel Ocaml_toplevels.ocamlnat))
 
 let check_ocaml_output = make_check_tool_output
-  "check-ocaml-output" Ocaml_toplevels.ocaml
+  "check-ocaml-output" (module (val Ocaml_toplevels.ocaml))
 
 let check_ocamlnat_output =
   native_action
     (make_check_tool_output
-      "check-ocamlnat-output" Ocaml_toplevels.ocamlnat)
+      "check-ocamlnat-output" (module (val Ocaml_toplevels.ocamlnat)))
 
 let config_variables _log env =
   Environments.add_bindings
@@ -1286,9 +1293,11 @@ let compiled_doc_name input = input ^ ".odoc"
 (* The compiler used for compiling both cmi file
    and plugins *)
 let compiler_for_ocamldoc =
-  let compiler = Ocaml_compilers.ocamlc_byte in
-  compile_modules compiler compiler#name
-    compiler#output_variable
+  let module Compiler = (val Ocaml_compilers.ocamlc_byte) in
+  compile_modules (module Compiler) Compiler.name
+    Compiler.output_variable
+
+module Ocamldoc = (val ocamldoc : Ocaml_tools.Tool)
 
 (* Within ocamldoc tests,
    modules="a.ml b.ml" is interpreted as a list of
@@ -1297,7 +1306,7 @@ let compiler_for_ocamldoc =
    before the main documentation is generated *)
 let compile_ocamldoc (basename,filetype as module_) log env =
   let expected_exit_status =
-    Ocaml_tools.expected_exit_status env (ocamldoc :> Ocaml_tools.tool) in
+    Ocaml_tools.expected_exit_status env ocamldoc in
   let what = Printf.sprintf "Compiling documentation for module %s" basename in
   Printf.fprintf log "%s\n%!" what;
   let filename =
@@ -1317,8 +1326,8 @@ let compile_ocamldoc (basename,filetype as module_) log env =
     Actions_helpers.run_cmd
       ~environment:(Environments.to_system_env env)
       ~stdin_variable: Ocaml_variables.compiler_stdin
-      ~stdout_variable:ocamldoc#output_variable
-      ~stderr_variable:ocamldoc#output_variable
+      ~stdout_variable:Ocamldoc.output_variable
+      ~stderr_variable:Ocamldoc.output_variable
       ~append:true
       log env commandline in
   if exit_status=expected_exit_status
@@ -1348,7 +1357,7 @@ let setup_ocamldoc_build_env =
   let root_file = Filename.chop_extension (Actions_helpers.testfile env) in
   let reference_prefix = Filename.make_path [source_directory; root_file] in
   let output = ocamldoc_output_file env root_file in
-  let reference= reference_prefix ^ ocamldoc#reference_filename_suffix env in
+  let reference= reference_prefix ^ Ocamldoc.reference_filename_suffix env in
   let backend = Environments.safe_lookup Ocaml_variables.ocamldoc_backend env in
   let env =
     Environments.apply_modifiers env  Ocaml_modifiers.(str @ unix)
@@ -1406,8 +1415,8 @@ let run_ocamldoc =
   let exit_status =
     Actions_helpers.run_cmd ~environment:(Environments.to_system_env env)
       ~stdin_variable: Ocaml_variables.compiler_stdin
-      ~stdout_variable:ocamldoc#output_variable
-      ~stderr_variable:ocamldoc#output_variable
+      ~stdout_variable:Ocamldoc.output_variable
+      ~stderr_variable:Ocamldoc.output_variable
       ~append:true
       log env commandline in
   if exit_status=0 then

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -435,7 +435,8 @@ let setup_compiler_build_env (compiler : Ocaml_compilers.compiler) log env =
     (r, env)
   end else (r, env)
 
-let setup_toplevel_build_env (module Toplevel : Ocaml_toplevels.Toplevel) log env =
+let setup_toplevel_build_env
+    (module Toplevel : Ocaml_toplevels.Toplevel) log env =
   setup_tool_build_env (module Toplevel) log env
 
 let mk_compiler_env_setup name (compiler : Ocaml_compilers.compiler) =

--- a/ocamltest/ocaml_compilers.ml
+++ b/ocamltest/ocaml_compilers.ml
@@ -17,7 +17,17 @@
 
 open Ocamltest_stdlib
 
-class compiler
+module type Compiler = sig
+  include Ocaml_tools.Tool
+  val host : Ocaml_backends.t
+  val target : Ocaml_backends.t
+  val program_variable : Variables.t
+  val program_output_variable : Variables.t option
+end
+
+type compiler = (module Compiler)
+
+let compiler
   ~(name : string)
   ~(flags : string)
   ~(directory : string)
@@ -26,41 +36,46 @@ class compiler
   ~(output_variable : Variables.t)
   ~(host : Ocaml_backends.t)
   ~(target : Ocaml_backends.t)
-= object (self) inherit Ocaml_tools.tool
-  ~name:name
-  ~family:"compiler"
-  ~flags:flags
-  ~directory:directory
-  ~exit_status_variable:exit_status_variable
-  ~reference_variable:reference_variable
-  ~output_variable:output_variable
-  as tool
+  : compiler
+  =
+  let module Tool =
+    (val Ocaml_tools.tool
+      ~name:name
+      ~family:"compiler"
+      ~flags:flags
+      ~directory:directory
+      ~exit_status_variable:exit_status_variable
+      ~reference_variable:reference_variable
+      ~output_variable:output_variable
+      () : Ocaml_tools.Tool)
+  in
+  (module struct
+    include Tool
+    let host = host
+    let target = target
 
-  method host = host
-  method target = target
+    let program_variable =
+      if Ocaml_backends.is_native host && not Sys.win32
+      then Builtin_variables.program2
+      else Builtin_variables.program
 
-  method program_variable =
-    if Ocaml_backends.is_native host && not Sys.win32
-    then Builtin_variables.program2
-    else Builtin_variables.program
+    let program_output_variable =
+      if Ocaml_backends.is_native host && not Sys.win32
+      then None
+      else Some Builtin_variables.output
 
-  method program_output_variable =
-    if Ocaml_backends.is_native host && not Sys.win32
-    then None
-    else Some Builtin_variables.output
+    let reference_file env prefix =
+      let default = Tool.reference_file env prefix in
+      if Sys.file_exists default then default else
+        let suffix = Tool.reference_filename_suffix env in
+        let mk s = (Filename.make_filename prefix s) ^ suffix in
+        let filename = mk
+            (Ocaml_backends.string_of_backend target) in
+        if Sys.file_exists filename then filename else
+          mk "compilers"
+  end)
 
-  method ! reference_file env prefix =
-    let default = tool#reference_file env prefix in
-    if Sys.file_exists default then default else
-    let suffix = self#reference_filename_suffix env in
-    let mk s = (Filename.make_filename prefix s) ^ suffix in
-    let filename = mk
-      (Ocaml_backends.string_of_backend target) in
-    if Sys.file_exists filename then filename else
-    mk "compilers"
-end
-
-let ocamlc_byte = new compiler
+let ocamlc_byte = compiler
   ~name: Ocaml_commands.ocamlrun_ocamlc
   ~flags: ""
   ~directory: "ocamlc.byte"
@@ -70,7 +85,7 @@ let ocamlc_byte = new compiler
   ~host: Ocaml_backends.Bytecode
   ~target: Ocaml_backends.Bytecode
 
-let ocamlc_opt = new compiler
+let ocamlc_opt = compiler
   ~name: Ocaml_files.ocamlc_dot_opt
   ~flags: ""
   ~directory: "ocamlc.opt"
@@ -80,7 +95,7 @@ let ocamlc_opt = new compiler
   ~host: Ocaml_backends.Native
   ~target: Ocaml_backends.Bytecode
 
-let ocamlopt_byte = new compiler
+let ocamlopt_byte = compiler
   ~name: Ocaml_commands.ocamlrun_ocamlopt
   ~flags: ""
   ~directory: "ocamlopt.byte"
@@ -90,7 +105,7 @@ let ocamlopt_byte = new compiler
   ~host: Ocaml_backends.Bytecode
   ~target: Ocaml_backends.Native
 
-let ocamlopt_opt = new compiler
+let ocamlopt_opt = compiler
   ~name: Ocaml_files.ocamlopt_dot_opt
   ~flags: ""
   ~directory: "ocamlopt.opt"

--- a/ocamltest/ocaml_compilers.mli
+++ b/ocamltest/ocaml_compilers.mli
@@ -15,7 +15,17 @@
 
 (* Descriptions of the OCaml compilers *)
 
-class compiler :
+module type Compiler = sig
+  include Ocaml_tools.Tool
+  val host : Ocaml_backends.t
+  val target : Ocaml_backends.t
+  val program_variable : Variables.t
+  val program_output_variable : Variables.t option
+end
+
+type compiler = (module Compiler)
+
+val compiler :
   name : string ->
   flags : string ->
   directory : string ->
@@ -24,12 +34,7 @@ class compiler :
   output_variable : Variables.t ->
   host : Ocaml_backends.t ->
   target : Ocaml_backends.t ->
-object inherit Ocaml_tools.tool
-  method host : Ocaml_backends.t
-  method target : Ocaml_backends.t
-  method program_variable : Variables.t
-  method program_output_variable : Variables.t option
-end
+  compiler
 
 val ocamlc_byte : compiler
 

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -85,7 +85,7 @@ let native =
     check_program_output;
   ] @
   (if not Sys.win32 then
-    opt_build
+    []
   else
     []
   ) in

--- a/ocamltest/ocaml_tools.ml
+++ b/ocamltest/ocaml_tools.ml
@@ -17,7 +17,29 @@
 
 open Ocamltest_stdlib
 
-class tool
+module type Tool = sig
+  val name : string
+  val family : string
+  val flags : string
+  val directory : string
+  val exit_status_variable : Variables.t
+  val reference_variable : Variables.t
+  val output_variable : Variables.t
+  val reference_filename_suffix : Environments.t -> string
+  val reference_file : Environments.t -> string -> string
+end
+
+type tool = (module Tool)
+
+let reference_filename_suffix_default env =
+  let tool_reference_suffix =
+    Environments.safe_lookup Ocaml_variables.compiler_reference_suffix env
+  in
+  if tool_reference_suffix<>""
+  then tool_reference_suffix ^ ".reference"
+  else ".reference"
+
+let tool
   ~(name : string)
   ~(family : string)
   ~(flags : string)
@@ -25,34 +47,35 @@ class tool
   ~(exit_status_variable : Variables.t)
   ~(reference_variable : Variables.t)
   ~(output_variable : Variables.t)
-= object (self)
-  method name = name
-  method family = family
-  method flags = flags
-  method directory = directory
-  method exit_status_variable = exit_status_variable
-  method reference_variable = reference_variable
-  method output_variable = output_variable
+  ?(reference_filename_suffix = reference_filename_suffix_default)
+  ()
+  : tool
+= (module struct
+  let name = name
+  let family = family
+  let flags = flags
+  let directory = directory
+  let exit_status_variable = exit_status_variable
+  let reference_variable = reference_variable
+  let output_variable = output_variable
+  let reference_filename_suffix = reference_filename_suffix
 
-  method reference_filename_suffix env =
-    let tool_reference_suffix =
-      Environments.safe_lookup Ocaml_variables.compiler_reference_suffix env
-    in
-    if tool_reference_suffix<>""
-    then tool_reference_suffix ^ ".reference"
-    else ".reference"
-
-  method reference_file env prefix =
-    let suffix = self#reference_filename_suffix env in
+  let reference_file env prefix =
+    let suffix = reference_filename_suffix env in
     (Filename.make_filename prefix directory) ^ suffix
-end
+end)
 
-let expected_exit_status env tool =
-  Actions_helpers.exit_status_of_variable env tool#exit_status_variable
-
+let expected_exit_status env (module Tool : Tool) =
+  Actions_helpers.exit_status_of_variable env Tool.exit_status_variable
 
 let ocamldoc =
-  object inherit
+  let reference_filename_suffix env =
+    let backend =
+      Environments.safe_lookup Ocaml_variables.ocamldoc_backend env in
+    if backend = "" then
+      ".reference"
+    else "." ^ backend ^ ".reference"
+  in
   tool
     ~name:Ocaml_files.ocamldoc
     ~family:"doc"
@@ -61,11 +84,4 @@ let ocamldoc =
     ~exit_status_variable:Ocaml_variables.ocamldoc_exit_status
     ~reference_variable:Ocaml_variables.ocamldoc_reference
     ~output_variable:Ocaml_variables.ocamldoc_output
-
-    method ! reference_filename_suffix env =
-      let backend =
-        Environments.safe_lookup Ocaml_variables.ocamldoc_backend env in
-      if backend = "" then
-        ".reference"
-      else "." ^ backend ^ ".reference"
-  end
+    ~reference_filename_suffix ()

--- a/ocamltest/ocaml_tools.mli
+++ b/ocamltest/ocaml_tools.mli
@@ -15,7 +15,21 @@
 
 (* Descriptions of the OCaml tools *)
 
-class tool :
+module type Tool = sig
+  val name : string
+  val family : string
+  val flags : string
+  val directory : string
+  val exit_status_variable : Variables.t
+  val reference_variable : Variables.t
+  val output_variable : Variables.t
+  val reference_filename_suffix : Environments.t -> string
+  val reference_file : Environments.t -> string -> string
+end
+
+type tool = (module Tool)
+
+val tool :
   name : string ->
   family : string ->
   flags : string ->
@@ -23,17 +37,9 @@ class tool :
   exit_status_variable : Variables.t ->
   reference_variable : Variables.t ->
   output_variable : Variables.t ->
-object
-  method name : string
-  method family : string
-  method flags : string
-  method directory : string
-  method exit_status_variable : Variables.t
-  method reference_variable : Variables.t
-  method output_variable : Variables.t
-  method reference_filename_suffix : Environments.t -> string
-  method reference_file : Environments.t -> string -> string
-end
+  ?reference_filename_suffix : (Environments.t -> string) ->
+  unit ->
+  tool
 
 val expected_exit_status : Environments.t -> tool -> int
 

--- a/ocamltest/ocaml_toplevels.ml
+++ b/ocamltest/ocaml_toplevels.ml
@@ -36,7 +36,7 @@ let toplevel
   ~(compiler : Ocaml_compilers.compiler)
   : toplevel
   =
-  let module Tool = 
+  let module Tool =
     (val Ocaml_tools.tool
       ~name:name
       ~family:"toplevel"

--- a/ocamltest/ocaml_toplevels.ml
+++ b/ocamltest/ocaml_toplevels.ml
@@ -17,7 +17,15 @@
 
 open Ocamltest_stdlib
 
-class toplevel
+module type Toplevel = sig
+  include Ocaml_tools.Tool
+  val backend : Ocaml_backends.t
+  val compiler : Ocaml_compilers.compiler
+end
+
+type toplevel = (module Toplevel)
+
+let toplevel
   ~(name : string)
   ~(flags : string)
   ~(directory : string)
@@ -26,30 +34,35 @@ class toplevel
   ~(output_variable : Variables.t)
   ~(backend : Ocaml_backends.t)
   ~(compiler : Ocaml_compilers.compiler)
-= object (self) inherit Ocaml_tools.tool
-  ~name:name
-  ~family:"toplevel"
-  ~flags:flags
-  ~directory:directory
-  ~exit_status_variable:exit_status_variable
-  ~reference_variable:reference_variable
-  ~output_variable:output_variable
-  as tool
-  method backend = backend
-  method compiler = compiler
-  method ! reference_file env prefix =
-    let default = tool#reference_file env prefix in
+  : toplevel
+  =
+  let module Tool = 
+    (val Ocaml_tools.tool
+      ~name:name
+      ~family:"toplevel"
+      ~flags:flags
+      ~directory:directory
+      ~exit_status_variable:exit_status_variable
+      ~reference_variable:reference_variable
+      ~output_variable:output_variable
+      () : Ocaml_tools.Tool)
+  in
+  (module struct
+    include Tool
+    let backend = backend
+    let compiler = compiler
+    let reference_file env prefix =
+    let default = Tool.reference_file env prefix in
     if Sys.file_exists default then default else
-    let suffix = self#reference_filename_suffix env in
+    let suffix = Tool.reference_filename_suffix env in
     let mk s = (Filename.make_filename prefix s) ^ suffix in
     let filename = mk
-      (Ocaml_backends.string_of_backend self#backend) in
+      (Ocaml_backends.string_of_backend backend) in
     if Sys.file_exists filename then filename else
     mk "compilers"
+  end)
 
-end
-
-let ocaml = new toplevel
+let ocaml = toplevel
   ~name: Ocaml_commands.ocamlrun_ocaml
   ~flags: ""
   ~directory: "ocaml"
@@ -59,7 +72,7 @@ let ocaml = new toplevel
   ~backend: Ocaml_backends.Bytecode
   ~compiler: Ocaml_compilers.ocamlc_byte
 
-let ocamlnat = new toplevel
+let ocamlnat = toplevel
   ~name: Ocaml_files.ocamlnat
   ~flags: "-S" (* Keep intermediate assembly files *)
   ~directory: "ocamlnat"

--- a/ocamltest/ocaml_toplevels.mli
+++ b/ocamltest/ocaml_toplevels.mli
@@ -15,7 +15,15 @@
 
 (* Descriptions of the OCaml toplevels *)
 
-class toplevel :
+module type Toplevel = sig
+  include Ocaml_tools.Tool
+  val backend : Ocaml_backends.t
+  val compiler : Ocaml_compilers.compiler
+end
+
+type toplevel = (module Toplevel)
+
+val toplevel :
   name : string ->
   flags : string ->
   directory : string ->
@@ -24,10 +32,7 @@ class toplevel :
   output_variable : Variables.t ->
   backend : Ocaml_backends.t ->
   compiler : Ocaml_compilers.compiler ->
-object inherit Ocaml_tools.tool
-  method backend : Ocaml_backends.t
-  method compiler : Ocaml_compilers.compiler
-end
+  toplevel
 
 val ocaml : toplevel
 

--- a/testsuite/tests/runtime-objects/instance_variable_lifting.ml
+++ b/testsuite/tests/runtime-objects/instance_variable_lifting.ml
@@ -1,0 +1,63 @@
+(* TEST *)
+
+(* This test checks that a specific transformation takes place.
+   If it fails by printing unexpected output, it means that
+   the optimisation has been lost.
+   If it fails with an exception (or segfault or other things),
+   then some thing has gone terribly wrong and needs to be fixed.
+
+   The transformation is about lifting immutable instance variable
+   reads out of closures, to prevent these closures from capturing
+   the whole self object when they only need a few of the fields.
+   See also [self_capture.ml] in this directory for an actual case
+   where this matters.
+*)
+
+class c = object
+  val x : int = 0
+  val mutable y : int = 1
+  method mx = let () = () in fun () -> x
+  method my = let () = () in fun () -> y
+  method update_y v = y <- v
+end
+
+type liveness = Live | Dead
+
+(* Equivalent to [work (alloc ())], but also checks
+   if the result of [alloc] is still alive at the end. *)
+let[@inline never] check_liveness ~alloc ~work =
+  let r = ref Live in
+  (* Switch context to a different function to make sure
+     no roots are kept to temporary values *)
+  let[@local never][@inline never] isolate () =
+    let v = alloc () in
+    Gc.finalise_last (fun () -> r := Dead) v;
+    work v
+  in
+  let result = isolate () in
+  Gc.full_major ();
+  result, !r
+    
+let () =
+  let get_x, live =
+    check_liveness ~alloc:(fun () -> new c)
+      ~work:(fun obj -> obj#mx)
+  in
+  assert (get_x () = 0);
+  begin match live with
+  | Dead -> ()
+  | Live ->
+    print_endline
+      "Missed optimisation: Object 1 should have been collected"
+  end;
+  let (get_y, update_y), live =
+    check_liveness ~alloc:(fun () -> new c)
+      ~work:(fun obj -> (obj#my, obj#update_y))
+  in
+  assert (get_y () = 1);
+  begin match live with
+  | Live -> ()
+  | Dead -> failwith "Object 2 should be still alive"
+  end;
+  update_y 42;
+  assert (get_y () = 42)

--- a/testsuite/tests/runtime-objects/instance_variable_lifting.ml
+++ b/testsuite/tests/runtime-objects/instance_variable_lifting.ml
@@ -37,7 +37,7 @@ let[@inline never] check_liveness ~alloc ~work =
   let result = isolate () in
   Gc.full_major ();
   result, !r
-    
+
 let () =
   let get_x, live =
     check_liveness ~alloc:(fun () -> new c)

--- a/testsuite/tests/runtime-objects/self_capture.ml
+++ b/testsuite/tests/runtime-objects/self_capture.ml
@@ -1,0 +1,19 @@
+(* TEST *)
+
+class foo (name : string) =
+  object (self)
+    initializer
+      Gc.finalise_last (fun () -> Printf.printf "%s is collected\n%!" name) self
+
+    method name = name
+  end
+
+let () =
+  let[@inline never][@local never] first () =
+    let f = new foo "first" in
+    Printf.printf "Done with %s\n%!" f#name
+  in
+  first ();
+  let f = new foo "second" in
+  Gc.compact ();
+  Printf.printf "Still holding %s\n%!" f#name

--- a/testsuite/tests/runtime-objects/self_capture.reference
+++ b/testsuite/tests/runtime-objects/self_capture.reference
@@ -1,0 +1,3 @@
+Done with first
+first is collected
+Still holding second

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -367,7 +367,7 @@ and expression i ppf x =
   List.iter (expression_extra i ppf) x.exp_extra;
   match x.exp_desc with
   | Texp_ident (li,_,_) -> line i ppf "Texp_ident %a\n" fmt_path li;
-  | Texp_instvar (_, li,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;
+  | Texp_instvar (_, li,_,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;
   | Texp_constant (c) -> line i ppf "Texp_constant %a\n" fmt_constant c;
   | Texp_let (rf, l, e) ->
       line i ppf "Texp_let %a\n" fmt_rec_flag rf;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -387,7 +387,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_send (exp, _) ->
       sub.expr sub exp
   | Texp_new (_, lid, _) -> iter_loc_lid sub lid
-  | Texp_instvar (_, _, s) -> iter_loc sub s
+  | Texp_instvar (_, _, _, s) -> iter_loc sub s
   | Texp_setinstvar (_, _, s, exp) ->
       iter_loc sub s;
       sub.expr sub exp

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -475,10 +475,11 @@ let expr sub x =
           map_loc_lid sub lid,
           cd
         )
-    | Texp_instvar (path1, path2, id) ->
+    | Texp_instvar (path1, path2, mut, id) ->
         Texp_instvar (
           path1,
           path2,
+          mut,
           map_loc sub id
         )
     | Texp_setinstvar (path1, path2, id, exp) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4563,12 +4563,12 @@ and type_expect_
       let path, desc = type_ident env ~recarg lid in
       let exp_desc =
         match desc.val_kind with
-        | Val_ivar (_, cl_num) ->
+        | Val_ivar (mut, cl_num) ->
             let (self_path, _) =
               Env.find_value_by_name
                 (Longident.Lident ("self-" ^ cl_num)) env
             in
-            Texp_instvar(self_path, path,
+            Texp_instvar(self_path, path, mut,
                          match lid.txt with
                              Longident.Lident txt -> { txt; loc = lid.loc }
                            | _ -> assert false)

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -132,7 +132,7 @@ and expression_desc =
         expression
   | Texp_send of expression * meth
   | Texp_new of Path.t * Longident.t loc * Types.class_declaration
-  | Texp_instvar of Path.t * Path.t * string loc
+  | Texp_instvar of Path.t * Path.t * mutable_flag * string loc
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_override of Path.t * (Ident.t * string loc * expression) list
   | Texp_assert of expression * Location.t

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -281,7 +281,7 @@ and expression_desc =
         expression
   | Texp_send of expression * meth
   | Texp_new of Path.t * Longident.t loc * Types.class_declaration
-  | Texp_instvar of Path.t * Path.t * string loc
+  | Texp_instvar of Path.t * Path.t * mutable_flag * string loc
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_override of Path.t * (Ident.t * string loc * expression) list
   | Texp_assert of expression * Location.t

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -547,7 +547,7 @@ let expression sub exp =
           | Tmeth_val id -> mkloc (Ident.name id) loc
           | Tmeth_ancestor(id, _) -> mkloc (Ident.name id) loc)
     | Texp_new (_path, lid, _) -> Pexp_new (map_loc sub lid)
-    | Texp_instvar (_, path, name) ->
+    | Texp_instvar (_, path, _mut, name) ->
       Pexp_ident ({loc = sub.location sub name.loc ; txt = lident_of_path path})
     | Texp_setinstvar (_, _path, lid, exp) ->
         Pexp_setinstvar (map_loc sub lid, sub.expr sub exp)

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -609,7 +609,7 @@ let rec expression : Typedtree.expression -> term_judg =
         G |- new c: m
       *)
       path pth << Dereference
-    | Texp_instvar (self_path, pth, _inst_var) ->
+    | Texp_instvar (self_path, pth, _mut, _inst_var) ->
         join [path self_path << Dereference; path pth]
     | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, [_, Arg arg])
       when is_ref vd ->


### PR DESCRIPTION
This PR is my latest attempt at fixing the expected but disappointing behaviour reported in #14861.
It works by lifting the load primitives used to compile instance variables to the beginning of the corresponding method, when that would be correct (i.e. when the variable is not mutable).

The first commit will be dropped before merging the PR (it only contains `ocamltest`-related changes), but I thought it would be interesting to show what kind of patches I need when working on objects.