### PR TITLE
Smaller code for stack reallocation on AMD64

### DIFF
--- a/Changes
+++ b/Changes
@@ -134,8 +134,7 @@ Working version
 
 - #?????: When reallocating the stack, consolidate all small-valued
   reallocations in a reallocation twice the stack-threshold, reducing
-  code size in the most common case. In addition, don't use the stack
-  to pass arguments, saving a push/pop. (on AMD64)
+  code size in the most common case (on AMD64).
   (Stefan Muenzel, review by ?????)
 
 ### Type system:

--- a/Changes
+++ b/Changes
@@ -132,6 +132,12 @@ Working version
 - #14814: a `caml_result_find_exception` helper for the `caml_result` type
   (Gabriel Scherer, review by Nicolás Ojeda Bär, request by Chris Vine)
 
+- #?????: When reallocating the stack, consolidate all small-valued
+  reallocations in a reallocation twice the stack-threshold, reducing
+  code size in the most common case. In addition, don't use the stack
+  to pass arguments, saving a push/pop. (on AMD64)
+  (Stefan Muenzel, review by ?????)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -940,15 +940,22 @@ let fundecl fundecl =
   | None -> ()
   | Some (overflow,ret) -> begin
       def_label overflow;
-      (* Pass the desired frame size on the stack, since all of the
-        argument-passing registers may be in use.
-        Also serves to align the stack properly before the call *)
-      I.push (int (Config.stack_threshold + max_frame_size / 8));
-      cfi_adjust_cfa_offset 8;
-        (* measured in words *)
-      emit_call "caml_call_realloc_stack";
-      I.pop r10; (* ignored *)
-      cfi_adjust_cfa_offset (-8);
+      let desired_frame_size =
+        Config.stack_threshold + max_frame_size / 8
+      in
+      if desired_frame_size <= Config.stack_threshold * 2
+      then begin
+        (* Consolidate all small-size stack reallocations in the same function,
+           reducing instruction count in the calling function itself. *)
+        emit_call "caml_call_realloc_stack_default";
+      end
+      else begin
+        (* Pass the desired frame size in r10, since all of the
+           argument-passing registers may be in use. Don't use the
+           stack since we have r10 and r11 available *)
+        I.mov (int desired_frame_size) r10;
+        emit_call "caml_call_realloc_stack";
+      end;
       I.jmp (label ret)
     end
   end;

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1014,6 +1014,7 @@ let begin_assembly() =
     D.extrn "caml_ml_array_bound_error" NEAR;
     D.extrn "caml_raise_exn" NEAR;
     D.extrn "caml_call_realloc_stack" NEAR;
+    D.extrn "caml_call_realloc_stack_default" NEAR;
     D.extrn "caml_reraise_exn" NEAR;
     D.extrn "caml_c_call_stack_args" NEAR;
     D.extrn "caml_assert_stack_invariants" NEAR;

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -950,11 +950,14 @@ let fundecl fundecl =
         emit_call "caml_call_realloc_stack_default";
       end
       else begin
-        (* Pass the desired frame size in r10, since all of the
-           argument-passing registers may be in use. Don't use the
-           stack since we have r10 and r11 available *)
-        I.mov (int desired_frame_size) r10;
+        (* Pass the desired frame size on the stack, since all of the
+           argument-passing registers may be in use.
+           We cannot use r10, because glibc does not preserve it in
+           _dl_runtime_resolve. *)
+        cfi_adjust_cfa_offset 8;
+        I.push (int desired_frame_size);
         emit_call "caml_call_realloc_stack";
+        cfi_adjust_cfa_offset (-8);
       end;
       I.jmp (label ret)
     end

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -607,7 +607,7 @@ CFI_STARTPROC
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
         SAVE_ALL_REGS
-        movq    RETADDR_ENTRY_SIZE(%rsp), C_ARG_1 /* argument */
+        movq    %r10, C_ARG_1 /* argument */
         SWITCH_OCAML_TO_C
         C_call  (GCALL(caml_try_realloc_stack))
         SWITCH_C_TO_OCAML
@@ -618,10 +618,17 @@ CFI_STARTPROC
         ret
 1:      RESTORE_ALL_REGS
         LEA_VAR(caml_exn_Stack_overflow, %rax)
-        add     $16, %rsp /* pop argument, retaddr */
+        add     $8, %rsp /* pop retaddr */
         jmp     GCALL(caml_raise_exn)
 CFI_ENDPROC
 END_FUNCTION(caml_call_realloc_stack)
+
+FUNCTION(caml_call_realloc_stack_default)
+CFI_STARTPROC
+        mov    $(2*Stack_threshold_words), %r10
+        jmp    GCALL(caml_call_realloc_stack)
+CFI_ENDPROC
+END_FUNCTION(caml_call_realloc_stack_default)
 
 FUNCTION(caml_call_gc)
 CFI_STARTPROC

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -605,10 +605,9 @@ G(caml_system__code_begin):
 FUNCTION(caml_call_realloc_stack)
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
-LBL(caml_call_realloc_stack):
         ENTER_FUNCTION
         SAVE_ALL_REGS
-        movq    %r10, C_ARG_1 /* argument */
+        movq    RETADDR_ENTRY_SIZE(%rsp), C_ARG_1 /* argument */
         SWITCH_OCAML_TO_C
         C_call  (GCALL(caml_try_realloc_stack))
         SWITCH_C_TO_OCAML
@@ -616,18 +615,21 @@ LBL(caml_call_realloc_stack):
         jz      1f
         RESTORE_ALL_REGS
         LEAVE_FUNCTION
-        ret
+        ret     $8
 1:      RESTORE_ALL_REGS
         LEA_VAR(caml_exn_Stack_overflow, %rax)
-        add     $8, %rsp /* pop retaddr */
+        add     $16, %rsp /* pop argument, retaddr */
         jmp     GCALL(caml_raise_exn)
 CFI_ENDPROC
 END_FUNCTION(caml_call_realloc_stack)
 
 FUNCTION(caml_call_realloc_stack_default)
 CFI_STARTPROC
-        mov     $(2*Stack_threshold_words), %r10
-        jmp     LBL(caml_call_realloc_stack)
+        ENTER_FUNCTION
+        push    $(2*Stack_threshold_words); CFI_ADJUST(8)
+        call   GCALL(caml_call_realloc_stack)
+        LEAVE_FUNCTION
+        ret
 CFI_ENDPROC
 END_FUNCTION(caml_call_realloc_stack_default)
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -605,6 +605,7 @@ G(caml_system__code_begin):
 FUNCTION(caml_call_realloc_stack)
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
+LBL(caml_call_realloc_stack):
         ENTER_FUNCTION
         SAVE_ALL_REGS
         movq    %r10, C_ARG_1 /* argument */
@@ -625,8 +626,8 @@ END_FUNCTION(caml_call_realloc_stack)
 
 FUNCTION(caml_call_realloc_stack_default)
 CFI_STARTPROC
-        mov    $(2*Stack_threshold_words), %r10
-        jmp    GCALL(caml_call_realloc_stack)
+        mov     $(2*Stack_threshold_words), %r10
+        jmp     LBL(caml_call_realloc_stack)
 CFI_ENDPROC
 END_FUNCTION(caml_call_realloc_stack_default)
 

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -224,7 +224,7 @@ caml_system__code_begin:
         ALIGN   4
 caml_call_realloc_stack:
         SAVE_ALL_REGS
-        mov     rcx,qword ptr [rsp+8]
+        mov     rcx,r10
         SWITCH_OCAML_TO_C
         call    caml_try_realloc_stack
         SWITCH_C_TO_OCAML
@@ -235,8 +235,14 @@ caml_call_realloc_stack:
 L104:
         RESTORE_ALL_REGS
         lea     rax, caml_exn_Stack_overflow
-        add     rsp, 16
+        add     rsp, 8
         jmp     caml_raise_exn
+
+        PUBLIC  caml_call_realloc_stack_default
+        ALIGN   4
+caml_call_realloc_stack_default:
+        mov     r10, 64 ; CR smuenzel: Need to get value from config
+        jmp     caml_call_realloc_stack
 
         PUBLIC  caml_call_gc
         ALIGN   4

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -28,6 +28,10 @@ void caml_call_realloc_stack(void)
 {
 
 };
+void caml_call_realloc_stack_default(void)
+{
+
+};
 #endif
 
 void caml_ml_array_bound_error(void)

--- a/testsuite/tests/native-debugger/lldb.linux.amd64.reference
+++ b/testsuite/tests/native-debugger/lldb.linux.amd64.reference
@@ -32,9 +32,9 @@ frame X: meander`_start
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, name = 'XXXX', stop reason = breakpoint 2.1
-    frame #0: 0x00000000000000 meander`caml_program
+    frame #0: 0x00000000000000 meander`caml_startup.code_begin
 (lldb) backtrace
-frame X: meander`caml_program
+frame X: meander`caml_startup.code_begin
 frame X: meander`caml_start_program
 frame X: meander`caml_startup_common
 frame X: meander`caml_startup_common
@@ -62,7 +62,7 @@ frame X: meander`ocaml_to_c
 frame X: meander`caml_c_call
 frame X: meander`camlMeander.omain
 frame X: meander`camlMeander.entry
-frame X: meander`caml_program
+frame X: meander`caml_startup.code_begin
 frame X: meander`caml_start_program
 frame X: meander`caml_startup_common
 frame X: meander`caml_startup_common
@@ -94,7 +94,7 @@ frame X: meander`ocaml_to_c
 frame X: meander`caml_c_call
 frame X: meander`camlMeander.omain
 frame X: meander`camlMeander.entry
-frame X: meander`caml_program
+frame X: meander`caml_startup.code_begin
 frame X: meander`caml_start_program
 frame X: meander`caml_startup_common
 frame X: meander`caml_startup_common


### PR DESCRIPTION
On AMD64, when we reallocate the stack:
1) Don't use the stack to pass the stack size parameter, since we have r10 and r11 available. That way, we reduce our stack usage by a tiny bit (although I guess we'll use the c stack when we actually get more ocaml stack space)
2) redirect most small  (< default stack threshold) allocations to a default function that increments by 2x the stack threshold.  This saves us having to pass the parameter at all, and thus saves one instruction per function that needs stack reallocation. This covers almost all reallocation -- very few functions exceed this stack size.

Overall, we reduce ocamlopt.opt's size by 0.31%  in flambda mode, which is a very modest improvement. 
However, this is a pretty small code change, and the 4-byte reduction of code per function is yielding a comparatively large size improvement for ocamlopt, so it might be worth looking at briefly.