### PR TITLE
Add Sys.filepath_exists and improve clarity of Sys.file_exists

### DIFF
--- a/Changes
+++ b/Changes
@@ -203,9 +203,9 @@ Working version
 
 ### Standard library:
 
-- #XXXX : Add `Sys.filepath_exists` and improve documentation
+- #14974 : Add `Sys.filepath_exists` and improve documentation
   for `Sys.file_exists`
-  (Khalid Belkassmi E.H., review by __)
+  (Khalid Belkassmi E.H., review by Kate Deplaix and Nicolás Ojeda Bär)
 
 - #14941, #13937: Add `{Option,Result}.try_value`
   (Michael Neumann, review by Daniel Bünzli, David Allsopp)

--- a/Changes
+++ b/Changes
@@ -203,6 +203,10 @@ Working version
 
 ### Standard library:
 
+- #XXXX : Add `Sys.filepath_exists` and improve documentation
+  for `Sys.file_exists`
+  (Khalid Belkassmi E.H., review by __)
+
 - #14941, #13937: Add `{Option,Result}.try_value`
   (Michael Neumann, review by Daniel Bünzli, David Allsopp)
 

--- a/Changes
+++ b/Changes
@@ -205,7 +205,8 @@ Working version
 
 - #14974 : Add `Sys.filepath_exists` and improve documentation
   for `Sys.file_exists`
-  (Khalid Belkassmi E.H., review by Kate Deplaix and Nicolás Ojeda Bär)
+  (Khalid Belkassmi E.H., review by Kate Deplaix, Nicolás Ojeda Bär,
+   Xavier Leroy and Daniel Bünzli)
 
 - #14941, #13937: Add `{Option,Result}.try_value`
   (Michael Neumann, review by Daniel Bünzli, David Allsopp)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -305,6 +305,22 @@ CAMLprim value caml_sys_file_exists(value name)
   return (Val_bool(mode != -1));
 }
 
+CAMLprim value caml_sys_filepath_exists(value name)
+{
+  int mode = caml_sys_file_mode(name);
+
+  if (mode != -1) {
+    return Val_true;
+  }
+
+  if (errno == ENOTDIR || errno == ENOENT) {
+    return Val_false;
+  }
+
+  caml_sys_error(name);
+  return Val_unit;
+}
+
 CAMLprim value caml_sys_is_directory(value name)
 {
   CAMLparam1(name);

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -307,18 +307,16 @@ CAMLprim value caml_sys_file_exists(value name)
 
 CAMLprim value caml_sys_filepath_exists(value name)
 {
+  CAMLparam1(name);
   int mode = caml_sys_file_mode(name);
 
-  if (mode != -1) {
-    return Val_true;
+  if (mode == -1) {
+    if (errno == ENOTDIR || errno == ENOENT)
+      CAMLreturn(Val_false);
+    caml_sys_error(name);
   }
 
-  if (errno == ENOTDIR || errno == ENOENT) {
-    return Val_false;
-  }
-
-  caml_sys_error(name);
-  return Val_unit;
+  CAMLreturn(Val_true);
 }
 
 CAMLprim value caml_sys_is_directory(value name)

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -55,6 +55,7 @@ external runtime_parameters : unit -> string = "caml_runtime_parameters"
 external poll_actions : unit -> unit = "%poll"
 
 external file_exists: string -> bool = "caml_sys_file_exists"
+external filepath_exists: string -> bool = "caml_sys_filepath_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
 external remove: string -> unit = "caml_sys_remove"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -43,38 +43,21 @@ val runtime_executable : string
 *)
 
 external file_exists : string -> bool = "caml_sys_file_exists"
-(** Tests if a file with the given name exists.
+(** [file_exists p] tests if the file path [p] exists.
 
-    [file_exists p] is:
-    {ul
-    {- [true] if and only if the file path [p] exists and the calling
-       process can [stat(2)] [p] successfully. Note that it does
-       not mean that you have the rights to operate on the file path.}
-    {- [false] if and only if [stat(2)] on [p] errors. Note that this
-       masks serious
-       {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
-       error conditions} and [EACCES] so the file may still exist. See
-       the warning below.}
-    }
-
-    {b Warning.} Do not report error message to end-users that claim
-    that [p] does not exist based on this function returning [false],
-    use {!Sys.filepath_exists} instead.
+    However, system errors such as insufficient permissions to search directories are
+    returned as [false], in which case the file path may actually exist.
+    It also masks serious error conditions in the system and returns them
+    as [false]. Unless you rely on that behavior, use {!Sys.filepath_exists}
+    instead.
 *)
 
 external filepath_exists : string -> bool = "caml_sys_filepath_exists"
-(** Tests if a file path with the given name exists.
+(** [filepath_exists p] tests if the file path [p] exists.
 
-    [filepath_exists p] is:
-    {ul
-    {- [true] if and only if the file path [p] exists and the calling
-       process can [stat(2)] it successfully. Note that it does
-       not mean that you have the rights to operate on the file path.}
-    {- [false] if and only if [stat(2)] errors with [ENOTDIR] or [ENOENT].}
-    {- [Sys_error _] if any other [stat(2)]
-        {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
-       error conditions} occurs, and notably [EACCES].}
-    }
+    If [false] is returned, the path [p] does not exist on the file system. All other
+    errors, including insufficient permissions to search directories, are reported by
+    a [Sys_error] exception.
 
     @since 5.6
 *)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -45,19 +45,19 @@ val runtime_executable : string
 external file_exists : string -> bool = "caml_sys_file_exists"
 (** [file_exists p] tests if the file path [p] exists.
 
-    However, system errors such as insufficient permissions to search directories are
-    returned as [false], in which case the file path may actually exist.
-    It also masks serious error conditions in the system and returns them
-    as [false]. Unless you rely on that behavior, use {!Sys.filepath_exists}
-    instead.
+    However, system errors such as insufficient permissions to search
+    directories are returned as [false], in which case the file path may
+    actually exist. It also masks serious error conditions in the system and
+    returns them as [false]. Unless you rely on that behavior, use
+    {!Sys.filepath_exists} instead.
 *)
 
 external filepath_exists : string -> bool = "caml_sys_filepath_exists"
 (** [filepath_exists p] tests if the file path [p] exists.
 
-    If [false] is returned, the path [p] does not exist on the file system. All other
-    errors, including insufficient permissions to search directories, are reported by
-    a [Sys_error] exception.
+    If [false] is returned, the path [p] does not exist on the file system. All
+    other errors, including insufficient permissions to search directories, are
+    reported by a [Sys_error] exception.
 
     @since 5.6
 *)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -43,7 +43,38 @@ val runtime_executable : string
 *)
 
 external file_exists : string -> bool = "caml_sys_file_exists"
-(** Test if a file with the given name exists. *)
+(** Tests if a file with the given name exists.
+
+    [file_exists p] is:
+    {ul
+    {- [true] if and only if the file path [p] exists and the calling
+       process can [stat(2)] [p] successfully. Note that it does
+       not mean that you have the rights to operate on the file path.}
+    {- [false] if and only if [stat(2)] on [p] errors. Note that this
+       masks serious
+       {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
+       error conditions} and [EACCES] so the file may still exist. See
+       the warning below.}
+    }
+
+    {b Warning.} Do not report error message to end-users that claim
+    that [p] does not exist based on this function returning [false],
+    use {!Sys.filepath_exists} instead.
+*)
+
+external filepath_exists : string -> bool = "caml_sys_filepath_exists"
+(** Tests if a filepath with the given name exists.
+
+    [filepath_exists p] is:
+    {ul
+    {- [true] if and only if the file path [p] exists and the calling
+       process can [stat(2)] it successfully. Note that it does
+       not mean that you have the rights to operate on the file path.}
+    {- [false] if and only if [stat(2)] errors with [ENOTDIR] or [ENOENT].}
+    {- [Sys_error _] if any other [stat(2)] {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
+       error conditions} occurs, and notably [EACCES].}
+    }
+*)
 
 external is_directory : string -> bool = "caml_sys_is_directory"
 (** Returns [true] if the given name refers to a directory,

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -63,7 +63,7 @@ external file_exists : string -> bool = "caml_sys_file_exists"
 *)
 
 external filepath_exists : string -> bool = "caml_sys_filepath_exists"
-(** Tests if a filepath with the given name exists.
+(** Tests if a file path with the given name exists.
 
     [filepath_exists p] is:
     {ul

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -75,6 +75,8 @@ external filepath_exists : string -> bool = "caml_sys_filepath_exists"
         {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
        error conditions} occurs, and notably [EACCES].}
     }
+
+    @since 5.6
 *)
 
 external is_directory : string -> bool = "caml_sys_is_directory"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -71,7 +71,8 @@ external filepath_exists : string -> bool = "caml_sys_filepath_exists"
        process can [stat(2)] it successfully. Note that it does
        not mean that you have the rights to operate on the file path.}
     {- [false] if and only if [stat(2)] errors with [ENOTDIR] or [ENOENT].}
-    {- [Sys_error _] if any other [stat(2)] {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
+    {- [Sys_error _] if any other [stat(2)]
+        {{:https://pubs.opengroup.org/onlinepubs/9799919799/functions/fstatat.html#tag_17_190_05}
        error conditions} occurs, and notably [EACCES].}
     }
 *)

--- a/testsuite/tests/lib-sys/file_exists.ml
+++ b/testsuite/tests/lib-sys/file_exists.ml
@@ -1,0 +1,66 @@
+(* TEST
+ include unix;
+ hasunix;
+ not windows;
+ bytecode;
+ native;
+*)
+
+(* Test Sys.file_exists and Sys.filepath_exists *)
+
+let writefile filename contents =
+  let oc = open_out_bin filename in
+  output_string oc contents;
+  close_out oc
+
+let safe_remove filename =
+  try Sys.remove filename with Sys_error _ -> ()
+
+let safe_rmdir dirname =
+  try Sys.rmdir dirname with Sys_error _ -> ()
+
+let show name f =
+  print_string name; print_string ": ";
+  (try print_string (string_of_bool (f ()))
+   with Sys_error msg -> print_string "Sys_error: "; print_string msg);
+  print_newline ()
+
+let () =
+  (* Existing regular file *)
+  let f = "exists.txt" in
+  writefile f "some content";
+  show "file_exists on existing file" (fun () -> Sys.file_exists f);
+  show "filepath_exists on existing file" (fun () -> Sys.filepath_exists f);
+
+  (* Non-existent file (ENOENT) *)
+  let nf = "does_not_exist.txt" in
+  show "file_exists on nonexistent file" (fun () -> Sys.file_exists nf);
+  show "filepath_exists on nonexistent file" (fun () -> Sys.filepath_exists nf);
+
+  (* Path component that is not a directory (ENOTDIR) *)
+  let notdir = "notadir.txt" in
+  writefile notdir "some content";
+  let bad_path = Filename.concat notdir "child" in
+  show "file_exists with ENOTDIR" (fun () -> Sys.file_exists bad_path);
+  show "filepath_exists with ENOTDIR" (fun () -> Sys.filepath_exists bad_path);
+
+  (* Unreadable directory (EACCES) *)
+  let dir = "noaccess_dir" in
+  let inner = Filename.concat dir "inner" in
+
+  (* In case there's some leftover from a previous failed/crashed run *)
+  if Sys.file_exists dir
+  then begin
+      Unix.chmod dir 0o755;
+      safe_remove inner;
+      safe_rmdir dir;
+  end;
+
+  Sys.mkdir dir 0o755;
+  writefile inner "some content";
+  Unix.chmod dir 0o000;
+  show "file_exists with EACCES" (fun () -> Sys.file_exists inner);
+  show "filepath_exists with EACCES" (fun () -> Sys.filepath_exists inner);
+  Unix.chmod dir 0o755;
+  safe_remove inner;
+  safe_rmdir dir

--- a/testsuite/tests/lib-sys/file_exists.ml
+++ b/testsuite/tests/lib-sys/file_exists.ml
@@ -2,7 +2,6 @@
  include unix;
  hasunix;
  not-root;
- not windows;
  bytecode;
  native;
 *)

--- a/testsuite/tests/lib-sys/file_exists.ml
+++ b/testsuite/tests/lib-sys/file_exists.ml
@@ -1,6 +1,7 @@
 (* TEST
  include unix;
  hasunix;
+ not-root;
  not windows;
  bytecode;
  native;
@@ -63,4 +64,9 @@ let () =
   show "filepath_exists with EACCES" (fun () -> Sys.filepath_exists inner);
   Unix.chmod dir 0o755;
   safe_remove inner;
-  safe_rmdir dir
+  safe_rmdir dir;
+
+  (* Pathname is longer than NAME_MAX (ENAMETOOLONG) *)
+  let too_long_pathname = String.make 256 'c' in
+  show "file_exists with ENAMETOOLONG" (fun () -> Sys.file_exists too_long_pathname);
+  show "filepath_exists with ENAMETOOLONG" (fun () -> Sys.filepath_exists too_long_pathname);

--- a/testsuite/tests/lib-sys/file_exists.ml
+++ b/testsuite/tests/lib-sys/file_exists.ml
@@ -2,6 +2,7 @@
  include unix;
  hasunix;
  not-root;
+ not windows;
  bytecode;
  native;
 *)

--- a/testsuite/tests/lib-sys/file_exists.reference
+++ b/testsuite/tests/lib-sys/file_exists.reference
@@ -1,0 +1,8 @@
+file_exists on existing file: true
+filepath_exists on existing file: true
+file_exists on nonexistent file: false
+filepath_exists on nonexistent file: false
+file_exists with ENOTDIR: false
+filepath_exists with ENOTDIR: false
+file_exists with EACCES: false
+filepath_exists with EACCES: Sys_error: noaccess_dir/inner: Permission denied

--- a/testsuite/tests/lib-sys/file_exists.reference
+++ b/testsuite/tests/lib-sys/file_exists.reference
@@ -6,3 +6,5 @@ file_exists with ENOTDIR: false
 filepath_exists with ENOTDIR: false
 file_exists with EACCES: false
 filepath_exists with EACCES: Sys_error: noaccess_dir/inner: Permission denied
+file_exists with ENAMETOOLONG: false
+filepath_exists with ENAMETOOLONG: Sys_error: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: File name too long


### PR DESCRIPTION
Hi ; ) Following what has been discussed in #12393, this PR introduces the proposed `Sys.filepath_exists` function and some tests along with the docstrings, attempting to improve the clarity of the existing `Sys.file_exists` function for users as well.