### PR TITLE
Elide the occurs-check for parameters that are fresh variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,6 +127,12 @@ Working version
   used.
   (Stefan Muenzel, report by Leo White, review by Jacques Garrigue)
 
+- #14897, #14913: When instantiating types with arguments, do not check if the
+  parameters occur in the arguments when the parameters are fresh
+  variables, avoiding potentially expensive checks with large arguments.
+  (Stefan Muenzel, review by Gabriel Scherer, Florian Angeletti, and
+   Jacques Garrigue)
+
 ### Code generation and optimizations:
 
 - #14575: Emit direct assembly for `Atomic.fetch_and_add`

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1846,7 +1846,7 @@ let instance_label ~fixed lbl =
 
 (* NB: since this is [unify_var], it raises [Unify], not [Unify_trace] *)
 let unify_var' = (* Forward declaration *)
-  ref (fun _env _ty1 _ty2 -> assert false)
+  ref (fun ~check_occur:_ _env _ty1 _ty2 -> assert false)
 
 let subst ~env ~level ?scope ~priv ~abbrev ?oty ~params ~args body =
   if List.length params <> List.length args then raise Cannot_subst;
@@ -1868,8 +1868,32 @@ let subst ~env ~level ?scope ~priv ~abbrev ?oty ~params ~args body =
     abbreviations := ref Mnil;
     let uenv = Expression {env; in_subst = true} in
     try
-      !unify_var' uenv body0 body';
-      List.iter2 (!unify_var' uenv) params' args;
+      !unify_var' ~check_occur:true uenv body0 body';
+      let _, first_gen_vars, others =
+        Misc.Stdlib.List.fold_left3
+          (fun (previous_gen, first_gen, others) p p' a ->
+             match get_desc p with
+             | Tvar _ when get_level p = generic_level
+                        && not (List.exists (eq_type p) previous_gen) ->
+                 p :: previous_gen, (p', a) :: first_gen, others
+             | _ ->
+                 previous_gen, first_gen, (p', a) :: others
+          )
+          ([],[],[])
+          params params' args
+      in
+      (* We can elide the occurs-check for the first occurence of parameters
+         that are a generalizable variable (and therefore will be instantiated
+         to a fresh variable).
+         This can be beneficial if the argument is a very large type, where
+         the occurs check would be expensive. Non-generalizable type variables
+         or non-variables cannot avoid the check, since we're not able to show
+         they cannot occur.
+      *)
+      Misc.Stdlib.List.rev_iter
+        (fun (p,a) -> !unify_var' uenv ~check_occur:false p a) first_gen_vars;
+      Misc.Stdlib.List.rev_iter
+        (fun (p,a) -> !unify_var' uenv ~check_occur:true p a) others;
       body'
     with Unify _ ->
       undo_abbrev ();
@@ -3923,16 +3947,16 @@ let unify_gadt (penv : Pattern_env.t) ~pat:ty1 ~expected:ty2 =
     Btype.backtrack snap;
     with_univar_pairs [] do_unify_gadt
 
-let unify_var uenv t1 t2 =
+let unify_var ~check_occur uenv t1 t2 =
   if eq_type t1 t2 then () else
   match get_desc t1, get_desc t2 with
-    Tvar _, Tconstr _ when deep_occur t1 t2 ->
+    Tvar _, Tconstr _ when check_occur && deep_occur t1 t2 ->
       unify uenv t1 t2
   | Tvar _, _ ->
       let env = get_env uenv in
       let reset_tracing = check_trace_gadt_instances env in
       begin try
-        occur_for Unify uenv t1 t2;
+        if check_occur then occur_for Unify uenv t1 t2;
         update_level_for Unify env (get_level t1) t2;
         update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2;
@@ -3950,7 +3974,7 @@ let _ = unify_var' := unify_var
 
 (* the final versions of unification functions *)
 let unify_var env ty1 ty2 =
-  unify_var (Expression {env; in_subst = false}) ty1 ty2
+  unify_var ~check_occur:true (Expression {env; in_subst = false}) ty1 ty2
 
 let unify_pairs env ty1 ty2 pairs =
   with_univar_pairs pairs (fun () ->

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -106,12 +106,12 @@ module Stdlib = struct
   module List = struct
     include Stdlib.List
 
-    let rec fold_left4 f accu l1 l2 l3 l4 =
-      match (l1, l2, l3, l4) with
-        ([], [], [], []) -> accu
-      | (a1::l1, a2::l2, a3::l3, a4::l4) ->
-          fold_left4 f (f accu a1 a2 a3 a4) l1 l2 l3 l4
-      | (_, _, _, _) -> invalid_arg "List.fold_left4"
+    let rec fold_left3 f accu l1 l2 l3 =
+      match (l1, l2, l3) with
+        ([], [], []) -> accu
+      | (a1::l1, a2::l2, a3::l3) ->
+          fold_left3 f (f accu a1 a2 a3) l1 l2 l3
+      | (_, _, _) -> invalid_arg "List.fold_left3"
 
     let rec compare cmp l1 l2 =
       match l1, l2 with
@@ -147,6 +147,13 @@ module Stdlib = struct
       | (_, _) -> raise (Invalid_argument "iteri2")
 
     let iteri2 f l1 l2 = iteri2 0 f l1 l2
+
+    let rec rev_iter f l =
+      match l with
+      | [] -> ()
+      | x :: xs ->
+          rev_iter f xs;
+          f x
 
     let some_if_all_elements_are_some l =
       let rec aux acc l =
@@ -207,6 +214,7 @@ module Stdlib = struct
           }
       in
       find_prefix ~longest_common_prefix_rev:[] first second
+
   end
 
   module Option = struct

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -116,13 +116,12 @@ module Stdlib : sig
   module List : sig
     include module type of struct include List end
 
-    val fold_left4
-      :  ('acc -> 'a0 -> 'a1 -> 'a2 -> 'a3 -> 'acc)
+    val fold_left3
+      :  ('acc -> 'a0 -> 'a1 -> 'a2 -> 'acc)
       -> 'acc
       -> 'a0 list
       -> 'a1 list
       -> 'a2 list
-      -> 'a3 list
       -> 'acc
 
     val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
@@ -146,6 +145,8 @@ module Stdlib : sig
     val iteri2 : (int -> 'a -> 'b -> unit) -> 'a list -> 'b list -> unit
     (** Same as {!List.iter2}, but the function is applied to the index of
         the element as first argument (counting from 0) *)
+
+    val rev_iter : ('a -> unit) -> 'a list -> unit
 
     val split_at : int -> 'a t -> 'a t * 'a t
     (** [split_at n l] returns the pair [before, after] where [before] is


### PR DESCRIPTION
#14897 reported a performance issue in js_of_ocaml due to keep-expansion (#11648).
It seems that a lot of the time is spent doing the occurs check while expanding the large object types to a form that can eventually be handled.

This PR elides the occurs check for the first variable argument of a type constructor, which should be safe, since this variable cannot yet appear in the argument, since it was freshly created. Subsequent parameters need to be dealt with through normal unification with the occurs check, because we don't attempt to check that it is safe (for example, constraints mean that we require the occurs-check).


On the file in #14897, runtime of the compiler is reduced from 5 minutes to 5 seconds

