### PR TITLE
major_gc.c: adopt early, adopt often (but not when terminating)

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -762,6 +762,9 @@ static void adopt_orphaned_work (void)
   value orph_ephe_list_live;
   struct caml_final_info *f, *myf, *temp;
 
+  if (caml_domain_is_terminating())
+    return;
+
 #ifdef DEBUG
   /* We mark ephemerons before orphaning them,
      and always re-adopt them during the same cycle. */
@@ -789,11 +792,7 @@ static void adopt_orphaned_work (void)
 
   while (f != NULL) {
     myf = domain_state->final_info;
-    CAMLassert (caml_gc_phase == Phase_sweep_and_mark_main);
 
-    /* updated_first/last may be true if the current domain is terminating
-       and has orphaned some finalisers but now has to adopt back (the same
-       or other) finalisers. */
     if (myf->updated_first){
       (void)caml_atomic_counter_incr(&num_domains_to_final_update_first);
       myf->updated_first = 0;
@@ -1774,15 +1773,24 @@ void caml_mark_roots_stw (int participant_count,
 
     latest_sweep_allocs = diffmod (work_counter, work_counter_at_sweep_start);
 
-    /* Orphaned work may contain roots so we adopt them first. */
-    adopt_orphaned_work();
-
     global_prepare_for_ephe_marking(participant_count);
   }
 
   caml_domain_state* domain = Caml_state;
 
   prepare_for_ephe_marking(domain);
+
+  /* Orphaned work may contain roots so we adopt them first.
+
+     Note: we do not adopt inside the barrier because terminating
+     domains do not adopt, so we must try to adopt on each domain to
+     ensure that at least one does.
+
+     Note: we adopt after [prepare_for_ephe_marking] so that the adoption
+     code observes the ephe-marking state correctly set up, same as when
+     it is called from a major slice.
+  */
+  adopt_orphaned_work();
 
   CAML_EV_BEGIN(EV_MAJOR_MARK_ROOTS);
   {
@@ -2162,6 +2170,8 @@ static void major_collection_slice(intnat howmuch,
   if (log_events) CAML_EV_BEGIN(EV_MAJOR_SLICE);
   call_timing_hook(&caml_major_slice_begin_hook);
 
+  adopt_orphaned_work();
+
   if (!domain_state->sweeping_done) {
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_SWEEP);
 
@@ -2209,6 +2219,11 @@ static void major_collection_slice(intnat howmuch,
   }
 
 mark_again:
+  /* We adopt a second time here so that if a domain goes back to
+     marking several times, it has a chance to adopt on each
+     iteration. */
+  adopt_orphaned_work();
+
   if (caml_marking_started() &&
       !domain_state->marking_done &&
       get_major_slice_work(mode) > 0) {
@@ -2256,10 +2271,6 @@ mark_again:
       /* This domain has updated finalise last values */
       (void)caml_atomic_counter_decr(&num_domains_to_final_update_last);
       /* Updating last cannot cause any marking */
-    }
-
-    if (!caml_domain_is_terminating()){
-      adopt_orphaned_work();
     }
 
     /* Ephemerons */


### PR DESCRIPTION
This is another ephemeron PR if @damiendoligez is available to review it, continuing towards orphaning/adoption simplifications following the master plan (and tree of branches) in https://github.com/ocaml/ocaml/discussions/14720#discussioncomment-16537367.

In the previous PR #14813, we fixed the checks that prevent moving to a new major GC cycle if orphaned work remain (to avoid having ephemerons remain orphaned from one cycle to the next). In the present PR we tweak the major-GC-slice code to ensure that the adoption runs "often enough" -- at least once per slice of major GC work. We then feel confident enough, that at least one domain adopts during each major GC cycle, and so we disable adoption for currently-terminating domains (which can typically cause wasted work).