### PR TITLE
Move `Btype.hash_variant` to `Obj`

### DIFF
--- a/.depend
+++ b/.depend
@@ -4621,7 +4621,6 @@ lambda/matching.cmo : \
     lambda/debuginfo.cmi \
     typing/data_types.cmi \
     utils/clflags.cmi \
-    typing/btype.cmi \
     parsing/asttypes.cmi \
     lambda/matching.cmi
 lambda/matching.cmx : \
@@ -4646,7 +4645,6 @@ lambda/matching.cmx : \
     lambda/debuginfo.cmx \
     typing/data_types.cmx \
     utils/clflags.cmx \
-    typing/btype.cmx \
     parsing/asttypes.cmx \
     lambda/matching.cmi
 lambda/matching.cmi : \
@@ -4782,7 +4780,6 @@ lambda/translclass.cmo : \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     utils/clflags.cmi \
-    typing/btype.cmi \
     parsing/asttypes.cmi \
     lambda/translclass.cmi
 lambda/translclass.cmx : \
@@ -4803,7 +4800,6 @@ lambda/translclass.cmx : \
     typing/env.cmx \
     lambda/debuginfo.cmx \
     utils/clflags.cmx \
-    typing/btype.cmx \
     parsing/asttypes.cmx \
     lambda/translclass.cmi
 lambda/translclass.cmi : \
@@ -4944,7 +4940,6 @@ lambda/translobj.cmo : \
     typing/env.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
-    typing/btype.cmi \
     parsing/asttypes.cmi \
     lambda/translobj.cmi
 lambda/translobj.cmx : \
@@ -4955,7 +4950,6 @@ lambda/translobj.cmx : \
     typing/env.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
-    typing/btype.cmx \
     parsing/asttypes.cmx \
     lambda/translobj.cmi
 lambda/translobj.cmi : \

--- a/Changes
+++ b/Changes
@@ -240,6 +240,10 @@ Working version
   than intuition might suggest, when presented with unusual filenames.
   (David Allsopp, review by Nicolás Ojeda Bär and Antonin Décimo)
 
+- #14939: Move the compiler's Btype.hash_variant (the OCaml implementation of
+  the runtime's caml_hash_variant) to Obj.hash_variant.
+  (David Allsopp, review by Léo Andrès and Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2094,7 +2094,7 @@ let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
         if row_field_repr (get_row_field lab row) = Rabsent then
           variants
         else
-          let tag = Btype.hash_variant lab in
+          let tag = Obj.hash_variant lab in
           match pato with
           | None ->
               add_in_div

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -1082,10 +1082,10 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   (* Sort methods by hash *)
   let pub_meths =
     List.sort
-      (fun s s' -> compare (Btype.hash_variant s) (Btype.hash_variant s'))
+      (fun s s' -> compare (Obj.hash_variant s) (Obj.hash_variant s'))
       pub_meths in
   (* Check for hash conflicts *)
-  let tags = List.map Btype.hash_variant pub_meths in
+  let tags = List.map Obj.hash_variant pub_meths in
   let rev_map = List.combine tags pub_meths in
   List.iter2
     (fun tag name ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -319,7 +319,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
   | Texp_extension_constructor (_, path) ->
       transl_extension_path (of_location ~scopes e.exp_loc) e.exp_env path
   | Texp_variant(l, arg) ->
-      let tag = Btype.hash_variant l in
+      let tag = Obj.hash_variant l in
       begin match arg with
         None -> Lconst(const_int tag)
       | Some arg ->

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -43,7 +43,7 @@ let method_cache = ref lambda_unit
 let method_count = ref 0
 let method_table = ref []
 
-let meth_tag s = Lconst(Const_int(Btype.hash_variant s))
+let meth_tag s = Lconst(Const_int(Obj.hash_variant s))
 
 let next_cache tag =
   let n = !method_count in

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -44,6 +44,20 @@ external dup : t -> t = "caml_obj_dup"
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
 external with_tag : int -> t -> t = "caml_obj_with_tag"
 
+(* Prevent module dependency on String and Char *)
+external string_get : string -> int -> char = "%string_safe_get"
+external string_length : string -> int = "%string_length"
+external char_code: char -> int = "%identity"
+let hash_variant s =
+  let accu = ref 0 in
+  for i = 0 to string_length s - 1 do
+    accu := 223 * !accu + char_code (string_get s i)
+  done;
+  (* reduce to 31 bits *)
+  accu := !accu land (1 lsl 31 - 1);
+  (* make it signed for 64 bits architectures *)
+  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
+
 let first_non_constant_constructor_tag = 0
 let last_non_constant_constructor_tag = 243
 

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -71,6 +71,9 @@ external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
 external with_tag : int -> t -> t = "caml_obj_with_tag"
   (* @since 4.09 *)
 
+val hash_variant: string -> int
+  (* @since 5.6 *)
+
 val first_non_constant_constructor_tag : int
 val last_non_constant_constructor_tag : int
 

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -568,7 +568,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           let tag : int = O.base_obj (O.field obj 0) in
           let rec find = function
             | (l, f) :: fields ->
-                if Btype.hash_variant l = tag then
+                if Obj.hash_variant l = tag then
                   match row_field_repr f with
                   | Rpresent(Some ty) | Reither(_,[ty],_) ->
                       let args =
@@ -583,7 +583,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           let tag : int = O.base_obj obj in
           let rec find = function
             | (l, _) :: fields ->
-                if Btype.hash_variant l = tag then
+                if Obj.hash_variant l = tag then
                   Oval_variant (l, None)
                 else find fields
             | [] -> Oval_stuff "<variant>" in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -243,15 +243,7 @@ let static_row row =
     (fun (_,f) -> match row_field_repr f with Reither _ -> false | _ -> true)
     (row_fields row)
 
-let hash_variant s =
-  let accu = ref 0 in
-  for i = 0 to String.length s - 1 do
-    accu := 223 * !accu + Char.code s.[i]
-  done;
-  (* reduce to 31 bits *)
-  accu := !accu land (1 lsl 31 - 1);
-  (* make it signed for 64 bits architectures *)
-  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
+let hash_variant = Obj.hash_variant
 
 let proxy ty =
   match get_desc ty with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3684,10 +3684,10 @@ and unify_row uenv row1 row2 =
   let r1, r2, pairs = merge_row_fields row1_fields row2_fields in
   if r1 <> [] && r2 <> [] then begin
     let ht = Hashtbl.create (List.length r1) in
-    List.iter (fun (l,_) -> Hashtbl.add ht (hash_variant l) l) r1;
+    List.iter (fun (l,_) -> Hashtbl.add ht (Obj.hash_variant l) l) r1;
     List.iter
       (fun (l,_) ->
-        try raise (Tags(l, Hashtbl.find ht (hash_variant l)))
+        try raise (Tags(l, Hashtbl.find ht (Obj.hash_variant l)))
         with Not_found -> ())
       r2
   end;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -639,7 +639,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let module HMap = Numbers.Int.Map in
       let hfields = ref HMap.empty in
       let add_typed_field loc l f =
-        let h = Btype.hash_variant l in
+        let h = Obj.hash_variant l in
         try
           let (l',f') = HMap.find h !hfields in
           (* Check for tag conflicts *)


### PR DESCRIPTION
`Btype.hash_variant` is the OCaml implementation of `caml_hash_variant` which forms part of the FFI for the _runtime_. I'd like to be able to use it without needing _compiler-libs_ (cf. https://github.com/oxcaml/oxcaml/pull/6530/changes/c81f3c07d896a37dc0fb6cab13326c25c5e35810).

It could sort of go in `Callback`, but really we're lacking a home for rutime-related things such as this. For now, I make the tentative suggestion to move the function to `Obj` on the basis that if in the future it finds a more correct home in the Standard Library, it's no skin off anyone's nose either to remove it, or just to alias it.

I leave `Btype.hash_variant` as an alias - the second commit switches the compiler to `Obj.hash_variant` directly, although I'm not totally convinced by that.