### PR TITLE
disable testsuite/tests/misc/sorts.ml, which is a benchmark

### DIFF
--- a/testsuite/tests/misc/sorts.ml
+++ b/testsuite/tests/misc/sorts.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+   skip; (* this is not a test, it is a benchmark *)
+*)
 
 (* Test bench for sorting algorithms. *)
 


### PR DESCRIPTION
This test takes 10-11s to run on my machine, does not check for a clear regression, and has never failed (as long as I can remember). This is just wasting CI time, so let us disable it.