### PR TITLE
Bytecode loading: guard against overflow in `caml_read_section_descriptors`

### DIFF
--- a/Changes
+++ b/Changes
@@ -132,6 +132,10 @@ Working version
 - #14814: a `caml_result_find_exception` helper for the `caml_result` type
   (Gabriel Scherer, review by Nicolás Ojeda Bär, request by Chris Vine)
 
+- #14872: harden loading of bytecode executable files against corrupted
+  or malicious files having 2^29 TOC entries or more.
+  (Xavier Leroy, review by Nicolás Ojeda Bär)
+
 * #14997: Default to and recommend large file and year 2038 support on 32-bit
   systems. LFS and 64-bit `time_t` _checks_ can be disabled by passing
   respectively `--disable-largefile` and `--disable-year2038` to configure.

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -96,6 +96,15 @@ CAMLextern caml_stat_block caml_stat_alloc(asize_t);
 CAMLmalloc(caml_stat_free, 1, 1)
 CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
 
+/* [caml_stat_calloc(num, size)] allocates a block of memory for an array
+   of [num] elements, each of them [size] bytes long, and initializes all its
+   bits to zero, effectively allocating a zero-initialized memory block of
+   [num * size] bytes. It throws an OCaml exception in case
+   the request fails, and so requires the runtime lock to be held.
+*/
+CAMLcalloc(caml_stat_free, 1, 1, 2)
+CAMLextern caml_stat_block caml_stat_calloc(asize_t, asize_t);
+
 /* [caml_stat_calloc_noexc(num, size)] allocates a block of memory for an array
    of [num] elements, each of them [size] bytes long, and initializes all its
    bits to zero, effectively allocating a zero-initialized memory block of

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -790,6 +790,16 @@ CAMLexport caml_stat_block caml_stat_calloc_noexc(asize_t num, asize_t sz)
   }
 }
 
+/* [sz] is a number of bytes */
+CAMLexport caml_stat_block caml_stat_calloc(asize_t num, asize_t sz)
+{
+  void *result = caml_stat_calloc_noexc(num, sz);
+  /* calloc() may return NULL if size is 0 or number of elements is 0 */
+  if ((result == NULL) && (sz != 0) && (num != 0))
+    caml_raise_out_of_memory();
+  return result;
+}
+
 CAMLexport caml_stat_string caml_stat_strdup_noexc(const char *s)
 {
   size_t slen = strlen(s);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -159,15 +159,14 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
 
 void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
 {
-  int toc_size;
-
-  toc_size = trail->num_sections * 8;
-  trail->section = caml_stat_alloc(toc_size);
-  lseek(fd, - (long) (TRAILER_SIZE + toc_size), SEEK_END);
+  size_t toc_size;
+  trail->section = caml_stat_calloc(trail->num_sections, 8);
+  toc_size = (size_t) trail->num_sections * 8;
+  lseek(fd, - (file_offset) (TRAILER_SIZE + toc_size), SEEK_END);
   if (read(fd, (char *) trail->section, toc_size) != toc_size)
     caml_fatal_error("cannot read section table");
   /* Fixup endianness of lengths */
-  for (int i = 0; i < trail->num_sections; i++)
+  for (uint32_t i = 0; i < trail->num_sections; i++)
     fixup_endianness_trailer(&(trail->section[i].len));
 }
 
@@ -178,13 +177,13 @@ void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
 int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
                                    const char *name)
 {
-  long ofs;
-
-  ofs = TRAILER_SIZE + trail->num_sections * 8;
-  for (int i = trail->num_sections - 1; i >= 0; i--) {
+  size_t ofs = TRAILER_SIZE + (size_t) trail->num_sections * 8;
+  uint32_t i = trail->num_sections;
+  while (i > 0) {
+    i -= 1;
     ofs += trail->section[i].len;
     if (strncmp(trail->section[i].name, name, 4) == 0) {
-      lseek(fd, -ofs, SEEK_END);
+      lseek(fd, - (file_offset) ofs, SEEK_END);
       return trail->section[i].len;
     }
   }


### PR DESCRIPTION
Not sure this can be exploited by a malicious bytecode executable with an unreasonable number of section descriptors, but better be safe.

FYI: @hannesm
