### PR TITLE
Fix #14881, external types subject to module constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -379,6 +379,10 @@ Working version
   (Pierre Chambart, report by Nathanaëlle Courant and
    Vincent Laviron review by Vincent Laviron)
 
+- #14881, #14882: fix printing of external types that are subject to module
+  constraints.
+  (Stefan Muenzel, review by ???)
+
 OCaml 5.5.0 (19 June 2026)
 -------------------------
 

--- a/Changes
+++ b/Changes
@@ -381,7 +381,7 @@ Working version
 
 - #14881, #14882: fix printing of external types that are subject to module
   constraints.
-  (Stefan Muenzel, review by ???)
+  (Stefan Muenzel, review by Florian Angeletti)
 
 OCaml 5.5.0 (19 June 2026)
 -------------------------

--- a/testsuite/tests/typing-misc/type_external.ml
+++ b/testsuite/tests/typing-misc/type_external.ml
@@ -293,8 +293,20 @@ module Q(P : P) : P with type t = P.t = struct
 end;;
 [%%expect{|
 module type P = sig type t = external "p" end
-Uncaught exception: Typemod.Error.In_context(_, _, _)
-
+Lines 4-6, characters 40-3:
+4 | ........................................struct
+5 |   type t = P.t
+6 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = P.t end
+       is not included in
+         sig type t = external "p" end
+       Type declarations do not match:
+         type t = P.t
+       is not included in
+         type t = external "p"
+       The first is abstract, but the second is external "p".
 |}]
 
 module type P1 = sig
@@ -305,8 +317,20 @@ module Q(P1 : P1) : P1 with type 'a t = 'a P1.t = struct
 end;;
 [%%expect{|
 module type P1 = sig type !'b t = external "p" end
-Uncaught exception: Typemod.Error.In_context(_, _, _)
-
+Lines 4-6, characters 50-3:
+4 | ..................................................struct
+5 |   type 'a t = 'a P1.t
+6 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type !'a t = 'a P1.t end
+       is not included in
+         sig type !'a t = external "p" end
+       Type declarations do not match:
+         type !'a t = 'a P1.t
+       is not included in
+         type !'a t = external "p"
+       The first is abstract, but the second is external "p".
 |}]
 
 module type P1 = sig
@@ -317,6 +341,18 @@ module Q(P1 : P1) : P1 with type 'a t = 'a P1.t = struct
 end;;
 [%%expect{|
 module type P1 = sig type +!'b t = external "p" end
-Uncaught exception: Typemod.Error.In_context(_, _, _)
-
+Lines 4-6, characters 50-3:
+4 | ..................................................struct
+5 |   type 'a t = 'a P1.t
+6 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type +!'a t = 'a P1.t end
+       is not included in
+         sig type +!'a t = external "p" end
+       Type declarations do not match:
+         type +!'a t = 'a P1.t
+       is not included in
+         type +!'a t = external "p"
+       The first is abstract, but the second is external "p".
 |}]

--- a/testsuite/tests/typing-misc/type_external.ml
+++ b/testsuite/tests/typing-misc/type_external.ml
@@ -283,3 +283,40 @@ type t = external {a|\\\|a};;
 [%%expect{|
 type t = external "\\\\\\"
 |}]
+
+(* manifest *)
+module type P = sig
+  type t = external "p"
+end
+module Q(P : P) : P with type t = P.t = struct
+  type t = P.t
+end;;
+[%%expect{|
+module type P = sig type t = external "p" end
+Uncaught exception: Typemod.Error.In_context(_, _, _)
+
+|}]
+
+module type P1 = sig
+  type !'b t = external "p"
+end
+module Q(P1 : P1) : P1 with type 'a t = 'a P1.t = struct
+  type 'a t = 'a P1.t
+end;;
+[%%expect{|
+module type P1 = sig type !'b t = external "p" end
+Uncaught exception: Typemod.Error.In_context(_, _, _)
+
+|}]
+
+module type P1 = sig
+  type +'b t = external "p"
+end
+module Q(P1 : P1) : P1 with type 'a t = 'a P1.t = struct
+  type 'a t = 'a P1.t
+end;;
+[%%expect{|
+module type P1 = sig type +!'b t = external "p" end
+Uncaught exception: Typemod.Error.In_context(_, _, _)
+
+|}]

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1483,7 +1483,7 @@ let tree_of_type_decl id decl =
     | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}
   in
   let type_defined decl =
-    let abstr =
+    let non_inferable_variance =
       match decl.type_kind with
         Type_abstract _ ->
           decl.type_manifest = None || decl.type_private = Private
@@ -1495,16 +1495,18 @@ let tree_of_type_decl id decl =
       | Type_open ->
           decl.type_manifest = None
       | Type_external _ ->
-          assert (decl.type_manifest = None); true
+          true
     in
     let vari =
       List.map2
         (fun ty v ->
           let is_var = is_Tvar ty in
-          let with_variance = !Clflags.print_variance || abstr || not is_var in
+          let with_variance =
+            !Clflags.print_variance || non_inferable_variance || not is_var
+          in
           let with_injectivity =
             !Clflags.print_variance ||
-            (abstr || not is_var) &&
+            (non_inferable_variance || not is_var) &&
             type_kind_is_abstract decl &&
             match decl.type_manifest with
             | None -> true


### PR DESCRIPTION
This only removes the assert, treating external types as always abstract (which I believe is the intention).

Add tests, including test with variance/injectivity annotations.