### PR TITLE
Sanitize the build environment

### DIFF
--- a/Changes
+++ b/Changes
@@ -421,6 +421,10 @@ Working version
   (Austin Thierault, review by Antonin Décimo, Edwin Török, David Allsopp and
    Olivier Nicole)
 
+- #14915: Remove OCaml's environment variables (CAML_LD_LIBRARY_PATH, etc.) from
+  the build environment.
+  (David Allsopp, review by Antonin Décimo)
+
 ### Bug fixes:
 
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an

--- a/Makefile.common
+++ b/Makefile.common
@@ -872,8 +872,18 @@ export MSYS := $(strip \
   $(filter-out winsymlinks winsymlinks:%, $(MSYS)) winsymlinks:nativestrict)
 endif
 
-# Invocations of the compilers during the build use -nostdlib which ensures that
-# existing installations and the OCAMLLIB/CAMLLIB environment variables don't
-# affect the build. There isn't an equivalent flag for the toplevel's
-# OCAMLTOP_INCLUDE_PATH, so it's scrubbed from the environment instead.
+# Sanitize the build environment from any of our environment variables which may
+# interfere with the build. See the list in testsuite/tools/environment.ml
+unexport CAML_DEBUG_FILE
+unexport CAML_LD_LIBRARY_PATH
+unexport CAMLLIB
+unexport CAMLRUNPARAM
+unexport CAMLSIGPIPE
+unexport OCAML_RUNTIME_EVENTS_DIR
+unexport OCAML_RUNTIME_EVENTS_PRESERVE
+unexport OCAML_RUNTIME_EVENTS_START
+unexport OCAMLLIB
+unexport OCAMLPARAM
+unexport OCAMLPROF_DUMP
+unexport OCAMLRUNPARAM
 unexport OCAMLTOP_INCLUDE_PATH


### PR DESCRIPTION
A further extension of the quick fix in #14914 ~~(which this PR sits on top of)~~.

This takes the list of environment variables already scrubbed by testsuite/tools/environment.ml during test-in-prefix runs and removes from the build environment.

I'm not sure that we necessarily want to remove `OCAMLPARAM` and `OCAMLRUNPARAM`, as these allow things to be injected into the build on purpose. I'm curious to know if that's actually done for release, though, or perhaps whether these could be preserved only for development builds? (but I haven't yet gone to much trouble to check)