### PR TITLE
arm64: use a store-release `stlr` instead of `dmb ishld; str` by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -184,6 +184,13 @@ Working version
   code independent of the number of linked modules.
   (Pierre Oechsel and Tim McGilchrist, review by Stefan Muenzel)
 
+- #13262, #14922: On arm64, use a store-release (`stlr`, or `stlur` when
+  FEAT_LRCPC2 is available) instead of `dmb ishld; str` for the memory barrier
+  following a mutable-field assignment.  A few old cores
+  (Cortex-A53/-A57/-A72/-A73) are slower with a release store and keep the
+  barrier; the default is chosen at configure time and can be overridden.
+  (Sebastian Pop and Xavier Leroy, review by Olivier Nicole)
+
 ### Standard library:
 
 - #10798: Atomic helper function

--- a/Changes
+++ b/Changes
@@ -189,7 +189,7 @@ Working version
   following a mutable-field assignment.  A few old cores
   (Cortex-A53/-A57/-A72/-A73) are slower with a release store and keep the
   barrier; the default is chosen at configure time and can be overridden.
-  (Sebastian Pop and Xavier Leroy, review by Olivier Nicole)
+  (Sebastian Pop and Xavier Leroy, review by Xavier Leroy and Olivier Nicole)
 
 ### Standard library:
 

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -26,9 +26,34 @@ let freebsd = (Config.system = "freebsd")
 
 let top_bits_ignore = (Config.system = "linux")
 
+(* Store-ordering strategy for the multicore memory-model barrier that
+   precedes a non-initializing store to a mutable field or array element.
+
+   By default this is a store-release [stlr], which gives the required
+   load->store ordering in a single instruction; with FEAT_LRCPC2 it becomes
+   [stlur] (a store-release with an unscaled immediate offset, avoiding an
+   address computation).  A few old cores (e.g. Cortex-A53, Cortex-A72) are
+   slower with a release store and instead use a [dmb ishld; str] barrier.
+
+   [configure] selects the default through [Config.model]: "lrcpc2" enables
+   stlur, "arm64_barrier" selects the barrier, anything else uses stlr.  The
+   defaults can be overridden on the command line. *)
+let store_release = ref (Config.model <> "arm64_barrier")
+let lrcpc2 = ref (Config.model = "lrcpc2")
+
 (* Machine-specific command-line options *)
 
-let command_line_options = []
+let command_line_options =
+  [ "-flrcpc2", Arg.Set lrcpc2,
+    " Use FEAT_LRCPC2 store-release with unscaled offset (stlur) for \
+     assignment stores (requires an Armv8.4+ assembler)";
+    "-fno-lrcpc2", Arg.Clear lrcpc2,
+    " Do not use FEAT_LRCPC2 stlur";
+    "-fbarrier-store", Arg.Clear store_release,
+    " Use a dmb ishld; str barrier instead of a store-release for \
+     assignment stores (faster on some old cores)";
+    "-fstore-release", Arg.Set store_release,
+    " Use a store-release (stlr/stlur) for assignment stores (default)" ]
 
 (* Addressing modes *)
 

--- a/asmcomp/arm64/arch.mli
+++ b/asmcomp/arm64/arch.mli
@@ -23,6 +23,13 @@ val freebsd : bool
 
 val top_bits_ignore : bool
 
+(* Use a store-release (stlr/stlur) for the assignment memory-model barrier
+   instead of dmb ishld; str. *)
+val store_release : bool ref
+
+(* FEAT_LRCPC2: use store-release with an unscaled immediate offset (stlur). *)
+val lrcpc2 : bool ref
+
 (* Machine-specific command-line options *)
 
 val command_line_options : (string * Arg.spec * string) list

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -486,10 +486,20 @@ module Size = struct
         | Iindexed _ -> 0
         | Ibased _ -> 1
       and pre_store =
-        match memory_chunk, assignment, macosx, addressing_mode with
-        | (Word_int | Word_val), true, true, Iindexed 0 -> 0
-        | (Word_int | Word_val), true, true, Iindexed n -> addsub_size n (* Compute dest address *)
-        | (Word_int | Word_val), true, false, _ -> 1 (* Barrier instruction *)
+        (* Matches the emission below.  With a store-release (the default:
+           stlr, or stlur under -flrcpc2) an Iindexed assignment word store
+           needs no prefix (stlur / stlr [base]) or just an add (stlr with a
+           nonzero offset).  Ibased assignments, and the -fbarrier-store path,
+           keep the [dmb ishld; str] barrier. *)
+        match memory_chunk, assignment, addressing_mode with
+        | (Word_int | Word_val), true, Iindexed n
+          when !store_release && !lrcpc2 && n >= -256 && n <= 255 ->
+          0 (* stlur, no addr calc *)
+        | (Word_int | Word_val), true, Iindexed 0 when !store_release ->
+          0 (* stlr [base] *)
+        | (Word_int | Word_val), true, Iindexed n when !store_release ->
+          addsub_size n (* add; stlr *)
+        | (Word_int | Word_val), true, _ -> 1 (* dmb ishld barrier *)
         | _ -> 0
       and store = match memory_chunk with Single -> 2 | _ -> 1 in
       based + pre_store + store
@@ -688,14 +698,17 @@ let name_for_float_comparison = function
    Since [stlr] does not support addressing modes, we compute [base + addr]
    explicitly. *)
 let emit_stlr src base addr =
-  assert macosx;
-  let dest_reg =
-    match addr with
-    | Iindexed 0 -> base
-    | Iindexed ofs -> emit_addimm reg_tmp1 base ofs; reg_tmp1
-    | Ibased _ -> assert false (* Ibased is not emitted under macOS *)
-  in
-  `	stlr	{emit_reg src}, [{emit_reg dest_reg}]\n`
+  match addr with
+  | Iindexed ofs when !lrcpc2 && ofs >= -256 && ofs <= 255 ->
+      (* FEAT_LRCPC2: store-release with an unscaled immediate offset, so no
+         separate address computation is needed. *)
+      `	stlur	{emit_reg src}, [{emit_reg base}, #{emit_int ofs}]\n`
+  | Iindexed 0 ->
+      `	stlr	{emit_reg src}, [{emit_reg base}]\n`
+  | Iindexed ofs ->
+      emit_addimm reg_tmp1 base ofs;
+      `	stlr	{emit_reg src}, [{emit_reg reg_tmp1}]\n`
+  | Ibased _ -> assert false (* Ibased keeps the barrier form; see below *)
 
 (* Output the assembly code for an instruction *)
 let emit_instr env i =
@@ -861,16 +874,28 @@ let emit_instr env i =
         | Sixtyfour ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         | Word_int | Word_val ->
-            begin match assignment, macosx with
-            | true, true ->
-                (* Release store for assignments on macOS. See
-                   https://github.com/ocaml/ocaml/issues/13262. *)
-                emit_stlr src base addr
-            | true, false ->
-                (* Memory model barrier for assignments. *)
-                `	dmb	ishld\n`;
-                `	str	{emit_reg src}, {emit_addressing addr base}\n`
-            | _, _ ->
+            begin match assignment with
+            | true ->
+                (* A non-initializing store to a mutable field or array element
+                   needs a load->store barrier for the multicore memory model.
+                   By default emit it as a store-release [stlr] (or [stlur]
+                   under -flrcpc2): this gives the required ordering in a
+                   single instruction and is much cheaper than a standalone
+                   [dmb ishld] on modern cores (see
+                   https://github.com/ocaml/ocaml/issues/13262).  [stlr]
+                   requires natural alignment (guaranteed here: unaligned
+                   64-bit stores use the [Sixtyfour] chunk) and a bare base
+                   register, so [Ibased] (statically-allocated mutable data)
+                   keeps the barrier form.  A few old cores (e.g. Cortex-A53,
+                   Cortex-A72) are faster with [dmb ishld; str] and select it
+                   via -fbarrier-store / configure. *)
+                begin match !store_release, addr with
+                | true, Iindexed _ -> emit_stlr src base addr
+                | _, _ ->
+                    `	dmb	ishld\n`;
+                    `	str	{emit_reg src}, {emit_addressing addr base}\n`
+                end
+            | false ->
                 (* Initializing store *)
                 `	str	{emit_reg src}, {emit_addressing addr base}\n`
             end
@@ -1254,6 +1279,9 @@ let data l =
 let begin_assembly() =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
+  (* [stlur] (enabled by -flrcpc2) needs an Armv8.4 assembler; macOS's
+     assembler already accepts it. *)
+  if !lrcpc2 && not macosx then `	.arch	armv8.4-a\n`;
   let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   `	.data\n`;
   `	.globl	{emit_symbol lbl_begin}\n`;

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -489,8 +489,8 @@ module Size = struct
         (* Matches the emission below.  With a store-release (the default:
            stlr, or stlur under -flrcpc2) an Iindexed assignment word store
            needs no prefix (stlur / stlr [base]) or just an add (stlr with a
-           nonzero offset).  Ibased assignments, and the -fbarrier-store path,
-           keep the [dmb ishld; str] barrier. *)
+           nonzero offset).  The -fbarrier-store path keeps the
+           [dmb ishld; str] barrier. *)
         match memory_chunk, assignment, addressing_mode with
         | (Word_int | Word_val), true, Iindexed n
           when !store_release && !lrcpc2 && n >= -256 && n <= 255 ->
@@ -499,6 +499,8 @@ module Size = struct
           0 (* stlr [base] *)
         | (Word_int | Word_val), true, Iindexed n when !store_release ->
           addsub_size n (* add; stlr *)
+        | (Word_int | Word_val), true, Ibased _ when !store_release ->
+          1 (* add :lo12: ; stlr *)
         | (Word_int | Word_val), true, _ -> 1 (* dmb ishld barrier *)
         | _ -> 0
       and store = match memory_chunk with Single -> 2 | _ -> 1 in
@@ -696,7 +698,9 @@ let name_for_float_comparison = function
 
 (* Output a release store [stlr] of register [src] at address [base + addr].
    Since [stlr] does not support addressing modes, we compute [base + addr]
-   explicitly. *)
+   explicitly.  We can also use [stlur] if supported to avoid the
+   [base + addr] computation in some case. *)
+
 let emit_stlr src base addr =
   match addr with
   | Iindexed ofs when !lrcpc2 && ofs >= -256 && ofs <= 255 ->
@@ -708,7 +712,32 @@ let emit_stlr src base addr =
   | Iindexed ofs ->
       emit_addimm reg_tmp1 base ofs;
       `	stlr	{emit_reg src}, [{emit_reg reg_tmp1}]\n`
-  | Ibased _ -> assert false (* Ibased keeps the barrier form; see below *)
+  | Ibased(s, ofs) ->
+      assert (not !Clflags.dlcode);  (* see selection.ml *)
+      (* [base] contains the high bits of [s + ofs], produced by [adrp] *)
+      `	add	{emit_reg reg_tmp1}, {emit_reg base}, #:lo12:{emit_symbol_offset s ofs}\n`;
+      `	stlr	{emit_reg src}, [{emit_reg reg_tmp1}]\n`
+
+(* Output a store of register [src] at address [base + addr], including
+   a load->store barrier, as required by the multicore memory model
+   for a non-initializing store to a mutable field or array element.
+   By default, emit it as a store-release [stlr] (or [stlur] under -flrcpc2):
+   this gives the required ordering in a single instruction
+   and is much cheaper than a standalone [dmb ishld] on modern cores
+   (see https://github.com/ocaml/ocaml/issues/13262).
+   [stlr] requires natural alignment, which is guaranteed for stores of
+   [Word_int] or [Word_val] chunks.  (Unaligned 64-bit stores use the
+   [Sixtyfour] chunk and need no barrier.)
+   A few old cores (e.g. Cortex-A53, Cortex-A72) are faster with
+   [dmb ishld; str] and select it via -fbarrier-store / configure. *)
+
+let emit_store_word_with_barrier src base addr =
+  if !store_release then
+    emit_stlr src base addr
+  else begin
+    `	dmb	ishld\n`;
+    `	str	{emit_reg src}, {emit_addressing addr base}\n`
+  end
 
 (* Output the assembly code for an instruction *)
 let emit_instr env i =
@@ -874,31 +903,13 @@ let emit_instr env i =
         | Sixtyfour ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         | Word_int | Word_val ->
-            begin match assignment with
-            | true ->
-                (* A non-initializing store to a mutable field or array element
-                   needs a load->store barrier for the multicore memory model.
-                   By default emit it as a store-release [stlr] (or [stlur]
-                   under -flrcpc2): this gives the required ordering in a
-                   single instruction and is much cheaper than a standalone
-                   [dmb ishld] on modern cores (see
-                   https://github.com/ocaml/ocaml/issues/13262).  [stlr]
-                   requires natural alignment (guaranteed here: unaligned
-                   64-bit stores use the [Sixtyfour] chunk) and a bare base
-                   register, so [Ibased] (statically-allocated mutable data)
-                   keeps the barrier form.  A few old cores (e.g. Cortex-A53,
-                   Cortex-A72) are faster with [dmb ishld; str] and select it
-                   via -fbarrier-store / configure. *)
-                begin match !store_release, addr with
-                | true, Iindexed _ -> emit_stlr src base addr
-                | _, _ ->
-                    `	dmb	ishld\n`;
-                    `	str	{emit_reg src}, {emit_addressing addr base}\n`
-                end
-            | false ->
-                (* Initializing store *)
-                `	str	{emit_reg src}, {emit_addressing addr base}\n`
-            end
+            if assignment then
+              (* Non-initializing store to a mutable field or array element.
+                 Needs a load->store barrier for the multicore memory model. *)
+              emit_store_word_with_barrier src base addr
+            else
+              (* Initializing store.  No barrier needed *)
+              `	str	{emit_reg src}, {emit_addressing addr base}\n`
         | Double ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         end

--- a/configure
+++ b/configure
@@ -19141,6 +19141,60 @@ fi ;; #(
      ;;
 esac
 
+# On arm64, choose how the multicore memory-model barrier that precedes a
+# non-initializing store to a mutable field/element is emitted (see
+# https://github.com/ocaml/ocaml/issues/13262).  The default is a
+# store-release (stlr).  If FEAT_LRCPC2 is available we use stlur (a
+# store-release with an unscaled offset, saving an address computation).  A
+# few old cores (Cortex-A53/-A57/-A72/-A73) are slower with a release store,
+# so we keep the dmb ishld; str barrier on them.  This is a build-host
+# heuristic (like the arm32 arch/fpu default) and can be overridden with
+# ocamlopt's -flrcpc2 / -fno-lrcpc2 / -fbarrier-store / -fstore-release.
+if test x"$arch" = "xarm64"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking arm64 store for the assignment memory barrier" >&5
+printf %s "checking arm64 store for the assignment memory barrier... " >&6; }
+   if test "$cross_compiling" = yes
+then :
+  ocaml_arm64_store="stlr (store-release, cross-compiling)"
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+        volatile long dst = 0;
+        long src = 1;
+        __asm__ __volatile__(".arch armv8.4-a\n\tstlur %0, [%1, #0]"
+          : : "r" (src), "r" (&dst) : "memory");
+        return dst == 1 ? 0 : 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  model=lrcpc2; ocaml_arm64_store="stlur (FEAT_LRCPC2)"
+else $as_nop
+  if test -r /proc/cpuinfo &&
+         grep -Eq 'CPU part.*(0xd03|0xd04|0xd07|0xd08|0xd09)' /proc/cpuinfo
+then :
+  model=arm64_barrier; ocaml_arm64_store="dmb ishld; str (old core)"
+else $as_nop
+  ocaml_arm64_store="stlr (store-release)"
+fi
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_arm64_store" >&5
+printf "%s\n" "$ocaml_arm64_store" >&6; }
+fi
+
 case $arch in #(
   amd64) :
     arch_specific_SOURCES='$(intel_SOURCES)' ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -1779,6 +1779,34 @@ AS_CASE([$target],
     [has_native_backend=yes; arch=amd64; system=none]
 )
 
+# On arm64, choose how the multicore memory-model barrier that precedes a
+# non-initializing store to a mutable field/element is emitted (see
+# https://github.com/ocaml/ocaml/issues/13262).  The default is a
+# store-release (stlr).  If FEAT_LRCPC2 is available we use stlur (a
+# store-release with an unscaled offset, saving an address computation).  A
+# few old cores (Cortex-A53/-A57/-A72/-A73) are slower with a release store,
+# so we keep the dmb ishld; str barrier on them.  This is a build-host
+# heuristic (like the arm32 arch/fpu default) and can be overridden with
+# ocamlopt's -flrcpc2 / -fno-lrcpc2 / -fbarrier-store / -fstore-release.
+AS_IF([test x"$arch" = "xarm64"],
+  [AC_MSG_CHECKING([arm64 store for the assignment memory barrier])
+   AC_RUN_IFELSE(
+     [AC_LANG_PROGRAM([], [[
+        volatile long dst = 0;
+        long src = 1;
+        __asm__ __volatile__(".arch armv8.4-a\n\tstlur %0, [%1, #0]"
+          : : "r" (src), "r" (&dst) : "memory");
+        return dst == 1 ? 0 : 1;
+      ]])],
+     [model=lrcpc2; ocaml_arm64_store="stlur (FEAT_LRCPC2)"],
+     [AS_IF(
+        [test -r /proc/cpuinfo &&
+         grep -Eq 'CPU part.*(0xd03|0xd04|0xd07|0xd08|0xd09)' /proc/cpuinfo],
+        [model=arm64_barrier; ocaml_arm64_store="dmb ishld; str (old core)"],
+        [ocaml_arm64_store="stlr (store-release)"])],
+     [ocaml_arm64_store="stlr (store-release, cross-compiling)"])
+   AC_MSG_RESULT([$ocaml_arm64_store])])
+
 AS_CASE([$arch],
   [amd64],
     [arch_specific_SOURCES='$(intel_SOURCES)'],

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -139,26 +139,24 @@
    This fence is here specifically to ensure the correctness of the
    ARMv8 assembly emitted for atomic writes implemented in C such as
    caml_atomic_exchange.
-   The reason we need it is that the ARMv8 emitted by the OCaml compiler
-   is more optimized than what current C compilers emit. We need to
-   ensure that non-atomic stores are ordered after prior atomic
-   operations and non-atomic loads. (More precisely, we need
-   happens-before between operations that synchronise with a prior
-   atomic operator / write to a prior atomic load, and operations that
-   read from this nonatomic store.) The best sequence a C compiler can
-   emit for nonatomic stores, under this constraint, is `dmb ishld;
-   stlr` (in `caml_modify` for instance).
+   The default ARMv8 instruction emitted by the OCaml compiler for a non-atomic
+   store is `stlr`. A few old cores (e.g. Cortex-A53, Cortex-A72) are faster
+   with `dmb ishld; str` and select it via `-fbarrier-store` / configure.
+   We need to ensure that non-atomic stores are ordered after prior atomic
+   operations and non-atomic loads. (More precisely, we need happens-before
+   between operations that synchronise with a prior atomic operator / write to
+   a prior atomic load, and operations that read from this nonatomic store.)
+   `stlr` provides these guarantees.
 
-   The OCaml compiler, on the other hand, emits `dmb ishld; str` with a
-   plain store, while emitting a `dmb ishst` barrier after atomic
-   operations. `dmb ishld` provides ordering with respect to prior reads
-   (covering both nonatomic loads and atomic ones), while `dmb ishst`
-   provides ordering with respect to prior writes. Since we only need
-   the ordering with respect to prior atomic writes, we can place the
-   `dmb ishst` after each atomic write rather than before nonatomic
-   writes. The extra release fence on the C side is here to emit this
+   When non-atomic stores are compiled as `dmb ishld; str`, however, we need to
+   emit a `dmb ishst` barrier after atomic operations. `dmb ishld` provides
+   ordering with respect to prior reads (covering both nonatomic loads and
+   atomic ones), while `dmb ishst` provides ordering with respect to prior
+   writes. Since we only need the ordering with respect to prior atomic writes,
+   we can place the `dmb ishst` after each atomic write rather than before
+   nonatomic writes. The extra release fence on the C side is here to emit this
    `dmb ishst` on ARMv8, in order to provide ordering to the weak `str`
-   instructions emitted by the OCaml compiler.
+   instructions the OCaml compiler may be configured to emit.
 */
 
 /* Note [MMPS]: Publication safety in the memory model.


### PR DESCRIPTION
The multicore memory model needs a load->store barrier before a
non-initializing store to a mutable word field or array element.  On
arm64 this was `dmb ishld; str` on every target except macOS, which uses
a store-release `stlr` (see #13262).

A store-release gives the same load->store ordering in a single
instruction and is much cheaper than a standalone `dmb ishld` on modern
cores, so make it the default for aligned Iindexed assignment word stores
(Word_int / Word_val) on all arm64 targets.  With `FEAT_LRCPC2` the
store-release uses an unscaled immediate offset (`stlur`) for offsets in
the `imm9` range (-256..255), avoiding the address computation `stlr`
otherwise needs.  Ibased addressing (statically-allocated mutable data)
keeps `dmb ishld; str` since a store-release has no symbol addressing.
Unaligned 64-bit stores use the `Sixtyfour` chunk, so `stlr`'s alignment
requirement is met.

A few old cores are slower with a release store than with the barrier:
on Cortex-A53 and Cortex-A72 `stlr` is ~1.4x-1.6x slower than
`dmb ishld; str` (matching the Raspberry Pi 4 report in #13262).  So
configure picks the default per build host: it runs a small `stlur` probe
to detect `FEAT_LRCPC2` (-> `stlur`), reads /proc/cpuinfo to special-case
those old cores (-> `dmb ishld; str`), and otherwise uses `stlr`.  The
choice is carried by Config.model and can be overridden with the new
`-flrcpc2` / `-fno-lrcpc2` / `-fbarrier-store` / `-fstore-release` options.
The GNU assembler is bumped to armv8.4-a when stlur is used (macOS's
assembler already accepts it).  The instr_size estimator matches the
emitted sequences.

Verified: builds/bootstraps and codegen correct on macOS (M3 -> `stlur`)
and Linux/Neoverse (-> `stlur`); configure selects the barrier on Graviton1
(Cortex-A72).  A store/barrier microbenchmark across arm64 cores shows
the release store is ~4x-50x faster on `FEAT_LRCPC2` cores and ~1.4x-1.6x
slower on the old cores it special-cases; data and benchmark at
https://github.com/sebpop/arm64-barriers/tree/more-data.