### PR TITLE
Make abstract types defined in structures injective

### DIFF
--- a/Changes
+++ b/Changes
@@ -497,6 +497,10 @@ Working version
 - #14890, fix pattern compilation in presence of the [min_int] constant pattern
   (Florian Angeletti, review by Luc Maranget)
 
+* #14982, ?: Remove assumption that abstract types defined in the current
+  module are injective and contractive
+  (Jacques Garrigue, report by Jeremy Yallop)
+
 OCaml 5.5.1
 -----------
 

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -8,7 +8,7 @@ Line 1:
 Error: Type declarations do not match:
          type !'a x = private [> `x ] constraint 'a = [> `x ]
        is not included in
-         type 'a x
+         type !'a x
        Their parameters differ
        The type "[> `x ] x" = "[> `x ]" is not equal to the type "'a"
 |}, Principal{|
@@ -16,7 +16,7 @@ Line 1:
 Error: Type declarations do not match:
          type !'a x = private 'a constraint 'a = [> `x ]
        is not included in
-         type 'a x
+         type !'a x
        Their parameters differ
        The type "[> `x ]" is not equal to the type "'a"
 |}];;

--- a/testsuite/tests/tool-toplevel/show_short_paths.ml
+++ b/testsuite/tests/tool-toplevel/show_short_paths.ml
@@ -14,6 +14,6 @@ type 'a list = [] | (::) of 'a * 'a list
 type 'a t;;
 #show t;;
 [%%expect {|
-type 'a t
-type 'a t
+type !'a t
+type !'a t
 |}];;

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -356,7 +356,7 @@ val cast_via_module_type_under_equality2 :
 |}]
 
 (* Test from issue #10768 *)
-type _ t
+type !_ t
 
 module type S = sig type t end
 
@@ -388,7 +388,7 @@ let get (type a) : a t -> (module S with type t = a)  = fun index ->
   in
   unpack dispatch
 [%%expect {|
-type _ t
+type !_ t
 module type S = sig type t end
 type pack = Pack : 'a t * (module S with type t = 'a) -> pack
 val dispatch : pack list ref = {contents = []}

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -50,7 +50,7 @@ end ;;
 let g (y : M.j t option) =
   let None = y in () ;;
 [%%expect{|
-module M : sig type 'a d type j = < m : 'c. 'c -> 'c d > end
+module M : sig type !'a d type j = < m : 'c. 'c -> 'c d > end
 Line 6, characters 2-20:
 6 |   let None = y in () ;;
       ^^^^^^^^^^^^^^^^^^
@@ -73,17 +73,11 @@ let g (y : M.j t option) =
 module M :
   sig
     type e
-    type 'a d
+    type !'a d
     type i = < m : 'c. 'c -> 'c d >
     type j = < m : 'c. 'c -> e >
   end
 type _ t = A : M.i t
-Line 9, characters 2-20:
-9 |   let None = y in () ;;
-      ^^^^^^^^^^^^^^^^^^
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-  Here is an example of a case that is not matched: "Some A"
-
 val g : M.j t option -> unit = <fun>
 |}]
 
@@ -99,17 +93,11 @@ let g (y : 'a M.j t option) =
 [%%expect{|
 module M :
   sig
-    type 'a d
+    type !'a d
     type i = < m : 'c. 'c -> 'c d >
     type 'a j = < m : 'c. 'c -> 'a >
   end
 type _ t = A : M.i t
-Line 9, characters 2-20:
-9 |   let None = y in () ;;
-      ^^^^^^^^^^^^^^^^^^
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-  Here is an example of a case that is not matched: "Some A"
-
 val g : 'a M.j t option -> unit = <fun>
 |}]
 
@@ -160,7 +148,7 @@ let f (y : M.j t) = match y with _ -> .;;
 [%%expect{|
 module M :
   sig
-    type 'a a
+    type !'a a
     type i = C of < m : 'c. 'c -> 'c -> 'c >
     type j = C of < m : 'c. 'c -> 'c a >
   end

--- a/testsuite/tests/typing-gadts/pr10735.ml
+++ b/testsuite/tests/typing-gadts/pr10735.ml
@@ -13,7 +13,7 @@ type 'a t
 type (_,_) eq = Refl : ('a,'a) eq
 [%%expect{|
 module X : sig type 'a t end
-type 'a t
+type !'a t
 type (_, _) eq = Refl : ('a, 'a) eq
 |}]
 

--- a/testsuite/tests/typing-gadts/pr11888.ml
+++ b/testsuite/tests/typing-gadts/pr11888.ml
@@ -3,7 +3,7 @@
 *)
 
 type z
-type 'a s
+type 'a s = private unit
 type _ nat =
   | Nz : z -> z nat
   | Nss : 'd nat -> 'd s s nat
@@ -12,7 +12,7 @@ type _ nat =
 
 [%%expect{|
 type z
-type 'a s
+type 'a s = private unit
 Lines 3-6, characters 0-27:
 3 | type _ nat =
 4 |   | Nz : z -> z nat
@@ -24,7 +24,7 @@ Error: In the GADT constructor
 |}];;
 
 type z
-type 'a s
+type 'a s = private unit
 type _ nat = ..
 type _ nat += Nz : z -> z nat
 type _ nat += Nss : 'd nat -> 'd s s nat
@@ -32,7 +32,7 @@ type _ nat += Nss : 'd nat -> 'd s s nat
 
 [%%expect{|
 type z
-type 'a s
+type 'a s = private unit
 type _ nat = ..
 type _ nat += Nz : z -> z nat
 Line 5, characters 0-40:

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -35,7 +35,7 @@ let () =
 
 (* Side-effect of the fix *)
 
-module M = struct type 'a p end
+module M : sig type 'a p end = struct type 'a p end
 type _ t = W: int M.p t
 [%%expect{|
 module M : sig type 'a p end

--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -20,9 +20,9 @@ let vexpr (type visit_action)
   | Global -> fun _ -> raise Exit
 ;;
 [%%expect{|
-type 'a visit_action
+type !'a visit_action
 type insert
-type 'a local_visit_action
+type !'a local_visit_action
 type ('a, 'result, 'visit_action) context =
     Local : ('a, 'a * insert, 'a local_visit_action) context
   | Global : ('a, 'a, 'a visit_action) context

--- a/testsuite/tests/typing-gadts/pr7234.ml
+++ b/testsuite/tests/typing-gadts/pr7234.ml
@@ -7,7 +7,7 @@ type 'a t;;
 let f (type a) (Neq n : (a, a t) eq) = n;;   (* warn! *)
 [%%expect{|
 type (_, _) eq = Eq : ('a, 'a) eq | Neq : int -> ('a, 'b) eq
-type 'a t
+type !'a t
 Line 3, characters 15-36:
 3 | let f (type a) (Neq n : (a, a t) eq) = n;;   (* warn! *)
                    ^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-gadts/pr7397.ml
+++ b/testsuite/tests/typing-gadts/pr7397.ml
@@ -15,7 +15,7 @@ end
 type _ response =
  | C : #a t response;;
 [%%expect{|
-type +'a t
+type +!'a t
 class type a = object method b : b end
 and b = object method a : a end
 type _ response = C : #a t response

--- a/testsuite/tests/typing-gadts/pr9019.ml
+++ b/testsuite/tests/typing-gadts/pr9019.ml
@@ -216,7 +216,7 @@ Exception: Match_failure ("", 9, 2).
 type 'a a = private [< `A of 'a];;
 let f (x : _ a) = match x with `A None -> ();;
 [%%expect{|
-type 'a a = private [< `A of 'a ]
+type !'a a = private [< `A of 'a ]
 Line 2, characters 18-44:
 2 | let f (x : _ a) = match x with `A None -> ();;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-misc/conjunctive_types.ml
+++ b/testsuite/tests/typing-misc/conjunctive_types.ml
@@ -80,7 +80,7 @@ type ('dim, 'res, 'a) cross = 'dim
   constraint 'dim =
     [< `three of 'res & 'p2 three * 'p1 one | `two of 'res & 'p2 * 'p1 z ]
   constraint 'a = 'p1 * 'p2
-type (+'dim, +'rank) t
+type (+!'dim, +!'rank) t
 type +'c scalar = ('a one, 'b z) t constraint 'c = 'a * 'b
 type +'c vec2 = ('a two, 'b one) t constraint 'c = 'a * 'b
 module type Vec =
@@ -173,7 +173,7 @@ type ('dim, 'res, 'a) cross = 'dim
   constraint 'dim =
     [< `three of 'res & 'p2 three * 'p1 one | `two of 'res & 'p2 * 'p1 z ]
   constraint 'a = 'p1 * 'p2
-type (+'dim, +'rank) t
+type (+!'dim, +!'rank) t
 type +'c scalar = ('a one, 'b z) t constraint 'c = 'a * 'b
 type +'c vec2 = ('a two, 'b one) t constraint 'c = 'a * 'b
 module type Vec =

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -405,7 +405,7 @@ type cycle = cycle id
 and 'a id = 'a
 and s = cycle t
 [%%expect{|
-type 'a t constraint 'a = 'b * 'c
+type !'a t constraint 'a = 'b * 'c
 Line 2, characters 0-21:
 2 | type cycle = cycle id
     ^^^^^^^^^^^^^^^^^^^^^
@@ -419,7 +419,7 @@ type 'a t = [`Foo]
 type 'a cstr constraint 'a = float
 [%%expect{|
 type +-'a t = [ `Foo ]
-type 'a cstr constraint 'a = float
+type !'a cstr constraint 'a = float
 |}]
 
 type s = int

--- a/testsuite/tests/typing-misc/distant_errors.ml
+++ b/testsuite/tests/typing-misc/distant_errors.ml
@@ -23,11 +23,11 @@ Lines 9-12, characters 6-3:
 12 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type _ t val f : 'a -> unit end
+         sig type !_ t val f : 'a -> unit end
        is not included in
          sig type (_, _) t val f : ('a, 'b) t -> unit end
        Type declarations do not match:
-         type _ t
+         type !_ t
        is not included in
          type (_, _) t
        They have different arities.

--- a/testsuite/tests/typing-misc/filter_params.ml
+++ b/testsuite/tests/typing-misc/filter_params.ml
@@ -4,5 +4,5 @@
 
 type ('a, 'b) t constraint 'a = 'b
 [%%expect{|
-type ('b, 'a) t constraint 'a = 'b
+type (!'b, !'a) t constraint 'a = 'b
 |}]

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -536,3 +536,19 @@ Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be injective invariant,
        but it is invariant.
 |}]
+
+(* #14982 *)
+module type S = sig type 'a t end
+include (struct type 'a t = unit end : S)
+let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
+;;
+[%%expect{|
+module type S = sig type 'a t end
+type 'a t
+Line 3, characters 79-84:
+3 | let inj_t : type a b. (a t, b t) Type.eq -> (a, b) Type.eq = function Equal -> Equal
+                                                                                   ^^^^^
+Error: The constructor "Equal" has type "(a, a) Type.eq"
+       but an expression was expected of type "(a, b) Type.eq"
+       Type "a" is not compatible with type "b"
+|}]

--- a/testsuite/tests/typing-misc/letitem.ml
+++ b/testsuite/tests/typing-misc/letitem.ml
@@ -82,7 +82,7 @@ let _ =
 
 type 'a t
 [%%expect{|
-type 'a t
+type !'a t
 |}]
 
 (* This was correct in OCaml 5.4,

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -11,7 +11,7 @@ let g : [< `b] t -> unit = fun _ -> ();;
 
 let h : [> `b] t -> unit = fun _ -> ();;
 [%%expect{|
-type 'a t
+type !'a t
 type a
 val f : < .. > t -> unit = <fun>
 val g : [< `b ] t -> unit = <fun>

--- a/testsuite/tests/typing-misc/pr9314.ml
+++ b/testsuite/tests/typing-misc/pr9314.ml
@@ -104,7 +104,7 @@ type 'a alpha_of_gamma = < alpha : 'c > alpha
   constraint 'a = < delta : 'b; gamma : < alpha : 'c > >
 type 'a beta_of_delta = < beta : 'b > beta
   constraint 'a = < delta : < beta : 'b >; gamma : 'c >
-type ('a, 'b) alphabeta
+type (!'a, !'b) alphabeta
 module Alphabeta :
   sig
     type ('a, 'just_alpha) t = {

--- a/testsuite/tests/typing-misc/variance.ml
+++ b/testsuite/tests/typing-misc/variance.ml
@@ -13,14 +13,14 @@ type - 'a t;;
 type +- 'a t;;
 type -+ 'a t;;
 [%%expect{|
-type +'a t
-type -'a t
-type +-'a t
-type +-'a t
-type +'a t
-type -'a t
-type +-'a t
-type +-'a t
+type +!'a t
+type -!'a t
+type +-!'a t
+type +-!'a t
+type +!'a t
+type -!'a t
+type +-!'a t
+type +-!'a t
 |}]
 (* Expect doesn't support syntax errors
 type + - 'a t
@@ -61,14 +61,14 @@ type !'a t = (module s with type t = 'a)
 |}]
 
 (* Composition *)
-type -'a n
+type -'a n = private unit
 type +'a p
 type !'a i
 
 type +'a error_np = 'a n p;;
 [%%expect{|
-type -'a n
-type +'a p
+type -'a n = private unit
+type +!'a p
 type !'a i
 Line 5, characters 0-26:
 5 | type +'a error_np = 'a n p;;
@@ -96,7 +96,7 @@ Line 1, characters 0-26:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be contravariant,
-       but it is covariant.
+       but it is injective covariant.
 |}]
 
 type -'a error_nn = 'a n n;;

--- a/testsuite/tests/typing-modular-explicits/gadt.ml
+++ b/testsuite/tests/typing-modular-explicits/gadt.ml
@@ -115,18 +115,17 @@ let f : ( (module X:S) -> (int * 'a) R.n, (module X:S) -> (float * 'b) R.n) Type
   | Type.Equal -> ()
 
 [%%expect{|
-module R : sig type 'a n end
+module R : sig type !'a n end
 module type S = sig type 'a t = X type u type v end
 Line 13, characters 4-14:
 13 |   | Type.Equal -> ()
          ^^^^^^^^^^
 Error: This pattern matches values of type
-         "((module X : S) -> (int * $'a) R.n,
-          (module X : S) -> (int * $'a) R.n)
+         "((module X : S) -> (int * 'a) R.n, (module X : S) -> (int * 'a) R.n)
          Type.eq"
        but a pattern was expected which matches values of type
-         "((module X : S) -> (int * $'a) R.n,
+         "((module X : S) -> (int * 'a) R.n,
           (module X : S) -> (float * 'b) R.n)
          Type.eq"
-       The type constructor "$'a" would escape its scope
+       Type "int" is not compatible with type "float"
 |}]

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -43,7 +43,7 @@ class type c = object method m : [ `A ] t end;;
 module M : sig val v : (#c as 'a) -> 'a end =
   struct let v x = ignore (x :> c); x end;;
 [%%expect{|
-type -'a t
+type -!'a t
 class type c = object method m : [ `A ] t end
 module M : sig val v : (#c as 'a) -> 'a end
 |}];;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -57,7 +57,7 @@ end = struct
   type ('b,'c,'a) t = ('b * 'c * 'a * 'c * 'a) x
 end
 [%%expect{|
-type 'a x
+type !'a x
 Lines 4-6, characters 6-3:
 4 | ......struct
 5 |   type ('b,'c,'a) t = ('b * 'c * 'a * 'c * 'a) x

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -776,7 +776,7 @@ x;;
 
 type 'a t;;
 [%%expect{|
-type 'a t
+type !'a t
 |}];;
 fun (x : 'a t as 'a) -> ();;
 [%%expect{|

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -993,7 +993,7 @@ and u = int t
 type 'a t constraint 'a = int;;
 type 'a u = 'a and 'a v = 'a u t;;
 [%%expect {|
-type 'a t constraint 'a = int
+type !'a t constraint 'a = int
 Line 2, characters 26-32:
 2 | type 'a u = 'a and 'a v = 'a u t;;
                               ^^^^^^

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -121,7 +121,7 @@ Line 1:
 Error: Type declarations do not match:
          type !'a t = private 'a constraint 'a = < x : int; .. >
        is not included in
-         type 'a t
+         type !'a t
        Their parameters differ
        The type < x : int; .. > is not equal to the type 'a
 type 'a t = private 'a constraint 'a = < x : int; .. >

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -121,7 +121,7 @@ Line 1:
 Error: Type declarations do not match:
          type !'a t = private < x : int; .. > constraint 'a = < x : int; .. >
        is not included in
-         type 'a t
+         type !'a t
        Their parameters differ
        The type < x : int; .. > t = < x : int; .. > is not equal to the type
          'a

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -143,7 +143,7 @@ module type S = sig
   val x : int mylist t2
 end with type 'a t2 := 'a t
 [%%expect {|
-type 'a t constraint 'a = 'b list
+type !'a t constraint 'a = 'b list
 module type S = sig type 'a mylist = 'a list val x : int mylist t end
 |}]
 
@@ -155,7 +155,7 @@ module type S = sig
   val x : int mylist t2
 end with type 'a t2 := 'a t * bool
 [%%expect {|
-type 'a t constraint 'a = 'b list
+type !'a t constraint 'a = 'b list
 Lines 2-6, characters 16-34:
 2 | ................sig
 3 |   type 'a t2 constraint 'a = 'b list

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -333,7 +333,7 @@ type ('a, 'p) t = private 'a s
 type 'a packed = T : ('a, _) t -> 'a packed [@@unboxed]
 ;;
 [%%expect{|
-type 'a s
+type !'a s
 type ('a, 'p) t = private 'a s
 type 'a packed = T : ('a, 'b) t -> 'a packed [@@unboxed]
 |}];;
@@ -354,7 +354,7 @@ val h : f = {field = []}
 type 'a t [@@immediate];;
 type u = U : 'a t -> u [@@unboxed];;
 [%%expect{|
-type 'a t [@@immediate]
+type !'a t [@@immediate]
 type u = U : 'a t -> u [@@unboxed]
 |}];;
 

--- a/testsuite/tests/typing-unboxed-types/test_flat.ml
+++ b/testsuite/tests/typing-unboxed-types/test_flat.ml
@@ -7,7 +7,7 @@
 type 'a abs;;
 type t16 = A : 'a abs -> t16 [@@ocaml.unboxed];;
 [%%expect{|
-type 'a abs
+type !'a abs
 Line 2, characters 0-46:
 2 | type t16 = A : 'a abs -> t16 [@@ocaml.unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -558,16 +558,6 @@ let without_assume_injective uenv f =
 
 (*** Checks for type definitions ***)
 
-let rec in_current_module = function
-  | Path.Pident _ -> true
-  | Path.Pdot _ | Path.Papply _ -> false
-  | Path.Pextra_ty (p, _) -> in_current_module p
-
-let in_pervasives p =
-  in_current_module p &&
-  try ignore (Env.find_type p Env.initial); true
-  with Not_found -> false
-
 let is_datatype decl=
   match decl.type_kind with
     Type_record _ | Type_variant _ | Type_open | Type_external _ -> true
@@ -2263,9 +2253,7 @@ let rec extract_package_modulo_subtype env ty =
   | _ -> raise Not_found
 
 let is_contractive env p =
-  try
-    let decl = Env.find_type p env in
-    in_pervasives p && decl.type_manifest = None || is_datatype decl
+  try is_datatype (Env.find_type p env)
   with Not_found -> false
 
 
@@ -3557,8 +3545,7 @@ and unify3 uenv t1' t2' =
             unify_list uenv tl1 tl2
           else if can_assume_injective uenv then
             without_assume_injective uenv (fun uenv -> unify_list uenv tl1 tl2)
-          else if in_current_module p1 (* || in_pervasives p1 *)
-               || List.exists
+          else if List.exists
                    (expands_to_datatype (get_env uenv))
                    (List.map (fun a -> a.abbr_path)
                       (Option.to_list (get_abbrev t1') @

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1259,7 +1259,7 @@ let add_types_to_env decls shapes env =
     decls shapes env
 
 (* Translate a set of type declarations, mutually recursive or not *)
-let transl_type_decl env rec_flag sdecl_list =
+let transl_type_decl ~impl env rec_flag sdecl_list =
   List.iter check_redefined_unit sdecl_list;
   (* Add dummy types for fixed rows *)
   let fixed_types = List.filter is_fixed_type sdecl_list in
@@ -1396,7 +1396,7 @@ let transl_type_decl env rec_flag sdecl_list =
     try
       decls
       |> name_recursion_decls sdecl_list
-      |> Typedecl_variance.update_decls env sdecl_list
+      |> Typedecl_variance.update_decls ~impl env sdecl_list
       |> Typedecl_immediacy.update_decls env
       |> Typedecl_separability.update_decls env
     with
@@ -2035,7 +2035,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   end;
   let new_sig_decl = name_recursion sdecl id new_sig_decl in
   let new_type_variance =
-    let required = Typedecl_variance.variance_of_sdecl sdecl in
+    let required = Typedecl_variance.variance_of_sdecl ~impl:false sdecl in
     try
       Typedecl_variance.compute_decl env ~check:(Some id) new_sig_decl required
     with Typedecl_variance.Error (loc, err) ->

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -17,7 +17,8 @@
 
 open Types
 val transl_type_decl:
-    Env.t -> Asttypes.rec_flag -> Parsetree.type_declaration list ->
+    impl:bool -> Env.t -> Asttypes.rec_flag ->
+    Parsetree.type_declaration list ->
     Typedtree.type_declaration list * Env.t * Shape.t list
 
 val transl_exception:

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -436,11 +436,19 @@ let transl_variance (v, i) =
 let variance_of_params ptype_params =
   List.map transl_variance (List.map snd ptype_params)
 
-let variance_of_sdecl sdecl =
-  variance_of_params sdecl.Parsetree.ptype_params
+let variance_of_sdecl ~impl (sdecl : Parsetree.type_declaration) =
+  let params = sdecl.ptype_params in
+  let params =
+    (* Add injectivity for abstract types in implementations *)
+    if impl && sdecl.ptype_kind = Parsetree.Ptype_abstract
+            && sdecl.ptype_manifest = None
+    then List.map (fun (t, (v,_i)) -> (t, (v, Injective))) params
+    else params
+  in
+  variance_of_params params
 
-let update_decls env sdecls decls =
-  let required = List.map variance_of_sdecl sdecls in
+let update_decls ~impl env sdecls decls =
+  let required = List.map (variance_of_sdecl ~impl) sdecls in
   Typedecl_properties.compute_property property env decls required
 
 let update_class_decls env cldecls =

--- a/typing/typedecl_variance.mli
+++ b/typing/typedecl_variance.mli
@@ -23,7 +23,7 @@ val variance_of_params :
   (Parsetree.core_type * (Asttypes.variance * Asttypes.injectivity)) list ->
   surface_variance list
 val variance_of_sdecl :
-  Parsetree.type_declaration -> surface_variance list
+  impl:bool -> Parsetree.type_declaration -> surface_variance list
 
 type prop = Variance.t list
 type req = surface_variance list
@@ -65,7 +65,7 @@ val compute_decl :
   Env.t -> check:Ident.t option -> type_declaration -> req -> prop
 
 val update_decls :
-  Env.t -> Parsetree.type_declaration list ->
+  impl:bool -> Env.t -> Parsetree.type_declaration list ->
   (Ident.t * type_declaration) list ->
   (Ident.t * type_declaration) list
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1700,7 +1700,7 @@ and transl_signature env sg =
         newenv
     | Psig_type (rec_flag, sdecls) ->
         let (decls, newenv, _) =
-          Typedecl.transl_type_decl env rec_flag sdecls
+          Typedecl.transl_type_decl ~impl:false env rec_flag sdecls
         in
         List.iter (fun td ->
             Signature_names.check_type names td.typ_loc td.typ_id;
@@ -1715,7 +1715,7 @@ and transl_signature env sg =
         newenv
     | Psig_typesubst sdecls ->
         let (decls, newenv, _) =
-          Typedecl.transl_type_decl env Nonrecursive sdecls
+          Typedecl.transl_type_decl ~impl:false env Nonrecursive sdecls
         in
         List.iter (fun td ->
             if td.typ_kind <> Ttype_abstract || td.typ_manifest = None ||
@@ -2903,7 +2903,7 @@ and type_str_item ~names ~toplevel ~funct_body anchor env shape_map
         newenv
     | Pstr_type (rec_flag, sdecls) ->
         let (decls, newenv, shapes) =
-          Typedecl.transl_type_decl env rec_flag sdecls
+          Typedecl.transl_type_decl ~impl:true env rec_flag sdecls
         in
         List.iter
           Signature_names.(fun td -> check_type names td.typ_loc td.typ_id)


### PR DESCRIPTION
This is a follow-up to #14982 and #14990.
An abstract type directly defined in a structure cannot be expanded.
As a result, it can always be seen as injective.
Note that this is different from abstract types in signatures, which could be exporting a non-injective type.

This change should be sound, but it has a bigger impact on the testsuite than expected.
One reason is that, in tests, abstract type definitions are often used to simulate abstract types coming from signatures.
A quick hack it to replace `type _ t` by `type _ t = private unit`, as it behave similarly to an abstract type in a signature (but not identically).
A more thorough approach would be to write something like
```ocaml
import (struct type _ t end : sig type _ t end)
```
which really hides the abstract type definition.
Since the cleanest way to go is not clear yet, I keep this PR as draft temporarily.