### PR TITLE
Remove useless call to Option.map in Btype.fold_row

### DIFF
--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -329,10 +329,10 @@ let fold_row f init row =
   match get_desc (row_more row) with
   | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil ->
     begin match
-      Option.map (fun (_,l) -> List.fold_left f result l) (row_name row)
+      row_name row
     with
     | None -> result
-    | Some result -> result
+    | Some (_,l) -> List.fold_left f result l
     end
   | _ -> assert false
 


### PR DESCRIPTION
Noticed while looking at #14900.
I don't think it matters for performance (I haven't measured any difference), but it looked so silly that I decided to make a PR anyway.