### PR TITLE
Fix in runtime : destruction of attributes object after use

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -40,6 +40,7 @@ static int st_thread_create(st_thread_id * res,
   if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   rc = pthread_create(&thr, &attr, fn, arg);
   if (res != NULL) *res = thr;
+  (void)pthread_attr_destroy(&attr);
   return rc;
 }
 

--- a/testsuite/tests/lib-systhreads/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register_cstubs.c
@@ -41,6 +41,7 @@ value spawn_thread(value clos)
   pthread_attr_init(&attr);
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   pthread_create(&thr, &attr, thread_func, (void *) clos);
+  (void)pthread_attr_destroy(&attr);
 #endif
   return Val_unit;
 }

--- a/testsuite/tests/parallel/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/parallel/test_c_thread_register_cstubs.c
@@ -92,6 +92,7 @@ void spawn_thread_internal(bool specific_domain, uintnat first_domain_unique_id,
   pthread_attr_init(&attr);
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   pthread_create(&thr, &attr, thread_func, args);
+  (void)pthread_attr_destroy(&attr);
 #endif
 }
 


### PR DESCRIPTION
Following [this discussion](https://github.com/ocaml/ocaml/pull/14860#discussion_r3441561208), this PR proposes a fix in runtime to correctly free memory that was allocated to a thread's attributes object.