### PR TITLE
Documentation on the ocamllex -w argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -310,6 +310,10 @@ Working version
 
 - #14598: Add `@since` annotations to `Runtime_events`. (Raphaël Proust)
 
+- #14902, #14944: Add documentation on ocamllex `-w` argument in the man page.
+  (Jeanne Pottier, review by Florian Angeletti, Gabriel Scherer
+  and Daniel Bünzli)
+
 ### Compiler user-interface and warnings:
 - #14887: More concise messages for the non-exhaustiveness warning.
   (Luc Maranget, review by Florian Angeletti)

--- a/man/ocamllex.1
+++ b/man/ocamllex.1
@@ -91,6 +91,22 @@ Print version string and exit.
 .B \-vnum
 Print short version number and exit.
 .TP
+.BI \-w " warning-list"
+Enable, disable, or mark as fatal the warnings specified by the argument
+.I warning-list
+using the same syntax as
+.BR ocamlc (1)
+and
+.BR ocamlopt (1).
+The only warning currently supported is
+.BR 'missing-case'.
+.B '-w -missing-case'
+will disable the warning,
+.B '-w +missing-case'
+will turn it on (default), and
+.B '-w @missing-case'
+will make it a fatal error.
+.TP
 .BR \-help " or " \-\-help
 Display a short usage summary and exit.
 


### PR DESCRIPTION
I added documentation in the man-page for the `-w` argument in ocamllex. This PR adresses issue #14902 .