### PR TITLE
Add Stdlib.Char.Ascii.is_punct

### DIFF
--- a/Changes
+++ b/Changes
@@ -197,6 +197,9 @@ Working version
 
 ### Standard library:
 
+- #xxxxx: Add `Char.Ascii.is_punct`
+  (Benoît Jubin, review by xxx)
+
 - #14941, #13937: Add `{Option,Result}.try_value`
   (Michael Neumann, review by Daniel Bünzli, David Allsopp)
 

--- a/stdlib/char.ml
+++ b/stdlib/char.ml
@@ -85,6 +85,8 @@ module Ascii = struct
   let is_graphic = function '!' .. '~' -> true | _ -> false
   let is_print = function ' ' .. '~' -> true | _ -> false
   let is_control = function '\x00' .. '\x1F' | '\x7F' -> true | _ -> false
+  let is_punct = function
+  | '!' .. '/' | ':' .. '@' | '[' .. '`' | '{' .. '~' -> true | _ -> false
 
   (* Decimal digits *)
 

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -16,7 +16,7 @@
 (** Character operations.
 
     Characters are the elements of [string] and [bytes]
-    values. Characters represent bytes, that is an integer in the
+    values. Characters represent bytes, that is, integers in the
     range \[[0x00];[0xFF]\].
 
     Some of the functions of this module interpret the characters in
@@ -89,15 +89,15 @@ module Ascii : sig
 
   val is_valid : char -> bool
    (** [is_valid c] is [true] if and only if [c] is an ASCII character,
-       that is a byte in the range \[{!min};{!max}\]. *)
+       that is, a byte in the range \[{!min};{!max}\]. *)
 
   val is_upper : char -> bool
   (** [is_upper c] is [true] if and only if [c] is an ASCII uppercase letter
-      ['A'] to ['Z'], that is a byte in the range \[[0x41];[0x5A]\]. *)
+      ['A'] to ['Z'], that is, a byte in the range \[[0x41];[0x5A]\]. *)
 
   val is_lower : char -> bool
   (** [is_lower c] is [true] if and only if [c] is an ASCII lowercase letter
-      ['a'] to ['z'], that is a byte in the range \[[0x61];[0x7A]\]. *)
+      ['a'] to ['z'], that is, a byte in the range \[[0x61];[0x7A]\]. *)
 
   val is_letter : char -> bool
   (** [is_letter c] is {!is_lower}[ c || ]{!is_upper}[ c]. *)
@@ -107,31 +107,36 @@ module Ascii : sig
 
   val is_white : char -> bool
   (** [is_white c] is [true] if and only if [c] is an ASCII white space
-      character, that is one of
+      character, that is, one of
       tab ['\t'] ([0x09]), newline ['\n'] ([0x0A]),
       vertical tab ([0x0B]), form feed ([0x0C]),
       carriage return ['\r'] ([0x0D]) or space [' '] ([0x20]),  *)
 
   val is_blank : char -> bool
   (** [is_blank c] is [true] if and only if [c] is an ASCII blank character,
-      that is either space [' '] ([0x20]) or tab ['\t'] ([0x09]). *)
+      that is, either space [' '] ([0x20]) or tab ['\t'] ([0x09]). *)
 
   val is_graphic : char -> bool
   (** [is_graphic c] is [true] if and only if [c] is an ASCII graphic
-      character, that is a byte in the range \[[0x21];[0x7E]\]. *)
+      character, that is, a byte in the range \[[0x21];[0x7E]\]. *)
 
   val is_print : char -> bool
   (** [is_print c] is {!is_graphic}[ c || c = ' ']. *)
 
   val is_control : char -> bool
   (** [is_control c] is [true] if and only if [c] is an ASCII control character,
-      that is a byte in the range \[[0x00];[0x1F]\] or [0x7F]. *)
+      that is, a byte in the range \[[0x00];[0x1F]\] or [0x7F]. *)
+
+  val is_punct : char -> bool
+  (** [is_punct c] is [true] if and only if [c] is an ASCII punctuation
+      character, that is, a graphic but not alphanumeric character.
+      @since 5.6 *)
 
   (** {1:decimal_digits Decimal digits} *)
 
   val is_digit : char -> bool
   (** [is_digit c] is [true] if and only if [c] is an ASCII decimal digit
-      ['0'] to ['9'], that is a byte in the range \[[0x30];[0x39]\]. *)
+      ['0'] to ['9'], that is, a byte in the range \[[0x30];[0x39]\]. *)
 
   val digit_to_int : char -> int
   (** [digit_to_int c] is the numerical value of a digit
@@ -147,7 +152,7 @@ module Ascii : sig
   val is_hex_digit : char -> bool
   (** [is_hex_digit c] is [true] if and only if [c] is an ASCII hexadecimal
       digit ['0'] to ['9'], ['a'] to ['f'] or ['A'] to ['F'],
-      that is a byte in one of the ranges \[[0x30];[0x39]\],
+      that is, a byte in one of the ranges \[[0x30];[0x39]\],
       \[[0x41];[0x46]\], \[[0x61];[0x66]\]. *)
 
   val hex_digit_to_int : char -> int

--- a/testsuite/tests/lib-char/test.ml
+++ b/testsuite/tests/lib-char/test.ml
@@ -41,6 +41,11 @@ let test_preds () =
   assert (Char.Ascii.is_control '\n');
   assert (Char.Ascii.is_control '\x7F');
   assert (not (Char.Ascii.is_control ' '));
+  assert (not (Char.Ascii.is_punct ' '));
+  assert (not (Char.Ascii.is_punct '1'));
+  assert (Char.Ascii.is_punct '?');
+  assert (not (Char.Ascii.is_punct 'A'));
+  assert ((Char.Ascii.is_punct '|'));
   ()
 
 let test_decimal () =

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -35,6 +35,7 @@ module C' :
         val is_graphic : char -> bool
         val is_print : char -> bool
         val is_control : char -> bool
+        val is_punct : char -> bool
         val is_digit : char -> bool
         val digit_to_int : char -> int
         val digit_of_int : int -> char


### PR DESCRIPTION
Add `Stdlib.Char.Ascii.is_punct`, which behaves like `ispunct` from the C standard library: https://en.cppreference.com/c/string/byte/ispunct.

This seems to be a leftover from #13695, which added all the other predicates in this family.

(Also fixes a few typos opportunistically.)

Note: the `.mli` files are inconsistent about whether to include a blank line before `@since`, so I chose not to add one. Let me know if one should be added.