### PR TITLE
RISC-V fix assembler errors when offset exceeds a 12-bit immediate

### DIFF
--- a/Changes
+++ b/Changes
@@ -397,6 +397,12 @@ Working version
   Now the runtime reports it as a fatal error instead.
   (Michael Bacarella, review by Gabriel Scherer)
 
+- #14943: On RISC-V, fix assembler errors from Ireturn_addr and Iextcall
+  with stack arguments when the offset exceeds a 12-bit immediate, by routing
+  both through the existing range-checked helpers.
+  (Tim McGilchrist, reported by Zane Hambly, reviews by Nicolás Ojeda Bär,
+   Miod Vallat and Zane Hambly)
+
 - #13777, #14347, #14348, #14421, #14498, #14526: Test that C++
   compilers can link with the OCaml runtime and include its headers.
   (Antonin Décimo, review by David Allsopp and Gabriel Scherer)

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -326,7 +326,9 @@ let emit_instr env i =
   | Lop(Iextcall{func; alloc; stack_ofs}) ->
       if stack_ofs > 0 then begin
         `	mv	{emit_reg reg_stack_arg_begin}, sp\n`;
-        `	addi	{emit_reg reg_stack_arg_end}, sp, {emit_int (Misc.align stack_ofs 16)}\n`;
+        (* reg_stack_arg_begin holds sp here *)
+        emit_addimm reg_stack_arg_end reg_stack_arg_begin
+          (Misc.align stack_ofs 16);
         `	la	{emit_reg reg_t2}, {emit_symbol func}\n`;
         `	{emit_call "caml_c_call_stack_args"}\n`;
         record_frame env i.live (Dbg_other i.dbg)
@@ -507,7 +509,7 @@ let emit_instr env i =
   | Lop (Ireturn_addr) ->
       let n = frame_size env in
       if env.f.fun_frame_required then
-        `	ld	{emit_reg i.res.(0)}, {emit_int (n - 8)}(sp)\n`
+        emit_load i.res.(0) (n - 8) "sp"
       else
         `	mv	{emit_reg i.res.(0)}, ra\n`;
   | Lreloadretaddr ->


### PR DESCRIPTION
Two places in the RISC-V backend emit an instruction with a 12-bit immediate whose value is not range-checked. When the value exceeds the signed 12-bit range (`[-2048, 2047]`), the assembler rejects the instruction and the build fails:

```
Error: illegal operands `add s0,sp,3216'
```

Both sites are fixed by routing through helpers that already exist in `asmcomp/riscv/emit.mlp` and fall back to a `li` + `add` sequence when the offset does not fit an immediate.

These are pre-existing bugs, independent of the frame-pointer work in #14506. They were surfaced while reviewing that PR: Zane Hambly hit the large-frame assembler error there, which prompted an audit of the rest of the backend for the same hazard. Both Ireturn_addr and Iextcall when used with stack arguments could produce offsets that exceeded the 12-bit immediate value on add and load instructions.