### PR TITLE
Fix expect test trailing output

### DIFF
--- a/Changes
+++ b/Changes
@@ -390,8 +390,8 @@ Working version
 - #14759: expose the function parsing OCAMLRUNPARAM for easier testing
   (Gabriel Scherer, view by Antonin Décimo and Nicolás Ojeda Bär)
 
-- #14643: Test `-recypes` in addition to `-principal` in expect tests. Run all
-  test variants in the same invocation.
+- #14643, #14959: Test `-recypes` in addition to `-principal` in expect tests.
+  Run all test variants in the same invocation.
   (Stefan Muenzel, review by Alistar O'Brien and Florian Angeletti)
 
 - #14900: Speed up deep_occur_rec, improving typechecking performance of

--- a/testsuite/tools/expect.ml
+++ b/testsuite/tools/expect.ml
@@ -558,7 +558,7 @@ let output_corrected oc ~file_contents (correction : _ Correction.t) =
   let output_body oc { str; tag } =
     Printf.fprintf oc "{%s|%s|%s}" tag str tag
   in
-  let output_for_all_clflags ?(output_empty=true) map =
+  let output_for_all_clflags ~trailing map =
     let normal =
       Parameter.Set.Map.find_opt Parameter.Set.empty map
       |> Option.value ~default:empty_str
@@ -567,10 +567,12 @@ let output_corrected oc ~file_contents (correction : _ Correction.t) =
       coalesce_outputs_and_order_by_lowest_flag ~normal map
     in
     (* don't output empty trailing output *)
-    if (not output_empty) && Parameter.Set.Map.is_empty ordered_by_lowest_flag
+    if trailing && Parameter.Set.Map.is_empty ordered_by_lowest_flag
        && normal.str = empty_str.str
     then ()
     else begin
+      if trailing
+      then Printf.fprintf oc "\n[%%%%expect";
       output_body oc normal;
       Parameter.Set.Map.iter
         (fun _ list ->
@@ -589,17 +591,19 @@ let output_corrected oc ~file_contents (correction : _ Correction.t) =
              list
         )
         ordered_by_lowest_flag;
+      if trailing
+      then Printf.fprintf oc "]\n";
     end
   in
   let ofs =
     List.fold_left correction.corrected_expectations ~init:0
       ~f:(fun ofs c ->
         output_slice oc file_contents ofs c.payload_loc.loc_start.pos_cnum;
-        output_for_all_clflags c.text;
+        output_for_all_clflags ~trailing:false c.text;
         c.payload_loc.loc_end.pos_cnum)
   in
   output_slice oc file_contents ofs (String.length file_contents);
-  output_for_all_clflags correction.trailing_output ~output_empty:false
+  output_for_all_clflags correction.trailing_output ~trailing:true
 
 let write_corrected ~file ~file_contents correction =
   let oc = open_out file in


### PR DESCRIPTION
I missed printing the expect "container" for the trailing output in #14643, this fixes it

I ran this new code on a test with trailing output, and it succeeds creating an expect node.