### PR TITLE
Disable the parsetree bot on forks

### DIFF
--- a/.github/workflows/parsetree-change.yml
+++ b/.github/workflows/parsetree-change.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   comment-and-label:
-    if: ${{! contains(github.event.pull_request.labels.*.name, 'parsetree-change')}}
+    if: ${{github.repository == 'ocaml/ocaml'
+           && !contains(github.event.pull_request.labels.*.name, 'parsetree-change')}}
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
I opened a self-PR and had this infernal bot tag people again! It it turns out the fix is more straight-forward than I'd expected - I've checked that what's given here definitely doesn't trigger on forks, and I temporarily changed it to `dra27/ocaml` to confirm that it the and trigger should still happen on ocaml/ocaml.