### PR TITLE
Extend fix #14982 by removing in_current_module and in_pervasives

### DIFF
--- a/Changes
+++ b/Changes
@@ -497,6 +497,10 @@ Working version
 - #14890, fix pattern compilation in presence of the [min_int] constant pattern
   (Florian Angeletti, review by Luc Maranget)
 
+* #14982, ?: Remove assumption that abstract types defined in the current
+  module are injective and contractive
+  (Jacques Garrigue, report by Jeremy Yallop)
+
 OCaml 5.5.1
 -----------
 

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -356,7 +356,7 @@ val cast_via_module_type_under_equality2 :
 |}]
 
 (* Test from issue #10768 *)
-type _ t
+type !_ t
 
 module type S = sig type t end
 
@@ -388,7 +388,7 @@ let get (type a) : a t -> (module S with type t = a)  = fun index ->
   in
   unpack dispatch
 [%%expect {|
-type _ t
+type !_ t
 module type S = sig type t end
 type pack = Pack : 'a t * (module S with type t = 'a) -> pack
 val dispatch : pack list ref = {contents = []}

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -536,3 +536,19 @@ Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be injective invariant,
        but it is invariant.
 |}]
+
+(* #14982 *)
+module type S = sig type 'a t end
+include (struct type 'a t = unit end : S)
+let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
+;;
+[%%expect{|
+module type S = sig type 'a t end
+type 'a t
+Line 3, characters 79-84:
+3 | let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
+                                                                                   ^^^^^
+Error: The constructor "Equal" has type "(a, a) Type.eq"
+       but an expression was expected of type "(a, b) Type.eq"
+       Type "a" is not compatible with type "b"
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -558,16 +558,6 @@ let without_assume_injective uenv f =
 
 (*** Checks for type definitions ***)
 
-let rec in_current_module = function
-  | Path.Pident _ -> true
-  | Path.Pdot _ | Path.Papply _ -> false
-  | Path.Pextra_ty (p, _) -> in_current_module p
-
-let in_pervasives p =
-  in_current_module p &&
-  try ignore (Env.find_type p Env.initial); true
-  with Not_found -> false
-
 let is_datatype decl=
   match decl.type_kind with
     Type_record _ | Type_variant _ | Type_open | Type_external _ -> true
@@ -2263,9 +2253,7 @@ let rec extract_package_modulo_subtype env ty =
   | _ -> raise Not_found
 
 let is_contractive env p =
-  try
-    let decl = Env.find_type p env in
-    in_pervasives p && decl.type_manifest = None || is_datatype decl
+  try is_datatype (Env.find_type p env)
   with Not_found -> false
 
 
@@ -3557,8 +3545,7 @@ and unify3 uenv t1' t2' =
             unify_list uenv tl1 tl2
           else if can_assume_injective uenv then
             without_assume_injective uenv (fun uenv -> unify_list uenv tl1 tl2)
-          else if in_current_module p1 (* || in_pervasives p1 *)
-               || List.exists
+          else if List.exists
                    (expands_to_datatype (get_env uenv))
                    (List.map (fun a -> a.abbr_path)
                       (Option.to_list (get_abbrev t1') @


### PR DESCRIPTION
In #14982 @yallop proposes a fix to a left over assumption about injectivity of abstract types defined in the current module. (This used to be true, but was invalidated when `included` was allowed to apply to arbitrary structures.)

This PR extends #14982 by completely removing the `in_current_module` and `in_pervasives` function from `ctype.ml` altogether.

A follow-up plan is to modify the injectivity inference so that abstract type definitions (in structures rather then signatures) become automatically injective, as this is always correct. But this extra work is best kept separate, as the impact on the testsuite is bigger than expected.