### PR TITLE
Gc: document that [stack_size] in 5.5 again has a value, and is not 0

### DIFF
--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -252,7 +252,7 @@ external stat : unit -> stat = "caml_gc_stat"
 ]
 (** Return the current values of the memory management counters in a
     [stat] record that represents the program's total memory stats.
-    The [heap_chunks], [free_blocks], [largest_free], and [stack_size] metrics
+    The [heap_chunks], [free_blocks], and [largest_free] metrics
     are currently not available in OCaml 5: their returned field values are
     therefore [0].
     This function causes a full major collection. *)


### PR DESCRIPTION
The description in the record has been updated, but not in the description of the stat function.