### PR TITLE
Don't assume abstract types defined in the current module are injective or contractive

### DIFF
--- a/Changes
+++ b/Changes
@@ -440,6 +440,10 @@ Working version
 
 ### Bug fixes:
 
+* #14982: Remove assumption that abstract types defined in the current
+  module are injective
+  (Jeremy Yallop)
+
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an
   event is larger than the configured ring buffer. Only really comes up
   if you run the instrumented runtime with a small OCAMLRUNPARAM=e= setting

--- a/Changes
+++ b/Changes
@@ -499,7 +499,7 @@ Working version
 
 * #14982: Remove assumption that abstract types defined in the current
   module are injective and contractive
-  (Jacques Garrigue and Jeremy Yallop)
+  (Jeremy Yallop, review by Jacques Garrigue)
 
 OCaml 5.5.1
 -----------

--- a/Changes
+++ b/Changes
@@ -440,10 +440,6 @@ Working version
 
 ### Bug fixes:
 
-* #14982: Remove assumption that abstract types defined in the current
-  module are injective
-  (Jeremy Yallop)
-
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an
   event is larger than the configured ring buffer. Only really comes up
   if you run the instrumented runtime with a small OCAMLRUNPARAM=e= setting
@@ -500,6 +496,10 @@ Working version
 
 - #14890, fix pattern compilation in presence of the [min_int] constant pattern
   (Florian Angeletti, review by Luc Maranget)
+
+* #14982: Remove assumption that abstract types defined in the current
+  module are injective and contractive
+  (Jacques Garrigue and Jeremy Yallop)
 
 OCaml 5.5.1
 -----------

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -356,7 +356,7 @@ val cast_via_module_type_under_equality2 :
 |}]
 
 (* Test from issue #10768 *)
-type _ t
+type !_ t
 
 module type S = sig type t end
 
@@ -388,7 +388,7 @@ let get (type a) : a t -> (module S with type t = a)  = fun index ->
   in
   unpack dispatch
 [%%expect {|
-type _ t
+type !_ t
 module type S = sig type t end
 type pack = Pack : 'a t * (module S with type t = 'a) -> pack
 val dispatch : pack list ref = {contents = []}

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -536,3 +536,19 @@ Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be injective invariant,
        but it is invariant.
 |}]
+
+
+module type S = sig type 'a t end
+include (struct type 'a t = unit end : S)
+let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
+;;
+[%%expect{|
+module type S = sig type 'a t end
+type 'a t
+Line 3, characters 79-84:
+3 | let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
+                                                                                   ^^^^^
+Error: The constructor "Equal" has type "(a, a) Type.eq"
+       but an expression was expected of type "(a, b) Type.eq"
+       Type "a" is not compatible with type "b"
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -558,16 +558,6 @@ let without_assume_injective uenv f =
 
 (*** Checks for type definitions ***)
 
-let rec in_current_module = function
-  | Path.Pident _ -> true
-  | Path.Pdot _ | Path.Papply _ -> false
-  | Path.Pextra_ty (p, _) -> in_current_module p
-
-let in_pervasives p =
-  in_current_module p &&
-  try ignore (Env.find_type p Env.initial); true
-  with Not_found -> false
-
 let is_datatype decl=
   match decl.type_kind with
     Type_record _ | Type_variant _ | Type_open | Type_external _ -> true
@@ -2263,9 +2253,7 @@ let rec extract_package_modulo_subtype env ty =
   | _ -> raise Not_found
 
 let is_contractive env p =
-  try
-    let decl = Env.find_type p env in
-    in_pervasives p && decl.type_manifest = None || is_datatype decl
+  try is_datatype (Env.find_type p env)
   with Not_found -> false
 
 
@@ -3557,8 +3545,7 @@ and unify3 uenv t1' t2' =
             unify_list uenv tl1 tl2
           else if can_assume_injective uenv then
             without_assume_injective uenv (fun uenv -> unify_list uenv tl1 tl2)
-          else if (* in_current_module p1 || in_pervasives p1 || *)
-                  List.exists
+          else if List.exists
                    (expands_to_datatype (get_env uenv))
                    (List.map (fun a -> a.abbr_path)
                       (Option.to_list (get_abbrev t1') @

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3557,8 +3557,8 @@ and unify3 uenv t1' t2' =
             unify_list uenv tl1 tl2
           else if can_assume_injective uenv then
             without_assume_injective uenv (fun uenv -> unify_list uenv tl1 tl2)
-          else if in_current_module p1 (* || in_pervasives p1 *)
-               || List.exists
+          else if (* in_current_module p1 || in_pervasives p1 || *)
+                  List.exists
                    (expands_to_datatype (get_env uenv))
                    (List.map (fun a -> a.abbr_path)
                       (Option.to_list (get_abbrev t1') @


### PR DESCRIPTION
Here's a module signature `S` that can only be inhabited for a type `t` that is not injective:

```ocaml
module type S = sig
  type 'a t
  val eq : ('a t, 'b t) Type.eq
end
```

Here's an instantiation of `S` in the current module with a definition of `t` that is not injective:

```ocaml
include (struct
          type 'a t = unit
          let eq = Type.Equal
        end : S)
```

After the `include`, `t` is an abstract type defined in the current module.  OCaml wrongly assumes such types to be injective, as shown by its accepting the following definition:

```ocaml
let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
```

The combination of `eq` and `inj_t` makes it possible to prove that arbitrary types are equal:

```ocaml
let a_eq_b : type a b. unit -> (a, b) Type.eq = fun () -> inj_t eq
```

A proof of equality between arbitrary types makes it possible to define a cast between arbitrary types:

```ocaml
let cast : type a b. a -> b = fun x -> match (a_eq_b () : (a, b) Type.eq) with Equal -> x
```

A cast between arbitrary types makes it possible to treat integers as strings:

```ocaml
let () = print_endline (cast 3)
```

leading to the unhappy result:
```
Segmentation fault
```

The fix is one line (don't assume abstract types in the current module are injective), and comes with a test for the fix (`testsuite/tests/typing-misc/injectivity.ml`) and a fix for a test (`testsuite/tests/typing-gadts/packed-module-recasting.ml`).

The bug was found with the help of Claude, which found a few more, too (to follow).





