### PR TITLE
fix record updates with unchanged atomic fields

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -75,6 +75,46 @@ let transl_extension_constructor ~scopes env path ext =
   | Text_rebind(path, _lid) ->
       transl_extension_path loc env path
 
+(* Compile record field accesses *)
+
+let transl_atomic_field ~scopes:_ lbl =
+  let offset =
+    match lbl.lbl_repres with
+    | Record_regular
+    | Record_inlined _ -> 0
+    | Record_float ->
+        fatal_error
+          "Translcore.transl_atomic_field: atomic field in float record"
+    | Record_unboxed _ ->
+        fatal_error
+          "Translcore.transl_atomic_field: atomic field in unboxed record"
+    | Record_extension _ -> 1
+  in
+  Lconst (Const_int (lbl.lbl_pos + offset))
+
+let transl_get_field ~scopes loc targ lbl imm_kind =
+  let loc = of_location ~scopes loc in
+  let unboxed =
+    match lbl.lbl_repres with Record_unboxed _ -> true | _ -> false
+  in
+  if unboxed then targ else
+  match lbl.lbl_atomic with
+  | Nonatomic ->
+    let prim =
+      match lbl.lbl_repres with
+      | Record_regular | Record_inlined _ ->
+        Pfield (lbl.lbl_pos, imm_kind, lbl.lbl_mut)
+      | Record_unboxed _ -> assert false
+      | Record_float ->
+        Pfloatfield lbl.lbl_pos
+      | Record_extension _ ->
+        Pfield (lbl.lbl_pos + 1, imm_kind, lbl.lbl_mut)
+    in
+    Lprim(prim, [targ], loc)
+  | Atomic ->
+    let pos = transl_atomic_field ~scopes lbl in
+    Lprim (Patomic_load, [targ; pos], loc)
+
 (* To propagate structured constants *)
 
 exception Not_constant
@@ -337,37 +377,24 @@ and transl_exp0 ~in_new_scope ~scopes e =
         fields representation extended_expression
   | Texp_atomic_loc (arg, _, lbl) ->
       let loc = of_location ~scopes e.exp_loc in
-      let (arg, lbl) = transl_atomic_loc ~scopes arg lbl in
-      make_atomic_loc ~loc arg lbl
-  | Texp_field (arg, _, ({ lbl_atomic = Atomic; _ } as lbl)) ->
-      let arg, lbl = transl_atomic_loc ~scopes arg lbl in
-      let loc = of_location ~scopes e.exp_loc in
-      Lprim (Patomic_load, [arg; lbl], loc)
+      let arg = transl_exp ~scopes arg in
+      let field = transl_atomic_field ~scopes lbl in
+      make_atomic_loc ~loc arg field
   | Texp_field (arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
-      begin match lbl.lbl_repres with
-          Record_regular | Record_inlined _ ->
-          Lprim (Pfield (lbl.lbl_pos, maybe_pointer e, lbl.lbl_mut), [targ],
-                 of_location ~scopes e.exp_loc)
-        | Record_unboxed _ -> targ
-        | Record_float ->
-          Lprim (Pfloatfield lbl.lbl_pos, [targ],
-                 of_location ~scopes e.exp_loc)
-        | Record_extension _ ->
-          Lprim (Pfield (lbl.lbl_pos + 1, maybe_pointer e, lbl.lbl_mut), [targ],
-                 of_location ~scopes e.exp_loc)
-      end
+      transl_get_field ~scopes e.exp_loc targ lbl (maybe_pointer e)
   | Texp_setfield (arg, _, ({ lbl_atomic = Atomic; _ } as lbl), newval) ->
       let prim =
         Primitive.simple
           ~name:"caml_atomic_exchange_field" ~arity:3 ~alloc:false
       in
-      let arg, lbl = transl_atomic_loc ~scopes arg lbl in
+      let arg = transl_exp ~scopes arg in
+      let field = transl_atomic_field ~scopes lbl in
       let newval = transl_exp ~scopes newval in
       let loc = of_location ~scopes e.exp_loc in
       Lprim (
         Pignore,
-        [Lprim (Pccall prim, [arg; lbl; newval], loc)],
+        [Lprim (Pccall prim, [arg; field; newval], loc)],
         loc
       )
   | Texp_setfield(arg, _, lbl, newval) ->
@@ -959,23 +986,6 @@ and transl_setinstvar ~scopes loc self var expr =
     [self; var; transl_exp ~scopes expr], loc)
 
 and transl_record ~scopes loc env fields repres opt_init_expr =
-  let atomic_load record_lam lbl =
-    let offset =
-      match lbl.lbl_repres with
-      | Record_regular
-      | Record_inlined _ -> 0
-      | Record_float ->
-          fatal_error
-            "Translcore.transl_record: atomic field in float record"
-      | Record_unboxed _ ->
-          fatal_error
-            "Translcore.transl_record: atomic field in unboxed record"
-      | Record_extension _ -> 1
-    in
-    let idx = Lconst (Const_int (lbl.lbl_pos + offset)) in
-    let loc = of_location ~scopes loc in
-    Lprim(Patomic_load, [record_lam; idx], loc)
-  in
   let size = Array.length fields in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
@@ -986,24 +996,13 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
        taken from init_expr if any *)
     let init_id = Ident.create_local "init" in
     let lv =
-      Array.mapi
-        (fun i (lbl, definition) ->
+      Array.map
+        (fun (lbl, definition) ->
            match definition with
-           | Kept (typ, mut) ->
-             if lbl.lbl_atomic = Atomic then
-               atomic_load (Lvar init_id) lbl, value_kind env typ
-             else 
+           | Kept (typ, _) ->
+               let imm_kind = maybe_pointer_type env typ in
                let field_kind = value_kind env typ in
-               let access =
-                 match repres with
-                 | Record_regular | Record_inlined _ ->
-                     Pfield (i, maybe_pointer_type env typ, mut)
-                 | Record_unboxed _ -> assert false
-                 | Record_extension _ ->
-                     Pfield (i + 1, maybe_pointer_type env typ, mut)
-                 | Record_float -> Pfloatfield i in
-               Lprim(access, [Lvar init_id],
-                     of_location ~scopes loc),
+               transl_get_field ~scopes loc (Lvar init_id) lbl imm_kind,
                field_kind
            | Overridden (_lid, expr) ->
                let field_kind = value_kind expr.exp_env expr.exp_type in
@@ -1070,8 +1069,9 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
           (* #14918: for atomic records we need a proper atomic read to
              take place; Pduprecord will take a non-atomic copy of all
              fields, so we re-assign the atomic fields afterwards. *)
-          let lam = atomic_load (Lvar copy_id) lbl in
-          let set = assign lbl (maybe_pointer_type env typ) lam in
+          let imm_kind = maybe_pointer_type env typ in
+          let lam = transl_get_field ~scopes loc  (Lvar copy_id) lbl imm_kind in
+          let set = assign lbl imm_kind lam in
           Lsequence(set, cont)
       | Kept (_typ, _mut) -> cont
       | Overridden (_lid, expr) ->
@@ -1088,23 +1088,6 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
              Array.fold_left update_field (Lvar copy_id) fields)
     end
   end
-
-and transl_atomic_loc ~scopes arg lbl =
-  let arg = transl_exp ~scopes arg in
-  let offset =
-    match lbl.lbl_repres with
-    | Record_regular
-    | Record_inlined _ -> 0
-    | Record_float ->
-        fatal_error
-          "Translcore.transl_atomic_loc: atomic field in float record"
-    | Record_unboxed _ ->
-        fatal_error
-          "Translcore.transl_atomic_loc: atomic field in unboxed record"
-    | Record_extension _ -> 1
-  in
-  let lbl = Lconst (Const_int (lbl.lbl_pos + offset)) in
-  (arg, lbl)
 
 and transl_match ~scopes e arg pat_expr_list partial =
   let rewrite_case (val_cases, exn_cases, static_handlers as acc)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -75,6 +75,18 @@ let transl_extension_constructor ~scopes env path ext =
   | Text_rebind(path, _lid) ->
       transl_extension_path loc env path
 
+(* To propagate structured constants *)
+
+exception Not_constant
+
+let extract_constant = function
+    Lconst sc -> sc
+  | _ -> raise Not_constant
+
+let extract_float = function
+    Const_float f -> f
+  | _ -> fatal_error "Translcore.extract_float"
+
 (* Compile record field accesses *)
 
 let transl_atomic_field ~scopes:_ lbl =
@@ -138,17 +150,35 @@ let transl_set_field ~scopes loc trec lbl imm_kind tnewval =
     in
     Lprim(Pignore, [Lprim (Pccall prim, [trec; pos; tnewval], loc)], loc)
 
-(* To propagate structured constants *)
-
-exception Not_constant
-
-let extract_constant = function
-    Lconst sc -> sc
-  | _ -> raise Not_constant
-
-let extract_float = function
-    Const_float f -> f
-  | _ -> fatal_error "Translcore.extract_float"
+let transl_record_init ~scopes loc env fields repres tvals shape =
+  let mut =
+    if Array.exists (fun (lbl, _) -> lbl.lbl_mut = Mutable) fields
+    then Mutable
+    else Immutable in
+  try
+    if mut = Mutable then raise Not_constant;
+    let cl = List.map extract_constant tvals in
+    match repres with
+    | Record_regular -> Lconst(Const_block(0, cl))
+    | Record_inlined tag -> Lconst(Const_block(tag, cl))
+    | Record_unboxed _ -> Lconst(match cl with [v] -> v | _ -> assert false)
+    | Record_float ->
+      Lconst(Const_float_array(List.map extract_float cl))
+    | Record_extension _ ->
+      raise Not_constant
+  with Not_constant ->
+    let loc = of_location ~scopes loc in
+    match repres with
+    | Record_regular ->
+      Lprim(Pmakeblock(0, mut, Some shape), tvals, loc)
+    | Record_inlined tag ->
+      Lprim(Pmakeblock(tag, mut, Some shape), tvals, loc)
+    | Record_unboxed _ -> (match tvals with [v] -> v | _ -> assert false)
+    | Record_float ->
+      Lprim(Pmakearray (Pfloatarray, mut), tvals, loc)
+    | Record_extension path ->
+      let slot = transl_extension_path loc env path in
+      Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape)), slot :: tvals, loc)
 
 (* Insertion of debugging events *)
 
@@ -1011,37 +1041,8 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
                transl_exp ~scopes expr, field_kind)
         fields
     in
-    let ll, shape = List.split (Array.to_list lv) in
-    let mut =
-      if Array.exists (fun (lbl, _) -> lbl.lbl_mut = Mutable) fields
-      then Mutable
-      else Immutable in
-    let lam =
-      try
-        if mut = Mutable then raise Not_constant;
-        let cl = List.map extract_constant ll in
-        match repres with
-        | Record_regular -> Lconst(Const_block(0, cl))
-        | Record_inlined tag -> Lconst(Const_block(tag, cl))
-        | Record_unboxed _ -> Lconst(match cl with [v] -> v | _ -> assert false)
-        | Record_float ->
-            Lconst(Const_float_array(List.map extract_float cl))
-        | Record_extension _ ->
-            raise Not_constant
-      with Not_constant ->
-        let loc = of_location ~scopes loc in
-        match repres with
-          Record_regular ->
-            Lprim(Pmakeblock(0, mut, Some shape), ll, loc)
-        | Record_inlined tag ->
-            Lprim(Pmakeblock(tag, mut, Some shape), ll, loc)
-        | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)
-        | Record_float ->
-            Lprim(Pmakearray (Pfloatarray, mut), ll, loc)
-        | Record_extension path ->
-            let slot = transl_extension_path loc env path in
-            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape)), slot :: ll, loc)
-    in
+    let tvals, shape = List.split (Array.to_list lv) in
+    let lam = transl_record_init ~scopes loc env fields repres tvals shape in
     begin match opt_init_expr with
       None -> lam
     | Some init_expr -> Llet(Strict, Pgenval, init_id,

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -115,6 +115,29 @@ let transl_get_field ~scopes loc targ lbl imm_kind =
     let pos = transl_atomic_field ~scopes lbl in
     Lprim (Patomic_load, [targ; pos], loc)
 
+let transl_set_field ~scopes loc trec lbl imm_kind tnewval =
+  let loc = of_location ~scopes loc in
+  match lbl.lbl_atomic with
+  | Nonatomic ->
+    let prim =
+      match lbl.lbl_repres with
+      | Record_regular
+      | Record_inlined _ ->
+        Psetfield(lbl.lbl_pos, imm_kind, Assignment)
+      | Record_unboxed _ -> assert false
+      | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
+      | Record_extension _ ->
+        Psetfield (lbl.lbl_pos + 1, imm_kind, Assignment)
+    in
+    Lprim(prim, [trec; tnewval], loc)
+  | Atomic ->
+    let pos = transl_atomic_field ~scopes lbl in
+    let prim =
+      Primitive.simple
+        ~name:"caml_atomic_exchange_field" ~arity:3 ~alloc:false
+    in
+    Lprim(Pignore, [Lprim (Pccall prim, [trec; pos; tnewval], loc)], loc)
+
 (* To propagate structured constants *)
 
 exception Not_constant
@@ -383,33 +406,12 @@ and transl_exp0 ~in_new_scope ~scopes e =
   | Texp_field (arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
       transl_get_field ~scopes e.exp_loc targ lbl (maybe_pointer e)
-  | Texp_setfield (arg, _, ({ lbl_atomic = Atomic; _ } as lbl), newval) ->
-      let prim =
-        Primitive.simple
-          ~name:"caml_atomic_exchange_field" ~arity:3 ~alloc:false
-      in
-      let arg = transl_exp ~scopes arg in
-      let field = transl_atomic_field ~scopes lbl in
-      let newval = transl_exp ~scopes newval in
-      let loc = of_location ~scopes e.exp_loc in
-      Lprim (
-        Pignore,
-        [Lprim (Pccall prim, [arg; field; newval], loc)],
-        loc
-      )
   | Texp_setfield(arg, _, lbl, newval) ->
-      let access =
-        match lbl.lbl_repres with
-          Record_regular
-        | Record_inlined _ ->
-          Psetfield(lbl.lbl_pos, maybe_pointer newval, Assignment)
-        | Record_unboxed _ -> assert false
-        | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
-        | Record_extension _ ->
-          Psetfield (lbl.lbl_pos + 1, maybe_pointer newval, Assignment)
-      in
-      Lprim(access, [transl_exp ~scopes arg; transl_exp ~scopes newval],
-            of_location ~scopes e.exp_loc)
+      let trec = transl_exp ~scopes arg in
+      let tnewval = transl_exp ~scopes newval in
+      transl_set_field ~scopes e.exp_loc
+        trec
+        lbl (maybe_pointer newval) tnewval
   | Texp_array (amut, expr_list) ->
       let kind = array_kind e in
       let ll = transl_list ~scopes expr_list in
@@ -1049,19 +1051,11 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     (* Take a shallow copy of the init record, then mutate the fields
        of the copy *)
     let copy_id = Ident.create_local "newrecord" in
-    let assign lbl value_kind lam =
-      let upd =
-        match repres with
-        | Record_regular
-        | Record_inlined _ ->
-            Psetfield(lbl.lbl_pos, value_kind, Assignment)
-        | Record_unboxed _ -> assert false
-        | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
-        | Record_extension _ ->
-            Psetfield(lbl.lbl_pos + 1, value_kind, Assignment)
-      in
-      Lprim(upd, [Lvar copy_id; lam],
-            of_location ~scopes loc)
+    let get_field lbl imm_kind =
+      transl_get_field ~scopes loc  (Lvar copy_id) lbl imm_kind
+    in
+    let set_field lbl imm_kind lam =
+      transl_set_field ~scopes loc (Lvar copy_id) lbl imm_kind lam
     in
     let update_field cont (lbl, definition) =
       match definition with
@@ -1070,13 +1064,13 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
              take place; Pduprecord will take a non-atomic copy of all
              fields, so we re-assign the atomic fields afterwards. *)
           let imm_kind = maybe_pointer_type env typ in
-          let lam = transl_get_field ~scopes loc  (Lvar copy_id) lbl imm_kind in
-          let set = assign lbl imm_kind lam in
+          let lam = get_field lbl imm_kind in
+          let set = set_field lbl imm_kind lam in
           Lsequence(set, cont)
       | Kept (_typ, _mut) -> cont
       | Overridden (_lid, expr) ->
           let lam = transl_exp ~scopes expr in
-          let set = assign lbl (maybe_pointer expr) lam in
+          let set = set_field lbl (maybe_pointer expr) lam in
           Lsequence(set, cont)
     in
     begin match opt_init_expr with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -959,6 +959,23 @@ and transl_setinstvar ~scopes loc self var expr =
     [self; var; transl_exp ~scopes expr], loc)
 
 and transl_record ~scopes loc env fields repres opt_init_expr =
+  let atomic_load record_lam lbl =
+    let offset =
+      match lbl.lbl_repres with
+      | Record_regular
+      | Record_inlined _ -> 0
+      | Record_float ->
+          fatal_error
+            "Translcore.transl_record: atomic field in float record"
+      | Record_unboxed _ ->
+          fatal_error
+            "Translcore.transl_record: atomic field in unboxed record"
+      | Record_extension _ -> 1
+    in
+    let idx = Lconst (Const_int (lbl.lbl_pos + offset)) in
+    let loc = of_location ~scopes loc in
+    Lprim(Patomic_load, [record_lam; idx], loc)
+  in
   let size = Array.length fields in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
@@ -970,13 +987,16 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     let init_id = Ident.create_local "init" in
     let lv =
       Array.mapi
-        (fun i (_, definition) ->
+        (fun i (lbl, definition) ->
            match definition with
            | Kept (typ, mut) ->
+             if lbl.lbl_atomic = Atomic then
+               atomic_load (Lvar init_id) lbl, value_kind env typ
+             else 
                let field_kind = value_kind env typ in
                let access =
                  match repres with
-                   Record_regular | Record_inlined _ ->
+                 | Record_regular | Record_inlined _ ->
                      Pfield (i, maybe_pointer_type env typ, mut)
                  | Record_unboxed _ -> assert false
                  | Record_extension _ ->
@@ -1030,23 +1050,34 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     (* Take a shallow copy of the init record, then mutate the fields
        of the copy *)
     let copy_id = Ident.create_local "newrecord" in
+    let assign lbl value_kind lam =
+      let upd =
+        match repres with
+        | Record_regular
+        | Record_inlined _ ->
+            Psetfield(lbl.lbl_pos, value_kind, Assignment)
+        | Record_unboxed _ -> assert false
+        | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
+        | Record_extension _ ->
+            Psetfield(lbl.lbl_pos + 1, value_kind, Assignment)
+      in
+      Lprim(upd, [Lvar copy_id; lam],
+            of_location ~scopes loc)
+    in
     let update_field cont (lbl, definition) =
       match definition with
-      | Kept _ -> cont
+      | Kept (typ, _mut) when lbl.lbl_atomic = Atomic ->
+          (* #14918: for atomic records we need a proper atomic read to
+             take place; Pduprecord will take a non-atomic copy of all
+             fields, so we re-assign the atomic fields afterwards. *)
+          let lam = atomic_load (Lvar copy_id) lbl in
+          let set = assign lbl (maybe_pointer_type env typ) lam in
+          Lsequence(set, cont)
+      | Kept (_typ, _mut) -> cont
       | Overridden (_lid, expr) ->
-          let upd =
-            match repres with
-              Record_regular
-            | Record_inlined _ ->
-                Psetfield(lbl.lbl_pos, maybe_pointer expr, Assignment)
-            | Record_unboxed _ -> assert false
-            | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
-            | Record_extension _ ->
-                Psetfield(lbl.lbl_pos + 1, maybe_pointer expr, Assignment)
-          in
-          Lsequence(Lprim(upd, [Lvar copy_id; transl_exp ~scopes expr],
-                          of_location ~scopes loc),
-                    cont)
+          let lam = transl_exp ~scopes expr in
+          let set = assign lbl (maybe_pointer expr) lam in
+          Lsequence(set, cont)
     in
     begin match opt_init_expr with
       None -> assert false

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -284,13 +284,11 @@ module Record_update_test = struct
     (* This should produce the same code as [update1] above. *)
     { r with x = 42 }
 end
-(* The output is currently INCORRECT, as [update2] generates
-   a non-atomic read. *)
 [%%expect{|
 (apply (field_mut 1 (global Toploop!)) "Record_update_test/434"
   (let
     (update1 = (function r (makemutable 0 (int,int) 42 (atomic_load r 1)))
-     update2 = (function r (makemutable 0 (int,int) 42 (field_int 1 r))))
+     update2 = (function r (makemutable 0 (int,int) 42 (atomic_load r 1))))
     (makeblock 0 update1 update2)))
 module Record_update_test :
   sig

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -269,3 +269,33 @@ module Pattern_matching_wildcard :
     val allowed : t -> int
   end
 |}]
+
+
+(* Record update expressions should generate atomic reads
+   for omitted atomic fields.
+
+   A bug about this was reported by Ryan Tjoa in #14918.
+*)
+module Record_update_test = struct
+  type t = { x : int; mutable y : int [@atomic] }
+  let update1 (r : t) =
+    { x = 42; y = r.y }
+  let update2 (r : t) =
+    (* This should produce the same code as [update1] above. *)
+    { r with x = 42 }
+end
+(* The output is currently INCORRECT, as [update2] generates
+   a non-atomic read. *)
+[%%expect{|
+(apply (field_mut 1 (global Toploop!)) "Record_update_test/434"
+  (let
+    (update1 = (function r (makemutable 0 (int,int) 42 (atomic_load r 1)))
+     update2 = (function r (makemutable 0 (int,int) 42 (field_int 1 r))))
+    (makeblock 0 update1 update2)))
+module Record_update_test :
+  sig
+    type t = { x : int; mutable y : int [@atomic]; }
+    val update1 : t -> t
+    val update2 : t -> t
+  end
+|}]


### PR DESCRIPTION
#14918 reports a code-generation bug with atomic fields on record update expressions `{ r with x1 = e1; x2 = e2; ... }`: if an atomic field for the record `r` is not in the explicitly-set fields `x1, x2, ...`, it will be implicitly copied from `r` *without* performing an atomic read.

There are two reasonable avenues to make this bug go away:

1. we could forbid record updates with implicit atomic fields: if `y` is atomic, you have to write `r with y = r.y` explicitly, or
2. we could implicitly perform an atomic read on those record updates

This PR implements approach (2), as an alternative to #14931 which implements approach (1).