### PR TITLE
Makefile: fix race with otherlibs str + unix.cmi/.cmx

### DIFF
--- a/Changes
+++ b/Changes
@@ -443,6 +443,13 @@ Working version
   (Austin Thierault, review by Antonin Décimo, Edwin Török, David Allsopp and
    Olivier Nicole)
 
+- Improve build reproducibility by letting only otherlibs/{str,unix} build their
+  own .cmi and .cmx. The generic %.cmi/%.cmx rules of the root Makefile were
+  racing with them under make -j and recorded a different source path, which
+  changed the interface digest (and, through it, most other compiled
+  artefacts) as well as the debug info packed into str.a and unix.a.
+  (Bernhard M. Wiedemann)
+
 ### Bug fixes:
 
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an

--- a/Makefile
+++ b/Makefile
@@ -2260,6 +2260,12 @@ ocamldebug_LIBRARIES = compilerlibs/ocamlcommon \
 otherlibs/unix/unix.cma: otherlibraries
 otherlibs/str/str.cma: otherlibraries
 
+# Root-directory targets depend on these .cmi/.cmx via .depend. The empty
+# recipes keep the generic %.cmi/%.cmx rules from racing with the otherlibs
+# sub-make, which records a different source path and digest in the artefacts.
+otherlibs/unix/unix.cmi otherlibs/str/str.cmi: otherlibraries ;
+otherlibs/unix/unix.cmx otherlibs/str/str.cmx: otherlibrariesopt ;
+
 debugger/%: VPATH += otherlibs/unix otherlibs/dynlink
 
 ocamldebug_COMPILER_SOURCES = $(addprefix toplevel/, \


### PR DESCRIPTION
Without this patch, the [openSUSE ocaml package](https://build.opensuse.org/package/show/openSUSE:Factory/ocaml) builds would unpredictably vary in hard to reproduce ways.

.depend makes root-directory targets (ocamldoc, the debugger, ...) depend on `otherlibs/str/str.cmi` and `otherlibs/unix/unix.cmi`. Nothing stopped the generic %.cmi rule of the root Makefile from building those itself, so under make -j they were compiled either from the root directory or by `make -C otherlibs`, whichever got there first.

The two compilations do not agree on the source path they record in the .cmi ("otherlibs/str/str.mli" vs "str.mli"), which changes the interface digest. Since that digest is embedded in every .cmi/.cmt/.cmx/.cma/.cmxa of every unit that (transitively) uses Str or Unix, a large part of the installed tree ended up differing from one build to the next, including ocamldoc, ocamldebug and all of otherlibs/{str,unix,systhreads}.

Give both files an empty recipe depending on otherlibraries, so the generic rule no longer applies and "make -C otherlibs" is always the one that compiles them.
And same for the `.cmx` variant.