### PR TITLE
Fix minor_allocated_bytes conversion.

### DIFF
--- a/Changes
+++ b/Changes
@@ -580,6 +580,10 @@ Working version
   out-of-range value and crashed when matching on it.
   (Tim McGilchrist, review by Florian Angeletti)
 
+- #14969: Fix the units of the runtime events counter EV_C_MINOR_ALLOCATED_WORDS
+  to report as the number of words of minor heap consumed, including headers.
+  (Tim McGilchrist, review by Nicolás Ojeda Bär)
+
 OCaml 5.5.1
 -----------
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -730,7 +730,7 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   CAML_EV_COUNTER(EV_C_MINOR_ALLOCATED, minor_allocated_bytes);
   CAML_EV_COUNTER(EV_C_MINOR_ALLOCATED_WORDS,
-                  Whsize_wosize(minor_allocated_bytes));
+                  Wsize_bsize(minor_allocated_bytes));
 
   CAML_EV_END(EV_MINOR);
   if (minor_allocated_bytes == 0)


### PR DESCRIPTION
Should use Wsize_bsize(minor_allocated_bytes) to convert bytes to words.

If accepted, this should be considered for back porting to 5.5 release branch. The counter and its bug arrived together in PR #14189.