### PR TITLE
#14891: fix scope error in ctype

### DIFF
--- a/Changes
+++ b/Changes
@@ -394,6 +394,23 @@ Working version
   constraints.
   (Stefan Muenzel, review by Florian Angeletti)
 
+OCaml 5.5.1
+-----------
+
+### Bug fixes:
+
+- #14891, #14982: fix scope error leading to an erroneous typechecking for
+  non-dependent application of module-dependent function in presence of
+  dependent first-class module types:
+  ```ocaml
+  module type T = sig module type S end
+  let f (module M:T) (m: (module M.S)) = m
+  module type P = sig type 'a t end
+  let error =
+    f (module struct module type S = P end) (module List)
+  ````
+  (Florian Angeletti, report by Hazem ElMasry, review by Gabriel Scherer)
+
 OCaml 5.5.0 (19 June 2026)
 -------------------------
 

--- a/testsuite/tests/typing-modular-explicits/general.ml
+++ b/testsuite/tests/typing-modular-explicits/general.ml
@@ -1531,3 +1531,19 @@ val helper : (module S with type t = 'a) -> 'b -> 'a = <fun>
 val outer : (module M : S with type e = 'a and type t = 'b) -> M.e -> M.t =
   <fun>
 |}]
+
+
+(* Bug #14891: nondep package type *)
+
+module type N = sig module type T end
+module type S = sig type 'a t end
+let f (module M:N) (x:(module M.T)) = x
+let app = f (module struct module type T = S end)
+let ok = f (module struct module type T = S end) (module List:S)
+[%%expect {|
+module type N = sig module type T end
+module type S = sig type 'a t end
+val f : (module M : N) -> (module M.T) -> (module M.T) = <fun>
+val app : (module S) -> (module S) = <fun>
+val ok : (module S) = <module>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2438,7 +2438,7 @@ let occur_univar_or_unscoped ?(inj_only=false) env ty =
       | Tpackage {pack_path = p; pack_constraints} ->
           begin match Path.check_for_unbound_unscoped_idents bound_id p with
           | Some i ->
-            occur_normalize_modtype_path env bound_uv bound_id i p
+            occur_normalize_modtype_path env bound_uv bound_id i p ty
               (fun pack_path -> Tpackage {pack_path; pack_constraints})
           | None ->
               List.iter (fun (_, t) -> occur_rec env bound_uv bound_id t)
@@ -2451,6 +2451,7 @@ let occur_univar_or_unscoped ?(inj_only=false) env ty =
           match id_escape with
           | Some i ->
             occur_normalize_modtype_path env bound_uv bound_id i pack.pack_path
+              ty
               (fun pack_path -> Tfunctor (l, id, {pack with pack_path}, ty))
           | None ->
               List.iter (fun (_, t) -> occur_rec env bound_uv bound_id t)
@@ -2475,7 +2476,7 @@ let occur_univar_or_unscoped ?(inj_only=false) env ty =
         occur_desc env bound_uv bound_id ty
       end else
         iter_type_expr (occur_rec env bound_uv bound_id) ty
-    and occur_normalize_modtype_path env bound_uv bound_id us p f =
+    and occur_normalize_modtype_path env bound_uv bound_id us p ty f =
       match Env.try_normalize_modtype_path env p with
       | None -> raise_escape_exn (Module (Ident.of_unscoped us))
       | Some p' ->
@@ -2590,7 +2591,7 @@ let identifier_escape env idl ty =
           begin match Path.find_free_opt idl pack.pack_path with
           | None -> iter_type_expr (occur idl) ty
           | Some i ->
-            occur_normalize_modtype_path env idl pack.pack_path i
+            occur_normalize_modtype_path env idl pack.pack_path i ty
               (fun pack_path -> Tpackage {pack with pack_path})
           end
       | Tobject (_, ({contents = Some (p, _)} as nm)) ->
@@ -2606,7 +2607,7 @@ let identifier_escape env idl ty =
       | Tfunctor (l, id, pack, t) ->
           begin match Path.find_free_opt idl pack.pack_path with
           | Some i ->
-              occur_normalize_modtype_path env idl pack.pack_path i
+              occur_normalize_modtype_path env idl pack.pack_path i ty
                 (fun pack_path -> Tfunctor (l, id, {pack with pack_path}, ty))
           | None ->
               List.iter (fun (_, t) -> occur idl t) pack.pack_constraints;
@@ -2631,7 +2632,7 @@ let identifier_escape env idl ty =
       occur ~ignore_mark:true idl ty
     end else
       iter_type_expr (occur idl) ty
-  and occur_normalize_modtype_path env idl p id f =
+  and occur_normalize_modtype_path env idl p id ty f =
     match Env.try_normalize_modtype_path env p with
     | None -> raise_escape_exn (Module id)
     | Some p' ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2577,7 +2577,7 @@ let enter_poly_for tr_exn env t1 tl1 t2 tl2 f =
     Similar to [nondep_type], however we remove the dependency in place,
     while [nondep] does a copy of the type.
 *)
-let identifier_escape env idl ty =
+let identifier_escape env idl initial_ty =
   with_type_mark begin fun mark ->
   let rec occur ?(ignore_mark=false) idl ty =
     if try_mark_node mark ty || ignore_mark then begin
@@ -2639,7 +2639,7 @@ let identifier_escape env idl ty =
       set_type_desc ty (f p');
       occur ~ignore_mark:true idl ty
   in
-  occur (List.map Ident.of_unscoped idl) ty
+  occur (List.map Ident.of_unscoped idl) initial_ty
   end
 
 let identifier_escape_for tr_exn env idl t =


### PR DESCRIPTION
This PR fixes #14891 by correcting a scoping mistake when trying to remove module dependency in package types:
due to this mistake, non-dependent application ended up erasing the whole result type with the corrected type for the first package type encountered.