### PR TITLE
typechecker: path equivalence modulo aliases

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3649,7 +3649,12 @@ module Unscoped = struct
   let with_pairs id_pairs env = {env with id_pairs}
   let get_pairs env = env.id_pairs
 
-  let path_equiv env p1 p2 = Path.equiv env.id_pairs p1 p2
+  let path_equiv env p1 p2 =
+    Path.equiv env.id_pairs p1 p2
+    || (* equivalence modulo normalization *)
+    let n1 = normalize_type_path None env p1 in
+    let n2 = normalize_type_path None env p2 in
+    (n1 != p1 || n2 != p2) && Path.same n1 n2
 end
 
 (* Error report *)


### PR DESCRIPTION
This is another performances fix linked to #14897.

Dune library wrapping creates a "double vision" problem were the types computed inside a library and outside the library uses different paths: the inner types paths involve the internal library entry point (for instance `Js_of_ocaml__`) whereas the outside type paths use the public library entry point (for instance `Js_of_ocaml`). The two paths are equivalent up to alias normalization but the difference is enough to throw off all the fast paths in unification that were dependent on path equivalence.

This PR fixes this performance issue by checking path equivalence modulo aliases.

This changes is enough to reduce the compilation time of the `Lwt_XmlHttpRequest` module down to 170 ms from more than 10 minutes with trunk, and 5 s on OCaml 5.5 .