### PR TITLE
Forbid functional updates that implicitly read atomic fields

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -970,9 +970,14 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     let init_id = Ident.create_local "init" in
     let lv =
       Array.mapi
-        (fun i (_, definition) ->
+        (fun i (lbl, definition) ->
            match definition with
            | Kept (typ, mut) ->
+               if lbl.lbl_atomic = Atomic then
+                 (* Rejected during typechecking to avoid need for
+                    implicit atomic loads *)
+                 fatal_error
+                   "transl_record: update expr implicitly copies atomic field";
                let field_kind = value_kind env typ in
                let access =
                  match repres with
@@ -1032,7 +1037,11 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     let copy_id = Ident.create_local "newrecord" in
     let update_field cont (lbl, definition) =
       match definition with
-      | Kept _ -> cont
+      | Kept _ ->
+          if lbl.lbl_atomic = Atomic then
+            fatal_error
+              "transl_record: update expr implicitly copies atomic field";
+          cont
       | Overridden (_lid, expr) ->
           let upd =
             match repres with

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -269,3 +269,119 @@ module Pattern_matching_wildcard :
     val allowed : t -> int
   end
 |}]
+
+(* We disallow functional updates that perform implicit loads of atomic fields. *)
+
+module Functional_update_error = struct
+  type t = { x : int ; mutable y : int [@atomic] }
+
+  (* The update performs an implicit atomic load of y. Not allowed! *)
+  let forbidden t = { t with x = 42 }
+end
+[%%expect{|
+Line 5, characters 22-23:
+5 |   let forbidden t = { t with x = 42 }
+                          ^
+Error: Functional updates that implicitly read atomic fields (here "y")
+       are forbidden. Hint: if you intend to copy the value
+       of an atomic field, do so explicitly: "{ t with y = t.y }"
+|}]
+
+(* Updates that overwrite all of the old record's atomic fields are allowed. *)
+
+module Functional_update_ok = struct
+  type t = { x : int ; mutable y : int [@atomic] }
+
+  (* The update performs no implicit atomic loads. Allowed! *)
+  let allowed t = { t with y = 42 }
+end
+[%%expect{|
+(apply (field_mut 1 (global Toploop!)) "Functional_update_ok/437"
+  (let (allowed = (function t (makemutable 0 (int,int) (field_int 0 t) 42)))
+    (makeblock 0 allowed)))
+module Functional_update_ok :
+  sig
+    type t = { x : int; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_copy_ok = struct
+  type t = { x : int ; mutable y : int [@atomic] }
+
+  (* The update performs an explicit atomic load. Allowed! *)
+  let allowed t = { t with y = t.y }
+end
+[%%expect{|
+(apply (field_mut 1 (global Toploop!)) "Functional_update_copy_ok/445"
+  (let
+    (allowed =
+       (function t
+         (makemutable 0 (int,int) (field_int 0 t) (atomic_load t 1))))
+    (makeblock 0 allowed)))
+module Functional_update_copy_ok :
+  sig
+    type t = { x : int; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_multi_error = struct
+  type t = { x : int ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let forbidden t = { t with y = 42 } (* implicit atomic load of z *)
+end
+[%%expect{|
+Line 4, characters 22-23:
+4 |   let forbidden t = { t with y = 42 } (* implicit atomic load of z *)
+                          ^
+Error: Functional updates that implicitly read atomic fields (here "z")
+       are forbidden. Hint: if you intend to copy the value
+       of an atomic field, do so explicitly: "{ t with z = t.z }"
+|}]
+
+module Functional_update_multi_ok = struct
+  type t = { x : int ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
+end
+[%%expect{|
+(apply (field_mut 1 (global Toploop!)) "Functional_update_multi_ok/461"
+  (let
+    (allowed =
+       (function t (makemutable 0 (int,int,int) (field_int 0 t) 42 67)))
+    (makeblock 0 allowed)))
+module Functional_update_multi_ok :
+  sig
+    type t = {
+      x : int;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_multi_copy_ok = struct
+  type t = { x : int ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
+end
+[%%expect{|
+(apply (field_mut 1 (global Toploop!)) "Functional_update_multi_copy_ok/470"
+  (let
+    (allowed =
+       (function t
+         (makemutable 0 (int,int,int) (field_int 0 t) (atomic_load t 1)
+           (atomic_load t 2))))
+    (makeblock 0 allowed)))
+module Functional_update_multi_copy_ok :
+  sig
+    type t = {
+      x : int;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -192,6 +192,7 @@ type error =
   | Invalid_atomic_loc_payload
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
+  | Atomic_in_functional_update of label
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Illegal_letrec_pat
@@ -2063,6 +2064,10 @@ let forbid_atomic_field_patterns loc penv (label_lid, label, pat) =
   in
   if label.lbl_atomic = Atomic && not (wildcard pat) then
     Error.log_or_raise loc !!penv (Atomic_in_pattern label_lid.txt)
+
+let forbid_atomic_in_record_update loc env lbl =
+  if lbl.lbl_atomic = Atomic then
+    Error.log_or_raise loc env (Atomic_in_functional_update lbl.lbl_name)
 
 (** [type_pat] propagates the expected type, and
     unification may update the typing environment. *)
@@ -5016,6 +5021,7 @@ and type_expect_
                     unify_exp_types loc env ty_arg1 ty_arg2;
                     with_explanation (fun () ->
                         unify_exp_types loc env (instance ty_expected) ty_res2);
+                    forbid_atomic_in_record_update exp.exp_loc env lbl;
                     Kept (ty_arg1, lbl.lbl_mut)
                   end
               in
@@ -8633,6 +8639,13 @@ let report_error ~loc env =
          will happen during pattern matching:@ the field may be read@ \
          zero, one or several times depending on the patterns around it."
         quoted_longident lid
+  | Atomic_in_functional_update l ->
+      Location.errorf ~loc
+        "Functional updates that implicitly read atomic fields (here %a)@ \
+         are forbidden. @{<hint>Hint@}: if you intend to copy the value@ \
+         of an atomic field, do so explicitly:@ %a"
+        Style.inline_code l
+        Style.inline_code ("{ t with " ^ l ^ " = t." ^ l ^ " }")
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -233,6 +233,7 @@ type error =
   | Invalid_atomic_loc_payload
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
+  | Atomic_in_functional_update of label
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Illegal_letrec_pat


### PR DESCRIPTION
Fixes #14918. A functional record update (`{ t with x = 42 }`) implicitly copies the fields that are not overridden. When one of those kept fields is atomic, this results in a nonatomic read of an atomic field.

This PR rejects such updates during typechecking with a new `Atomic_in_functional_update` error (mirroring how atomic fields are already forbidden in patterns). Functional updates that overwrite all of a record's atomic fields are still allowed.

Add defensive fatal_errors in transl_record for the kept-atomic-field cases.

## Example
```
type t = { x : int ; mutable y : int [@atomic] }
let f t = { t with x = 42 }
```

### Before
Functional record update performs a nonatomic read of `y`. Compiled with `-dlambda`:

```
(setglobal Prob!
  (let
    (f/277 =
       (function t/279 (makemutable 0 (int,int) 42 (field_int 1 t/279))))
    (makeblock 0 f/277)))
```

### After

Compile error.

```
File "/tmp/prob.ml", line 2, characters 12-13:
2 | let f t = { t with x = 42 }
                ^
Error: Functional updates that implicitly read atomic fields (here y)
       are forbidden. Hint: if you intend to copy the value
       of an atomic field, do so explicitly: { t with y = t.y }
```