### PR TITLE
Reoptimize `ocamlc -g`

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -225,6 +225,7 @@ let merge_events ev ev' =
     (* Discard following events, supposedly less informative *)
     | Event_after _, (Event_after _ | Event_before) -> ev, ev'
   in
+  if min.ev_kind = Event_pseudo then maj else
   copy_event maj maj.ev_kind (merge_infos maj min) (merge_repr maj min)
 
 let weaken_event ev cont =

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -358,10 +358,6 @@ let beta_reduce params body args =
 (* Simplification of lets *)
 
 let simplify_lets lam =
-
-  (* Disable optimisations for bytecode compilation with -g flag *)
-  let optimize = !Clflags.native_code || not !Clflags.debug in
-
   (* First pass: count the occurrences of all let-bound identifiers *)
 
   let occ = (Hashtbl.create 83: (Ident.t, int ref) Hashtbl.t) in
@@ -409,7 +405,7 @@ let simplify_lets lam =
   | Lapply{ap_func = ll; ap_args = args} ->
       let no_opt () = count bv ll; List.iter (count bv) args in
       begin match ll with
-      | Lfunction lf when optimize ->
+      | Lfunction lf ->
           begin match exact_application lf args with
           | None -> no_opt ()
           | Some exact_args ->
@@ -419,7 +415,7 @@ let simplify_lets lam =
       end
   | Lfunction fn ->
       count_lfunction fn
-  | Llet(_str, _k, v, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, Lvar w, l2) ->
       (* v will be replaced by w in l2, so each occurrence of v in l2
          increases w's refcount *)
       count (bind_var bv v) l2;
@@ -497,13 +493,13 @@ let simplify_lets lam =
 
   let mklet str kind v e1 e2 =
     match e2 with
-    | Lvar w when optimize && Ident.same v w -> e1
+    | Lvar w when Ident.same v w -> e1
     | _ -> Llet (str, kind,v,e1,e2)
   in
 
   let mkmutlet kind v e1 e2 =
     match e2 with
-    | Lmutvar w when optimize && Ident.same v w -> e1
+    | Lmutvar w when Ident.same v w -> e1
     | _ -> Lmutlet (kind,v,e1,e2)
   in
 
@@ -520,7 +516,7 @@ let simplify_lets lam =
         Lapply {ap with ap_func = simplif ap.ap_func;
                         ap_args = List.map simplif ap.ap_args} in
       begin match ll with
-      | Lfunction lf when optimize ->
+      | Lfunction lf ->
           begin match exact_application lf args with
           | None -> no_opt ()
           | Some exact_args ->
@@ -533,7 +529,7 @@ let simplify_lets lam =
       begin match simplif l with
         Lfunction{kind=Curried; params=params'; return=return2; body;
                   attr=attr2; loc}
-        when kind = Curried && optimize &&
+        when kind = Curried &&
              attr1.may_fuse_arity && attr2.may_fuse_arity &&
              List.length params + List.length params' <= Lambda.max_arity() ->
           (* The return type is the type of the value returned after
@@ -546,12 +542,12 @@ let simplify_lets lam =
       | body ->
           lfunction ~kind ~params ~return:return1 ~body ~attr:attr1 ~loc
       end
-  | Llet(_str, _k, v, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, Lvar w, l2)  ->
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
   | Llet(Strict, kind, v,
          Lprim(Pmakeblock(0, Mutable, kind_ref) as prim, [linit], loc), lbody)
-    when optimize ->
+    ->
       let slinit = simplif linit in
       let slbody = simplif lbody in
       begin try
@@ -567,7 +563,7 @@ let simplify_lets lam =
   | Llet(Alias, kind, v, l1, l2) ->
       begin match count_var v with
         0 -> simplif l2
-      | 1 when optimize -> Hashtbl.add subst v (simplif l1); simplif l2
+      | 1 -> Hashtbl.add subst v (simplif l1); simplif l2
       | _ -> Llet(Alias, kind, v, simplif l1, simplif l2)
       end
   | Llet(StrictOpt, kind, v, l1, l2) ->
@@ -949,9 +945,7 @@ let simplify_local_functions lam =
 let simplify_lambda lam =
   let lam =
     lam
-    |> (if !Clflags.native_code || not !Clflags.debug
-        then simplify_local_functions else Fun.id
-       )
+    |> simplify_local_functions
     |> simplify_exits
     |> simplify_lets
     |> Tmc.rewrite

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -1036,7 +1036,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
         begin try
           (* Doesn't seem to improve size for bytecode *)
           (* if not !Clflags.native_code then raise Not_found; *)
-          if not arr || !Clflags.debug then raise Not_found;
+          if not arr then raise Not_found;
           builtin_meths [self] env env2 (lfunction args body')
         with Not_found ->
           [lfunction ((self, Pgenval) :: args)


### PR DESCRIPTION
The lambda-code generated when using `ocamlc -g` differs from the code generated by `ocamlc -no-g` or `ocamlopt`, for two orthogonal reasons:

1. More debug events are inserted in bytecode (in translcore, translmod, translprim), and extra debug events can prevent certain optimizations. (For example the sharing of right-hand-sides during pattern-matching compilation is blocked by runtime events, intentionally.)
2. Certain optimizations in Lambda.simplif are disabled by `ocamlc -g`. I understand is that the intention is to keep the code structure closer to the source, to make the program easier to debug. (But we don't do this for `ocamlopt -g` because we want things to be fast, and `ocamldebug` only works on bytecode programs.)

In this PR I propose to get rid of (2), to enable the lambda-simplifications also in debug mode, and more generally to stop making code-generation decisions depending on whether `-g` is used. (I remember discussing this with @lthls or maybe @nojb in the past.)
The intention is to keep the code produced by these three configurations closer to each other, to avoid surprises and prepare a switch to `-g` by default for ocamlc ( https://github.com/ocaml/ocaml/issues/6728#issuecomment-5083788409 ).

Comments:

- I don't understand `ocamldebug` well enough to tell if this could have a catastrophic effect for `ocamldebug` users (eg. Rocq developers). @xavierleroy or @damiendoligez may be able to tell whether this is a terrible idea for this reason.

- I quickly encountered a bug with `Bytegen.merge_repr` crashing when enabling let-simplification. This is caused by the inlining of a function, which causes function-body debug events to appear in the middle of other debug events, and the code of `Bytegen` that merges debug events was apparently never tested in this context. A repro case is the following:

       let f x = (fun _ -> ()) x

   which creates the following `-dlambda`:

      (let
        (f/4 =
           (function x/6 : int
             (funct-body Repro.f repro.ml(1)<ghost>:6-25
               (before Repro.f repro.ml(1):10-25
                 (after Repro.f repro.ml(1):10-25
                   (funct-body Repro.f.(fun) repro.ml(1):10-23
                     (before Repro.f.(fun) repro.ml(1):20-22 0)))))))

   This PR includes a fix for this bug in bytegen.ml, but I don't understand this code well so I am not sure that the fix is good enough. In trunk the code of `merge_events` claims to discard Event_pseudo events (such as the `funct-body` event), but in fact does pass them to `merge_infos` an `merge_repr` which crash in this case. My fix makes `Event_pseudo` events really discarded, we return the other event directly.

- The present PR will improve codegen for Dune users of bytecode programs, which already use `-g` by default. This probably has no impact (except possibly a degradation for bytecode-debugger usage) as bytecode programs are not performance-sensitive anyway. But it will also affect `{js,wasm}_of_ocaml`. I don't expect noticeable changes as those already perform a lot of optimizations on their side which probably subsume lambda/Simplif optimizations, but let's cc @hhugo and @vouillon anyway.