### PR TITLE
Support relocatable cross compilers

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -180,7 +180,7 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Configure, build and install Linux-to-Windows OCaml
+      - name: Configure, build and install Linux-to-ARM-Linux OCaml
         run: |
           set -x
           ./configure --prefix="$HOME/cross" --target=aarch64-linux-gnu \

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -50,7 +50,9 @@ jobs:
           set -x
           ./configure --disable-warn-error --disable-ocamldoc \
               --disable-ocamltest --disable-stdlib-manpages \
-              --prefix="$PREFIX" || failed=$?
+              --prefix="$PREFIX" --with-additional-stublibsdir \
+              --with-relative-libdir --enable-runtime-search \
+              --enable-runtime-search-target=fallback || failed=$?
           if ((failed)) ; then set +x
             echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
             cat config.log ; echo '::endgroup::' ; exit $failed

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -93,6 +93,8 @@ jobs:
         run: |
           set -x
           ./configure --prefix="$HOME/cross" --target=x86_64-w64-mingw32 \
+              --with-additional-stublibsdir --with-relative-libdir \
+              --enable-runtime-search --enable-runtime-search-target=fallback \
               TARGET_LIBDIR="$TESTDIR" || failed=$?
           if ((failed)) ; then set +x
             echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
@@ -120,6 +122,21 @@ jobs:
           name: x86_64-w64-mingw32-executable
           path: example.exe
           retention-days: 1
+      - name: Move the cross compiler
+        run: |
+          mv $HOME/cross $HOME/relocated
+          ln -srf "$HOME/relocated/bin/flexlink.opt.exe" "$HOME/.local/bin/flexlink"
+      - name: Show opt.opt configuration after relocation
+        run: |
+          set -x
+          $HOME/relocated/bin/ocamlopt.opt.exe -config
+          cat runtime/build_config.h
+      - name: Cross compile a small program after relocation
+        run: |
+          printf %s "$EXAMPLE_PROGRAM$COMPLIBS_PROG_X86_64" > example.ml
+          set -x
+          cat example.ml
+          $HOME/relocated/bin/ocamlopt.opt.exe -I $HOME/relocated/lib/ocaml/compiler-libs/ ocamlcommon.cmxa ocamloptcomp.cmxa example.ml -o example.exe -verbose
       - name: Test cross sak
         run: |
           printf %s "$STR_UTF16" > utf16.ref
@@ -167,6 +184,8 @@ jobs:
         run: |
           set -x
           ./configure --prefix="$HOME/cross" --target=aarch64-linux-gnu \
+              --with-additional-stublibsdir --with-relative-libdir \
+              --enable-runtime-search --enable-runtime-search-target=fallback \
               || failed=$?
           if ((failed)) ; then set +x
             echo ; echo "::group::config.log content ($(wc -l config.log) lines)"
@@ -185,6 +204,24 @@ jobs:
           set -x
           cat example.ml
           $HOME/cross/bin/ocamlopt.opt -I $HOME/cross/lib/ocaml/compiler-libs/ ocamlcommon.cmxa ocamloptcomp.cmxa example.ml -o example -verbose
+      - name: Run the small example program
+        run: |
+          set -x
+          qemu-aarch64 -L /usr/aarch64-linux-gnu example
+      - name: Move the cross compiler
+        run: |
+          mv $HOME/cross $HOME/relocated
+      - name: Show opt.opt configuration
+        run: |
+          set -x
+          $HOME/relocated/bin/ocamlopt.opt -config
+          cat runtime/build_config.h
+      - name: Cross compile a small program
+        run: |
+          printf %s "$EXAMPLE_PROGRAM$COMPLIBS_PROG_AARCH64" > example.ml
+          set -x
+          cat example.ml
+          $HOME/relocated/bin/ocamlopt.opt -I $HOME/relocated/lib/ocaml/compiler-libs/ ocamlcommon.cmxa ocamloptcomp.cmxa example.ml -o example -verbose
       - name: Run the small example program
         run: |
           set -x
@@ -255,6 +292,8 @@ jobs:
           # program should _not_ be run with cleanup on exit (so no
           # `c=1` in `OCAMLRUNPARAM`)
           ./configure --prefix="$HOME/cross" --target=$TARGET \
+              --with-additional-stublibsdir --with-relative-libdir \
+              --enable-runtime-search --enable-runtime-search-target=fallback \
               TARGET_LIBDIR="/dummy/directory" \
               CC="$DIR/clang --target=$TARGET" \
               AR="$DIR/llvm-ar" \

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -167,6 +167,11 @@ DOCDIR=@docdir@
 TARGET_LIBDIR=@TARGET_LIBDIR@
 TARGET_LIBDIR_IS_RELATIVE=@target_libdir_is_relative@
 
+### Where to look for the standard library on host
+# The difference with LIBDIR (in Makefile.config) is that this is just the
+# relative path when --with-relative-libdir is enabled
+HOST_LIBDIR=@host_libdir@
+
 unix_directory = @unix_directory@
 unix_library = @unix_library@
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -531,10 +531,6 @@ ifeq "$(TARGET_LIBDIR_IS_RELATIVE)" "true"
       $(if $(SRCDIR_REAL_ENCODED),:.=$(SRCDIR_REAL_ENCODED))
 endif # ifeq "$(TARGET_LIBDIR_IS_RELATIVE)" "true"
 
-# Allow Makefile.cross to override the Standard Library default for the compiler
-# itself.
-HOST_LIBDIR ?= $(TARGET_LIBDIR)
-
 OC_COMMON_LINKFLAGS += \
   -set-runtime-default \
     $(call QUOTE_SINGLE,standard_library_default=$(HOST_LIBDIR))

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -53,8 +53,7 @@ CROSS_OVERRIDES=OCAMLRUN=ocamlrun NEW_OCAMLRUN=ocamlrun \
 # be overridden with -set-runtime-default so that cross/bin/ocamlopt instead has
 # cross/lib/ocaml for Config.standard_library_default
 CROSS_COMPILER_OVERRIDES=$(CROSS_OVERRIDES) CAMLC=ocamlc CAMLOPT=ocamlopt \
-  BEST_OCAMLC=ocamlc BEST_OCAMLOPT=ocamlopt BEST_OCAMLLEX=ocamllex \
-  HOST_LIBDIR="$(LIBDIR)"
+  BEST_OCAMLC=ocamlc BEST_OCAMLOPT=ocamlopt BEST_OCAMLLEX=ocamllex
 CROSS_COMPILERLIBS_OVERRIDES=$(CROSS_OVERRIDES) CAMLC=ocamlc \
   CAMLOPT="$(ROOTDIR)/ocamlopt.opt$(EXE) $(STDLIBFLAGS)"
 

--- a/configure
+++ b/configure
@@ -4087,6 +4087,12 @@ case $host in #(
   *) :
     host_dir_sep='/' ;;
 esac
+case $target in #(
+  *-w64-mingw32*|*-pc-windows) :
+    target_dir_sep='\' ;; #(
+  *) :
+    target_dir_sep='/' ;;
+esac
 
 # Environment variables that are taken into account
 
@@ -24510,7 +24516,10 @@ then :
   if test x"$bindir_to_libdir" != 'x'
 then :
   ocaml_libdir="$bindir_to_libdir"
-    target_libdir_is_relative=true
+    if test x"$TARGET_LIBDIR" = x
+then :
+  target_libdir_is_relative=true
+fi
     case $cygwin_build_env,$host in #(
   true,*-w64-mingw32*|true,*-pc-windows) :
     build_bindir_to_libdir="$(LC_ALL=C.UTF-8 cygpath \
@@ -24533,6 +24542,13 @@ then :
   as_fn_error $? "--with-relative-libdir and --libdir cannot both be specified" "$LINENO" 5
 fi
 fi
+
+case $TARGET_LIBDIR in #(
+  .|..|.${target_dir_sep}*|..${target_dir_sep}*) :
+    target_libdir_is_relative=true ;; #(
+  *) :
+     ;;
+esac
 
 host_libdir='${TARGET_LIBDIR}'
 

--- a/configure
+++ b/configure
@@ -818,6 +818,7 @@ target_libdir_is_relative
 ar_supports_response_files
 QS
 TARGET_LIBDIR
+host_libdir
 ocaml_libdir
 ocaml_bindir
 ocaml_prefix
@@ -3605,6 +3606,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L038
 
 
  # TODO: rename this variable
+
 
 
 
@@ -24532,9 +24534,19 @@ then :
 fi
 fi
 
-if test x"$bindir_to_libdir" != 'x' && test x"$TARGET_LIBDIR" != 'x'
+host_libdir='${TARGET_LIBDIR}'
+
+if $cross_compiler
+then :
+  if test x"$bindir_to_libdir" != 'x'
+then :
+  host_libdir="$bindir_to_libdir"
+fi
+else $as_nop
+  if test x"$bindir_to_libdir" != 'x' && test x"$TARGET_LIBDIR" != 'x'
 then :
   as_fn_error $? "--with-relative-libdir and TARGET_LIBDIR cannot both be specified" "$LINENO" 5
+fi
 fi
 
 # Define a few macros that were defined in config/m-nt.h

--- a/configure
+++ b/configure
@@ -4081,11 +4081,11 @@ fi
 
 # Environment-specific set-up
 
-case $target in #(
+case $host in #(
   *-w64-mingw32*|*-pc-windows) :
-    default_separator='\' ;; #(
+    host_dir_sep='\' ;; #(
   *) :
-    default_separator='/' ;;
+    host_dir_sep='/' ;;
 esac
 
 # Environment variables that are taken into account
@@ -4381,7 +4381,7 @@ then :
   no) :
     ocaml_additional_stublibs_dir='' ;; #(
   yes) :
-    ocaml_additional_stublibs_dir="..${default_separator}stublibs" ;; #(
+    ocaml_additional_stublibs_dir="..${host_dir_sep}stublibs" ;; #(
   *) :
     ocaml_additional_stublibs_dir="$withval" ;;
 esac
@@ -4467,7 +4467,7 @@ then :
   no) :
     bindir_to_libdir='' ;; #(
   yes) :
-    bindir_to_libdir="..${default_separator}lib${default_separator}ocaml" ;; #(
+    bindir_to_libdir="..${host_dir_sep}lib${host_dir_sep}ocaml" ;; #(
   *) :
     bindir_to_libdir="$withval" ;;
 esac
@@ -25815,7 +25815,7 @@ fi
 ocaml_additional_stublibs_dir=\
 '$(echo "$ocaml_additional_stublibs_dir" | sed -e "s/'/'\"'\"'/g")'
   ocaml_libdir='$(echo "$ocaml_libdir" | sed -e "s/'/'\"'\"'/g")'
-  default_separator='$default_separator'
+  host_dir_sep='$host_dir_sep'
   supports_shared_libraries='$supports_shared_libraries'
 
 _ACEOF
@@ -26996,7 +26996,7 @@ ltmain=$ac_aux_dir/ltmain.sh
   test x"$ocaml_additional_stublibs_dir" = 'x' || \
     echo "$ocaml_additional_stublibs_dir" > runtime/ld.conf
   if $supports_shared_libraries; then
-    echo ".${default_separator}stublibs" >> runtime/ld.conf
+    echo ".${host_dir_sep}stublibs" >> runtime/ld.conf
   fi
   echo "." >> runtime/ld.conf ;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -297,6 +297,7 @@ AC_SUBST([compute_deps])
 AC_SUBST([ocaml_prefix])
 AC_SUBST([ocaml_bindir])
 AC_SUBST([ocaml_libdir])
+AC_SUBST([host_libdir])
 AC_SUBST([TARGET_LIBDIR])
 AC_SUBST([QS])
 AC_SUBST([ar_supports_response_files])
@@ -3136,9 +3137,14 @@ AS_IF([test x"$libdir_given" = 'xno'],
     [AC_MSG_ERROR(m4_normalize([--with-relative-libdir and --libdir cannot both
       be specified]))])])
 
-AS_IF([test x"$bindir_to_libdir" != 'x' && test x"$TARGET_LIBDIR" != 'x'],
-  [AC_MSG_ERROR(m4_normalize([--with-relative-libdir and TARGET_LIBDIR cannot
-    both be specified]))])
+host_libdir='${TARGET_LIBDIR}'
+
+AS_IF([$cross_compiler],
+  [AS_IF([test x"$bindir_to_libdir" != 'x'],
+    [host_libdir="$bindir_to_libdir"])],
+  [AS_IF([test x"$bindir_to_libdir" != 'x' && test x"$TARGET_LIBDIR" != 'x'],
+    [AC_MSG_ERROR(m4_normalize([--with-relative-libdir and TARGET_LIBDIR cannot
+      both be specified]))])])
 
 # Define a few macros that were defined in config/m-nt.h
 # but whose value is not guessed properly by configure

--- a/configure.ac
+++ b/configure.ac
@@ -479,11 +479,12 @@ AS_IF([test -n "$csc"],
 dnl The separator should be being treated differently for host/target for
 dnl cross-compilers, but the installation layout for cross-compilers is already
 dnl incorrect (for example, ld.conf is processed by _both_ the host and target
-dnl runtimes), so this is left as target-specific for now.
-AS_CASE([$target],
+dnl runtimes), so this is left as host-specific for now as being more useful
+dnl (ie things break at compile-time if paths are incorrect on the host)
+AS_CASE([$host],
   [*-w64-mingw32*|*-pc-windows],
-    [default_separator='\'],
-  [default_separator='/'])
+    [host_dir_sep='\'],
+  [host_dir_sep='/'])
 
 # Environment variables that are taken into account
 
@@ -684,7 +685,7 @@ AC_ARG_WITH([additional-stublibsdir],
     [no],
       [ocaml_additional_stublibs_dir=''],
     [yes],
-      [ocaml_additional_stublibs_dir="..${default_separator}stublibs"],
+      [ocaml_additional_stublibs_dir="..${host_dir_sep}stublibs"],
     [ocaml_additional_stublibs_dir="$withval"])],
   [ocaml_additional_stublibs_dir=''])
 
@@ -741,7 +742,7 @@ AC_ARG_WITH([relative-libdir],
     [no],
       [bindir_to_libdir=''],
     [yes],
-      [bindir_to_libdir="..${default_separator}lib${default_separator}ocaml"],
+      [bindir_to_libdir="..${host_dir_sep}lib${host_dir_sep}ocaml"],
     [bindir_to_libdir="$withval"])],
   [bindir_to_libdir=''])
 
@@ -3277,13 +3278,13 @@ AC_CONFIG_COMMANDS([runtime/ld.conf],
   test x"$ocaml_additional_stublibs_dir" = 'x' || \
     echo "$ocaml_additional_stublibs_dir" > runtime/ld.conf
   if $supports_shared_libraries; then
-    echo ".${default_separator}stublibs" >> runtime/ld.conf
+    echo ".${host_dir_sep}stublibs" >> runtime/ld.conf
   fi
   echo "." >> runtime/ld.conf],
   [ocaml_additional_stublibs_dir=\
 '$(echo "$ocaml_additional_stublibs_dir" | sed -e "s/'/'\"'\"'/g")'
   ocaml_libdir='$(echo "$ocaml_libdir" | sed -e "s/'/'\"'\"'/g")'
-  default_separator='$default_separator'
+  host_dir_sep='$host_dir_sep'
   supports_shared_libraries='$supports_shared_libraries'])
 
 # Just before config.status is generated, determine the final values for MKEXE,

--- a/configure.ac
+++ b/configure.ac
@@ -485,6 +485,10 @@ AS_CASE([$host],
   [*-w64-mingw32*|*-pc-windows],
     [host_dir_sep='\'],
   [host_dir_sep='/'])
+AS_CASE([$target],
+  [*-w64-mingw32*|*-pc-windows],
+    [target_dir_sep='\'],
+  [target_dir_sep='/'])
 
 # Environment variables that are taken into account
 
@@ -3123,7 +3127,8 @@ AS_CASE([$cygwin_build_env,$host],
 AS_IF([test x"$libdir_given" = 'xno'],
   [AS_IF([test x"$bindir_to_libdir" != 'x'],
     [ocaml_libdir="$bindir_to_libdir"
-    target_libdir_is_relative=true
+    AS_IF([test x"$TARGET_LIBDIR" = x],
+      [target_libdir_is_relative=true])
     AS_CASE([$cygwin_build_env,$host],
       [true,*-w64-mingw32*|true,*-pc-windows],
         [build_bindir_to_libdir="$(LC_ALL=C.UTF-8 cygpath \
@@ -3137,6 +3142,10 @@ AS_IF([test x"$libdir_given" = 'xno'],
   [AS_IF([test x"$bindir_to_libdir" != 'x'],
     [AC_MSG_ERROR(m4_normalize([--with-relative-libdir and --libdir cannot both
       be specified]))])])
+
+AS_CASE([$TARGET_LIBDIR],
+  [.|..|.${target_dir_sep}*|..${target_dir_sep}*],
+    [target_libdir_is_relative=true])
 
 host_libdir='${TARGET_LIBDIR}'
 


### PR DESCRIPTION
This PR make it possible to build relocatable cross compilers. In particular, it allows the call `configure --with-relative-libdir TARGET_LIBDIR=...` which was explicitly forbidden as setting (a merged host and target) libdir twice.

This is obviously meant to be labelled with `run-crosscompiler-tests`.

#### Brief overview

- Update the CI tests, so that the cross compiler CI workflow tests also the relocatability.
  - 2287e31731 CI: Update the configuration of the non-cross compiler
  - 62051686ec Test in CI that the cross compilers are relocatable
- Add a new `configure` variable to store the host relative libdir path (and not only its concatenation with bindir) to reconcile the non-cross and cross cases
  - b4e9a6fbcc Set `HOST_LIBDIR` during configuration
- Favour host paths over target paths as it provides better results
  - cf91c9f4d4 Change a `configure`-internal variable for cross compilers
- Make sure `TARGET_LIBDIR_IS_RELATIVE` is really about `TARGET_LIBDIR` and not the host libdir. By the way, my impression is that the use of `TARGET_LIBDIR_IS_RELATIVE` to extend `BUILD_PATH_PREFIX_MAP` in `Makefile.common` is more about host than target; in the test harness, I’m not sure. Should this be changed @dra27?
  - 3e788bc22d Use `TARGET_LIBDIR` when available to set `target_libdir_is_relative`
- Typo fix
  - eff4326cb9 Fix a typo in a CI step name