### PR TITLE
Fix mislabeled Pmty_extension in printast dump

### DIFF
--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -742,7 +742,7 @@ and module_type i ppf x =
       line i ppf "Pmty_typeof\n";
       module_expr i ppf m;
   | Pmty_extension (s, arg) ->
-      line i ppf "Pmod_extension \"%s\"\n" s.txt;
+      line i ppf "Pmty_extension \"%s\"\n" s.txt;
       payload i ppf arg
 
 and signature i ppf x = list i signature_item ppf x

--- a/testsuite/tests/parsing/extensions.compilers.reference
+++ b/testsuite/tests/parsing/extensions.compilers.reference
@@ -250,7 +250,7 @@
       signature_item (extensions.ml[22,507+8]..[22,507+25])
         Psig_module "M" (extensions.ml[22,507+15]..[22,507+16])
         module_type (extensions.ml[22,507+19]..[22,507+25])
-          Pmod_extension "baz"
+          Pmty_extension "baz"
           []
     ]
   structure_item (extensions.ml[23,534+0]..[25,606+23])


### PR DESCRIPTION
The -dparsetree dumper printed module type extensions with the label "Pmod_extension" (copy-pasted from module_expr) instead of "Pmty_extension".