### PR TITLE
Inline the full-application part of caml_apply

### DIFF
--- a/Changes
+++ b/Changes
@@ -195,6 +195,9 @@ Working version
   barrier; the default is chosen at configure time and can be overridden.
   (Sebastian Pop and Xavier Leroy, review by Xavier Leroy and Olivier Nicole)
 
+- #?????: Inline the full-application case of caml_apply
+  (Stefan Muenzel, review by ???)
+
 ### Standard library:
 
 - #10798: Atomic helper function

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -27,6 +27,23 @@ let bind name arg fn =
     Cvar _ | Cconst_int _ | Cconst_natint _ | Cconst_symbol _ -> fn arg
   | _ -> let id = V.create_local name in Clet(VP.create id, arg, fn (Cvar id))
 
+let bind_list name args fn =
+  let lets, vars =
+    List.map
+      (function
+        | Cvar _ | Cconst_int _ | Cconst_natint _ | Cconst_symbol _ as arg ->
+            (fun x -> x), arg
+        | arg ->
+            let id = V.create_local name in
+            (fun next -> Clet(VP.create id, arg, next)), Cvar id)
+      args
+    |> List.split
+  in
+  List.fold_right
+    (fun f acc -> f acc)
+    lets (fn vars)
+
+
 let bind_load name arg fn =
   match arg with
   | Cop(Cload _, [Cvar _], _) -> fn arg
@@ -1781,10 +1798,27 @@ let generic_apply mut clos args dbg =
           dbg))
   | _ ->
       let arity = List.length args in
-      let cargs =
-        Cconst_symbol(apply_function_sym arity, dbg) :: args @ [clos]
-      in
-      Cop(Capply typ_val, cargs, dbg)
+      bind "fun" clos (fun clos ->
+          bind_list "args" args (fun args ->
+              let all_args = args @ [clos] in
+              bind "cfun"
+                (Cifthenelse(
+                    Cop(Ccmpi Ceq
+                       , [Cop(Casr,
+                              [get_field_gen Asttypes.Mutable clos 1 (dbg);
+                               Cconst_int(pos_arity_in_closinfo, dbg)], dbg);
+                          Cconst_int(arity, dbg)], dbg),
+                    dbg,
+                    get_field_codepointer Asttypes.Mutable clos 2 (dbg),
+                    dbg,
+                    Cconst_symbol(apply_function_sym arity, dbg),
+                    dbg
+                  ))
+                (fun cfun ->
+                   Cop(Capply typ_val, cfun :: all_args, dbg)
+                )
+            )
+        )
 
 let send kind met obj args dbg =
   let call_met obj args clos =
@@ -1871,13 +1905,11 @@ let placeholder_fun_dbg ~human_name:_ = Debuginfo.none
 
 (* Generate an application function:
      (defun caml_applyN (a1 ... aN clos)
-       (if (= clos.arity N)
-         (app clos.direct a1 ... aN clos)
-         (let (clos1 (app clos.code a1 clos)
-               clos2 (app clos1.code a2 clos)
-               ...
-               closN-1 (app closN-2.code aN-1 closN-2))
-           (app closN-1.code aN closN-1))))
+       (let (clos1 (app clos.code a1 clos)
+             clos2 (app clos1.code a2 clos)
+             ...
+             closN-1 (app closN-2.code aN-1 closN-2))
+         (app closN-1.code aN closN-1))))
 *)
 
 let apply_function_body arity =
@@ -1901,22 +1933,7 @@ let apply_function_body arity =
            app_fun newclos (n+1))
     end in
   let args = Array.to_list arg in
-  let all_args = args @ [clos] in
-  (args, clos,
-   if arity = 1 then app_fun clos 0 else
-   Cifthenelse(
-   Cop(Ccmpi Ceq, [Cop(Casr,
-                       [get_field_gen Asttypes.Mutable (Cvar clos) 1 (dbg());
-                        Cconst_int(pos_arity_in_closinfo, dbg())], dbg());
-                   Cconst_int(arity, dbg())], dbg()),
-   dbg (),
-   Cop(Capply typ_val,
-       get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
-       :: List.map (fun s -> Cvar s) all_args,
-       dbg ()),
-   dbg (),
-   app_fun clos 0,
-   dbg ()))
+  (args, clos, app_fun clos 0)
 
 let send_function arity =
   let dbg = placeholder_dbg in

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -54,11 +54,14 @@ let caml_black = Nativeint.shift_left (Nativeint.of_int 3) 8
 
 (* Loads *)
 
+let mk_load mutability memory_chunk =
+  Cload {memory_chunk; mutability; is_atomic=false}
+
 let mk_load_immut memory_chunk =
-  Cload {memory_chunk; mutability=Immutable; is_atomic=false}
+  mk_load Immutable memory_chunk
 
 let mk_load_mut memory_chunk =
-  Cload {memory_chunk; mutability=Mutable; is_atomic=false}
+  mk_load Mutable memory_chunk
 
 let mk_load_atomic memory_chunk =
   Cload {memory_chunk; mutability=Mutable; is_atomic=true}
@@ -95,6 +98,14 @@ let caml_int64_ops = "caml_int64_ops"
 
 let pos_arity_in_closinfo = 8 * size_addr - 8
        (* arity = the top 8 bits of the closinfo word *)
+
+let arity_offset =
+  if big_endian then 0 else size_addr - 1
+
+let get_arity mut ptr dbg =
+  Cop(
+    mk_load mut Byte_signed,
+    [Cop(Cadda, [ptr; Cconst_int(size_addr + arity_offset, dbg)], dbg)], dbg)
 
 let closure_info ~arity ~startenv =
   assert (-128 <= arity && arity <= 127);
@@ -1804,12 +1815,10 @@ let generic_apply mut clos args dbg =
               bind "cfun"
                 (Cifthenelse(
                     Cop(Ccmpi Ceq
-                       , [Cop(Casr,
-                              [get_field_gen Asttypes.Mutable clos 1 (dbg);
-                               Cconst_int(pos_arity_in_closinfo, dbg)], dbg);
+                       , [ get_arity mut clos dbg;
                           Cconst_int(arity, dbg)], dbg),
                     dbg,
-                    get_field_codepointer Asttypes.Mutable clos 2 (dbg),
+                    get_field_codepointer mut clos 2 (dbg),
                     dbg,
                     Cconst_symbol(apply_function_sym arity, dbg),
                     dbg


### PR DESCRIPTION
Similar to #198, but we structure the code so that the argument loading is not repeated for the caml_apply and full application call, in order to not increase code size too much. This is especially important for functions with many arguments.

On my own function-call heavy benchmarks, I see an approximately 25% reduction in runtime (this is when the program runtime is dominated by function calls) [1]
Stdlib Map improves by around 2% on the same benchmark

Result from coq-bench:
```
┌─────────────────────────────────────┬─────────────────────────┬───────────────────────────────────────┬─────────────────────────┐
│                                     │      user time [s]      │           CPU instructions            │  max resident mem [KB]  │
│                                     │                         │                                       │                         │
│            package_name             │   NEW      OLD    PDIFF │      NEW             OLD        PDIFF │   NEW      OLD    PDIFF │
├─────────────────────────────────────┼─────────────────────────┼───────────────────────────────────────┼─────────────────────────┤
│                        rocq-bignums │   22.75    23.72  -4.09 │   150202389187    152089825667  -1.24 │  501144   501108   0.01 │
│          rocq-metarocq-translations │   14.63    15.08  -2.98 │   107620923162    108332644515  -0.66 │  913796   911660   0.23 │
│                  rocq-mathcomp-boot │   38.16    39.32  -2.95 │   223869980591    227165344880  -1.45 │  706876   707328  -0.06 │
│                        coq-coqprime │   51.78    52.98  -2.27 │   359327846642    362894078994  -0.98 │  889896   891468  -0.18 │
│                 coq-category-theory │  741.91   758.82  -2.23 │  5529864693374   5616172716829  -1.54 │ 5850520  5851900  -0.02 │
│                 rocq-metarocq-pcuic │  512.65   524.03  -2.17 │  3323125667423   3367519125800  -1.32 │ 1619316  1617500   0.11 │
│                    coq-math-classes │   72.36    73.84  -2.00 │   465562084734    470969980047  -1.15 │  552288   554292  -0.36 │
│                        rocq-runtime │  425.20   433.69  -1.96 │  3354747458428   3430818797036  -2.22 │  818916   816852   0.25 │
│                           coq-color │  215.71   219.75  -1.84 │  1432658949782   1448093200650  -1.07 │ 1179772  1181756  -0.17 │
│              coq-mathcomp-odd-order │  555.15   565.26  -1.79 │  3807264786269   3857504616574  -1.30 │ 2431496  2428740   0.11 │
│                        coq-rewriter │  311.48   317.05  -1.76 │  2286112485260   2313548425829  -1.19 │ 1498756  1500940  -0.15 │
│           rocq-metarocq-safechecker │  278.24   282.45  -1.49 │  2108567883380   2157565277214  -2.27 │ 1580652  1577360   0.21 │
│                        coq-bedrock2 │  326.77   331.65  -1.47 │  2667833983874   2698639530780  -1.14 │  884060   885684  -0.18 │
│         coq-rewriter-perf-SuperFast │  466.74   473.54  -1.44 │  3241600095241   3288400151719  -1.42 │ 1193412  1186404   0.59 │
│                    coq-fiat-parsers │  271.07   274.83  -1.37 │  2119305177451   2138022961013  -0.88 │ 2076472  2074840   0.08 │
│               rocq-mathcomp-algebra │  385.08   390.15  -1.30 │  2654926154115   2698814884734  -1.63 │ 1685104  1683592   0.09 │
│ coq-neural-net-interp-computed-lite │  257.92   260.61  -1.03 │  2427716003625   2423458368359   0.18 │  891480   892292  -0.09 │
│                       coq-fiat-core │   58.25    58.83  -0.99 │   400844265238    403254906030  -0.60 │  531768   531712   0.01 │
│        coq-fiat-crypto-with-bedrock │ 6772.78  6838.06  -0.95 │ 54353141459908  54925396388958  -1.04 │ 3757440  3756352   0.03 │
│               rocq-metarocq-erasure │  368.73   372.21  -0.93 │  2528925273461   2571721411067  -1.66 │ 1725488  1727392  -0.11 │
│                            coq-corn │  576.53   580.89  -0.75 │  3908050325425   3963219302620  -1.39 │  662848   664244  -0.21 │
│                         rocq-stdlib │  402.05   404.79  -0.68 │  1543799134716   1559474171482  -1.01 │  762040   761568   0.06 │
│  rocq-mathcomp-group-representation │   96.66    97.20  -0.56 │   646311810487    654781452193  -1.29 │ 1801636  1804072  -0.14 │
│                 rocq-mathcomp-field │  211.19   212.24  -0.49 │  1439799960780   1464298926467  -1.67 │ 2038432  2037812   0.03 │
│              rocq-metarocq-template │   80.17    80.50  -0.41 │   554377220380    558511210610  -0.74 │ 1264188  1263520   0.05 │
│                         coq-unimath │ 1854.22  1861.56  -0.39 │ 14871409591276  15032752386855  -1.07 │ 1791128  1788232   0.16 │
│                       coq-fourcolor │ 1532.19  1533.53  -0.09 │ 12460685962785  12473817238292  -0.11 │ 1098288  1098264   0.00 │
│               coq-mathcomp-analysis │ 1104.06  1104.09  -0.00 │  7643923134829   7739585633264  -1.24 │ 2259080  2260148  -0.05 │
│                           rocq-core │    8.41     8.41   0.00 │    53427603101     53830759002  -0.75 │  559216   558460   0.14 │
│                            coq-hott │  157.63   157.61   0.01 │  1065318958727   1077835848952  -1.16 │  495100   496436  -0.27 │
│              rocq-mathcomp-solvable │   86.38    86.23   0.17 │   575814711736    582344131134  -1.12 │ 1200340  1202156  -0.15 │
│                 rocq-mathcomp-order │   87.24    87.07   0.20 │   578053254618    589575622287  -1.95 │ 1612544  1612104   0.03 │
│               coq-engine-bench-lite │  120.42   120.03   0.32 │   899242390591    907537779861  -0.91 │  850868   848572   0.27 │
│                 rocq-metarocq-utils │   23.74    23.64   0.42 │   157376575803    158903525245  -0.96 │  651088   648444   0.41 │
│                      rocq-equations │   13.10    13.02   0.61 │   101569551193    102082872546  -0.50 │  443184   446448  -0.73 │
│                      coq-coquelicot │   34.93    34.66   0.78 │   214481553687    217165714855  -1.24 │  895256   896728  -0.16 │
│             rocq-mathcomp-ssreflect │    1.27     1.26   0.79 │     8211655908      8230722611  -0.23 │  643956   645012  -0.16 │
│                           rocq-elpi │   24.02    23.73   1.22 │   175505966373    176654755107  -0.65 │  515508   521112  -1.08 │
│                rocq-metarocq-common │   37.86    37.16   1.88 │   237938356115    240768601839  -1.18 │  983144   981592   0.16 │
│                         coq-coqutil │   45.81    44.83   2.19 │   302610302339    305431675503  -0.92 │  612240   611952   0.05 │
│          rocq-mathcomp-finite-group │   25.42    24.67   3.04 │   158908877051    160887033809  -1.23 │  638292   633168   0.81 │
│                            coq-core │    6.56     6.28   4.46 │    47969521300     48576425447  -1.25 │  137920   138912  -0.71 │
└─────────────────────────────────────┴─────────────────────────┴───────────────────────────────────────┴─────────────────────────┘
```

Seems like we're always lower on instructions (by at least 1%), and faster on most of the longer-running benchmarks. coq-bench was run with flambda on rocq 5cd4cdd2 on a AMD Ryzen 9 3900X. ocaml version 5.5.1 and 5.5.1 + this PR


Code size (0.56% increase)
30801920 bytes (ocamlopt.opt, 5.5.1+dev0-2026-06-19, flambda)
30973952 bytes (ocamlopt.opt, 5.5.1+dev0-2026-06-19, flambda, plus this PR)


For completeness, I went through the "Contributing Optimizations" part of the guidelines:

Benefits:
- Faster code due to fewer calls going via the caml_apply trampoline

When it applies:
- When the function application is full (all arguments are present). This should be the
  most common case

When it is detrimental:
- Code size is increased slightly, so instruction cache won't be used as effciently
- If most applications are partial, I expect a slight slowdown.

Open Source Benchmarks:
- See above

Correctness:
- Fundamentally, this PR only rearranges code that was being run anyway. So the correctness
  argument is that the code didn't really change.


[1] You can run the "equal" benchmark here: https://github.com/smuenzel/proof_balanced/blob/master/bcaml/bench/bench.ml, which runs a complicated CPS-style traversal of a map
