### PR TITLE
compress the definition of path compression

### DIFF
--- a/typing/types.ml
+++ b/typing/types.ml
@@ -571,6 +571,7 @@ let repr_slow_path t =
     | Tlink t' ->
       follow t t'
     | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
+      repr_update t (Tlink t');
       follow t t'
     | Texpand (t', _, _) ->
       follow t t'

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -541,32 +541,6 @@ let commu_var () = Cvar {commu=Cunknown}
 
 (**** Representative of a type ****)
 
-let repr_update t_orig d =
-  log_change (Ccompress (t_orig, t_orig.desc, d));
-  t_orig.desc <- d
-
-let rec repr_expand update t_orig t path args =
-  match t.desc with
-  | Tlink t' | Texpand (t', _, _) ->
-      repr_expand true t_orig t' path args
-  | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
-      repr_expand true t_orig t' path args
-  | _ ->
-      if update then repr_update t_orig (Texpand (t, path, args));
-      t
-
-let rec repr_link update t_orig t =
-  match t.desc with
-  | Tlink t' ->
-      repr_link true t_orig t'
-  | Texpand (t', path, args) ->
-      repr_expand true t_orig t' path args
-  | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
-      repr_link true t_orig t'
-  | _ ->
-      if update then repr_update t_orig (Tlink t);
-      t
-
 (* A non-normalized type may contain an arbitrarily long chain of
    [Tlink] or [Texpand] prefixing the actual node (neither
    [Tlink] nor [Texpand]).
@@ -579,22 +553,40 @@ let rec repr_link update t_orig t =
    Before:
       t -> t1 -(path1,args1)-> t2 -> t3 -(path2,args2)-> t'
    After:
-      t -(path1,args1)-> t'
+      t, t1 -(path1,args1)-> t'
+      t2, t3 -(path2,args2) -> t'
    Before:
       t -> t1 -> t2 -> t'
    After:
-      t -> t'
+      t, t1, t2 -> t'
  *)
 
+let repr_update t_orig d =
+  log_change (Ccompress (t_orig, t_orig.desc, d));
+  t_orig.desc <- d
+
 let repr_slow_path t =
-  match t.desc with
-  | Tlink t' ->
-      repr_link false t t'
-  | Texpand (t', path, args) ->
-      repr_expand false t t' path args
-  | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
-      repr_link true t t'
-  | _ -> t
+  let rec repr t =
+    match t.desc with
+    | Tlink t' ->
+      follow t t'
+    | Tfield (_, k, _, t') when field_kind_internal_repr k = FKabsent ->
+      follow t t'
+    | Texpand (t', _, _) ->
+      follow t t'
+    | _ -> t
+  and follow t t' =
+    let tr = repr t' in
+    if tr != t' then begin
+      (* At this point [t'.desc] has been updated to [Tlink] or [Texpand]. *)
+      match t.desc with
+      | Texpand (_, path, args) ->
+        repr_update t (Texpand (tr, path, args))
+      | Tlink _ | Tfield _ -> repr_update t t'.desc
+      | _ -> assert false (* unreachable from [repr] *)
+    end;
+    tr
+  in repr t
 
 (* [repr] is called on almost every access to any type expression, so
    we isolate and inline the simple cases. *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -612,7 +612,7 @@ let [@inline hint] repr t =
   | Tpackage _
   | Tfunctor _
   | Tsubst _ -> t
-  | _ -> repr_slow_path t
+  | Tlink _ | Texpand _ | Tfield _ -> repr_slow_path t
 
 (* scope_field and marks *)
 


### PR DESCRIPTION
I was reading a commit of @Octachron ( fe04c3e4c055cb0ebf25edf6b1e077ee2023e96c ) and felt frustrated/confused by the fact that the logic to do path compression is repeated three times in types.ml currently. I propose the following refactored version, which I suspect could be easier to evolve in the future.

cc @Octachron @garrigue @smuenzel 

Comments:

1. It might be very slightly slower? I don't think that this will be noticeable because path compression should be the uncommon case. In particular, it is not tail-recursive anymore.
2. This definition compresses more, as it also updates intermediary nodes encountered during the traversal. (I updated the ASCII art in the comment to make this manifest.) In theory this can avoid some quadratic blowups in repeated compression, but I suppose that these cases never occurred in practice. It is just easier to implement this way.