### PR TITLE
All underscore

### DIFF
--- a/Changes
+++ b/Changes
@@ -252,6 +252,8 @@ Working version
 - #14598: Add `@since` annotations to `Runtime_events`. (Raphaël Proust)
 
 ### Compiler user-interface and warnings:
+- #14887: More concise messages for the non-exhaustiveness warning.
+  (Luc Maranget, review by Florian Angeletti)
 
 - #14051: Improved error messages for first-class modules with a missing
   constrained type.

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -386,3 +386,57 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 module Single_row_optim :
   sig type t = A | B val non_exhaustive : t * t * t * t -> unit end
 |}]
+
+module PrintPat = struct
+(* New presentation  of counter-examples of exhaustiveness.
+   The new presentation as patterns still can be used to complement
+    the flagged pattern-matching expression, conveys the same information
+    as before and is more concise.
+*)
+  module T = struct
+    type r = { x:int; y:int; z:bool;}
+    type t = A | B of int | C of int * int | D of int * int * r
+    type t2 = E of { a:r; b:r; }
+  end
+
+  let f = function
+    | T.A -> 0
+
+  let g = function
+    | T.D (_,_,{T.z=true;_}) -> 0
+
+  let h = function
+    | T.E { a={T.z=true; _}; b=_; } -> ()
+end;;
+[%%expect {|
+Lines 13-14, characters 10-14:
+13 | ..........function
+14 |     | T.A -> 0
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "(B _|C _|D _)"
+
+Lines 16-17, characters 10-33:
+16 | ..........function
+17 |     | T.D (_,_,{T.z=true;_}) -> 0
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "D (_, _, {z=false; _ })"
+
+Lines 19-20, characters 10-41:
+19 | ..........function
+20 |     | T.E { a={T.z=true; _}; b=_; } -> ()
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "E {a={z=false; _ }; _ }"
+
+module PrintPat :
+  sig
+    module T :
+      sig
+        type r = { x : int; y : int; z : bool; }
+        type t = A | B of int | C of int * int | D of int * int * r
+        type t2 = E of { a : r; b : r; }
+      end
+    val f : T.t -> int
+    val g : T.t -> int
+    val h : T.t2 -> unit
+  end
+|}]

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -46,6 +46,13 @@ let pretty_extra ppf (cstr, _loc, _attrs) pretty_rest rest =
   | Tpat_open _ ->
      fprintf ppf "@[(# %a)@]" pretty_rest rest
 
+let rec is_underscore v =
+  match v.pat_desc with
+  | Tpat_any -> true
+  | Tpat_record (lvs,_) ->  List.for_all is_field_underscore lvs
+  | _ -> false
+and is_field_underscore (_,_,v) = is_underscore v
+
 let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
   match v.pat_extra with
     | extra :: rem ->
@@ -68,7 +75,10 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
         ("::", [v1;v2], None) ->
           fprintf ppf "@[%a::@,%a@]" pretty_car v1 pretty_cdr v2
       | (_, _, None) ->
-          fprintf ppf "@[<2>%s@ @[(%a)@]@]" name (pretty_vals ",") vs
+          if List.for_all is_underscore vs then
+            fprintf ppf "@[<2>%s _@]" name
+          else
+            fprintf ppf "@[<2>%s@ @[(%a)@]@]" name (pretty_vals ",") vs
       | (_, _, Some ([], _t)) ->
           fprintf ppf "@[<2>%s@ @[(%a : _)@]@]" name (pretty_vals ",") vs
       | (_, _, Some (vl, _t)) ->
@@ -81,10 +91,8 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
   | Tpat_variant (l, Some w, _) ->
       fprintf ppf "@[<2>`%s@ %a@]" l pretty_arg w
   | Tpat_record (lvs,_) ->
-      let filtered_lvs = List.filter
-          (function
-            | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
-            | _ -> true) lvs in
+      let filtered_lvs = (* do not show lbl=_ *)
+        List.filter (Fun.negate is_field_underscore) lvs in
       begin match filtered_lvs with
       | [] -> fprintf ppf "{ _ }"
       | (_, lbl, _) :: q ->


### PR DESCRIPTION
This PR changes the printing of patterns, making examples of non-matched values more concise. More precisely, `A (_,_)` is now printed as `A _`.
