### PR TITLE
Add missing EV_MINOR_EPHE_CLEAN constructor to runtime_phase

### DIFF
--- a/Changes
+++ b/Changes
@@ -568,6 +568,13 @@ Working version
   undersized and custom event registration wrote through a truncated offset.
   (Tim McGilchrist, review by Xavier Leroy and Sadiq Jaffer)
 
+- #14966: add the missing EV_MINOR_EPHE_CLEAN constructor to
+  Runtime_events.runtime_phase, introduced in #13643. The runtime has emitted
+  this phase since 5.4, when a minor collection has to clean locked ephemerons,
+  but the OCaml type had no constructor for it, so consumers were handed an
+  out-of-range value and crashed when matching on it.
+  (Tim McGilchrist, review by Florian Angeletti)
+
 OCaml 5.5.1
 -----------
 

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -95,6 +95,7 @@ type runtime_phase =
 | EV_COMPACT_FORWARD
 | EV_COMPACT_RELEASE
 | EV_EMPTY_MINOR
+| EV_MINOR_EPHE_CLEAN
 
 type lifecycle =
   EV_RING_START
@@ -206,6 +207,7 @@ let runtime_phase_name phase =
   | EV_COMPACT_FORWARD -> "compaction_forward"
   | EV_COMPACT_RELEASE -> "compaction_release"
   | EV_EMPTY_MINOR -> "empty_minor"
+  | EV_MINOR_EPHE_CLEAN -> "minor_ephe_clean"
 
 let lifecycle_name lifecycle =
   match lifecycle with

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -469,6 +469,13 @@ Event spanning a domain needing to empty its minor heap for a new allocation.
 This includes time spent trying to become stop-the-world leader.
 @since 5.4
 *)
+| EV_MINOR_EPHE_CLEAN
+(**
+Event spanning the cleaning of ephemerons whose keys were locked during a minor
+GC. Keys that were promoted are updated to their new location and ephemerons
+whose keys were collected are emptied.
+@since 5.4
+*)
 
 (** Lifecycle events for Runtime_events and domains. *)
 type lifecycle =


### PR DESCRIPTION
The runtime has emitted this phase since 5.4 (#13643), when a minor collection has to clean locked ephemerons, but the OCaml type had no constructor for it, so consumers were handed an out-of-range value and crashed when matching on it.

**Reproducer:**

```
  (* ocamlc -I +runtime_events runtime_events.cma min.ml -o min && ./min *)
  open Runtime_events

  let () =
    start ();
    let cursor = create_cursor None in
    let callbacks =
      Callbacks.create ~runtime_begin:(fun _ _ phase ->
        Printf.printf "%d %s\n%!" (Obj.magic phase : int) (runtime_phase_name phase))
        ()
    in
    let key = ref (Sys.opaque_identity "k") in
    let ephe = Ephemeron.K1.make key "d" in
    Gc.minor ();
    ignore (Sys.opaque_identity (key, ephe));
    ignore (read_poll cursor callbacks None)
```

Against an opam 5.4.0 switch it prints eleven phases and stops dead at the twelfth:
```
  ...
  41 minor_local_roots_promote
  EXIT=138          # 128 + SIGBUS
```

With the branch applied it prints 49 minor_ephe_clean and exits 0. One ephemeron with a young, still-reachable key and a single Gc.minor () is enough.

This should be considered for inclusion in 5.4 and 5.5 bugfix releases.