### PR TITLE
Fix termination of caml_shutdown() with ephemerons

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -800,7 +800,9 @@ static void adopt_orphaned_work (void)
   value orph_ephe_list_live;
   struct caml_final_info *f, *myf, *temp;
 
-  if (caml_domain_is_terminating())
+  /* There is no point for a terminating domain to adopt, unless it is the last
+     one (runtime shutting down). */
+  if (caml_domain_is_terminating() && !caml_domain_alone())
     return;
 
 #ifdef DEBUG


### PR DESCRIPTION
With `OCAMLRUNPARAM="c=1"` (so-called cleanup at exit mode) the final collection cycle gets stuck in phase `Phase_sweep_and_mark_main` because:

1. There are orphan ephemerons leftover from a dead domain to adopt, which prevents the progressing to the next phase
2. The final domain never adopts them, because of the optimisation “if you are a terminating domain, do not adopt as there is no point”. The optimisation’s logic causes an infinite loop if the terminating domain is the last one—which only happens when the runtime is shut down with `caml_shutdown`.

This fixes the infinite loops in `weak-ephe-final/ephetest_par.ml` and `weak-ephe-final/weak_array_par_2.ml` in “cleanup at exit” mode, which have been plaguing the CI for weeks. (And partly solves #14594.)

Joint work with @damiendoligez, who suggests we may be better off dropping the optimisation altogether, on account that it has been the source of bugs in the past.

Cc @gasche you might be interested as you worked on simplifying orphaning.