### PR TITLE
Fix compiler cloning in the opam sandbox on macOS

### DIFF
--- a/Changes
+++ b/Changes
@@ -506,6 +506,11 @@ OCaml 5.5.1
 - #14871, #14914: Ignore OCAMLTOP_INCLUDE_PATH during the build.
   (David Allsopp, report by Andreas Rossberg, review by Florian Angeletti)
 
+- #14901, #14923: Fix the generated installation script to cope with macOS's
+  geriatric version of bash when executing in opam's sandbox.
+  (David Allsopp, report by Julian Fondren and Sacha-Élie Ayoun, investigation
+   and initial fix by Kate Deplaix, review by Florian Angeletti)
+
 - #14940, fix a memory leak in the OCaml runtime by bounding the size
   of the internal cache of stacks.
   (Vesa Karvonen, Florian Angeletti, review by Gabriel Scherer)

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -142,7 +142,7 @@ Install () {
   mkdir -p "share/ocaml"
   cp "$ret/config.status" "$ret/config.cache" "share/ocaml"
   cp "$ret/ocaml-compiler-clone.sh" "share/ocaml/clone"
-  sh $script ~/local/_opam
+  sh $script ~/local/_opam "$PWD"
   cd "$ret"
   rm -rf install
   rm ocaml-compiler-clone.sh

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -142,7 +142,7 @@ Install () {
   mkdir -p "share/ocaml"
   cp "$ret/config.status" "$ret/config.cache" "share/ocaml"
   cp "$ret/ocaml-compiler-clone.sh" "share/ocaml/clone"
-  sh $script ~/local/_opam "$PWD"
+  sh $script "$PWD" ~/local/_opam
   cd "$ret"
   rm -rf install
   rm ocaml-compiler-clone.sh

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -214,8 +214,8 @@ case "$1" in
       cp "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" \
            'destdir/share/ocaml/clone'
       cd destdir
-      sh "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" "$OCAMLROOT/_opam" \
-                                                            "$PWD"
+      sh "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" "$PWD" \
+                                                            "$OCAMLROOT/_opam"
     )
     rm -rf "$OCAMLROOT"
     $MAKE -C "$FULL_BUILD_PREFIX-$PORT" OPAM_PACKAGE_NAME=ocaml-variants \

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -214,7 +214,8 @@ case "$1" in
       cp "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" \
            'destdir/share/ocaml/clone'
       cd destdir
-      sh "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" "$OCAMLROOT/_opam"
+      sh "$FULL_BUILD_PREFIX-$PORT/ocaml-compiler-clone.sh" "$OCAMLROOT/_opam" \
+                                                            "$PWD"
     )
     rm -rf "$OCAMLROOT"
     $MAKE -C "$FULL_BUILD_PREFIX-$PORT" OPAM_PACKAGE_NAME=ocaml-variants \

--- a/tools/opam/generate.ml
+++ b/tools/opam/generate.ml
@@ -81,8 +81,9 @@ let generate_install file =
 (* [process_clone oc process] processes clone-* in the current directory,
    emitting mkdir commands to [oc] and passing the directory name and a channel
    set to the start of each clone file to [process]. The clone files are erased
-   after processing. *)
-let process_clone oc process =
+   after processing. [prefix] is the literal string to place in double-quotes
+   for the installation prefix (either ["$1"] or ["$2"]). *)
+let process_clone oc ~prefix process =
   let process_file file =
     if String.starts_with ~prefix:"clone-" file then begin
       let dir =
@@ -90,7 +91,7 @@ let process_clone oc process =
                    (String.sub file 6 (String.length file - 6))
         |> valid_section
       in
-      output_endline oc {|mkdir -p "$1"'/%s'|} dir;
+      output_endline oc {|mkdir -p "%s"'/%s'|} prefix dir;
       In_channel.with_open_text file @@ process oc dir;
       remove_file file
     end
@@ -99,11 +100,12 @@ let process_clone oc process =
   Array.sort String.compare files;
   Array.iter process_file files
 
-(* [process_symlinks oc ~mkdir] processes create-symlinks, if it exists, writing
-   any required mkdir commands to [oc] if [~mkdir = true] and also the
+(* [process_symlinks oc ~mkdir ~prefix] processes create-symlinks, if it exists,
+   writing any required mkdir commands to [oc] if [mkdir = true] and also the
    appropriate ln / mklink commands. create-symlinks is erased after
-   processing. *)
-let process_symlinks oc ~mkdir =
+   processing. [prefix] is the literal string to place in double-quotes for the
+   installation prefix (either ["$1"] or ["$2"]). *)
+let process_symlinks oc ~mkdir ~prefix =
   let module StringSet = Set.Make(String) in
   let file = "create-symlinks" in
   if Sys.file_exists file then
@@ -118,7 +120,7 @@ let process_symlinks oc ~mkdir =
       In_channel.with_open_text file @@ fun ic ->
         List.rev (In_channel.fold_lines parse [] ic)
     in
-    output_endline oc {|cd "$1"|};
+    output_endline oc {|cd "%s"|} prefix;
     let _ =
       let create_dir seen (dir, _, _) =
         if not (StringSet.mem dir seen) && String.contains dir '/' then
@@ -144,7 +146,7 @@ let process_symlinks oc ~mkdir =
         output_endline oc {|  $CP '%s/%s' '%s/%s'|} dir target dir source
       in
       output_endline oc {|cmd /c "mklink __ln_test mklink-test"|};
-      output_endline oc {|if test -L "$1/__ln_test"; then|};
+      output_endline oc {|if test -L "%s/__ln_test"; then|} prefix;
       List.iter mklink lines;
       output_endline oc {|else|};
       List.iter cp lines;
@@ -165,7 +167,7 @@ let copy_files oc dir =
 
 let clone_files oc dir ic =
   output_endline oc
-    {|src="$2" dest="$1"'/%s' xargs sh "$1/clone-files" <<'EOF'|} dir;
+    {|src="$1" dest="$2"'/%s' xargs sh "$2/clone-files" <<'EOF'|} dir;
   In_channel.fold_lines (fun _ -> output_endline oc "%s") () ic;
   output_endline oc {|EOF|}
 
@@ -176,8 +178,8 @@ let () =
     Out_channel.with_open_bin (package ^ "-fixup.sh") @@ fun oc ->
       output_endline oc {|#!/bin/sh
 set -eu|};
-      process_clone oc copy_files;
-      process_symlinks oc ~mkdir:true
+      process_clone oc ~prefix:"$1" copy_files;
+      process_symlinks oc ~mkdir:true ~prefix:"$1"
   end else begin
     (* Don't pass -p to cp on Windows - it's never going to be relevant (no
        execute bit which needs preserving) and there are scenarios in which it's
@@ -188,22 +190,22 @@ set -eu|};
     Out_channel.with_open_bin (package ^ "-clone.sh") @@ fun oc ->
       output_endline oc {|#!/bin/sh
 set -eu
-mkdir -p "$1"
-rm -f "$1/__cp_test" "$1/__ln_test"
-if cp --reflink=always "$2/doc/ocaml/LICENSE" "$1/__cp_test" 2>/dev/null; then
-  rm -f "$1/__cp_test"
+mkdir -p "$2"
+rm -f "$2/__cp_test" "$2/__ln_test"
+if cp --reflink=always "$1/doc/ocaml/LICENSE" "$2/__cp_test" 2>/dev/null; then
+  rm -f "$2/__cp_test"
   CP='cp --reflink=always -%sf'
-  if ! test -e "$1/clone-files"; then
-    echo 'cd "$src" && '"$CP"' "$@" "$dest/"' > "$1/clone-files"
+  if ! test -e "$2/clone-files"; then
+    echo 'cd "$src" && '"$CP"' "$@" "$dest/"' > "$2/clone-files"
   fi
 else
   CP='cp -%sf'
-  if ! test -e "$1/clone-files"; then
-    if ln -f "$2/doc/ocaml/LICENSE" "$1/__ln_test" 2>/dev/null; then
-      rm -f "$1/__ln_test"
-      echo 'cd "$src" && ln -f "$@" "$dest/"' > "$1/clone-files"
+  if ! test -e "$2/clone-files"; then
+    if ln -f "$1/doc/ocaml/LICENSE" "$2/__ln_test" 2>/dev/null; then
+      rm -f "$2/__ln_test"
+      echo 'cd "$src" && ln -f "$@" "$dest/"' > "$2/clone-files"
     else
-      echo 'cd "$src" && '"$CP"' "$@" "$dest/"' > "$1/clone-files"
+      echo 'cd "$src" && '"$CP"' "$@" "$dest/"' > "$2/clone-files"
     fi
   fi
 fi|} preserve preserve;
@@ -211,12 +213,12 @@ fi|} preserve preserve;
         output_endline oc "share/ocaml/clone";
         if Sys.file_exists "config.cache" then
           output_endline oc "share/ocaml/config.cache");
-      process_clone oc clone_files;
+      process_clone oc ~prefix:"$2" clone_files;
       (*  ld.conf is a configuration file, so is always copied.
           Makefile.config and config.status will both contain the original
           prefix, which must be updated. *)
-      output_endline oc {|cp "$2/lib/ocaml/ld.conf" "$1/lib/ocaml/ld.conf"
-cat > "$1/prefix.awk" <<'ENDAWK'
+      output_endline oc {|cp "$1/lib/ocaml/ld.conf" "$2/lib/ocaml/ld.conf"
+cat > "$2/prefix.awk" <<'ENDAWK'
 {
   rest = $0
   while ((p = index(rest, ENVIRON["O"]))) {
@@ -226,10 +228,10 @@ cat > "$1/prefix.awk" <<'ENDAWK'
   print rest
 }
 ENDAWK
-prefix="$(sed -ne 's/^prefix *= *//p' "$2/lib/ocaml/Makefile.config")"
+prefix="$(sed -ne 's/^prefix *= *//p' "$1/lib/ocaml/Makefile.config")"
 for file in lib/ocaml/Makefile.config share/ocaml/config.status; do
-  O="$prefix" N="$1" awk -f "$1/prefix.awk" "$2/$file" > "$1/$file"
+  O="$prefix" N="$2" awk -f "$2/prefix.awk" "$1/$file" > "$2/$file"
 done
-rm -f "$1/clone-files" "$1/prefix.awk"|};
-      process_symlinks oc ~mkdir:false
+rm -f "$2/clone-files" "$2/prefix.awk"|};
+      process_symlinks oc ~mkdir:false ~prefix:"$2"
   end

--- a/tools/opam/generate.ml
+++ b/tools/opam/generate.ml
@@ -165,7 +165,7 @@ let copy_files oc dir =
 
 let clone_files oc dir ic =
   output_endline oc
-    {|dest="$1"'/%s' xargs sh "$1/clone-files" <<'EOF'|} dir;
+    {|src="$2" dest="$1"'/%s' xargs sh "$1/clone-files" <<'EOF'|} dir;
   In_channel.fold_lines (fun _ -> output_endline oc "%s") () ic;
   output_endline oc {|EOF|}
 
@@ -190,20 +190,20 @@ set -eu|};
 set -eu
 mkdir -p "$1"
 rm -f "$1/__cp_test" "$1/__ln_test"
-if cp --reflink=always doc/ocaml/LICENSE "$1/__cp_test" 2>/dev/null; then
+if cp --reflink=always "$2/doc/ocaml/LICENSE" "$1/__cp_test" 2>/dev/null; then
   rm -f "$1/__cp_test"
   CP='cp --reflink=always -%sf'
   if ! test -e "$1/clone-files"; then
-    echo "$CP"' "$@" "$dest/"' > "$1/clone-files"
+    echo 'cd "$src" && '"$CP"' "$@" "$dest/"' > "$1/clone-files"
   fi
 else
   CP='cp -%sf'
   if ! test -e "$1/clone-files"; then
-    if ln -f doc/ocaml/LICENSE "$1/__ln_test" 2>/dev/null; then
+    if ln -f "$2/doc/ocaml/LICENSE" "$1/__ln_test" 2>/dev/null; then
       rm -f "$1/__ln_test"
-      echo 'ln -f "$@" "$dest/"' > "$1/clone-files"
+      echo 'cd "$src" && ln -f "$@" "$dest/"' > "$1/clone-files"
     else
-      echo "$CP"' "$@" "$dest/"' > "$1/clone-files"
+      echo 'cd "$src" && '"$CP"' "$@" "$dest/"' > "$1/clone-files"
     fi
   fi
 fi|} preserve preserve;
@@ -215,7 +215,7 @@ fi|} preserve preserve;
       (*  ld.conf is a configuration file, so is always copied.
           Makefile.config and config.status will both contain the original
           prefix, which must be updated. *)
-      output_endline oc {|cp lib/ocaml/ld.conf "$1/lib/ocaml/ld.conf"
+      output_endline oc {|cp "$2/lib/ocaml/ld.conf" "$1/lib/ocaml/ld.conf"
 cat > "$1/prefix.awk" <<'ENDAWK'
 {
   rest = $0
@@ -226,9 +226,9 @@ cat > "$1/prefix.awk" <<'ENDAWK'
   print rest
 }
 ENDAWK
-prefix="$(sed -ne 's/^prefix *= *//p' lib/ocaml/Makefile.config)"
+prefix="$(sed -ne 's/^prefix *= *//p' "$2/lib/ocaml/Makefile.config")"
 for file in lib/ocaml/Makefile.config share/ocaml/config.status; do
-  O="$prefix" N="$1" awk -f "$1/prefix.awk" "$file" > "$1/$file"
+  O="$prefix" N="$1" awk -f "$1/prefix.awk" "$2/$file" > "$1/$file"
 done
 rm -f "$1/clone-files" "$1/prefix.awk"|};
       process_symlinks oc ~mkdir:false

--- a/tools/opam/process.sh
+++ b/tools/opam/process.sh
@@ -60,7 +60,7 @@ if [ x"$make_args" = 'xinstall' ]; then
     origin="$(tail -n 1 build-id)"
     origin_prefix="$(opam var --safe --switch="$origin" prefix | tr -d '\r')"
     echo "🪄 Duplicating $origin_prefix"
-    sh "$origin_prefix/share/ocaml/clone" "$prefix" "$origin_prefix"
+    sh "$origin_prefix/share/ocaml/clone" "$origin_prefix" "$prefix"
   fi
 
   exit 0

--- a/tools/opam/process.sh
+++ b/tools/opam/process.sh
@@ -60,7 +60,7 @@ if [ x"$make_args" = 'xinstall' ]; then
     origin="$(tail -n 1 build-id)"
     origin_prefix="$(opam var --safe --switch="$origin" prefix | tr -d '\r')"
     echo "🪄 Duplicating $origin_prefix"
-    ( cd "$origin_prefix" && sh ./share/ocaml/clone "$prefix" )
+    sh "$origin_prefix/share/ocaml/clone" "$prefix" "$origin_prefix"
   fi
 
   exit 0


### PR DESCRIPTION
This is an alternate to #14901, but owes its core to @kit-ty-kate's investigation and fix. I wasn't too happy with the additional subshells being spawned, and fixing that suggested changing the argument order for the script which was all becoming a bit noisy just add to @kit-ty-kate's PR, so here it is as a separate one!

Some background on the cloning script:
- The `xargs` + HEREDOC pattern is necessary for two reasons. Firstly, the file lists are too long and blow command line lengths on Linux, let alone on Windows. Wildcards would be wholly inappropriate here - we must be explicit about the files being cloned, because additional ones may have bee added since the compiler was installed. In the future we may even check that they haven't been altered as well. `xargs` was invented to solve this kind of problem, and trying to solve this using `while` loops and so forth is appreciably slower on Linux and insanely slower on Windows.
- It's very important that neither the source or destination prefix values are ever manipulated or written to a file, because then we would have to worry about escaping. i.e. they can be passed in arguments and put into variables, but they must then only be passed as arguments (or in variables) to other commands, otherwise we enter indescribable escaping hell.
- There's a certain amount of dance needed to ensure that Windows `mklink` always behaves, that prevents some natural uses of `ln`. Basically, we need to avoid passing full paths to the argument of mklink.

For some measure of simplicity, therefore, the original clone script generated by tools/opam/generate.ml expects to be executed _in_ the source prefix, and therefore uses safe relative paths from there. The destination prefix is passed in `$1`. Unfortunately, as noted in https://github.com/ocaml/opam-repository/issues/29496#issuecomment-4791341931, this doesn't work in opam's sandbox on macOS, because of its absurdly ancient version of bash (which is used to implement `sh`).

The first commit in this PR changes the generated clone script to expect the source prefix in `$2`, leaving it to the caller to ensure that the current directory is writeable. The generated script only changes directory when creating symlinks at the very end - the change is the _destination_ prefix (so must be writeable), but it also simply precedes a series of calls to `ln`. This is simpler than the approach in #14901, pleasingly reducing the number of subshells used (the downside is it requires more careful scrutiny of the implicit paths being used previously - @kit-ty-kate's approach ensured that the HEREDOC parts returned to the safely writeable build directory, but still allowed the rest of the script to execute from the source prefix, as before).

However, doing that means that the clone script is invoked with its source and destination arguments the "wrong" way around for copy commands. All this stuff is confusing enough, without adopting assembly notation for moves. The second commit therefore swaps the arguments round. I strongly recommend reviewing the two commits separately.

This can be tested on macOS for released OCaml 5.5.0 with:

```console
$ opam switch create source-switch --repos=5.5.0-fixes=git+https://github.com/dra27/opam-repository.git#relocatable-5.5.0-fixes ocaml.5.5.0
...
$ opam switch create cloned-switch --repos=5.5.0-fixes ocaml.5.5.0
```

Note that the compiler is unaltered by that package - it's simply replacing the cloning scripts used _after_ the compiler has been built with the ones from this PR.

The PR can also be tested manually on macOS:

```console
# Build trunk - we're only changing the opam scripts here
$ git checkout explicit-clone~2
$ ./configure --prefix $PWD/orig --docdir $PWD/orig/doc/ocaml --with-relative-libdir --enable-runtime-search && make -j && make install
$ make INSTALL_MODE=clone install
$ mkdir -p orig/share/ocaml
# Dummy files, so the cloning script has something to process for these
$ touch orig/share/ocaml/{clone,config.status,config.cache}
```

The failure mode can then be seen with:
```console
$ mkdir switches
$ cd switches
$ ~/.opam/opam-init/hooks/sandbox.sh build sh -c "cd ../orig && sh ../ocaml-compiler-clone.sh $PWD/cloned"
../ocaml-compiler-clone.sh: line 23: cannot create temp file for here document: Operation not permitted
```
(the sandbox script makes the current directory writeable, the `cd ../orig` emulates what tools/opam/process.sh does before calling the clone script)

The first commit can then be seen to work with:
```console
$ git -C .. checkout explicit-clone~1
$ make -C .. INSTALL_MODE=clone install
$ rm -rf cloned
$ ~/.opam/opam-init/hooks/sandbox.sh build sh ../ocaml-compiler-clone.sh $PWD/cloned ../orig
$ diff -Naur cloned ../orig
# Diff in Makefile.config only, as expected
```

and likewise the tip commit can then be seen to work with:
```console
$ git -C .. checkout explicit-clone
$ make -C .. INSTALL_MODE=clone install
$ rm -rf cloned
# Note reversed arguments!
$ ~/.opam/opam-init/hooks/sandbox.sh build sh ../ocaml-compiler-clone.sh ../orig $PWD/cloned
$ diff -Naur cloned ../orig
# Diff in Makefile.config only
```