### PR TITLE
Make Runtime_events.User.write non-allocating

### DIFF
--- a/Changes
+++ b/Changes
@@ -281,6 +281,11 @@ Working version
   under certain circumstances.
   (Zhang Rui, review by Nicolás Ojeda Bär, Antonin Décimo and David Allsopp)
 
+- #14984: Cache one write buffer for each domain in
+  `Runtime_events.User.write`, instead of a list for each thread. A write of
+  a custom event does not allocate in the usual single-threaded case.
+  (Anil Madhavapeddy, review by Thomas Leonard and Sadiq Jaffer)
+
 ### Tools:
 
 - #14318, #14709, ocamldoc: use "Module_name (Library name)" rather than

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -311,7 +311,10 @@ module User = struct
     | Type.Custom _ ->
         let cache = Domain.DLS.get write_buffer in
         let buf = Atomic.exchange cache Bytes.empty in
-        (* Must match RUNTIME_EVENTS_MAX_MSG_LENGTH which is (1 << 10) *)
+        (* The buffer size is 1024 bytes. This size must be equal to
+           the maximum value length in the documentation of
+           [User.register] in runtime_events.mli, and to the size of
+           the consumer's read buffer in runtime_events_consumer.c. *)
         let buf = if Bytes.length buf = 0 then Bytes.create 1024 else buf in
         begin match user_write buf event value with
         | () -> Atomic.set cache buf

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -297,11 +297,15 @@ module User = struct
      want to write a lot of custom events fast, so we want to cache
      the write buffer across calls.
 
-     To be safe for multi-domain programs, the cache lives in
-     domain-local storage. Each domain caches a single buffer, with
-     the slot emptied while the buffer is in us. Contending threads
-     will allocate a fresh buffer, and the last writer to finish
-     retains its buffer. At most one buffer per domain is kept live. *)
+     The cache lives in domain-local storage. This makes it safe for
+     multi-domain programs. The [Atomic] is also necessary:
+     systhreads of the same domain share the slot, and the runtime
+     can stop a thread, or run a signal handler, in the serializer
+     callback. Each domain caches a single buffer. The slot is empty
+     while the buffer is in use. If two writes on the same domain
+     overlap, the second write allocates a new buffer, and the
+     writer that completes last keeps its buffer. Thus each domain
+     keeps at most one buffer between writes. *)
   let write_buffer = Domain.DLS.new_key (fun () -> Atomic.make Bytes.empty)
 
   let write (type a) (event : a t) (value : a) =

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -292,58 +292,31 @@ module User = struct
 
   let register name tag typ = user_register name (Some tag) typ
 
-  let with_write_buffer =
-    (* [caml_runtime_events_user_write] needs a write buffer in which
-       the user-provided serializer will write its data. The user may
-       want to write a lot of custom events fast, so we want to cache
-       the write buffer across calls.
+  (* [caml_runtime_events_user_write] needs a write buffer in which
+     the user-provided serializer will write its data. The user may
+     want to write a lot of custom events fast, so we want to cache
+     the write buffer across calls.
 
-       To be safe for multi-domain programs, we use domain-local
-       storage for the write buffer. To accommodate for multi-threaded
-       programs (without depending on the Thread module), we store
-       a list of caches for each domain. This might leak a bit of
-       memory: the number of buffers for a domain is equal to the
-       maximum number of threads that requested a buffer concurrently,
-       and we never free those buffers. *)
-    let create_buffer () = Bytes.create 1024 in
-    let write_buffer_cache = Domain.DLS.new_key (fun () -> ref []) in
-    let pop_or_create buffers =
-      (* intended to be thread-safe *)
-      (* begin atomic *)
-      match !buffers with
-      | [] ->
-          (* end atomic *)
-          create_buffer ()
-      | b::bs ->
-          buffers := bs;
-          (* end atomic *)
-          b
-    in
-    let[@poll error] compare_and_set r old_val new_val =
-      if !r == old_val then (r := new_val; true)
-      else false
-    in
-    let rec push buffers buf =
-      (* intended to be thread-safe *)
-      let old_buffers = !buffers in
-      let new_buffers = buf :: old_buffers in
-      (* retry if !buffers changed under our feet: *)
-      if compare_and_set buffers old_buffers new_buffers
-      then ()
-      else push buffers buf
-    in
-    fun consumer ->
-      let buffers = Domain.DLS.get write_buffer_cache in
-      let buf = pop_or_create buffers in
-      Fun.protect ~finally:(fun () -> push buffers buf)
-        (fun () -> consumer buf)
+     To be safe for multi-domain programs, the cache lives in
+     domain-local storage. Each domain caches a single buffer, with
+     the slot emptied while the buffer is in us. Contending threads
+     will allocate a fresh buffer, and the last writer to finish
+     retains its buffer. At most one buffer per domain is kept live. *)
+  let write_buffer = Domain.DLS.new_key (fun () -> Atomic.make Bytes.empty)
 
   let write (type a) (event : a t) (value : a) =
     if runtime_events_are_active () then
     (* only custom events need a write buffer *)
     match event.typ with
     | Type.Custom _ ->
-        with_write_buffer (fun buf -> user_write buf event value)
+        let cache = Domain.DLS.get write_buffer in
+        let buf = Atomic.exchange cache Bytes.empty in
+        (* Must match RUNTIME_EVENTS_MAX_MSG_LENGTH which is (1 << 10) *)
+        let buf = if Bytes.length buf = 0 then Bytes.create 1024 else buf in
+        begin match user_write buf event value with
+        | () -> Atomic.set cache buf
+        | exception exn -> Atomic.set cache buf; raise exn
+        end
     | Type.Unit | Type.Int | Type.Span ->
         user_write Bytes.empty event value
 

--- a/testsuite/tests/lib-runtime-events/test_user_write_alloc.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_write_alloc.ml
@@ -1,0 +1,52 @@
+(* TEST
+ include runtime_events;
+*)
+
+(* Check that [Runtime_events.User.write] does not allocate. *)
+
+open Runtime_events
+
+type User.tag += Alloc_test
+
+let counter = User.register "alloc.counter" Alloc_test Type.int
+
+let custom_type =
+  let encode buf () = Bytes.set buf 0 'x'; 1 in
+  let decode _buf _size = () in
+  Type.register ~encode ~decode
+
+let custom = User.register "alloc.custom" Alloc_test custom_type
+
+let n = 1000
+
+let measure f =
+  let before = Gc.minor_words () in
+  f ();
+  let after = Gc.minor_words () in
+  after -. before
+
+let () =
+  start ();
+  User.write counter 0;
+  User.write custom ();
+  let baseline = measure (fun () -> ()) in
+  let int_words = measure (fun () ->
+    for i = 1 to n do User.write counter i done)
+  in
+  let custom_words = measure (fun () ->
+    for _ = 1 to n do User.write custom () done)
+  in
+  assert (int_words = baseline);
+  assert (custom_words = baseline);
+  (* sanity check that the events reached  event ring *)
+  let seen = ref 0 in
+  let handler _domain_id _ts _event _value = incr seen in
+  let cursor = create_cursor None in
+  let callbacks =
+    Callbacks.create ()
+    |> Callbacks.add_user_event Type.int handler
+    |> Callbacks.add_user_event custom_type handler
+  in
+  ignore (read_poll cursor callbacks None);
+  free_cursor cursor;
+  assert (!seen > 0)

--- a/testsuite/tests/lib-runtime-events/test_user_write_alloc.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_write_alloc.ml
@@ -38,7 +38,7 @@ let () =
   in
   assert (int_words = baseline);
   assert (custom_words = baseline);
-  (* sanity check that the events reached  event ring *)
+  (* Make sure that the events reached the event ring. *)
   let seen = ref 0 in
   let handler _domain_id _ts _event _value = incr seen in
   let cursor = create_cursor None in


### PR DESCRIPTION
This change alters `Runtime_events.User.write` to no longer allocate by changing the per-domain write-buffer cache for custom events into a single atomic bytes slot in DLS. It replaces a list-based cache accessed via closures (which was causing the allocation per event, see ocaml-multicore/eio#914).

The old path allocated ~23 words/event and about 3x that under thread contention (the cas swap) as far as I can tell from measurements using statmemprof.

The new path doesn't allocate in steady state. The cache buffer churn also seems to improve because the buffer is checked out only for the duration of the serializer call and not across Fun.protect poll points. I could use some more eyes experienced in runtime events to verify this is all still correct; it's simpler, at least, and the regress tests pass!

cc @sadiqj 