### PR TITLE
Fix installation in opam with invalid `OCAMLTOP_INCLUDE_PATH`

### DIFF
--- a/Changes
+++ b/Changes
@@ -494,6 +494,9 @@ OCaml 5.5.1
   ````
   (Florian Angeletti, report by Hazem ElMasry, review by Gabriel Scherer)
 
+- #14871, #14914: Ignore OCAMLTOP_INCLUDE_PATH during the build.
+  (David Allsopp, report by Andreas Rossberg, review by Florian Angeletti)
+
 - #14940, fix a memory leak in the OCaml runtime by bounding the size
   of the internal cache of stacks.
   (Vesa Karvonen, Florian Angeletti, review by Gabriel Scherer)

--- a/Makefile.common
+++ b/Makefile.common
@@ -871,3 +871,9 @@ export CYGWIN := $(strip \
 export MSYS := $(strip \
   $(filter-out winsymlinks winsymlinks:%, $(MSYS)) winsymlinks:nativestrict)
 endif
+
+# Invocations of the compilers during the build use -nostdlib which ensures that
+# existing installations and the OCAMLLIB/CAMLLIB environment variables don't
+# affect the build. There isn't an equivalent flag for the toplevel's
+# OCAMLTOP_INCLUDE_PATH, so it's scrubbed from the environment instead.
+unexport OCAMLTOP_INCLUDE_PATH


### PR DESCRIPTION
There is a series of things going wrong in #14871 where fixing any one of them actually solves the problem observed. This is the simplest fix, which I think is the most appropriate for 5.5.1.

When we invoke the compiler during the build, we use `-nostdlib` to ensure that the compiler doesn't attempt to read files already installed in the installation prefix (and this also ignores `OCAMLLIB` in the environment).

#14246 added tools/opam/generate.ml which is executed using the toplevel (`./ocaml`) and this also receives `-nostdlib`. However, there is another source of paths from the environment in `OCAMLTOP_INCLUDE_PATH` and this should be ignored too.

My assistant informs me that GNU make's `unexport` is very old, in particular older than the `undefine` which is annoyingly absent on macOS's ancient GNU make.