### PR TITLE
let-rec check: give generic arrays dynamic size

### DIFF
--- a/Changes
+++ b/Changes
@@ -450,6 +450,10 @@ Working version
 
 ### Bug fixes:
 
+- #14993: the let-rec check should give generic arrays dynamic size,
+  since floats and addresses have different sizes on 32-bit systems.
+  (Jeremy Yallop)
+
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an
   event is larger than the configured ring buffer. Only really comes up
   if you run the instrumented runtime with a small OCAMLRUNPARAM=e= setting

--- a/Changes
+++ b/Changes
@@ -452,7 +452,7 @@ Working version
 
 - #14993: the let-rec check should give generic arrays dynamic size,
   since floats and addresses have different sizes on 32-bit systems.
-  (Jeremy Yallop)
+  (Jeremy Yallop, review by Vincent Laviron)
 
 - #13335: Fix infinite loop in runtime_events.c's write_to_ring when an
   event is larger than the configured ring buffer. Only really comes up

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -278,7 +278,9 @@ let compute_static_size lam =
     | Pmakearray (kind, _) ->
         let size = List.length args in
         begin match kind with
-        | Pgenarray | Paddrarray | Pintarray ->
+        | Pgenarray ->
+            dynamic_size ()
+        | Paddrarray | Pintarray ->
             Block (Regular_block size)
         | Pfloatarray ->
             Block (Float_record size)

--- a/testsuite/tests/letrec-check/flat_float_array.ml
+++ b/testsuite/tests/letrec-check/flat_float_array.ml
@@ -50,3 +50,14 @@ Line 1, characters 31-41:
                                    ^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of "let rec"
 |}]
+
+(* PR #14993: on 32-bit systems, doubles and addresses are different
+   sizes, so a generic array literal that may be instantiated to a flat
+   float array must be classified as having dynamic size.  Before #14993
+   the following code produced a segmentation fault. *)
+let make v = let rec a = [| v; v; v; v; v; v; v; v |] in a
+let fa = make 2.5
+[%%expect {|
+val make : 'a -> 'a array = <fun>
+val fa : float array = [|2.5; 2.5; 2.5; 2.5; 2.5; 2.5; 2.5; 2.5|]
+|}]

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -196,7 +196,10 @@ let classify_expression : Typedtree.expression -> sd =
         Dynamic
 
     | Texp_array _ ->
-        Static
+       begin match Typeopt.array_kind e with
+       | Pgenarray -> Dynamic
+       | Pfloatarray | Paddrarray | Pintarray -> Static
+       end
     | Texp_pack mexp ->
         classify_module_expression env mexp
     | Texp_function _ ->


### PR DESCRIPTION
The let-rec check classifies expressions according to whether they have statically-known size.  For example, in the following expression

```ocaml
let rec x = if b then (fun x -> x)
                         else (fun x -> x + y + z)
[...]
```
the size of the right-hand side can't be determined statically, because the size of the closure depends on the value of `b`.

The flat float array optimization introduces a hidden branch in the initialization of an array of unknown type.  For example, in the following code, whether the array `[| v; v; v; v; v; v; v; v |] ` is allocated as an unboxed float array or an array of boxed values (or immediates) is determined at run time by the value of `v`:

```ocaml
let make v = let rec a = [| v; v; v; v; v; v; v; v |] in a
```

On 32-bit systems floats (i.e. doubles) and addresses have different sizes, so the pre-PR approach of treating the size of `a` as if it were statically known to contain addresses leads to overwriting memory in the case where the actual elements turn out to be doubles:

```ocaml
# make 2.5;;
Segmentation fault
```

The fix is to use type information to distinguish between different types of array: only arrays of (sufficeintly) known type have static size for the purpose of let-rec safety.

(This bug was found with Claude's help.)