### PR TITLE
Make ring buffer file size a size_t to avoid integer overflow

### DIFF
--- a/Changes
+++ b/Changes
@@ -515,6 +515,11 @@ Working version
   module are injective and contractive
   (Jeremy Yallop, review by Jacques Garrigue)
 
+- #14999, #15000: Fix integer overflow in the runtime_events ring buffer size
+  computation. With OCAMLRUNPARAM=e=21 or higher the ring file was created
+  undersized and custom event registration wrote through a truncated offset.
+  (Tim McGilchrist, review by Xavier Leroy and Sadiq Jaffer)
+
 OCaml 5.5.1
 -----------
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -88,7 +88,7 @@ typedef enum { EV_RUNTIME, EV_USER } ev_category;
 
 /* These store state for the current ring buffers open for writing */
 static struct runtime_events_metadata_header *current_metadata = NULL;
-static int current_ring_total_size;
+static size_t current_ring_total_size;
 static char_os *runtime_events_path;
 static char_os *current_ring_loc = NULL;
 
@@ -238,7 +238,7 @@ void caml_runtime_events_destroy(void) {
 static void runtime_events_create_from_stw_single(void) {
   /* Don't initialise runtime_events twice */
   if (!atomic_load_acquire(&runtime_events_enabled)) {
-    int ring_headers_length, ring_data_length;
+    size_t ring_headers_length, ring_data_length;
 #ifdef _WIN32
     DWORD pid = GetCurrentProcessId();
 #else
@@ -256,12 +256,23 @@ static void runtime_events_create_from_stw_single(void) {
                   T("%ld.events"), pid);
     }
 
-    current_ring_total_size =
-        RUNTIME_EVENTS_MAX_CUSTOM_EVENTS *
+    /* Computed in 64 bits: max_domains * ring_size_bytes can exceed the range
+       of a 32-bit size_t at large OCAMLRUNPARAM e or d settings, so the result
+       is checked before it is narrowed. */
+    uint64_t ring_total_size =
+        (uint64_t)RUNTIME_EVENTS_MAX_CUSTOM_EVENTS *
           sizeof(struct runtime_events_custom_event) +
-        caml_params->max_domains * (ring_size_words * sizeof(uint64_t) +
+        (uint64_t)caml_params->max_domains *
+          ((uint64_t)ring_size_words * sizeof(uint64_t) +
                         sizeof(struct runtime_events_buffer_header)) +
         sizeof(struct runtime_events_metadata_header);
+
+    if (ring_total_size > SIZE_MAX) {
+      caml_fatal_error("Ring buffer of %" PRIu64 " bytes exceeds the address "
+                       "space, reduce OCAMLRUNPARAM e or d", ring_total_size);
+    }
+
+    current_ring_total_size = (size_t)ring_total_size;
 
 #ifdef _WIN32
     ring_file_handle = CreateFile(
@@ -285,12 +296,13 @@ static void runtime_events_create_from_stw_single(void) {
       }
     }
 
+    /* Shifting a 32-bit size_t by 32 is undefined, so widen first. */
     ring_handle = CreateFileMapping(
       ring_file_handle,
       NULL,
       PAGE_READWRITE,
-      0,
-      current_ring_total_size,
+      (DWORD)((uint64_t)current_ring_total_size >> 32),
+      (DWORD)(current_ring_total_size & 0xFFFFFFFF),
       NULL
     );
 


### PR DESCRIPTION
current_ring_total_size size it holds is `max_domains * ring_size_bytes` plus headers, which passes 2 GiB at ordinary settings. Make the value a size_t and defensively check whether there will be overflow.

Fix for https://github.com/ocaml/ocaml/issues/14999

I'm less confident in the Windows changes as I don't have a Windows machine to test on. The Unix side has been tested against Linux AMD64 and macOS ARM64. 