### PR TITLE
Guideline for LLM usage in bug reports

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -30,24 +30,24 @@ a direct counterpart, with entirely human-produced content.
    security reports; or experiments involving humans without their advance
    consent.
 
-## Guidelines relevant to AI-assisted bug report
+## Guidelines relevant to AI-assisted bug reports
 
-Our advice is to avoid adding LLM-generated contents or explanation to
+Our advice is to avoid adding LLM-generated contents or explanations to
 your initial bug report: a bug report should be to the point and
 contain only human-verified information. Adding LLM-generated contents
-runs counter to those objectives, often even if the generated contents
+runs counter to those objectives, even if the generated contents
 looks useful to you.
 
-Indeed, judging the quality of a LLM generated contents about an
-unknown code base require a lot of efforts. Simultaneously, estimating
+Indeed, judging the quality of a LLM-generated content about an
+unknown code base requires a lot of effort. Simultaneously, estimating
 the faithfulness of LLM-generated contents without knowing your prior
 understanding of the code base, nor your prompt, nor the model context
-also require a lot of efforts. Such efforts are in most cases better
+also requires a lot of effort. Such efforts are in most cases better
 spent investigating the bug itself.
 
 Moreover, mixing human and LLM-generated contents in the same report
 without a clear separation should be imperatively avoided. Indeed,
-the absence of a clear delineation between the two contents make it
+the absence of a clear delineation between the two contents makes it
 very hard to ascertain the reliability of any part of the mixed
 contents.
 

--- a/AI.md
+++ b/AI.md
@@ -29,3 +29,30 @@ a direct counterpart, with entirely human-produced content.
    of code that contributors do not understand; plagiarised works; hallucinated
    security reports; or experiments involving humans without their advance
    consent.
+
+## Guidelines relevant to AI-assisted bug report
+
+Our advice is to avoid adding LLM-generated contents or explanation to
+your initial bug report: a bug report should be to the point and
+contain only human-verified information. Adding LLM-generated contents
+runs counter to those objectives, often even if the generated contents
+looks useful to you.
+
+Indeed, judging the quality of a LLM generated contents about an
+unknown code base require a lot of efforts. Simultaneously, estimating
+the faithfulness of LLM-generated contents without knowing your prior
+understanding of the code base, nor your prompt, nor the model context
+also require a lot of efforts. Such efforts are in most cases better
+spent investigating the bug itself.
+
+Moreover, mixing human and LLM-generated contents in the same report
+without a clear separation should be imperatively avoided. Indeed,
+the absence of a clear delineation between the two contents make it
+very hard to ascertain the reliability of any part of the mixed
+contents.
+
+We also advise some caution when shrinking reproduction case with
+LLMs. If you have any doubts about the LLM-shrinked reproduction case,
+please report both the original reproduction case and the shrinked
+one. In extreme cases, we have witnessed LLMs convincing people to
+reduce their bug report to a hallucination.

--- a/README.adoc
+++ b/README.adoc
@@ -142,7 +142,9 @@ https://github.com/ocaml/ocaml/issues
 
 To be effective, bug reports should include a complete program (preferably
 small) that exhibits the unexpected behavior, and the configuration you are
-using (machine type, etc).
+using (machine type, etc), it is also preferable to avoid adding
+LLM-generated contents or explanation to your bug report, see
+link:AI.md[].
 
 == Contributing
 

--- a/README.adoc
+++ b/README.adoc
@@ -144,7 +144,8 @@ To be effective, bug reports should include a complete program (preferably
 small) that exhibits the unexpected behavior, and the configuration you are
 using (machine type, etc), it is also preferable to avoid adding
 LLM-generated contents or explanation to your bug report, see
-link:AI.md[].
+link:AI.md#guidelines-relevant-to-ai-assisted-bug-reports[AI.md] for a more
+in-depth explanation.
 
 == Contributing
 


### PR DESCRIPTION
As suggested in #14842, this PR proposes to add few paragraph in the AI guideline to recommend not mixing LLM-generated inside bug report.

The objective of this guideline is to try to minimize the time lost by both the reporter and the maintainer by avoiding mixing a reliable and important bug report with approximative LLM-generated contents by explaining why such mixing
is counter-productive.

I have also added a word of caution about trusting LLM to shrink reproduction case to document the fact that we have witnessed LLM eliminating the reported bug from the supposed reproduction case.