### PR TITLE
Keep continuation inside the `Typedtree`

### DIFF
--- a/Changes
+++ b/Changes
@@ -404,6 +404,9 @@ Working version
 - #14932: Fix `-dtypedtree` printing of `Twith_modtypesubst`.
   (Corentin De Souza, review by Nicolás Ojeda Bär)
 
+- #14946: Keep the continuation inside the typedtree using a dedicated type.
+  (Xavier Van de Woestyne, review by Florian Angeletti)
+
 ### Build system:
 
 - #14552: Export `AR` and `ARFLAGS` in Makefile.config.

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -592,7 +592,8 @@ and transl_guard ~scopes guard rhs =
 
 and transl_cont cont c_cont body =
   match cont, c_cont with
-  | Some id1, Some (id2, _) -> Llet(Alias, Pgenval, id2, Lvar id1, body)
+  | Some id1, Some {cont_id = id2; _} ->
+      Llet(Alias, Pgenval, id2, Lvar id1, body)
   | None, None
   | Some _, None -> body
   | None, Some _ -> assert false

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -592,7 +592,7 @@ and transl_guard ~scopes guard rhs =
 
 and transl_cont cont c_cont body =
   match cont, c_cont with
-  | Some id1, Some id2 -> Llet(Alias, Pgenval, id2, Lvar id1, body)
+  | Some id1, Some (id2, _) -> Llet(Alias, Pgenval, id2, Lvar id1, body)
   | None, None
   | Some _, None -> body
   | None, Some _ -> assert false

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -664,10 +664,11 @@ let class_field sub {cf_loc; cf_desc; cf_attributes; _} =
 
 let value_bindings sub (_, list) = List.iter (sub.value_binding sub) list
 
-let case sub {c_lhs; c_guard; c_rhs} =
+let case sub {c_lhs; c_guard; c_rhs; c_cont} =
   sub.pat sub c_lhs;
   Option.iter (sub.expr sub) c_guard;
-  sub.expr sub c_rhs
+  sub.expr sub c_rhs;
+  Option.iter (fun { cont_loc; _} -> sub.location sub cont_loc) c_cont
 
 let value_binding sub ({vb_loc; vb_pat; vb_expr; vb_attributes; _} as vb) =
   sub.item_declaration sub (Value_binding vb);

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -666,9 +666,9 @@ let value_bindings sub (_, list) = List.iter (sub.value_binding sub) list
 
 let case sub {c_lhs; c_guard; c_rhs; c_cont} =
   sub.pat sub c_lhs;
+  Option.iter (fun { cont_loc; _} -> sub.location sub cont_loc) c_cont;
   Option.iter (sub.expr sub) c_guard;
-  sub.expr sub c_rhs;
-  Option.iter (fun { cont_loc; _} -> sub.location sub cont_loc) c_cont
+  sub.expr sub c_rhs
 
 let value_binding sub ({vb_loc; vb_pat; vb_expr; vb_attributes; _} as vb) =
   sub.item_declaration sub (Value_binding vb);

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -878,7 +878,8 @@ let case
     c_lhs = sub.pat sub c_lhs;
     c_guard = Option.map (sub.expr sub) c_guard;
     c_rhs = sub.expr sub c_rhs;
-    c_cont
+    c_cont = Option.map (fun cont ->
+        {cont with cont_loc = sub.location sub cont.cont_loc}) c_cont
   }
 
 let value_binding sub x =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -684,11 +684,10 @@ let type_continuation_pat env expected_ty sp =
   | Ppat_var name ->
       let id = Ident.create_local name.txt in
       let desc =
-        { val_type = expected_ty; val_kind = Val_reg;
-          Types.val_loc = loc; val_attributes = [];
-          val_uid = Uid.mk ~current_unit:(Env.get_current_unit ()); }
+        { cont_id = id; cont_loc = loc; cont_type = expected_ty;
+          cont_uid = Uid.mk ~current_unit:(Env.get_current_unit ()); }
       in
-        Some (id, desc)
+        Some desc
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
   | _ -> Error.log_and_raise loc env Invalid_continuation_pattern
@@ -894,13 +893,13 @@ type type_pat_state =
 
 let continuation_variable = function
   | None -> []
-  | Some (id, (desc:Types.value_description)) ->
-    [{pv_id = id;
-     pv_type = desc.val_type;
-     pv_loc = desc.val_loc;
+  | Some {cont_id; cont_loc; cont_type; cont_uid} ->
+    [{pv_id = cont_id;
+     pv_type = cont_type;
+     pv_loc = cont_loc;
      pv_kind = Continuation_var;
-     pv_attributes = desc.val_attributes;
-     pv_uid= desc.val_uid}]
+     pv_attributes = [];
+     pv_uid= cont_uid}]
 
 let create_type_pat_state ?cont allow_modules =
   let tps_module_variables =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7344,7 +7344,6 @@ and type_cases
     ~type_body:begin
       fun { pc_guard; pc_rhs } pat ~when_env ~ext_env ~cont ~ty_expected
         ~ty_infer ~contains_gadt:_ ->
-        let cont = Option.map (fun (id,_) -> id) cont in
         let guard =
           match pc_guard with
           | None -> None

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -155,10 +155,18 @@ and meth =
   | Tmeth_val of Ident.t
   | Tmeth_ancestor of Ident.t * Path.t
 
+and cont_desc =
+  {
+    cont_id:Ident.t;
+    cont_loc:Location.t;
+    cont_type: Types.type_expr;
+    cont_uid: Uid.t
+  }
+
 and 'k case =
     {
      c_lhs: 'k general_pattern;
-     c_cont: (Ident.t * Types.value_description) option;
+     c_cont: cont_desc option;
      c_guard: expression option;
      c_rhs: expression;
     }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -158,7 +158,7 @@ and meth =
 and 'k case =
     {
      c_lhs: 'k general_pattern;
-     c_cont: Ident.t option;
+     c_cont: (Ident.t * Types.value_description) option;
      c_guard: expression option;
      c_rhs: expression;
     }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -304,10 +304,18 @@ and meth =
   | Tmeth_val of Ident.t
   | Tmeth_ancestor of Ident.t * Path.t
 
+and cont_desc =
+  {
+    cont_id:Ident.t;
+    cont_loc:Location.t;
+    cont_type: Types.type_expr;
+    cont_uid: Uid.t
+  }
+
 and 'k case =
     {
      c_lhs: 'k general_pattern;
-     c_cont: (Ident.t * Types.value_description) option;
+     c_cont: cont_desc option;
      c_guard: expression option;
      c_rhs: expression;
     }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -307,7 +307,7 @@ and meth =
 and 'k case =
     {
      c_lhs: 'k general_pattern;
-     c_cont: Ident.t option;
+     c_cont: (Ident.t * Types.value_description) option;
      c_guard: expression option;
      c_rhs: expression;
     }


### PR DESCRIPTION
We're using continuation in Merlin, and this, once again, reduces the upgrade gap. See:
<https://github.com/ocaml/merlin/commit/4695c3a379e6aaaa3b2edc58d799a06f8970b596>

(Not sure if a `Changes` entry is needed)