### PR TITLE
stdlib: better complexity for {Map,Set}.union on related maps/sets

### DIFF
--- a/Changes
+++ b/Changes
@@ -247,6 +247,9 @@ Working version
   than intuition might suggest, when presented with unusual filenames.
   (David Allsopp, review by Nicolás Ojeda Bär and Antonin Décimo)
 
+- #14949: better complexity for {Map,Set}.union on related maps/sets
+  (Valentin Gatien-Baron, review by ..)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -418,6 +418,7 @@ module Make(Ord: OrderedType) = struct
           assert false
 
     let rec union f s1 s2 =
+      if s1 == s2 then s1 else
       match (s1, s2) with
       | (Empty, s) | (s, Empty) -> s
       | (Node {l=l1; v=v1; d=d1; r=r1; h=h1},

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -276,6 +276,7 @@ module Make(Ord: OrderedType) =
               else bal l v rr
 
     let rec union s1 s2 =
+      if s1 == s2 then s1 else
       match (s1, s2) with
         (Empty, t2) -> t2
       | (t1, Empty) -> t1


### PR DESCRIPTION
These functions have a O(n log(n)) complexity with n being the size of the largest map/set. I'm not sure what it is afterwards (maybe O(d log(n)) where d is the number of nodes unique to either side?), but it is e.g. O(log n) on `Map.union (+) map (Map.add a b map)`. With n=10M, this operation goes from 1s to 0ms.

That's useful when carrying a map along a graph: maps get reused when the graph branches out, and then tweaked maps get merged a bit later when the graph branches back in.

I didn't look for every function that could use this treatment. I would have updated Map.symmetric_diff, but there is no such function.