### PR TITLE
Improve `CAMLthread_local` definition for C/C++ interoperability

### DIFF
--- a/Changes
+++ b/Changes
@@ -118,6 +118,10 @@ Working version
 - #14506: Add frame pointers support for RISC-V Linux.
   (Miod Vallat and Tim McGilchrist, review by Zane Hambly)
 
+- #14911, #14943: Fix declarations of thread-local symbols with external linkage
+  for C++ interoperability.
+  (Antonin Décimo, report by Kate Deplaix, review by ??)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/Changes
+++ b/Changes
@@ -120,7 +120,7 @@ Working version
 
 - #14911, #14943: Fix declarations of thread-local symbols with external linkage
   for C++ interoperability.
-  (Antonin Décimo, report by Kate Deplaix, review by ??)
+  (Antonin Décimo, report by Kate Deplaix, review by David Allsopp)
 
 ### Type system:
 

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -47,7 +47,17 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern CAMLthread_local(caml_domain_state* caml_state);
+/* Use legacy thread-local extensions for symbols with external linkage
+ * (on declarations and definitions) for interoperability with C++.
+ * C11 _Thread_local may be used for symbols with internal linkage. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(__cplusplus)
+  [[msvc::no_tls_guard]]
+#endif
+  CAMLextern __declspec(thread) caml_domain_state* caml_state;
+#else
+  CAMLextern __thread caml_domain_state* caml_state;
+#endif
   #define Caml_state_opt caml_state
 #else
 #if __has_attribute(pure) || defined(__GNUC__)

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -47,7 +47,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern CAMLthread_local caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local(caml_domain_state* caml_state);
   #define Caml_state_opt caml_state
 #else
 #if __has_attribute(pure) || defined(__GNUC__)

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "misc.h"
 
-extern CAMLthread_local(intnat caml_icount);
+extern _Thread_local intnat caml_icount;
 void caml_stop_here (void);
 void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "misc.h"
 
-extern CAMLthread_local intnat caml_icount;
+extern CAMLthread_local(intnat caml_icount);
 void caml_stop_here (void);
 void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -165,19 +165,6 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLalign(n) _Alignas(n)
 #endif
 
-/* Use CAMLthread_local for symbols with external linkage (on declarations and
-   definitions) for interoperability with C++. C11 _Thread_local may be used for
-   symbols with internal linkage. */
-#if defined(_MSC_VER) && !defined(__clang__)
-#if defined(__cplusplus)
-#define CAMLthread_local(decl) __declspec(thread) decl [[msvc::no_tls_guard]]
-#else
-#define CAMLthread_local(decl) __declspec(thread) decl
-#endif
-#else
-#define CAMLthread_local(decl) __thread decl
-#endif
-
 /* Prefetching */
 
 #ifdef CAML_INTERNALS

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -165,13 +165,17 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLalign(n) _Alignas(n)
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
-    defined(__cplusplus) && !defined(__CYGWIN__)
-    /* #14220: flexlink does not support C++11 's thread_local,
-       so prefer _Thread_local on Cygwin systems. */
-#define CAMLthread_local thread_local
+/* Use CAMLthread_local for symbols with external linkage (on declarations and
+   definitions) for interoperability with C++. C11 _Thread_local may be used for
+   symbols with internal linkage. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(__cplusplus)
+#define CAMLthread_local(decl) __declspec(thread) decl [[msvc::no_tls_guard]]
 #else
-#define CAMLthread_local _Thread_local
+#define CAMLthread_local(decl) __declspec(thread) decl
+#endif
+#else
+#define CAMLthread_local(decl) __thread decl
 #endif
 
 /* Prefetching */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -632,7 +632,7 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-CAMLextern CAMLthread_local int caml_lockdepth;
+CAMLextern CAMLthread_local(int caml_lockdepth);
 #define DEBUG_LOCK(m) (caml_lockdepth++)
 #define DEBUG_UNLOCK(m) (caml_lockdepth--)
 #else

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -632,7 +632,7 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-CAMLextern CAMLthread_local(int caml_lockdepth);
+CAMLextern _Thread_local int caml_lockdepth;
 #define DEBUG_LOCK(m) (caml_lockdepth++)
 #define DEBUG_UNLOCK(m) (caml_lockdepth--)
 #else

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -202,7 +202,7 @@ struct dom_internal {
 };
 typedef struct dom_internal dom_internal;
 
-static CAMLthread_local dom_internal* domain_self;
+static _Thread_local dom_internal* domain_self;
 
 static struct {
   /* enter barrier for STW sections, participating domains arrive into
@@ -359,7 +359,7 @@ static void stop_active_domain(dom_internal* dom) {
   check_stw_domains();
 }
 
-CAMLexport CAMLthread_local caml_domain_state* caml_state;
+CAMLexport CAMLthread_local(caml_domain_state* caml_state);
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */
@@ -369,7 +369,7 @@ CAMLexport caml_domain_state* caml_get_domain_state(void)
 }
 #endif
 
-static CAMLthread_local uintnat previous_domain_id = -1;
+static _Thread_local uintnat previous_domain_id = -1;
 
 CAMLexport
 bool caml_thread_running_on_expected_domain(uintnat expected_unique_id)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -359,7 +359,16 @@ static void stop_active_domain(dom_internal* dom) {
   check_stw_domains();
 }
 
-CAMLexport CAMLthread_local(caml_domain_state* caml_state);
+/* Use legacy thread-local extensions for symbols with external linkage
+ * (on declarations and definitions) for interoperability with C++. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(__cplusplus)
+[[msvc::no_tls_guard]]
+#endif
+CAMLexport __declspec(thread) caml_domain_state* caml_state;
+#else
+CAMLexport __thread caml_domain_state* caml_state;
+#endif
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -32,7 +32,7 @@
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Greater than zero when the current thread is scanning the roots */
-static CAMLthread_local int iterating_roots = 0;
+static _Thread_local int iterating_roots = 0;
 
 enum { ROOT_PRESENT = 0, ROOT_DELETED = 1 };
 

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -42,7 +42,7 @@ static char const * const names_of_instructions [] = {
 
 extern code_t caml_start_code;
 
-CAMLthread_local(intnat caml_icount) = 0;
+_Thread_local intnat caml_icount = 0;
 
 void caml_stop_here (void)
 {

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -42,7 +42,7 @@ static char const * const names_of_instructions [] = {
 
 extern code_t caml_start_code;
 
-CAMLthread_local intnat caml_icount = 0;
+CAMLthread_local(intnat caml_icount) = 0;
 
 void caml_stop_here (void)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -242,7 +242,7 @@ Caml_inline void check_trap_barrier_for_effect
 #endif
 
 #ifdef DEBUG
-static CAMLthread_local intnat caml_bcodcount;
+static _Thread_local intnat caml_bcodcount;
 #endif
 
 static value raise_unhandled_effect;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -82,7 +82,7 @@ static char dummy_buff[1];
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static CAMLthread_local struct channel* last_channel_locked = NULL;
+static _Thread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -60,7 +60,7 @@ CAMLnoret void caml_debug_abort(const char_os * file_os, int line) {
 #endif
 
 #if defined(DEBUG)
-static CAMLthread_local int noalloc_level = 0;
+static _Thread_local int noalloc_level = 0;
 int caml_noalloc_begin(void)
 {
   return noalloc_level++;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -49,7 +49,7 @@ void caml_plat_fatal_error(const char * action, int err)
 /* Mutexes */
 
 #ifdef DEBUG
-CAMLexport CAMLthread_local(int caml_lockdepth) = 0;
+CAMLexport _Thread_local int caml_lockdepth = 0;
 #endif
 
 void caml_plat_assert_all_locks_unlocked(void)

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -49,7 +49,7 @@ void caml_plat_fatal_error(const char * action, int err)
 /* Mutexes */
 
 #ifdef DEBUG
-CAMLexport CAMLthread_local int caml_lockdepth = 0;
+CAMLexport CAMLthread_local(int caml_lockdepth) = 0;
 #endif
 
 void caml_plat_assert_all_locks_unlocked(void)

--- a/testsuite/tests/lib-marshal/intextaux_par.c
+++ b/testsuite/tests/lib-marshal/intextaux_par.c
@@ -20,7 +20,7 @@
 #define CAML_INTERNALS
 
 #define BLOCK_SIZE 512
-static CAMLthread_local char marshal_block[BLOCK_SIZE];
+static _Thread_local char marshal_block[BLOCK_SIZE];
 
 value marshal_to_block(value vlen, value v, value vflags)
 {


### PR DESCRIPTION
For symbols with external linkage, care must be taken for C&NoBreak;+&NoBreak;+ interoperability.

Use the `__declspec(thread)` qualifier for MSVC in C&NoBreak;+&NoBreak;+, and add the `[[msvc::no_tls_guard]]` attribute to prevent MSVC from using TLS guards in C&NoBreak;+&NoBreak;+. MSVC in C11 doesn't support this attribute. Clang-cl doesn't support this MSVC attribute.

Use the legacy `__thread` extension of GCC and Clang, that should have the C11 `_Thread_local` semantics in all cases.

Fixes #14911 (see https://github.com/ocaml/ocaml/issues/14911#issuecomment-4920072173 for an explanation), see also #12811, #13541, https://github.com/ocaml/ocaml/pull/14220#issuecomment-3254629771, [`_Thread_local` for better C&NoBreak;⁠+&NoBreak;⁠+ interoperability with C (N2850)](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2850.pdf).

The error is caught by the Cygwin job in the CI, enabled by the `CI: Full matrix` label, with the `lib-unix/unix-sockaddr/sockaddr_cxx` test: see [these logs](https://github.com/ocaml/ocaml/actions/runs/29364498871/job/87192601262?pr=14921#step:14:793).

For symbols with internal linkage, I've decided to stay close to the C11 standard and use the `_Thread_local` keyword rather than extra tricks, but we could use `CAMLthread_local` for them too. 

<hr>

I have a more complex but also more complete proposal that works in standard C&NoBreak;+&NoBreak;+&NoBreak;20, and uses fallback with compilers extensions. Since it is more complex, it is also possibly more debatable, so I'm submitting the minimal working patch.

```c++
#if !defined(__cplusplus) || __has_extension(c_thread_local)
#define CAMLthread_local(decl) _Thread_local decl
#elif defined(_MSC_VER) && !defined(__clang__)
#define CAMLthread_local(decl) thread_local decl [[msvc::no_tls_guard]]
#elif defined(__cpp_constinit)
#define CAMLthread_local(decl) thread_local constinit decl
#elif __has_cpp_attribute(clang::require_constant_initialization)
#define CAMLthread_local(decl)                                  \
  thread_local decl [[clang::require_constant_initialization]]
#elif defined(__GNUC__) && __GNUC__ >= 10
#define CAMLthread_local(decl) thread_local __constinit decl
#elif defined(__GNUC__)
#define CAMLthread_local(decl) __thread decl
#else
#error "No C-thread-local for interoperability with C++"
#endif

#ifdef __cplusplus
extern "C" {
#endif

extern CAMLthread_local(struct s *p); // an extern declaration

#ifdef __cplusplus
}
#endif

CAMLthread_local(struct *s p); // a extern definition (in a C file)
static _Thread_local struct *s q; // a static definition (in a C file)
```