### PR TITLE
opam clone: Fix macOS support

### DIFF
--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -142,7 +142,7 @@ Install () {
   mkdir -p "share/ocaml"
   cp "$ret/config.status" "$ret/config.cache" "share/ocaml"
   cp "$ret/ocaml-compiler-clone.sh" "share/ocaml/clone"
-  sh $script ~/local/_opam
+  sh $script ~/local/_opam "$(pwd)"
   cd "$ret"
   rm -rf install
   rm ocaml-compiler-clone.sh

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -214,7 +214,7 @@ case "$1" in
       cp "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" \
            'destdir/share/ocaml/clone'
       cd destdir
-      sh "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" "$OCAMLROOT/_opam"
+      sh "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" "$OCAMLROOT/_opam" "$(pwd)"
     )
     rm -rf "$OCAMLROOT"
     $MAKE -C "$FULL_BUILD_PREFIX-$PORT" OPAM_PACKAGE_NAME=ocaml-variants \

--- a/tools/opam/generate.ml
+++ b/tools/opam/generate.ml
@@ -165,9 +165,12 @@ let copy_files oc dir =
 
 let clone_files oc dir ic =
   output_endline oc
-    {|dest="$1"'/%s' xargs sh "$1/clone-files" <<'EOF'|} dir;
+    {|(
+cd "$build_dir"
+dest="$1"'/%s' origin_prefix=$origin_prefix xargs sh "$1/clone-files" <<'EOF'|} dir;
   In_channel.fold_lines (fun _ -> output_endline oc "%s") () ic;
-  output_endline oc {|EOF|}
+  output_endline oc {|EOF|};
+  output_endline oc {|)|}
 
 let () =
   if mode = "opam" then begin
@@ -188,22 +191,24 @@ set -eu|};
     Out_channel.with_open_bin (package ^ "-clone.sh") @@ fun oc ->
       output_endline oc {|#!/bin/sh
 set -eu
+origin_prefix=$(pwd)
+build_dir=$2
 mkdir -p "$1"
 rm -f "$1/__cp_test" "$1/__ln_test"
 if cp --reflink=always doc/ocaml/LICENSE "$1/__cp_test" 2>/dev/null; then
   rm -f "$1/__cp_test"
   CP='cp --reflink=always -%sf'
   if ! test -e "$1/clone-files"; then
-    echo "$CP"' "$@" "$dest/"' > "$1/clone-files"
+    echo 'cd "$origin_prefix" && '"$CP"' "$@" "$dest/"' > "$1/clone-files"
   fi
 else
   CP='cp -%sf'
   if ! test -e "$1/clone-files"; then
     if ln -f doc/ocaml/LICENSE "$1/__ln_test" 2>/dev/null; then
       rm -f "$1/__ln_test"
-      echo 'ln -f "$@" "$dest/"' > "$1/clone-files"
+      echo 'cd "$origin_prefix" && ln -f "$@" "$dest/"' > "$1/clone-files"
     else
-      echo "$CP"' "$@" "$dest/"' > "$1/clone-files"
+      echo 'cd "$origin_prefix" && '"$CP"' "$@" "$dest/"' > "$1/clone-files"
     fi
   fi
 fi|} preserve preserve;
@@ -216,6 +221,8 @@ fi|} preserve preserve;
           Makefile.config and config.status will both contain the original
           prefix, which must be updated. *)
       output_endline oc {|cp lib/ocaml/ld.conf "$1/lib/ocaml/ld.conf"
+(
+cd "$build_dir"
 cat > "$1/prefix.awk" <<'ENDAWK'
 {
   rest = $0
@@ -226,6 +233,7 @@ cat > "$1/prefix.awk" <<'ENDAWK'
   print rest
 }
 ENDAWK
+)
 prefix="$(sed -ne 's/^prefix *= *//p' lib/ocaml/Makefile.config)"
 for file in lib/ocaml/Makefile.config share/ocaml/config.status; do
   O="$prefix" N="$1" awk -f "$1/prefix.awk" "$file" > "$1/$file"

--- a/tools/opam/process.sh
+++ b/tools/opam/process.sh
@@ -57,10 +57,11 @@ if [ x"$make_args" = 'xinstall' ]; then
     echo "📜 Using make install"
     "$make" install
   else
+    build_dir=$(pwd)
     origin="$(tail -n 1 build-id)"
     origin_prefix="$(opam var --safe --switch="$origin" prefix | tr -d '\r')"
     echo "🪄 Duplicating $origin_prefix"
-    ( cd "$origin_prefix" && sh ./share/ocaml/clone "$prefix" )
+    ( cd "$origin_prefix" && sh ./share/ocaml/clone "$prefix" "$build_dir" )
   fi
 
   exit 0


### PR DESCRIPTION
macOS uses an old version of bash as default /bin/sh where `<< EOF` will create a temporary file in `$PWD` (or `$TMPDIR` but only if `$TMPDIR != $(getconf DARWIN_USER_TEMP_DIR)`, aka. not the default)

Fixes https://github.com/ocaml/opam-repository/issues/29496

cc @dra27 @Octachron 