### PR TITLE
printtyped: fix Twith_modtypesubst

### DIFF
--- a/Changes
+++ b/Changes
@@ -375,6 +375,9 @@ Working version
   certain large types, as seen in #14897.
   (Stefan Muenzel, review by Gabriel Scherer and Vincent Laviron)
 
+- #14932: Fix `-dtypedtree` printing of `Twith_modtypesubst`.
+  (Corentin De Souza, review by Nicolás Ojeda Bär)
+
 ### Build system:
 
 - #14552: Export `AR` and `ARFLAGS` in Makefile.config.

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -866,7 +866,7 @@ and with_constraint i ppf x =
       line i ppf "Twith_modtype\n";
       module_type (i+1) ppf mty
   | Twith_modtypesubst mty ->
-      line i ppf "Twith_modtype\n";
+      line i ppf "Twith_modtypesubst\n";
       module_type (i+1) ppf mty
 
 and module_expr i ppf x =


### PR DESCRIPTION
On code with module type substitution (`... with module type S := ...`), in the typedtree dumped by `-dtypedtree`, the constraint was displayed as `Twith_modtype` instead of `Twith_modtypesubst`

## Example
```
$ cat twith_modtypesubst.ml
module type MT = sig
  module type S
end with module type S := sig end
```
Before:
```
$ ocamlopt -dtypedtree twith_modtypesubst.ml 
[
  structure_item (twith_modtypesubst.ml[1,0+0]..twith_modtypesubst.ml[3,37+33])
    Tstr_modtype "MT/275"
      module_type (twith_modtypesubst.ml[1,0+17]..twith_modtypesubst.ml[3,37+33])
        Tmty_with
        module_type (twith_modtypesubst.ml[1,0+17]..twith_modtypesubst.ml[3,37+3])
          Tmty_signature
          [
            signature_item (twith_modtypesubst.ml[2,21+2]..twith_modtypesubst.ml[2,21+15])
              Tsig_modtype "S/274"
              #abstract          ]
        [
          "S/274"
            Twith_modtype
              module_type (twith_modtypesubst.ml[3,37+26]..twith_modtypesubst.ml[3,37+33])
                Tmty_signature
                []
        ]
]
```
After:
```
$ ocamlopt -dtypedtree twith_modtypesubst.ml 
[
  structure_item (twith_modtypesubst.ml[1,0+0]..twith_modtypesubst.ml[3,37+33])
    Tstr_modtype "MT/275"
      module_type (twith_modtypesubst.ml[1,0+17]..twith_modtypesubst.ml[3,37+33])
        Tmty_with
        module_type (twith_modtypesubst.ml[1,0+17]..twith_modtypesubst.ml[3,37+3])
          Tmty_signature
          [
            signature_item (twith_modtypesubst.ml[2,21+2]..twith_modtypesubst.ml[2,21+15])
              Tsig_modtype "S/274"
              #abstract          ]
        [
          "S/274"
            Twith_modtypesubst
              module_type (twith_modtypesubst.ml[3,37+26]..twith_modtypesubst.ml[3,37+33])
                Tmty_signature
                []
        ]
]
```