### PR TITLE
Fix win32 select handle leak

### DIFF
--- a/Changes
+++ b/Changes
@@ -429,6 +429,15 @@ Working version
 
 ### Bug fixes:
 
+- #14975: Windows: fix handle leak in `Unix.select`. When the file descriptor
+  set contains anything other than sockets, `select` falls back to a worker
+  thread emulation in which any error during setup or waiting caused the whole
+  cleanup loop to be skipped, leaking one event handle per socket and leaving
+  the sockets registered with `WSAEventSelect` and in non-blocking mode. Also
+  fix a one-element overflow of the event array when a worker services
+  `MAXIMUM_SELECT_OBJECTS` sockets.
+  (Romain Beauxis, review by TBD)
+
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an
   event is larger than the configured ring buffer. Only really comes up
   if you run the instrumented runtime with a small OCAMLRUNPARAM=e= setting

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -490,12 +490,14 @@ static void socket_poll (HANDLE hStop, void *_data)
 {
   LPSELECTDATA   lpSelectData;
   LPSELECTQUERY    iterQuery;
-  HANDLE           aEvents[MAXIMUM_SELECT_OBJECTS];
+  /* One event per query, plus hStop */
+  HANDLE           aEvents[MAXIMUM_SELECT_OBJECTS + 1];
   DWORD            nEvents;
   long             maskEvents;
   u_long           iMode;
   SELECTMODE       mode;
   WSANETWORKEVENTS events;
+  BOOL             bCollectResults;
 
   lpSelectData = (LPSELECTDATA)_data;
 
@@ -504,6 +506,7 @@ static void socket_poll (HANDLE hStop, void *_data)
   {
     iterQuery = &(lpSelectData->aQueries[nEvents]);
     aEvents[nEvents] = CreateEvent(NULL, TRUE, FALSE, NULL);
+    check_error(lpSelectData, aEvents[nEvents] == NULL);
     maskEvents = 0;
     mode = iterQuery->EMode;
     if ((mode & SELECT_MODE_READ) != 0)
@@ -543,63 +546,66 @@ static void socket_poll (HANDLE hStop, void *_data)
           INFINITE) == WAIT_FAILED);
   };
 
-  if (lpSelectData->nError == 0)
+  /* Results are only meaningful if nothing failed so far, but the events and
+     the WSAEventSelect associations must be released in every case. */
+  bCollectResults = (lpSelectData->nError == 0);
+
+  for (DWORD i = 0; i < lpSelectData->nQueriesCount; i++)
   {
-    for (DWORD i = 0; i < lpSelectData->nQueriesCount; i++)
+    iterQuery = &(lpSelectData->aQueries[i]);
+    if (bCollectResults && WaitForSingleObject(aEvents[i], 0) == WAIT_OBJECT_0)
     {
-      iterQuery = &(lpSelectData->aQueries[i]);
-      if (WaitForSingleObject(aEvents[i], 0) == WAIT_OBJECT_0)
+      DEBUG_PRINT("Socket %d has pending events", (i - 1));
+      /* Find out what kind of events were raised
+       */
+      if (WSAEnumNetworkEvents((SOCKET)(iterQuery->hFileDescr),
+                               aEvents[i], &events) == 0)
       {
-        DEBUG_PRINT("Socket %d has pending events", (i - 1));
-        if (iterQuery != NULL)
+        if ((iterQuery->EMode & SELECT_MODE_READ) != 0
+            && (events.lNetworkEvents & (FD_READ | FD_ACCEPT | FD_CLOSE)) != 0)
         {
-          /* Find out what kind of events were raised
-           */
-          if (WSAEnumNetworkEvents((SOCKET)(iterQuery->hFileDescr),
-                                   aEvents[i], &events) == 0)
-          {
-            if ((iterQuery->EMode & SELECT_MODE_READ) != 0
-                && (events.lNetworkEvents & (FD_READ | FD_ACCEPT | FD_CLOSE))
-                   != 0)
-            {
-              select_data_result_add(lpSelectData, SELECT_MODE_READ,
-                                     iterQuery->lpOrigIdx);
-            }
-            if ((iterQuery->EMode & SELECT_MODE_WRITE) != 0
-                && (events.lNetworkEvents & (FD_WRITE | FD_CONNECT | FD_CLOSE))
-                   != 0)
-            {
-              select_data_result_add(lpSelectData, SELECT_MODE_WRITE,
-                                     iterQuery->lpOrigIdx);
-            }
-            if ((iterQuery->EMode & SELECT_MODE_EXCEPT) != 0
-                && (events.lNetworkEvents & FD_OOB) != 0)
-            {
-              select_data_result_add(lpSelectData, SELECT_MODE_EXCEPT,
-                                     iterQuery->lpOrigIdx);
-            }
-          }
+          select_data_result_add(lpSelectData, SELECT_MODE_READ,
+                                 iterQuery->lpOrigIdx);
+        }
+        if ((iterQuery->EMode & SELECT_MODE_WRITE) != 0
+            && (events.lNetworkEvents & (FD_WRITE | FD_CONNECT | FD_CLOSE))
+               != 0)
+        {
+          select_data_result_add(lpSelectData, SELECT_MODE_WRITE,
+                                 iterQuery->lpOrigIdx);
+        }
+        if ((iterQuery->EMode & SELECT_MODE_EXCEPT) != 0
+            && (events.lNetworkEvents & FD_OOB) != 0)
+        {
+          select_data_result_add(lpSelectData, SELECT_MODE_EXCEPT,
+                                 iterQuery->lpOrigIdx);
         }
       }
-      /* WSAEventSelect() automatically sets socket to nonblocking mode.
-         Restore the blocking one. */
-      if (iterQuery->uFlagsFd & FLAGS_FD_IS_BLOCKING)
-      {
-        DEBUG_PRINT("Restore a blocking socket");
-        iMode = 0;
-        check_error(lpSelectData,
-          WSAEventSelect((SOCKET)(iterQuery->hFileDescr), aEvents[i], 0) != 0 ||
-          ioctlsocket((SOCKET)(iterQuery->hFileDescr), FIONBIO, &iMode) != 0);
-      }
-      else
-      {
-        check_error(lpSelectData,
-          WSAEventSelect((SOCKET)(iterQuery->hFileDescr), aEvents[i], 0) != 0);
-      };
-
-      CloseHandle(aEvents[i]);
-      aEvents[i] = INVALID_HANDLE_VALUE;
     }
+
+    if (aEvents[i] == NULL)
+    {
+      continue;
+    }
+
+    /* WSAEventSelect() automatically sets socket to nonblocking mode.
+       Restore the blocking one. */
+    if (iterQuery->uFlagsFd & FLAGS_FD_IS_BLOCKING)
+    {
+      DEBUG_PRINT("Restore a blocking socket");
+      iMode = 0;
+      check_error(lpSelectData,
+        WSAEventSelect((SOCKET)(iterQuery->hFileDescr), aEvents[i], 0) != 0 ||
+        ioctlsocket((SOCKET)(iterQuery->hFileDescr), FIONBIO, &iMode) != 0);
+    }
+    else
+    {
+      check_error(lpSelectData,
+        WSAEventSelect((SOCKET)(iterQuery->hFileDescr), aEvents[i], 0) != 0);
+    };
+
+    CloseHandle(aEvents[i]);
+    aEvents[i] = INVALID_HANDLE_VALUE;
   }
 }
 

--- a/testsuite/tests/lib-unix/win-select/select_error_cleanup.ml
+++ b/testsuite/tests/lib-unix/win-select/select_error_cleanup.ml
@@ -1,0 +1,51 @@
+(* TEST
+ include unix;
+ hasunix;
+ target-windows;
+ {
+   bytecode;
+ }{
+   native;
+ }
+*)
+
+(* On Windows, Unix.select falls back to a worker thread emulation as soon as
+   the descriptor set is not made exclusively of sockets. That path registers
+   every socket with WSAEventSelect and undoes it at the end of the call. An
+   error used to skip the whole cleanup, leaving the sockets registered and in
+   non-blocking mode, and leaking one event handle per socket.
+
+   ioctlsocket(FIONBIO) fails with WSAEINVAL while a WSAEventSelect
+   registration is active, so Unix.clear_nonblock detects a skipped cleanup. *)
+
+let () =
+  let listening = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.bind listening (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  Unix.listen listening 1;
+  let client = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.connect client (Unix.getsockname listening);
+  let server, _ = Unix.accept listening in
+
+  (* The pipe is what forces select onto the emulation path. *)
+  let pipe_read, pipe_write = Unix.pipe () in
+  (* A descriptor closed behind select's back, as happens when a server closes
+     a client socket from another thread. WSAEventSelect then fails on it, and
+     it must not prevent the other sockets from being cleaned up. *)
+  let closed = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.close closed;
+
+  begin match Unix.select [server; closed; pipe_read] [] [] 0.0 with
+  | _ -> print_string "UNEXPECTED: select did not fail on a closed socket\n"
+  | exception Unix.Unix_error _ ->
+    begin match Unix.clear_nonblock server with
+    | () -> print_string "OK\n"
+    | exception Unix.Unix_error (Unix.EINVAL, _, _) ->
+      print_string "FAIL: socket still registered with WSAEventSelect\n"
+    end
+  end;
+
+  Unix.close pipe_read;
+  Unix.close pipe_write;
+  Unix.close server;
+  Unix.close client;
+  Unix.close listening

--- a/testsuite/tests/lib-unix/win-select/select_error_cleanup.reference
+++ b/testsuite/tests/lib-unix/win-select/select_error_cleanup.reference
@@ -1,0 +1,1 @@
+FAIL: socket still registered with WSAEventSelect

--- a/testsuite/tests/lib-unix/win-select/select_error_cleanup.reference
+++ b/testsuite/tests/lib-unix/win-select/select_error_cleanup.reference
@@ -1,1 +1,1 @@
-FAIL: socket still registered with WSAEventSelect
+OK


### PR DESCRIPTION
This is a LLM-driven bug reported initially by liquidsoap users at https://github.com/savonet/liquidsoap/pull/5290 and confirmed on the code base.

The commits are split in two:
1. First commit adding a regression test and showing a socket not being properly cleaned up. This was tested with `wine` locally which does not implement `GetProcessHandleCount` so the test was switched to trigger on the socket not being restored to non-blocking, which is one of the process applied when the socket is properly handled when exiting the select loop. A more rigorous test demonstrating the socket leak can also be implemented but I will not be able to run it locally.
2. Second commit introduces the fix and flips the test reference back to `OK`.

PS: this message is written by a reguler person (myself!)