### PR TITLE
fix(runtime): print errno on sigaltstack errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -111,6 +111,11 @@ Working version
   GetFileInformationByName call underpinning the CRT's stat implementation.
   (David Allsopp, review by Nicolás Ojeda Bär and Antonin Décimo)
 
+- #14928: Include strerror(errno) in the fatal error message when the signal
+  stack for domain 0 cannot be allocated or reset, aiding diagnosis of startup
+  failures.
+  (Nathan Taylor)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14842, #14845: Keep expansion and

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -584,12 +584,13 @@ void * caml_init_signal_stack(void)
 void caml_free_signal_stack(void * signal_stack)
 {
 #ifdef POSIX_SIGNALS
+  char buf[128];
   stack_t stk, disable;
   disable.ss_flags = SS_DISABLE;
   disable.ss_sp = NULL;  /* not required but avoids a valgrind false alarm */
   disable.ss_size = SIGSTKSZ; /* macOS wants a valid size here */
   if (sigaltstack(&disable, &stk) < 0) {
-    const char *msg = strerror(errno);
+    char *msg = caml_strerror(errno, buf, sizeof(buf));
     caml_fatal_error("Failed to reset signal stack: %s", msg);
   }
   /* Check whether someone else installed their own signal stack */
@@ -616,9 +617,10 @@ void caml_init_signals(void)
 {
   /* Set up alternate signal stack for domain 0 */
 #ifdef POSIX_SIGNALS
+  char buf[128];
   caml_signal_stack_0 = caml_init_signal_stack();
   if (caml_signal_stack_0 == NULL) {
-    const char *msg = strerror(errno);
+    char *msg = caml_strerror(errno, buf, sizeof(buf));
     caml_fatal_error("Failed to allocate signal stack for domain 0: %s", msg);
   }
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -589,7 +589,8 @@ void caml_free_signal_stack(void * signal_stack)
   disable.ss_sp = NULL;  /* not required but avoids a valgrind false alarm */
   disable.ss_size = SIGSTKSZ; /* macOS wants a valid size here */
   if (sigaltstack(&disable, &stk) < 0) {
-    caml_fatal_error("Failed to reset signal stack (err %d)", errno);
+    const char *msg = strerror(errno);
+    caml_fatal_error("Failed to reset signal stack: %s", msg);
   }
   /* Check whether someone else installed their own signal stack */
   if (!(stk.ss_flags & SS_DISABLE) && stk.ss_sp != signal_stack) {
@@ -617,7 +618,8 @@ void caml_init_signals(void)
 #ifdef POSIX_SIGNALS
   caml_signal_stack_0 = caml_init_signal_stack();
   if (caml_signal_stack_0 == NULL) {
-    caml_fatal_error("Failed to allocate signal stack for domain 0");
+    const char *msg = strerror(errno);
+    caml_fatal_error("Failed to allocate signal stack for domain 0: %s", msg);
   }
 
   /* gprof installs a signal handler for SIGPROF.


### PR DESCRIPTION
Dear OCaml maintainers,

Internally at Semgrep, we've been trying to diagnose some failures that stem from not being able to correctly set up the signal stack.  Currently, `caml_init_signals` only prints `Failed to allocate signal stack for domain 0` (that is, we drop the errno, so we're not exactly sure what's going wrong).  This patch simply turns the errno into a printable string via `strerror(3)` and adds that to the output.  Similarly, `caml_free_signal_stack` did sort of the right thing in that it prints out the errno number but not the string form; this patch passes that usage through `strerror` as well.

Since this error only happens very occasionally, I've not been able to directly test this patch beyond "force a failure and set errno" one-off test, but we are also pulling this into [our fork](https://github.com/semgrep/ocaml/pull/19) for internal use, too.

Thanks, and to the Europeans, hope you are staying cool,
Nathan