### PR TITLE
Default to and recommend large file and year 2038 support on 32-bit

### DIFF
--- a/Changes
+++ b/Changes
@@ -132,6 +132,11 @@ Working version
 - #14814: a `caml_result_find_exception` helper for the `caml_result` type
   (Gabriel Scherer, review by Nicolás Ojeda Bär, request by Chris Vine)
 
+* #14997: Default to and recommend large file and year 2038 support on 32-bit
+  systems. LFS and 64-bit `time_t` _checks_ can be disabled by passing
+  respectively `--disable-largefile` and `--disable-year2038` to configure.
+  (Antonin Décimo, review by Miod Vallat)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/configure
+++ b/configure
@@ -709,6 +709,7 @@ ac_includes_default="\
 
 ac_header_c_list=
 ac_func_c_list=
+enable_year2038=yes
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 DIFF_FLAGS
@@ -1077,6 +1078,8 @@ with_aix_soname
 with_gnu_ld
 with_sysroot
 enable_libtool_lock
+enable_largefile
+enable_year2038
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1794,6 +1797,8 @@ Optional Features:
                           shared library versioning (aka "SONAME") variant to
                           provide on AIX, [default=aix].
   --disable-libtool-lock  avoid locking (might break parallel builds)
+  --disable-largefile     omit support for large files
+  --disable-year2038      don't support timestamps after 2038
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -16059,25 +16064,242 @@ fi
 esac
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
-# Enable 64-bit time_t in time.h
 case $target in #(
   i686-w64-mingw32*) :
-    internal_cflags="$internal_cflags -mfpmath=sse -msse2"
-    # This instructs _mingw.h to adopt the switch in Visual Studio 8 (2005) to
-    # make time_t a 64-bit value.
-    internal_cppflags="$internal_cppflags -D__MINGW_USE_VC2005_COMPAT" ;; #(
+    internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
   *) :
      ;;
 esac
 
-# Use 64-bit file offset if possible
-# See also AC_SYS_LARGEFILE
-# Problem: flags are added to CC rather than CPPFLAGS
+# Default to enabling large file support and year 2038 support on 32-bit.
+# Check whether --enable-largefile was given.
+if test ${enable_largefile+y}
+then :
+  enableval=$enable_largefile;
+fi
+if test "$enable_largefile,$enable_year2038" != no,no
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
+printf %s "checking for $CPPFLAGS option for large files... " >&6; }
+if test ${ac_cv_sys_largefile_opts+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_save_CPPFLAGS=$CPPFLAGS
+  ac_opt_found=no
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
+    if test x"$ac_opt" != x"none needed"
+then :
+  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
+fi
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <sys/types.h>
+#ifndef FTYPE
+# define FTYPE off_t
+#endif
+ /* Check that FTYPE can represent 2**63 - 1 correctly.
+    We can't simply define LARGE_FTYPE to be 9223372036854775807,
+    since some C++ compilers masquerading as C compilers
+    incorrectly reject 9223372036854775807.  */
+#define LARGE_FTYPE (((FTYPE) 1 << 31 << 31) - 1 + ((FTYPE) 1 << 31 << 31))
+  int FTYPE_is_large[(LARGE_FTYPE % 2147483629 == 721
+		       && LARGE_FTYPE % 2147483647 == 1)
+		      ? 1 : -1];
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  if test x"$ac_opt" = x"none needed"
+then :
+  # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
+	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
+	 if ac_fn_c_try_compile "$LINENO"
+then :
+
+else case e in #(
+  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
+	    if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_opt='-D_FILE_OFFSET_BITS=64'
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam
+fi
+      ac_cv_sys_largefile_opts=$ac_opt
+      ac_opt_found=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+    test $ac_opt_found = no || break
+  done
+  CPPFLAGS=$ac_save_CPPFLAGS
+
+  test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_largefile_opts" >&5
+printf "%s\n" "$ac_cv_sys_largefile_opts" >&6; }
+
+ac_have_largefile=yes
+case $ac_cv_sys_largefile_opts in #(
+  "none needed") :
+     ;; #(
+  "supported through gnulib") :
+     ;; #(
+  "support not detected") :
+    ac_have_largefile=no ;; #(
+  "-D_FILE_OFFSET_BITS=64") :
+
+printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
+ ;; #(
+  "-D_LARGE_FILES=1") :
+
+printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
+ ;; #(
+  *) :
+    as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
+esac
+
+if test "$enable_year2038" != no
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
+printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
+if test ${ac_cv_sys_year2038_opts+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_save_CPPFLAGS="$CPPFLAGS"
+  ac_opt_found=no
+  for ac_opt in "none needed" "-D_TIME_BITS=64" "-D__MINGW_USE_VC2005_COMPAT" "-U_USE_32_BIT_TIME_T -D__MINGW_USE_VC2005_COMPAT"; do
+    if test x"$ac_opt" != x"none needed"
+then :
+  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
+fi
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  #include <time.h>
+  /* Check that time_t can represent 2**32 - 1 correctly.  */
+  #define LARGE_TIME_T \\
+    ((time_t) (((time_t) 1 << 30) - 1 + 3 * ((time_t) 1 << 30)))
+  int verify_time_t_range[(LARGE_TIME_T / 65537 == 65535
+                           && LARGE_TIME_T % 65537 == 0)
+                          ? 1 : -1];
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_sys_year2038_opts="$ac_opt"
+      ac_opt_found=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+    test $ac_opt_found = no || break
+  done
+  CPPFLAGS="$ac_save_CPPFLAGS"
+  test $ac_opt_found = yes || ac_cv_sys_year2038_opts="support not detected" ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_year2038_opts" >&5
+printf "%s\n" "$ac_cv_sys_year2038_opts" >&6; }
+
+ac_have_year2038=yes
+case $ac_cv_sys_year2038_opts in #(
+  "none needed") :
+     ;; #(
+  "support not detected") :
+    ac_have_year2038=no ;; #(
+  "-D_TIME_BITS=64") :
+
+printf "%s\n" "#define _TIME_BITS 64" >>confdefs.h
+ ;; #(
+  "-D__MINGW_USE_VC2005_COMPAT") :
+
+printf "%s\n" "#define __MINGW_USE_VC2005_COMPAT 1" >>confdefs.h
+ ;; #(
+  "-U_USE_32_BIT_TIME_T"*) :
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+as_fn_error $? "the 'time_t' type is currently forced to be 32-bit. It
+will stop working after mid-January 2038. Remove
+_USE_32BIT_TIME_T from the compiler flags.
+See 'config.log' for more details" "$LINENO" 5; } ;; #(
+  *) :
+    as_fn_error $? "internal error: bad value for \$ac_cv_sys_year2038_opts" "$LINENO" 5 ;;
+esac
+
+fi
+
+fi
+if test "$enable_year2038,$ac_have_year2038,$cross_compiling" = yes,no,no
+then :
+  # If we're not cross compiling and 'touch' works with a large
+  # timestamp, then we can presume the system supports wider time_t
+  # *somehow* and we just weren't able to detect it.  One common
+  # case that we deliberately *don't* probe for is a system that
+  # supports both 32- and 64-bit ABIs but only the 64-bit ABI offers
+  # wide time_t.  (It would be inappropriate for us to override an
+  # intentional use of -m32.)  Error out, demanding use of
+  # --disable-year2038 if this is intentional.
+  if TZ=UTC0 touch -t 210602070628.15 conftest.time 2>/dev/null
+then :
+  case `TZ=UTC0 LC_ALL=C ls -l conftest.time 2>/dev/null` in #(
+  *'Feb  7  2106'* | *'Feb  7 17:10'*) :
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+as_fn_error $? "this system appears to support timestamps after
+mid-January 2038, but no mechanism for enabling wide
+'time_t' was detected. Did you mean to build a 64-bit
+binary? (E.g., 'CC=\"${CC} -m64\"'.) To proceed with
+32-bit time_t, configure with '--disable-year2038'.
+See 'config.log' for more details" "$LINENO" 5; } ;; #(
+  *) :
+     ;;
+esac
+fi
+fi
 case $target in #(
-  *-w64-mingw32*|*-pc-windows) :
+  *-pc-windows) :
      ;; #(
   *) :
-    common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64" ;;
+    # LFS and 64-bit time_t are always enabled.
+  if test "$enable_year2038,$ac_have_year2038" = yes,no
+then :
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+as_fn_error $? "could not enable timestamps after mid-January 2038.
+This package recommends support for these later
+timestamps. However, to proceed with signed 32-bit
+time_t even though it will fail then, configure with
+'--disable-year2038'.
+See 'config.log' for more details" "$LINENO" 5; }
+fi
+  case $ac_cv_sys_largefile_opts in #(
+  "none needed"|"support not detected") :
+     ;; #(
+  *) :
+    common_cppflags="$common_cppflags $ac_cv_sys_largefile_opts" ;;
+esac
+  case $ac_cv_sys_year2038_opts in #(
+  "none needed"|"support not detected") :
+     ;; #(
+  *) :
+    common_cppflags="$common_cppflags $ac_cv_sys_year2038_opts" ;;
+esac ;;
 esac
 
 # Require Windows 8 / Server 2012 or later
@@ -25611,6 +25833,12 @@ LTLIBOBJS=$ac_ltlibobjs
       QS="o${QS}"
     fi
   done
+
+# Check whether --enable-year2038 was given.
+if test ${enable_year2038+y}
+then :
+  enableval=$enable_year2038;
+fi
 
 cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1180,20 +1180,20 @@ AS_CASE([$target],
       [internal_cflags="$internal_cflags -mprfchw"], [], [$warn_error_flag])])
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
-# Enable 64-bit time_t in time.h
 AS_CASE([$target],
   [i686-w64-mingw32*],
-    [internal_cflags="$internal_cflags -mfpmath=sse -msse2"
-    # This instructs _mingw.h to adopt the switch in Visual Studio 8 (2005) to
-    # make time_t a 64-bit value.
-    internal_cppflags="$internal_cppflags -D__MINGW_USE_VC2005_COMPAT"])
+    [internal_cflags="$internal_cflags -mfpmath=sse -msse2"])
 
-# Use 64-bit file offset if possible
-# See also AC_SYS_LARGEFILE
-# Problem: flags are added to CC rather than CPPFLAGS
+# Default to enabling large file support and year 2038 support on 32-bit.
 AS_CASE([$target],
-  [*-w64-mingw32*|*-pc-windows], [],
-  [common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64"])
+  [*-pc-windows], [], # LFS and 64-bit time_t are always enabled.
+  [AC_SYS_YEAR2038_RECOMMENDED
+  AS_CASE([$ac_cv_sys_largefile_opts],
+    ["none needed"|"support not detected"], [],
+    [common_cppflags="$common_cppflags $ac_cv_sys_largefile_opts"])
+  AS_CASE([$ac_cv_sys_year2038_opts],
+    ["none needed"|"support not detected"], [],
+    [common_cppflags="$common_cppflags $ac_cv_sys_year2038_opts"])])
 
 # Require Windows 8 / Server 2012 or later
 AS_CASE([$target],

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -25,7 +25,7 @@
 #include "mlvalues.h"
 #include "platform.h"
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 typedef int64_t file_offset;
 #else
 #include <sys/types.h>

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -52,7 +52,9 @@
 
 #if defined(_WIN32)
 #include <io.h>
+#if defined(_MSC_VER)
 #define lseek _lseeki64
+#endif
 #endif
 
 /* Representation of channel status and direction:


### PR DESCRIPTION
Use Autoconf support for widening types related to sizes of files and file systems. Also request the widening of the `time_t` type as needed to represent timestamps after mid-January 2038 [Y2K38 problem][Y2K38].

Only 32-bit systems are affected. The `i686-pc-windows` and `i686-w64-mingw32` targets already use LFS and 64-bit `time_t`. Currently, all other 32-bit targets use LFS, but are unlikely to use a 64-bit `time_t`.

The macros are passed to the command-line rather than written into the `caml/config.h` header, to preserve current behavior, and for consistency. Writing the macros to the config header will only work if the header is included before system headers, which we cannot guarantee in third-party code.

The macros are not needed on 64-bits systems (we were needlessly passing `_FILE_OFFSET_BITS=64`).

The _checks_ can be disabled by passing `--disable-largefile` or `--disable-year2038` to configure. Disabling the LFS check will also disable the Y2K38 check.

See in the Autoconf manual:
- [`AC_SYS_LARGEFILE`][sys_largefile],
- [`AC_SYS_YEAR2038`][sys_y2k38],
- [`AC_SYS_YEAR2038_RECOMMEND`][sys_y2k38_rec].

See also in the glibc manual [`_FILE_OFFSET_BITS`][fob] and [`_TIME_BITS`][tb].

MinGW-w64 14 now supports [`_FILE_OFFSET_BITS`][mingw-fob] and [`_TIME_BITS`][mingw-tb], prefer this option at the cost of a small drift in the shared Windows code. Effectively, the MinGW-w64 port gains the ability to _disable_ LFS and 64-bit `time_t`. Support for 32-bit `time_t` in MSVC is [opt-out][msvc]. Nothing changes for the MSVC port.

[sys_largefile]: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/autoconf.html#index-AC_005fSYS_005fLARGEFILE-1
[sys_y2k38]: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/autoconf.html#index-AC_005fSYS_005fYEAR2038-1
[sys_y2k38_rec]: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/autoconf.html#index-AC_005fSYS_005fYEAR2038_005fRECOMMENDED-1
[fob]: https://sourceware.org/glibc/manual/2.44/html_mono/libc.html#index-_005fFILE_005fOFFSET_005fBITS
[tb]: https://sourceware.org/glibc/manual/2.44/html_mono/libc.html#index-_005fTIME_005fBITS
[mingw-tb]: https://github.com/mingw-w64/mingw-w64/commit/fe21b7ec19b2a765a8e20821543e309ac687117c
[mingw-fob]: https://github.com/mingw-w64/mingw-w64/commit/eeee1d0ce632da62fb2451c4c988f34d9f1ef7a6
[msvc]: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/time-time32-time64?view=msvc-180
[Y2K38]: https://en.wikipedia.org/wiki/Year_2038_problem

Follow-up to #14953.