### PR TITLE
stdlib: expose that Atomic.t is not a float in the interface

### DIFF
--- a/Changes
+++ b/Changes
@@ -243,6 +243,10 @@ Working version
   barrier; the default is chosen at configure time and can be overridden.
   (Sebastian Pop and Xavier Leroy, review by Xavier Leroy and Olivier Nicole)
 
+- #14977: expose Atomic.t representation in the interface for better
+  code generation.
+  (Edwin Török, suggestions by Vincent Laviron, Daniel Bünzli, review by ...)
+
 ### Standard library:
 
 - #14974 : Add `Sys.filepath_exists` and improve documentation

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -24,7 +24,11 @@
 *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type !'a t
+type !'a t = private {
+    mutable contents: 'a [@atomic]
+    [@deprecated "Atomic.t 'contents' is exposed only to improve performance"]
+}
+
 
 (** Create an atomic reference. *)
 val make : 'a -> 'a t


### PR DESCRIPTION
This enables better code generation when flat-float-array is on (which is the default).

Fixes https://github.com/ocaml/ocaml/issues/14976