### PR TITLE
Override `BINDIR` during build in `Makefile.cross`

### DIFF
--- a/Makefile.cross
+++ b/Makefile.cross
@@ -25,6 +25,12 @@
 # have to be lazier.
 HOST_ZSTD_LIBS=ZSTD_LIBS=$(shell ocamlopt -config-var compression_c_libraries)
 
+# As the bytecode binaries will be compiled with the host compiler, they should
+# look for the host ocamlrun to launch them, so we override $(BINDIR) so that
+# $(BYTECODE_LAUNCHER_FLAGS) pick up the correct directory for the
+# `-launch-method`
+HOST_BINDIR:=BINDIR=$(dir $(shell command -v ocamlrun))
+
 # The build system adds various include directories which pertain to the current
 # tree, including -I runtime, which is necessary for -custom executables.
 # ocamltest is always a -custom executable, but some others (ocamldoc; the
@@ -39,7 +45,7 @@ HOST_ZSTD_LIBS=ZSTD_LIBS=$(shell ocamlopt -config-var compression_c_libraries)
 VPATH := + $(VPATH)
 
 CROSS_OVERRIDES=OCAMLRUN=ocamlrun NEW_OCAMLRUN=ocamlrun \
-  BOOT_OCAMLLEX=ocamllex OCAMLYACC=ocamlyacc
+  BOOT_OCAMLLEX=ocamllex OCAMLYACC=ocamlyacc $(HOST_BINDIR)
 # The cross-compiler is linked as build/bin/ocamlopt -o cross/bin/ocamlopt
 # Config.standard_library_default for cross/bin/ocamlopt would by default be the
 # value for build/bin/ocamlopt (i.e. build/lib/ocaml), which is not what is


### PR DESCRIPTION
During build of cross compilers, override `BINDIR` to set the correct `-launch-method` for bytecode programs.

In the context of cross compilation, the `ocamlrun` that should be picked up to run the bytecode programs is the host one as they are compiled with the host `ocamlc`. So this patch adds the `BINDIR` variable to the set of overrides, to have it to point to the directory of the host `ocamlrun`.

This patch fixes an issue in OCaml 5.5.0 RC1 when trying to build an OCaml/Solo5 cross compiler as [@hannesm reported](https://github.com/mirage/ocaml-solo5/pull/167). I’ve run the cross-compiler CI tests to make sure that doesn’t break at least those other use cases.

@Octachron: as it’s a bug fix modifying only the cross-compilation-specific `Makefile.cross`, could it be considered for inclusion in 5.5.0?

Could the `run-crosscompiler-tests` label be set?
And I would say that no Change entry is really necessary.