### PR TITLE
Small build fixes, found on Cygwin

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -635,7 +635,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 WORKDIR /mnt
 ENTRYPOINT ["tools/autogen"]
 EOF
-git rebase trunk --exec "docker run --rm -it -v $PWD:/mnt ocaml-make-configure:latest"
+git rebase trunk --exec "docker run --rm --user $(id -u):$(id -g) -it -v $PWD:/mnt ocaml-make-configure:latest"
 ----
 
 ==== GitHub's Continuous Integration: GitHub Actions and AppVeyor

--- a/configure
+++ b/configure
@@ -16082,7 +16082,7 @@ esac
 
 # Require Windows 8 / Server 2012 or later
 case $target in #(
-  *-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
     internal_cppflags="$internal_cppflags -D_WIN32_WINNT=0x602" ;; #(
   *) :
      ;;

--- a/configure
+++ b/configure
@@ -673,7 +673,7 @@ PACKAGE_TARNAME='ocaml'
 PACKAGE_VERSION='5.6.0+dev0-2026-01-26'
 PACKAGE_STRING='OCaml 5.6.0+dev0-2026-01-26'
 PACKAGE_BUGREPORT='caml-list@inria.fr'
-PACKAGE_URL='http://www.ocaml.org'
+PACKAGE_URL='https://ocaml.org/'
 
 ac_unique_file="runtime/interp.c"
 # Factoring default headers for most tests.
@@ -1865,7 +1865,7 @@ Use these variables to override the choices made by 'configure' or to help
 it to find libraries and programs with nonstandard names/locations.
 
 Report bugs to <caml-list@inria.fr>.
-OCaml home page: <http://www.ocaml.org>.
+OCaml home page: <https://ocaml.org/>.
 _ACEOF
 ac_status=$?
 fi
@@ -26219,7 +26219,7 @@ Configuration commands:
 $config_commands
 
 Report bugs to <caml-list@inria.fr>.
-OCaml home page: <http://www.ocaml.org>."
+OCaml home page: <https://ocaml.org/>."
 
 _ACEOF
 ac_cs_config=`printf "%s\n" "$ac_configure_args" | sed "$ac_safe_unquote"`

--- a/configure
+++ b/configure
@@ -24901,8 +24901,12 @@ fi
 
   test -n "$DIFF" && break
 done
-test -n "$DIFF" || DIFF="as_fn_error $? "ocamltest requires a diff tool" "$LINENO" 5"
+test -n "$DIFF" || DIFF="false"
 
+  if test x"$DIFF" = "xfalse"
+then :
+  as_fn_error $? "ocamltest requires a diff tool" "$LINENO" 5
+fi
   case $DIFF in #(
   diff) :
     flags_to_test='--strip-trailing-cr -u' ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_INIT([OCaml],
         [OCAML__VERSION],
         [caml-list@inria.fr],
         [ocaml],
-        [http://www.ocaml.org])
+        [https://ocaml.org/])
 
 AC_MSG_NOTICE([Configuring OCaml version AC_PACKAGE_VERSION])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1197,7 +1197,7 @@ AS_CASE([$target],
 
 # Require Windows 8 / Server 2012 or later
 AS_CASE([$target],
-  [*-w64-mingw32*|*-pc-windows],
+  [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
     [internal_cppflags="$internal_cppflags -D_WIN32_WINNT=0x602"])
 
 # Adjust according to target

--- a/configure.ac
+++ b/configure.ac
@@ -2932,7 +2932,8 @@ AS_IF([$build_ocamltest],
   AC_CONFIG_LINKS([
     ocamltest/ocamltest_unix.ml:${ocamltest_unix_mod}
   ])
-  AC_CHECK_PROGS([DIFF], [patdiff diff],
+  AC_CHECK_PROGS([DIFF], [patdiff diff], [false])
+  AS_IF([test x"$DIFF" = "xfalse"],
     [AC_MSG_ERROR([ocamltest requires a diff tool])])
   AS_CASE([$DIFF], [diff], [flags_to_test='--strip-trailing-cr -u'])
   AC_CACHE_CHECK([for extra $DIFF flags],

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #endif
 #ifdef __CYGWIN__
-#include </usr/include/io.h>
+#include <io.h>
 #endif
 #include "caml/alloc.h"
 #include "caml/camlatomic.h"


### PR DESCRIPTION
- ~doc: Ubuntu 26.04 has migrated to Autoconf 2.72, GHA has not
  I use this Dockerfile when my host system has moved on to newer Autotools and I still need to satisfy the hygiene CI when regenerating the configure script.~ (merged in #14926).
- configure: fix use of [`AC_CHECK_PROGS`](https://www.gnu.org/software/autoconf/manual/autoconf-2.71/autoconf.html#index-AC_005fCHECK_005fPROGS-1) when no diff tool is found
  The parameters of the macro are:
  ```
  AC_CHECK_PROGS(variable, progs-to-check-for, [value-if-not-found], [path = '$PATH'])
  ```
  It would error otherwise with a snippet of code in place of a message.
  Fixes de89a501b8cfea3b069d17ff077801bb0c3868c5 in #13705 (mine).
- configure: Cygwin targets also need `_WIN32_WINNT=0x602`
  The build of ocamltest is broken on Cygwin without this patch. Odd that this wasn't caught.
  It is possible for Cygwin programs to call the Win32 API, and [ocamltest does just that](https://github.com/ocaml/ocaml/blob/e53a032298229338268c3dc3640214e1fa710c95/ocamltest/run_stubs.c#L129). The macro is needed to get the definition of [`GetTokenInformation`](https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation).
  Follow-up of #14484 (also mine).
- cygwin: use relative instead of absolute include path to `<io.h>`
  Useful if one were to try a C cross-compiler for a Cygwin target. (but who would do that)