### PR TITLE
Recursive non-syntactic functions: optimise renamings

### DIFF
--- a/Changes
+++ b/Changes
@@ -149,6 +149,11 @@ Working version
   (Xavier Leroy, suggestion by Github user @nickbetteridge, review by
    Nicolás Ojeda Bär)
 
+- #14876, #14885: Better compilation for recursive functions where
+  local aliases are introduced before the function itself.
+  The pattern is uncommon in hand-written code but some ppxes produce it.
+  (Vincent Laviron, report by Sacha-Élie Ayoun, review by Gabriel Scherer)
+
 ### Standard library:
 
 - #10798: Atomic helper function

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -430,6 +430,11 @@ let lfunction_with_body { kind; params; return; body = _; attr; loc } body =
        { aux }
      and i_lifted = fun x -> i_context.aux x
    ]}
+
+   If the context contains let-bindings for pure expressions, we can also
+   substitute these expressions into the function body instead. The current
+   implementation only performs this transformation for variable renamings
+   (let x = y in ...).
 *)
 
 type lifted_function =
@@ -454,10 +459,15 @@ let lifted_block_mut : Asttypes.mutable_flag = Immutable
 
 let no_loc = Debuginfo.Scoped_location.Loc_unknown
 
-let rec split_static_function block_var local_idents lam :
+let rec split_static_function block_var local_idents renamings lam :
   Lambda.lambda split_result =
   match lam with
   | Lvar v ->
+    let v =
+      match Ident.Map.find_opt v renamings with
+      | Some v' -> v'
+      | None -> v
+    in
     (* Eta-expand *)
     (* Note: knowing the arity might let us generate slightly better code *)
     let param = Ident.create_local "let_rec_param" in
@@ -499,6 +509,11 @@ let rec split_static_function block_var local_idents lam :
           (succ i, Ident.Map.add var access subst, Lvar var :: fields))
         local_free_vars (0, Ident.Map.empty, [])
     in
+    let subst =
+      Ident.Map.fold (fun var_left var_right subst ->
+          Ident.Map.add var_left (Lvar var_right) subst)
+        renamings subst
+    in
     (* Note: When there are no local free variables, we don't need the
        substitution and we don't need to generate code for pre-allocating
        and backpatching a block of size 0.
@@ -515,14 +530,36 @@ let rec split_static_function block_var local_idents lam :
              no_loc)
     in
     Reachable (lifted, block)
+  | Llet (lkind, vkind, var_left, Lvar var_right, body) ->
+    (* Simple renaming: use direct substitution *)
+    (* We need the right-hand side of the renamings map to not mention
+       any variable from the left-hand side, so we apply previous
+       renamings eagerly *)
+    let var_right_renamed =
+      match Ident.Map.find_opt var_right renamings with
+      | None -> var_right
+      | Some v -> v
+    in
+    let+ body =
+      split_static_function block_var local_idents
+        (Ident.Map.add var_left var_right_renamed renamings) body
+    in
+    (* The [body] here is the expression for the closure block. We could apply
+       the renaming to it too, but it would be a bit tedious (and of non-linear
+       complexity) so instead we keep the original binding.
+       (All occurrences of [var_left] have disappeared from the lifted function,
+       but occurrences can remain in [body].) *)
+    Llet (lkind, vkind, var_left, Lvar var_right, body)
   | Llet (lkind, vkind, var, def, body) ->
     let+ body =
-      split_static_function block_var (Ident.Set.add var local_idents) body
+      split_static_function block_var (Ident.Set.add var local_idents)
+        renamings body
     in
     Llet (lkind, vkind, var, def, body)
   | Lmutlet (vkind, var, def, body) ->
     let+ body =
-      split_static_function block_var (Ident.Set.add var local_idents) body
+      split_static_function block_var (Ident.Set.add var local_idents)
+        renamings body
     in
     Lmutlet (vkind, var, def, body)
   | Lletrec (bindings, body) ->
@@ -531,16 +568,21 @@ let rec split_static_function block_var local_idents lam :
         local_idents bindings
     in
     let+ body =
-      split_static_function block_var local_idents body
+      split_static_function block_var local_idents renamings body
     in
     Lletrec (bindings, body)
   | Lprim (Praise _, _, _) -> Unreachable
   | Lstaticraise _ -> Unreachable
   | Lswitch (arg, sw, loc) ->
-    let sw_consts_res = rebuild_arms block_var local_idents sw.sw_consts in
-    let sw_blocks_res = rebuild_arms block_var local_idents sw.sw_blocks in
+    let sw_consts_res =
+      rebuild_arms block_var local_idents renamings sw.sw_consts
+    in
+    let sw_blocks_res =
+      rebuild_arms block_var local_idents renamings sw.sw_blocks
+    in
     let sw_failaction_res =
-      Option.map (split_static_function block_var local_idents) sw.sw_failaction
+      Option.map (split_static_function block_var local_idents renamings)
+        sw.sw_failaction
     in
     begin match sw_consts_res, sw_blocks_res, sw_failaction_res with
     | Unreachable, Unreachable, (None | Some Unreachable) -> Unreachable
@@ -558,9 +600,10 @@ let rec split_static_function block_var local_idents lam :
       Misc.fatal_error "letrec: multiple functions"
     end
   | Lstringswitch (arg, arms, failaction, loc) ->
-    let arms_res = rebuild_arms block_var local_idents arms in
+    let arms_res = rebuild_arms block_var local_idents renamings arms in
     let failaction_res =
-      Option.map (split_static_function block_var local_idents) failaction
+      Option.map (split_static_function block_var local_idents renamings)
+        failaction
     in
     begin match arms_res, failaction_res with
     | Unreachable, (None | Some Unreachable) -> Unreachable
@@ -572,13 +615,15 @@ let rec split_static_function block_var local_idents lam :
       Misc.fatal_error "letrec: multiple functions"
     end
   | Lstaticcatch (body, (nfail, params), handler) ->
-    let body_res = split_static_function block_var local_idents body in
+    let body_res =
+      split_static_function block_var local_idents renamings body
+    in
     let handler_res =
       let local_idents =
         List.fold_left (fun vars (var, _) -> Ident.Set.add var vars)
           local_idents params
       in
-      split_static_function block_var local_idents handler
+      split_static_function block_var local_idents renamings handler
     in
     begin match body_res, handler_res with
     | Unreachable, Unreachable -> Unreachable
@@ -590,10 +635,12 @@ let rec split_static_function block_var local_idents lam :
       Misc.fatal_error "letrec: multiple functions"
     end
   | Ltrywith (body, exn_var, handler) ->
-    let body_res = split_static_function block_var local_idents body in
+    let body_res =
+      split_static_function block_var local_idents renamings body
+    in
     let handler_res =
       split_static_function block_var
-        (Ident.Set.add exn_var local_idents) handler
+        (Ident.Set.add exn_var local_idents) renamings handler
     in
     begin match body_res, handler_res with
     | Unreachable, Unreachable -> Unreachable
@@ -605,8 +652,12 @@ let rec split_static_function block_var local_idents lam :
       Misc.fatal_error "letrec: multiple functions"
     end
   | Lifthenelse (cond, ifso, ifnot) ->
-    let ifso_res = split_static_function block_var local_idents ifso in
-    let ifnot_res = split_static_function block_var local_idents ifnot in
+    let ifso_res =
+      split_static_function block_var local_idents renamings ifso
+    in
+    let ifnot_res =
+      split_static_function block_var local_idents renamings ifnot
+    in
     begin match ifso_res, ifnot_res with
     | Unreachable, Unreachable -> Unreachable
     | Reachable (lfun, ifso), Unreachable ->
@@ -617,10 +668,10 @@ let rec split_static_function block_var local_idents lam :
       Misc.fatal_error "letrec: multiple functions"
     end
   | Lsequence (e1, e2) ->
-    let+ e2 = split_static_function block_var local_idents e2 in
+    let+ e2 = split_static_function block_var local_idents renamings e2 in
     Lsequence (e1, e2)
   | Levent (lam, lev) ->
-    let+ lam = split_static_function block_var local_idents lam in
+    let+ lam = split_static_function block_var local_idents renamings lam in
     Levent (lam, lev)
   | Lmutvar _
   | Lconst _
@@ -632,14 +683,14 @@ let rec split_static_function block_var local_idents lam :
   | Lsend _
   | Lifused _ -> Misc.fatal_error "letrec binding is not a static function"
 and rebuild_arms :
-  type a. _ -> _ -> (a * Lambda.lambda) list ->
+  type a. _ -> _ -> _ -> (a * Lambda.lambda) list ->
   (a * Lambda.lambda) list split_result =
-  fun block_var local_idents arms ->
+  fun block_var local_idents renamings arms ->
   match arms with
   | [] -> Unreachable
   | (i, lam) :: arms ->
-    let res = rebuild_arms block_var local_idents arms in
-    let lam_res = split_static_function block_var local_idents lam in
+    let res = rebuild_arms block_var local_idents renamings arms in
+    let lam_res = split_static_function block_var local_idents renamings lam in
     match lam_res, res with
     | Unreachable, Unreachable -> Unreachable
     | Reachable (lfun, lam), Unreachable ->
@@ -850,7 +901,9 @@ let compile_letrec input_bindings body =
               }
             | _ ->
               let ctx_id = Ident.create_local "letrec_function_context" in
-              begin match split_static_function ctx_id Ident.Set.empty def with
+              begin match
+                split_static_function ctx_id Ident.Set.empty Ident.Map.empty def
+              with
               | Unreachable ->
                 Misc.fatal_error "letrec: no function for binding"
               | Reachable ({ lfun; free_vars_block_size }, lam) ->

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -498,6 +498,14 @@ let rec split_static_function block_var local_idents renamings lam :
                Lprim (Pmakeblock (0, lifted_block_mut, None), [Lvar v], no_loc))
   | Lfunction lfun ->
     let free_vars = Lambda.free_variables lfun.body in
+    (* Translate the free variables through renamings *)
+    let free_vars =
+      Ident.Map.fold (fun left right free_vars ->
+          if Ident.Set.mem left free_vars
+          then Ident.Set.add right (Ident.Set.remove left free_vars)
+          else free_vars)
+        renamings free_vars
+    in
     let local_free_vars = Ident.Set.inter free_vars local_idents in
     let free_vars_block_size, subst, block_fields_rev =
       Ident.Set.fold (fun var (i, subst, fields) ->
@@ -511,7 +519,9 @@ let rec split_static_function block_var local_idents renamings lam :
     in
     let subst =
       Ident.Map.fold (fun var_left var_right subst ->
-          Ident.Map.add var_left (Lvar var_right) subst)
+          Ident.Map.add var_left
+            (Lambda.subst (fun _ _ env -> env) subst (Lvar var_right))
+            subst)
         renamings subst
     in
     (* Note: When there are no local free variables, we don't need the

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -497,15 +497,8 @@ let rec split_static_function block_var local_idents renamings lam :
     Reachable (lifted,
                Lprim (Pmakeblock (0, lifted_block_mut, None), [Lvar v], no_loc))
   | Lfunction lfun ->
-    let free_vars = Lambda.free_variables lfun.body in
-    (* Translate the free variables through renamings *)
-    let free_vars =
-      Ident.Map.fold (fun left right free_vars ->
-          if Ident.Set.mem left free_vars
-          then Ident.Set.add right (Ident.Set.remove left free_vars)
-          else free_vars)
-        renamings free_vars
-    in
+    let body = Lambda.rename renamings lfun.body in
+    let free_vars = Lambda.free_variables body in
     let local_free_vars = Ident.Set.inter free_vars local_idents in
     let free_vars_block_size, subst, block_fields_rev =
       Ident.Set.fold (fun var (i, subst, fields) ->
@@ -517,13 +510,6 @@ let rec split_static_function block_var local_idents renamings lam :
           (succ i, Ident.Map.add var access subst, Lvar var :: fields))
         local_free_vars (0, Ident.Map.empty, [])
     in
-    let subst =
-      Ident.Map.fold (fun var_left var_right subst ->
-          Ident.Map.add var_left
-            (Lambda.subst (fun _ _ env -> env) subst (Lvar var_right))
-            subst)
-        renamings subst
-    in
     (* Note: When there are no local free variables, we don't need the
        substitution and we don't need to generate code for pre-allocating
        and backpatching a block of size 0.
@@ -531,7 +517,7 @@ let rec split_static_function block_var local_idents renamings lam :
        noticeably worse, so we use it for simplicity. *)
     let new_fun =
       lfunction_with_body lfun
-        (Lambda.subst (fun _ _ env -> env) subst lfun.body)
+        (Lambda.subst (fun _ _ env -> env) subst body)
     in
     let lifted = { lfun = new_fun; free_vars_block_size } in
     let block =

--- a/testsuite/tests/letrec-compilation/renamings.ml
+++ b/testsuite/tests/letrec-compilation/renamings.ml
@@ -96,3 +96,18 @@ module M : sig val x : int end
       (apply (field_mut 1 (global Toploop!)) "baz" baz/0))))
 val baz : unit -> int = <fun>
 |}];;
+
+let rec foobar =
+  let x = (1, 2) in
+  let z = x in
+  fun () -> z
+[%%expect {|
+(let (letrec_function_context/3 = (caml_alloc_dummy 1))
+  (letrec
+    (foobar/0 (function param/5[int] (field_imm 0 letrec_function_context/3)))
+    (seq
+      (caml_update_dummy letrec_function_context/3
+        (let (x/3 = [0: 1 2] z/1 = x/3) (makeblock 0 x/3)))
+      (apply (field_mut 1 (global Toploop!)) "foobar" foobar/0))))
+val foobar : unit -> int * int = <fun>
+|}];;

--- a/testsuite/tests/letrec-compilation/renamings.ml
+++ b/testsuite/tests/letrec-compilation/renamings.ml
@@ -1,0 +1,98 @@
+(* TEST
+ flags = "-drawlambda -dcanonical-ids";
+ expect;
+*)
+
+(* Checking that the optimisation for avoiding capture
+   of simple aliases in non-syntactic recursive function definitions
+   works properly *)
+
+(* Original example from issue number 14876 *)
+type expr = Lit of int | Many of expr list
+
+let rec depth : expr -> int =
+    let __0 = depth in
+    function
+    | Lit _ -> 0
+    | Many l ->
+      List.fold_left (fun acc b -> Int.max acc (__0 b)) 0 l
+[%%expect {|
+0
+type expr = Lit of int | Many of expr list
+(let (letrec_function_context/0 = (caml_alloc_dummy 0))
+  (letrec
+    (depth/0
+       (function param/0 : int
+         (switch* param/0
+          case tag 0: (let (*match*/0 =a (field_imm 0 param/0)) 0)
+          case tag 1:
+           (let (l/0 =a (field_imm 0 param/0))
+             (apply (field_imm 29 (global Stdlib__List!))
+               (function acc/0[int] b/0 : int
+                 (apply (field_imm 14 (global Stdlib__Int!)) acc/0
+                   (apply depth/0 b/0)))
+               0 l/0)))))
+    (seq
+      (caml_update_dummy letrec_function_context/0
+        (let (__0/0 = depth/0) (makeblock 0)))
+      (apply (field_mut 1 (global Toploop!)) "depth" depth/0))))
+val depth : expr -> int = <fun>
+|}];;
+
+(* A few more complicated cases, with capture of renamed variables.
+   Only [b] should end up as part of [foo]'s function context. *)
+
+let rec foo =
+  let x = foo in
+  let y = x in
+  let z = bar in
+  let a = z in
+  let b () = y (); a () in
+  fun () -> x (); y (); z (); a (); b ()
+and bar () = foo ()
+[%%expect {|
+(let (letrec_function_context/1 = (caml_alloc_dummy 1))
+  (letrec
+    (foo/0
+       (function param/1[int]
+         (seq (apply foo/0 0) (apply foo/0 0) (apply bar/0 0) (apply bar/0 0)
+           (apply (field_imm 0 letrec_function_context/1) 0)))
+      bar/0 (function param/2[int] (apply foo/0 0)))
+    (seq
+      (caml_update_dummy letrec_function_context/1
+        (let
+          (x/0 = foo/0
+           y/0 = x/0
+           z/0 = bar/0
+           a/0 = z/0
+           b/1 = (function param/3[int] (seq (apply y/0 0) (apply a/0 0))))
+          (makeblock 0 b/1)))
+      (apply (field_mut 1 (global Toploop!)) "foo" foo/0)
+      (apply (field_mut 1 (global Toploop!)) "bar" bar/0))))
+val foo : unit -> 'a = <fun>
+val bar : unit -> 'a = <fun>
+|}];;
+
+(* A case not currently handled, for reference *)
+
+module M = struct let x = 0 end
+
+let rec baz =
+  let x = M.x in
+  fun () -> x
+[%%expect {|
+(apply (field_mut 1 (global Toploop!)) "M/421"
+  (let (x/1 =[int] 0) (makeblock 0 x/1)))
+module M : sig val x : int end
+(let
+  (M/0 = (apply (field_mut 0 (global Toploop!)) "M/421")
+   letrec_function_context/2 = (caml_alloc_dummy 1))
+  (letrec
+    (baz/0
+       (function param/4[int] : int (field_imm 0 letrec_function_context/2)))
+    (seq
+      (caml_update_dummy letrec_function_context/2
+        (let (x/2 =[int] (field_imm 0 M/0)) (makeblock 0 x/2)))
+      (apply (field_mut 1 (global Toploop!)) "baz" baz/0))))
+val baz : unit -> int = <fun>
+|}];;


### PR DESCRIPTION
This PR implements a solution to one of the problems reported in #14876, to avoid going through a pseudo-closure block for variables that are just aliases to something that exists outside the recursive definition (or defined by the recursive definition).

@gasche this should be exactly what we discussed yesterday (no extra features, no unexpected difficulties).