### PR TITLE
Result.all, Option.all for collapsing lists of values

### DIFF
--- a/Changes
+++ b/Changes
@@ -258,6 +258,9 @@ Working version
   the runtime's caml_hash_variant) to Obj.hash_variant.
   (David Allsopp, review by Léo Andrès and Nicolás Ojeda Bär)
 
+- #14964: Add `{Option,Result}.all`
+  (Brian Ward, review by ?)
+
 ### Other libraries:
 
 * #14788: The Win32 error code `ERROR_DIRECTORY` (= 267) is now mapped to

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -729,9 +729,11 @@ stdlib__Repr.cmx : repr.ml \
 stdlib__Repr.cmi : repr.mli
 stdlib__Result.cmo : result.ml \
     stdlib__Seq.cmi \
+    stdlib__List.cmi \
     stdlib__Result.cmi
 stdlib__Result.cmx : result.ml \
     stdlib__Seq.cmx \
+    stdlib__List.cmx \
     stdlib__Result.cmi
 stdlib__Result.cmi : result.mli \
     stdlib__Seq.cmi

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -606,9 +606,11 @@ stdlib__Oo.cmi : oo.mli \
     camlinternalOO.cmi
 stdlib__Option.cmo : option.ml \
     stdlib__Seq.cmi \
+    stdlib__List.cmi \
     stdlib__Option.cmi
 stdlib__Option.cmx : option.ml \
     stdlib__Seq.cmx \
+    stdlib__List.cmx \
     stdlib__Option.cmi
 stdlib__Option.cmi : option.mli \
     stdlib__Seq.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -44,13 +44,13 @@ STDLIB_MODULE_BASENAMES = \
   camlinternalLazy \
   lazy \
   seq \
+  list \
   option \
   pair \
   result \
   bool \
   char \
   uchar \
-  list \
   int \
   array \
   iarray \

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -36,6 +36,13 @@ let blend f o1 o2 = match o1, o2 with
   | (Some _ as x), None | None, (Some _ as x) -> x
   | Some v1, Some v2 -> Some (f v1 v2)
 
+let all os =
+  let rec loop ac = function
+    | [] -> Some (List.rev ac)
+    | Some v :: os -> loop (v::ac) os
+    | None :: _ -> None in
+  loop [] os
+
 let equal eq o0 o1 = match o0, o1 with
 | Some v0, Some v1 -> eq v0 v1
 | None, None -> true

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -66,6 +66,12 @@ val blend : ('a -> 'a -> 'a) -> 'a option -> 'a option -> 'a option
 
     @since 5.5 *)
 
+val all : 'a option list -> 'a list option
+(** [all os] is [Some vs] if every option in [os] is a [Some v] and
+    [None] otherwise
+
+    @since 5.6 *)
+
 val for_all : ('a -> bool) -> 'a option -> bool
 (** [for_all p] behaves like {!List.for_all} [p]
     on a list of zero or one element:

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -36,6 +36,13 @@ let retract = function Ok v -> v | Error v -> v
 let iter f = function Ok v -> f v | Error _ -> ()
 let iter_error f = function Error e -> f e | Ok _ -> ()
 let try_value r f = match r with | Error e -> f e | _ -> r
+let all rs =
+  let rec loop ac = function
+    | [] -> Ok (List.rev ac)
+    | Ok v :: rs -> loop (v::ac) rs
+    | Error e :: _ -> Error e in
+  loop [] rs
+
 let is_ok = function Ok _ -> true | Error _ -> false
 let is_error = function Error _ -> true | Ok _ -> false
 

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -95,6 +95,12 @@ val try_value : ('a, 'e) result -> ('e -> ('a, 'e) result) -> ('a, 'e) result
 
     @since 5.6 *)
 
+val all : ('a, 'e) result list -> ('a list, 'e) result
+(** [all rs] is [Ok vs] if every result in [rs] is a [Ok v], or
+    [Error e] for the first result which is not.
+
+    @since 5.6 *)
+
 (** {1:preds Predicates and comparisons} *)
 
 val is_ok : ('a, 'e) result -> bool

--- a/testsuite/tests/lib-option/test.ml
+++ b/testsuite/tests/lib-option/test.ml
@@ -60,6 +60,12 @@ let test_try_value () =
   assert (Option.try_value None (fun () -> None) = None);
   ()
 
+let test_all () =
+  assert (Option.all [] = Some []);
+  assert (Option.all [Some 1; Some 2; Some 3] = Some [1; 2; 3] );
+  assert (Option.all [Some 1; None; Some 2; None] = None);
+  ()
+
 let test_is_none_some () =
   assert (Option.is_none None = true);
   assert (Option.is_some None = false);
@@ -120,6 +126,7 @@ let tests () =
   test_fold ();
   test_iter ();
   test_try_value ();
+  test_all ();
   test_is_none_some ();
   test_equal ();
   test_compare ();

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -89,6 +89,12 @@ let test_try_value () =
   assert (Result.try_value (Error 2) (fun i -> Error (i+1)) = (Error 3));
   ()
 
+let test_all () =
+  assert (Result.all [] = Ok []);
+  assert (Result.all [Ok 1; Ok 2; Ok 3] = Ok [1; 2; 3] );
+  assert (Result.all [Ok 1; Error "first"; Ok 2; Error "second"] = Error "first");
+  ()
+
 let test_is_ok_error () =
   assert (Result.is_ok (Ok 2) = true);
   assert (Result.is_error (Ok 2) = false);
@@ -170,6 +176,7 @@ let tests () =
   test_retract ();
   test_iters ();
   test_try_value ();
+  test_all ();
   test_is_ok_error ();
   test_equal ();
   test_compare ();


### PR DESCRIPTION
These are two functions which are helpful for "transposing" lists of optional/possibly-erroring values into optional/possibly-erroring lists, e.g., turning a `'a option list` into a `'a list option`. They differ from something like `List.filter` in that they are all-or-nothing, either all the values are on the happy path and you get back a list, or you get back None/Error

For naming, I went with the name used in `Base`, which seems to be [common in other libraries](https://doc.sherlocode.com/?q=t%20list%20-%3E%20list%20t). A few other libraries call these functions `flatten_l`, or give them different names for the two types such as `all_some` and `all_ok`.

The closest I could find to a prior discussion is https://github.com/ocaml/ocaml/pull/12805, which was discussing a more specialized function for lists of results