### PR TITLE
Use `GetFileAttributes` instead of `stat_os` for Sys primitives on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -106,6 +106,11 @@ Working version
   stack size when creating a thread
   (Jeanne Pottier, review by Antonin Décimo, request by Nathan Taylor)
 
+- #14919: Use GetFileAttributes instead of stat_os to implement Sys.file_exists
+  on Windows, avoiding at least one instance of a kernel bug in the
+  GetFileInformationByName call underpinning the CRT's stat implementation.
+  (David Allsopp, review by Nicolás Ojeda Bär and Antonin Décimo)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -17,6 +17,7 @@
 
 /* Basic system calls */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -275,7 +276,24 @@ static int caml_sys_file_mode(value name)
   if (! caml_string_is_c_safe(name)) { errno = ENOENT; return -1; }
   p = caml_stat_strdup_to_os(String_val(name));
   caml_enter_blocking_section();
+#ifdef _WIN32
+  /* GetFileAttributes and stat() both return the same value on error */
+  static_assert(INVALID_FILE_ATTRIBUTES == ((DWORD)-1), "");
+  /* stat_os continues to be hilariously unreliable on Windows. On Windows 11,
+     GetFileInformationByName is used to implement _wstati64 more quickly than
+     using GetFileInformationByHandleEx. However, GetFileAttributes also doesn't
+     require the file to be opened, so we choose to stick with the
+     tried-and-tested, hopefully hitting fewer kernel bugs in the process. */
+  ret = GetFileAttributes(p);
+  if (ret == INVALID_FILE_ATTRIBUTES)
+    errno = caml_posixerr_of_win32err(GetLastError());
+  else if (ret & FILE_ATTRIBUTE_DIRECTORY)
+    st.st_mode = _S_IFDIR | _S_IEXEC;
+  else
+    st.st_mode = _S_IFREG;
+#else
   ret = stat_os(p, &st);
+#endif
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) return -1; else return st.st_mode;


### PR DESCRIPTION
On my 26200.8655 Windows system at the moment, I create a directory `C:\Users\DRA\AppData\Local\Temp\repro`:

```
OCaml version 5.6.0+dev0-2026-01-26
Enter #help;; for help.

# Sys.file_exists "C:\\Users\\DRA\\AppData\\Local\\Temp\\repro:xxx";;
- : bool = true
```

Strange - there is definitely no alternate data stream for that directory called `xxx`. Stranger:

```
# Sys.chdir "C:\\Users\\DRA\\AppData\\Local\\Temp\\repro";;
- : unit = ()
# Sys.file_exists "C:\\Users\\DRA\\AppData\\Local\\Temp\\repro:xxx";;
- : bool = false
```

That's right - change the cwd (or in another process) and the result of `Sys.file_exists` toggles to the correct value. Change back:

```
# Sys.chdir "C:\\";;
- : unit = ()
# Sys.file_exists "C:\\Users\\DRA\\AppData\\Local\\Temp\\repro:xxx";;
- : bool = true
```

and it switches again. In https://github.com/ocaml/ocaml/issues/14871#issuecomment-4892058464, I reference the results of a gist which boils this down to an issue in [GetFileInformationByName](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfileinformationbyname), which is used since Windows 11 24H2 to implement parts of `stat` in a single kernel call (the older approach is to open the file and use `GetFileInformationByHandleEx`). The Windows kernel bug is being a bit of a heisenbug, but it looks to me like it might have been introduced in May with 26200.8457. That feels consistent, given that the original trigger (https://github.com/ocaml/opam/issues/6456) has been known for a while, and given that when this triggers it effectively disables the interpreter, it's surprising there's not been more noise (even with an older compiler, I'd expect the `ocaml` package - which also runs an OCaml script - to encounter this).

Call me old-fashioned, but I prefer functions that actually work to functions that are meant to be fast.

In #462, runtime/sys.c was of course left alone because the reimplementation of `stat` lives in the Unix library. The use of `stat` for `Sys.file_exists` has always been using a sledgehammer to crack a nut, so this PR finally takes the plunge in the runtime and switches to use the venerable [`GetFileAttributes`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesw).

On the implementation, my reasoning goes:
1. If `caml_sys_file_mode` were moved to runtime/{unix,win32}.c, it becomes a public function and would need a fuller implementation on Windows, creating duplication between otherlibs/unix/stat\_win32.c
2. If instead `caml_sys_file_exists` and `caml_sys_is_directory` were likewise moved, the shared logic (path-checking, etc.) would be duplicated and in two separate files, which is bad
3. runtime/sys.c already has various small bits of `#ifdef _WIN32`

I concluded that putting OS-specific stuff in runtime/{unix,win32}.c is more what you'd call 'guidelines' than actual rules, and opted to emulate just enough of `st_mode` locally in runtime/sys.c. However, I'm quite happy to be dissuaded.