### PR TITLE
feat: add Sys.file_exists' function raising Sys_error

### DIFF
--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -305,6 +305,14 @@ CAMLprim value caml_sys_file_exists(value name)
   return (Val_bool(mode != -1));
 }
 
+CAMLprim value caml_sys_file_exists_syserr(value name)
+{
+  CAMLparam1(name);
+  int mode = caml_sys_file_mode(name);
+  if (mode == -1) caml_sys_error(name);
+  CAMLreturn(Val_bool(1));
+}
+
 CAMLprim value caml_sys_is_directory(value name)
 {
   CAMLparam1(name);

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -55,6 +55,7 @@ external runtime_parameters : unit -> string = "caml_runtime_parameters"
 external poll_actions : unit -> unit = "%poll"
 
 external file_exists: string -> bool = "caml_sys_file_exists"
+external file_exists': string -> bool = "caml_sys_file_exists_syserr"
 external is_directory : string -> bool = "caml_sys_is_directory"
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
 external remove: string -> unit = "caml_sys_remove"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -45,6 +45,11 @@ val runtime_executable : string
 external file_exists : string -> bool = "caml_sys_file_exists"
 (** Test if a file with the given name exists. *)
 
+external file_exists' : string -> bool = "caml_sys_file_exists_syserr"
+(** Test if a file with the given name exists.
+    @raise Sys_error if no file exists with the given name.
+*)
+
 external is_directory : string -> bool = "caml_sys_is_directory"
 (** Returns [true] if the given name refers to a directory,
     [false] if it refers to another kind of file.


### PR DESCRIPTION
Hi ! This implements the `Sys.file_exists'` function discussed in #12393 as an alternative to the current `Sys.file_exists` that returns `false` even on errors.

Other things that are not proposed in this PR yet, that I can add if everything's good :

- A warning regarding the deprecation of the regular `Sys.file_exists` as @ dbuenzli suggested ? 
- A `@since <version>` tag in the docstring ?

```
# let check_if_exists_og c = Sys.file_exists c;;
val check_if_exists_og : string -> bool = <fun>

# let check_if_exists_new c = Sys.file_exists' c;;
val check_if_exists_new : string -> bool = <fun>
```

should give

```
# check_if_exists_og "sys.ml";;
- : bool = true
# check_if_exists_new "sys.ml";;
- : bool = true
# check_if_exists_og "sysa.ml";;
- : bool = false
# check_if_exists_new "sysa.ml";;
Exception: Sys_error "sysa.ml: No such file or directory".
```