### PR TITLE
runtime: Fix sigaltstack call with musl on certain Intel CPUs

### DIFF
--- a/Changes
+++ b/Changes
@@ -118,6 +118,11 @@ Working version
 - #14506: Add frame pointers support for RISC-V Linux.
   (Miod Vallat and Tim McGilchrist, review by Zane Hambly)
 
+- #14933: Respect `sysconf(_SC_SIGSTKSZ)` when choosing the size for the
+  alternate signal stack, avoiding fatal errors when linked against musl libc on
+  some Intel CPUs.
+  (Nat Mote, review by Florian Angeletti and Miod Vallat)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -21,6 +21,9 @@
 #include <errno.h>
 #include <stdbool.h>
 #include "caml/config.h"
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 #ifdef USE_MMAP_MAP_STACK
 #include <sys/mman.h>
 #endif
@@ -545,12 +548,40 @@ CAMLprim value caml_sys_rev_convert_signal_number(value signo)
   return Val_int(caml_rev_convert_signal_number(Int_val(signo)));
 }
 
+#ifdef POSIX_SIGNALS
+/* On Linux, the minimum signal stack size is architecture-dependent, whereas
+ * SIGSTKSZ can be a build-time constant and may be smaller than the run-time
+ * minimum (e.g. on musl with certain Intel CPUs). Thus, we call sysconf for the
+ * run-time value ourselves. */
+Caml_inline size_t caml_sigstksz(void)
+{
+  /* Compute the recommended signal stack size only once. Atomic due to benign
+   * concurrent reads during domain init. */
+  static _Atomic size_t cache = 0;
+  size_t size = atomic_load_relaxed(&cache);
+  if (size == 0) {
+    long sz;
+#ifdef _SC_SIGSTKSZ
+    /* glibc/musl only */
+    sz = sysconf(_SC_SIGSTKSZ);
+    if (sz <= 0)
+      sz = SIGSTKSZ;
+#else
+    sz = SIGSTKSZ;
+#endif
+    size = (size_t) sz;
+    atomic_store_relaxed(&cache, size);
+  }
+  return size;
+}
+#endif /* POSIX_SIGNALS */
+
 void * caml_init_signal_stack(void)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk;
   stk.ss_flags = 0;
-  stk.ss_size = SIGSTKSZ;
+  stk.ss_size = caml_sigstksz();
   /* The memory used for the alternate signal stack must not free'd before
      calling sigaltstack with SS_DISABLE. malloc/mmap is therefore used rather
      than caml_stat_alloc_noexc so that if a shutdown path erroneously fails
@@ -563,7 +594,7 @@ void * caml_init_signal_stack(void)
   if (stk.ss_sp == MAP_FAILED)
     return NULL;
   if (sigaltstack(&stk, NULL) < 0) {
-    munmap(stk.ss_sp, SIGSTKSZ);
+    munmap(stk.ss_sp, stk.ss_size);
     return NULL;
   }
 #else
@@ -587,7 +618,7 @@ void caml_free_signal_stack(void * signal_stack)
   stack_t stk, disable;
   disable.ss_flags = SS_DISABLE;
   disable.ss_sp = NULL;  /* not required but avoids a valgrind false alarm */
-  disable.ss_size = SIGSTKSZ; /* macOS wants a valid size here */
+  disable.ss_size = caml_sigstksz(); /* macOS wants a valid size here */
   if (sigaltstack(&disable, &stk) < 0) {
     caml_fatal_error("Failed to reset signal stack (err %d)", errno);
   }
@@ -599,7 +630,7 @@ void caml_free_signal_stack(void * signal_stack)
   /* Memory was allocated with malloc/mmap directly (see
      caml_init_signal_stack) */
 #ifdef USE_MMAP_MAP_STACK
-  munmap(signal_stack, SIGSTKSZ);
+  munmap(signal_stack, caml_sigstksz());
 #else
   free(signal_stack);
 #endif /* USE_MMAP_MAP_STACK */


### PR DESCRIPTION
## The Problem

The OCaml runtime calls `sigaltstack` with the size of the stack set to `SIGSTKSZ`. Musl libc defines that as a build-time constant.

Musl 1.2.6 includes [a change](https://git.musl-libc.org/cgit/musl/commit/?id=300a1f53907a4acaadd9a696d0c67eee6fc10430) that errors if the size passed to `sigaltstack` is less than `sysconf(_SC_MINSIGSTKSZ)`. This value is determined at runtime based on `AT_MINSIGSTKSZ`. The kernel determines `AT_MINSIGSTKSZ` based in part on constants provided by the CPU. As a result, `sysconf(_SC_MINSIGSTKSZ)` can be greater than `SIGSTKSZ`, leading to a fatal error in the OCaml runtime when linked against musl 1.2.6 or later.

Specifically, I have observed this on Alpine 3.24 (which ships with musl 1.2.6) on a host system with an Intel(R) Xeon(R) Platinum 8488C CPU. It sets `AT_MINSIGSTKSZ` to `11952`, `sysconf(_SC_MINSIGSTKSZ)` to `12976`, and `SIGSTKSZ` is hardcoded at compiler build time to `8192`. When the OCaml runtime calls `sigaltstack` with a size of `8192`, it triggers musl's new check and fails with `Fatal error: Failed to allocate signal stack for domain 0`. OCaml programs cannot survive in this environment.

## The Fix

The fix is fairly straightforward. We dynamically choose the size of the signal stack based on `sysconf(_SC_MINSIGSTKSZ)`, when available. This logic is gated behind an `#ifdef` because on some platforms (e.g. macOS) it is not available.

One flag for reviewers: We now call the new `caml_signal_stack_size` utility to provide the size for `munmap`. The correctness of this decision relies on the assumption that this function will always return the same value within a single program execution. I believe that this is a valid assumption.

We have also merged this into our own fork at https://github.com/semgrep/ocaml/pull/21.

## Test plan

It doesn't seem feasible to add automated tests for such a hardware and system-specific issue. I manually validated that with this patch, a hello world OCaml program can run on the system described above. I have integrated this change into our OCaml fork and adopted it in Semgrep. All of our CI passes, including on the offending Intel CPUs with Alpine 3.24. We have builds and tests for macOS (both x86 and ARM), Linux (both x86 and ARM), and Windows (x86).

## Miscellaneous

Per OCaml's AI policy, I am disclosing that I used LLMs extensively to identify this issue and to produce the fix. I reviewed the facts and the code and I wrote the comments and this PR description without LLMs.