### PR TITLE
runtime: add caml_result_format_exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -123,6 +123,10 @@ Working version
   some Intel CPUs.
   (Nat Mote, review by Florian Angeletti and Miod Vallat)
 
+- #14998: Add `caml_result_format_exception`, to print the exception carried by
+  a `caml_result` without accessing the internal representation of the type.
+  (Romain Beauxis)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1569,6 +1569,12 @@ and macros:
 \item "int caml_result_is_exception(caml_result "\var{res}")"
   (in "<caml/mlvalues.h>") is true if \var{res} represents an exception.
 
+\item "char * caml_result_format_exception(caml_result "\var{res}")"
+  (in "<caml/printexc.h>") returns a string representation of the
+  exception contained in \var{res}, or "NULL" if \var{res} is not an
+  exception. The string is allocated with "caml_stat_alloc" and must be
+  freed by the caller with "caml_stat_free".
+
 \item The macro "CAMLlocalresult(foo)" (in "<caml/memory.h>") is the
   "caml_result" counterpart of "CAMLlocal1": it declares a local
   variable of type "caml_result", whose content is tracked by the

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -102,6 +102,7 @@ typedef struct caml_result_private caml_result;
    - Result_value, Result_exception
    - caml_result_is_exception
    - caml_get_value_or_raise (in fail.h)
+   - caml_result_format_exception (in printexc.h)
 */
 struct caml_result_private {
   int is_exception;

--- a/runtime/caml/printexc.h
+++ b/runtime/caml/printexc.h
@@ -23,7 +23,18 @@
 extern "C" {
 #endif
 
-CAMLextern char * caml_format_exception (value);
+/* Returns a string representation of the exception [exn], allocated with
+   [caml_stat_alloc], or NULL if the allocation failed. It is the
+   responsibility of the caller to free it with [caml_stat_free]. */
+CAMLextern char * caml_format_exception (value exn);
+
+/* Same as [caml_format_exception] for the exception carried by [result],
+   or NULL if [result] is not an exception. */
+Caml_inline char * caml_result_format_exception (caml_result result)
+{
+  if (! caml_result_is_exception(result)) return NULL;
+  return caml_format_exception(result.data);
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Is it intentional to have no accessor for the exception in `caml_result_private`? If so, could we at least describe it?

More generally, a lot of code require extracting/stopping/storing exceptions from C callbacks, in particular code calling OCaml from callback-based C libraries so this feels like a big missing API is the new one..