### PR TITLE
Update documentation for functions using `nanosleep`

### DIFF
--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -90,7 +90,7 @@ val exit : unit -> unit
 
 val delay: float -> unit
 (** [delay d] suspends the execution of the calling thread for
-   [d] seconds. The other program threads continue to run during
+   at least [d] seconds. The other program threads continue to run during
    this time. *)
 
 val join : t -> unit

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1277,10 +1277,10 @@ val alarm : int -> int
    @raise Invalid_argument on Windows *)
 
 val sleep : int -> unit
-(** Stop execution for the given number of seconds. *)
+(** Stop execution for at least the given number of seconds. *)
 
 val sleepf : float -> unit
-(** Stop execution for the given number of seconds.  Like [sleep],
+(** Stop execution for at least the given number of seconds.  Like [sleep],
     but fractions of seconds are supported.
 
     @since 4.03 (4.12 in UnixLabels) *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1277,10 +1277,10 @@ val alarm : int -> int
    @raise Invalid_argument on Windows *)
 
 val sleep : int -> unit
-(** Stop execution for the given number of seconds. *)
+(** Stop execution for at least the given number of seconds. *)
 
 val sleepf : float -> unit
-(** Stop execution for the given number of seconds.  Like [sleep],
+(** Stop execution for at least the given number of seconds.  Like [sleep],
     but fractions of seconds are supported.
 
     @since 4.03 (4.12 in UnixLabels) *)


### PR DESCRIPTION
This is a follow-on from #13339. The various sleep functions must not return until the specified number of seconds has elapsed, but they are permitted to wait for longer.

This is simply documenting how the behaviour has always been, so I don't think either Changes nor `@since` is required.