### PR TITLE
Typing recovery, new follow up

### DIFF
--- a/Changes
+++ b/Changes
@@ -344,8 +344,8 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #14241, #14824, #14945: Introduction of a typing recovery mechanism to
-  collect more than one typing error, facilitating integration with editors
+- #14241, #14824, #14945, #14963: Introduction of a typing recovery mechanism
+  to collect more than one typing error, facilitating integration with editors
   that need to report more than one error.
   (Xavier Van de Woestyne, Ulysse Gerard, Thomas Refis and Frédéric
   Bour, review by Florian Angeletti and Thomas Refis)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -219,6 +219,8 @@ type error =
 let not_principal fmt =
   Format_doc.Doc.kmsg (fun x -> Warnings.Not_principal x) fmt
 
+exception Error_forward of Location.error
+
 module Error : sig
   (* For the purpose of error recovery, we want to ensure that user facing
       errors are always "logged" and never simply raised. *)
@@ -406,7 +408,6 @@ end = struct
     else
       raise (In_context (loc, env, err))
 
-
   let log_or_raise loc env err =
     if !Clflags.typing_recovery then
       Typing_recovery.log_or_raise (freeze_error (loc, env, err))
@@ -415,12 +416,10 @@ end = struct
 
   let () =
     Typing_recovery.register_recoverable (function
-        | In_context _ -> true
+        | In_context _ | Error_forward _ -> true
         | _ -> false
       )
 end
-
-exception Error_forward of Location.error
 
 let check_scope_escape loc env level ty =
   try Ctype.check_scope_escape env level ty

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5055,7 +5055,8 @@ and type_expect_
          which it wouldn't if it didn't know that it was in a record
          expression context. *)
       begin try suspended ()
-      with Error.In_context _ when !Clflags.typing_recovery ->
+      with exn when !Clflags.typing_recovery
+                 && Typing_recovery.is_recoverable exn ->
         re {
           exp_desc = Texp_record {
             fields = [||]; representation = Record_regular;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -101,7 +101,7 @@ end = struct
 
   let () =
     Typing_recovery.register_recoverable (function
-        | In_context _ -> true
+        | In_context _ | Error_forward _ -> true
         | _ -> false
       )
 end
@@ -2443,7 +2443,7 @@ let rec type_module ?(alias=false) ~strengthen ~funct_body anchor env smod =
   if !Clflags.typing_recovery then
     Typing_recovery_state.with_saved_types (fun () ->
         try delayed ()
-        with Error.In_context _  ->
+        with exn when Typing_recovery.is_recoverable exn  ->
           { mod_desc = Tmod_structure {
                 str_items = [];
                 str_type = [];

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2452,7 +2452,7 @@ let rec type_module ?(alias=false) ~strengthen ~funct_body anchor env smod =
           (* Here, we would like to be able to catch all recoverable
              errors using [Typing_recovery.is_recoverable], as is the
              case in Merlin. However, in Merlin, nonexistent modules
-             are replaced with typed holes. Here, since we don’t catch
+             are replaced with typed holes. Here, since we don't catch
              the errors, we lose some nodes of the typed tree (those
              that reference nonexistent modules), but we retain the
              recovery mechanism for errors related to module dependent

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2449,14 +2449,6 @@ let rec type_module ?(alias=false) ~strengthen ~funct_body anchor env smod =
     Typing_recovery_state.with_saved_types (fun () ->
         try delayed ()
         with Error.In_context _  ->
-          (* Here, we would like to be able to catch all recoverable
-             errors using [Typing_recovery.is_recoverable], as is the
-             case in Merlin. However, in Merlin, nonexistent modules
-             are replaced with typed holes. Here, since we don't catch
-             the errors, we lose some nodes of the typed tree (those
-             that reference nonexistent modules), but we retain the
-             recovery mechanism for errors related to module dependent
-             functions.  *)
           { mod_desc = Tmod_structure {
                 str_items = [];
                 str_type = [];

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2449,11 +2449,14 @@ let rec type_module ?(alias=false) ~strengthen ~funct_body anchor env smod =
     Typing_recovery_state.with_saved_types (fun () ->
         try delayed ()
         with Error.In_context _  ->
-          (* Here, we lose some nodes in the typed tree because we don't
-             catch some errors related to [Env]. However, since we can't
-             synthesize a hole in place of a module, this causes problems
-             for dependent function modules in capturing all recoverable
-             errors here. *)
+          (* Here, we would like to be able to catch all recoverable
+             errors using [Typing_recovery.is_recoverable], as is the
+             case in Merlin. However, in Merlin, nonexistent modules
+             are replaced with typed holes. Here, since we don’t catch
+             the errors, we lose some nodes of the typed tree (those
+             that reference nonexistent modules), but we retain the
+             recovery mechanism for errors related to module dependent
+             functions.  *)
           { mod_desc = Tmod_structure {
                 str_items = [];
                 str_type = [];

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -154,10 +154,15 @@ let initial_env ~loc ~initially_opened_module
     try
       snd (type_open_ Override env loc {txt;loc})
     with
-    | Typetexp.Error.In_context _
-    | Cmi_format.Error _
-    | Env.Error.In_context _
-    | Persistent_env.Error _ when !Clflags.typing_recovery -> env
+      (Typetexp.Error.In_context _
+      | Cmi_format.Error _
+      | Env.Error.In_context _
+      | Persistent_env.Error _) as exn when !Clflags.typing_recovery ->
+        (* Handles errors when the file is empty (but the context is
+           incorrect). If the error has already been logged, it will
+           be overwritten by the final set. *)
+        Typing_recovery.log_or_raise exn;
+        env
   in
   let add_units env units =
     String.Set.fold

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2448,7 +2448,12 @@ let rec type_module ?(alias=false) ~strengthen ~funct_body anchor env smod =
   if !Clflags.typing_recovery then
     Typing_recovery_state.with_saved_types (fun () ->
         try delayed ()
-        with exn when Typing_recovery.is_recoverable exn  ->
+        with Error.In_context _  ->
+          (* Here, we lose some nodes in the typed tree because we don't
+             catch some errors related to [Env]. However, since we can't
+             synthesize a hole in place of a module, this causes problems
+             for dependent function modules in capturing all recoverable
+             errors here. *)
           { mod_desc = Tmod_structure {
                 str_items = [];
                 str_type = [];
@@ -2760,7 +2765,10 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
         | Pmod_ident l -> Includemod.Named_leftmost_functor l.txt
         | _ -> Includemod.Anonymous_functor
       in
-      raise(Includemod.Apply_error {loc=apply_loc;env;app_name;mty_f;args})
+      (* In Merlin, we can recover because we can synthesize an
+         artificial module with a typed hole. *)
+      Typing_recovery.log_and_raise
+        (Includemod.Apply_error {loc=apply_loc;env;app_name;mty_f;args})
 
 and type_open_decl ?used_slot ?toplevel ~funct_body names env sod =
   Builtin_attributes.warning_scope sod.popen_attributes


### PR DESCRIPTION
A few issues (presumably the last ones for now) that came up while porting Merlin to the new recovery (cc @voodoos).

This is, broadly speaking, an explanation of how to take advantage of the new centralization of recoverable errors in certain cases introduced by the previous PR, along with some additional explanations.