### PR TITLE
Harden treatment of `:` as a separator on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -212,6 +212,11 @@ Working version
   Ulugbek Abdullaev, Hezekiah M. Carty, Simon Cruanes, Daniel Bünzli, Yotam
   Barnoy, Michael Hendricks and Léo Andrès)
 
+* #14916: On Windows, the Filename functions only treat colon strictly as drive
+  separator. Previously it was treated as a directory separator in more places
+  than intuition might suggest, when presented with unusual filenames.
+  (David Allsopp, review by Nicolás Ojeda Bär and Antonin Décimo)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -120,7 +120,9 @@ module Win32 : SYSDEPS = struct
   let current_dir_name = "."
   let parent_dir_name = ".."
   let dir_sep = "\\"
-  let is_dir_sep s i = let c = s.[i] in c = '/' || c = '\\' || c = ':'
+  let is_dir_sep s i =
+    let c = s.[i] in
+    c = '/' || c = '\\' || c = ':' && i = 1
   let is_relative n =
     (String.length n < 1 || n.[0] <> '/')
     && (String.length n < 1 || n.[0] <> '\\')


### PR DESCRIPTION
#14871 reveals that `Filename.concat "C:\\Foo:" "bar"` is presently `C:\Foo:bar`. That is a valid filename, but it's not a particularly reasonable output from `Filename.concat`.

There are various things still wrong with corner and parasitic cases in `Filename` where Windows paths are concerned. I don't propose fixing them all now, but the proposal in this PR - to treat `:` as strictly a volume separator - does make the treatment of the valid `C:\Devel\hello.txt::$DATA` somewhat more logical. In particular, while I'm not sure exactly what `Filename.basename "C:\\Devel\\hello.txt::$DATA"` should be, I'm very sure that `Filename.dirname "C:\\Devel\\hello.txt::$DATA"` should _not_ be `C:\Devel\hello.txt` and this PR makes it `C:\Devel` and I think that the `hello.txt::$DATA` is a slightly more reasonable `basename`.

It also makes `Filename.concat "C:\\Foo:" "bar"` the somewhat less surprising `C:\Foo:\bar`.