### PR TITLE
Add runtime events for direct major allocations and GC ramp-up

### DIFF
--- a/Changes
+++ b/Changes
@@ -146,10 +146,13 @@ Working version
   (Xavier Leroy, report by Akshay Singh, review by Nicolás Ojeda Bär
   and Antonin Décimo)
 
-- #15001: Add EV_C_MAJOR_DIRECT_ALLOCATED_WORDS runtime events counter,
+- #15001: Add runtime events counters EV_C_MAJOR_DIRECT_ALLOCATED_WORDS,
+  EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS and EV_C_MAJOR_RESUMED_ALLOCATED_WORDS,
   reporting the words allocated directly in the major heap as opposed to
-  promoted from the minor heap.
-  (Tim McGilchrist, review by ??????)
+  promoted from the minor heap, the words suspended during a GC ramp-up phase
+  and the words returned by Gc.ramp_down. Add the span
+  EV_EXPLICIT_GC_RAMP_UP covering a call to Gc.ramp_up.
+  (Tim McGilchrist, review by Sadiq Jaffer and Gabriel Scherer)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -146,6 +146,11 @@ Working version
   (Xavier Leroy, report by Akshay Singh, review by Nicolás Ojeda Bär
   and Antonin Décimo)
 
+- #15001: Add EV_C_MAJOR_DIRECT_ALLOCATED_WORDS runtime events counter,
+  reporting the words allocated directly in the major heap as opposed to
+  promoted from the minor heap.
+  (Tim McGilchrist, review by ??????)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -44,6 +44,7 @@ type runtime_counter =
 | EV_C_MAJOR_SLICE_BUDGET
 | EV_C_MINOR_ALLOCATED_WORDS
 | EV_C_MINOR_PROMOTED_WORDS
+| EV_C_MAJOR_DIRECT_ALLOCATED_WORDS
 
 type runtime_phase =
 | EV_EXPLICIT_GC_SET
@@ -154,6 +155,8 @@ let runtime_counter_name counter =
       "major_slice_target"
   | EV_C_MAJOR_SLICE_BUDGET ->
       "major_slice_budget"
+  | EV_C_MAJOR_DIRECT_ALLOCATED_WORDS ->
+      "major_direct_allocated_words"
 
 
 let runtime_phase_name phase =

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -45,6 +45,8 @@ type runtime_counter =
 | EV_C_MINOR_ALLOCATED_WORDS
 | EV_C_MINOR_PROMOTED_WORDS
 | EV_C_MAJOR_DIRECT_ALLOCATED_WORDS
+| EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS
+| EV_C_MAJOR_RESUMED_ALLOCATED_WORDS
 
 type runtime_phase =
 | EV_EXPLICIT_GC_SET
@@ -97,6 +99,7 @@ type runtime_phase =
 | EV_COMPACT_RELEASE
 | EV_EMPTY_MINOR
 | EV_MINOR_EPHE_CLEAN
+| EV_EXPLICIT_GC_RAMP_UP
 
 type lifecycle =
   EV_RING_START
@@ -157,6 +160,10 @@ let runtime_counter_name counter =
       "major_slice_budget"
   | EV_C_MAJOR_DIRECT_ALLOCATED_WORDS ->
       "major_direct_allocated_words"
+  | EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS ->
+      "major_suspended_allocated_words"
+  | EV_C_MAJOR_RESUMED_ALLOCATED_WORDS ->
+      "major_resumed_allocated_words"
 
 
 let runtime_phase_name phase =
@@ -211,6 +218,7 @@ let runtime_phase_name phase =
   | EV_COMPACT_RELEASE -> "compaction_release"
   | EV_EMPTY_MINOR -> "empty_minor"
   | EV_MINOR_EPHE_CLEAN -> "minor_ephe_clean"
+  | EV_EXPLICIT_GC_RAMP_UP -> "explicit_gc_ramp_up"
 
 let lifecycle_name lifecycle =
   match lifecycle with

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -205,7 +205,22 @@ in the last minor collection.
 (**
 Direct allocations to the major heap of this Domain in {b words}, since the
 last major slice. This excludes words promoted from the minor heap, which are
-counted in EV_C_MAJOR_ALLOCATED_WORDS. Words include block headers.
+counted in EV_C_MAJOR_ALLOCATED_WORDS.
+@since 5.6
+*)
+| EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS
+(**
+Allocations of this Domain in {b words} that were suspended during a GC
+ramp-up phase, since the last major slice. The major slice paces against
+EV_C_MAJOR_ALLOCATED_WORDS less this counter plus
+EV_C_MAJOR_RESUMED_ALLOCATED_WORDS. Zero outside a ramp-up phase.
+@since 5.6
+*)
+| EV_C_MAJOR_RESUMED_ALLOCATED_WORDS
+(**
+Allocations of this Domain in {b words} returned by Gc.ramp_down since the
+last major slice. Work suspended during a ramp-up phase and never resumed is
+never collected against.
 @since 5.6
 *)
 
@@ -482,6 +497,12 @@ Event spanning the cleaning of ephemerons whose keys were locked during a minor
 GC. Keys that were promoted are updated to their new location and ephemerons
 whose keys were collected are emptied.
 @since 5.4
+*)
+| EV_EXPLICIT_GC_RAMP_UP
+(**
+Event spanning a call to Gc.ramp_up, during which the major slice suspends the
+collection work that new allocations would otherwise incur.
+@since 5.6
 *)
 
 (** Lifecycle events for Runtime_events and domains. *)

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -201,6 +201,13 @@ Total {b words} promoted from the minor heap of this Domain to the major heap
 in the last minor collection.
 @since 5.4
 *)
+| EV_C_MAJOR_DIRECT_ALLOCATED_WORDS
+(**
+Direct allocations to the major heap of this Domain in {b words}, since the
+last major slice. This excludes words promoted from the minor heap, which are
+counted in EV_C_MAJOR_ALLOCATED_WORDS. Words include block headers.
+@since 5.6
+*)
 
 (** The type for span events emitted by the runtime. *)
 type runtime_phase =

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -122,6 +122,7 @@ typedef enum {
     EV_COMPACT_RELEASE,
     EV_EMPTY_MINOR,
     EV_MINOR_EPHE_CLEAN,
+    EV_EXPLICIT_GC_RAMP_UP,
 } ev_runtime_phase;
 
 typedef enum {
@@ -159,7 +160,9 @@ typedef enum {
     EV_C_MINOR_ALLOCATED_WORDS,
     EV_C_MINOR_PROMOTED_WORDS,
 
-    EV_C_MAJOR_DIRECT_ALLOCATED_WORDS
+    EV_C_MAJOR_DIRECT_ALLOCATED_WORDS,
+    EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS,
+    EV_C_MAJOR_RESUMED_ALLOCATED_WORDS
 } ev_runtime_counter;
 
 typedef enum {

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -157,8 +157,9 @@ typedef enum {
     EV_C_MAJOR_SLICE_BUDGET,
 
     EV_C_MINOR_ALLOCATED_WORDS,
-    EV_C_MINOR_PROMOTED_WORDS
+    EV_C_MINOR_PROMOTED_WORDS,
 
+    EV_C_MAJOR_DIRECT_ALLOCATED_WORDS
 } ev_runtime_counter;
 
 typedef enum {

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -465,6 +465,7 @@ caml_result caml_gc_ramp_up(value callback, uintnat *out_suspended_words) {
        outer phase. */
 
     CAML_GC_MESSAGE(SLICESIZE, "Entering a GC ramp-up phase.\n");
+    CAML_EV_BEGIN(EV_EXPLICIT_GC_RAMP_UP);
 
     intnat ramp_up_already = (Caml_state->gc_policy & CAML_GC_RAMP_UP);
     if (!ramp_up_already)
@@ -490,6 +491,8 @@ caml_result caml_gc_ramp_up(value callback, uintnat *out_suspended_words) {
 
     if (!ramp_up_already)
       Caml_state->gc_policy = (Caml_state->gc_policy & ~CAML_GC_RAMP_UP);
+
+    CAML_EV_END(EV_EXPLICIT_GC_RAMP_UP);
 
     return res;
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1177,7 +1177,10 @@ update_major_slice_work(intnat howmuch,
     CAML_EV_COUNTER(EV_C_MAJOR_HEAP_WORDS, (uintnat)heap_words);
     CAML_EV_COUNTER(EV_C_MAJOR_ALLOCATED_WORDS, my_alloc_count);
     CAML_EV_COUNTER(EV_C_MAJOR_DIRECT_ALLOCATED_WORDS, my_alloc_direct_count);
-    /* TODO: add counters for suspended and resumed allocs. */
+    CAML_EV_COUNTER(EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS,
+                    my_alloc_suspended_count);
+    CAML_EV_COUNTER(EV_C_MAJOR_RESUMED_ALLOCATED_WORDS,
+                    my_alloc_resumed_count);
     CAML_EV_COUNTER(EV_C_MAJOR_ALLOCATED_WORK, alloc_work);
     CAML_EV_COUNTER(EV_C_MAJOR_DEPENDENT_WORK, dependent_work);
     CAML_EV_COUNTER(EV_C_MAJOR_EXTRA_WORK, extra_work);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1176,7 +1176,8 @@ update_major_slice_work(intnat howmuch,
   if (log_events) {
     CAML_EV_COUNTER(EV_C_MAJOR_HEAP_WORDS, (uintnat)heap_words);
     CAML_EV_COUNTER(EV_C_MAJOR_ALLOCATED_WORDS, my_alloc_count);
-    /* TODO: add counters for direct, suspended, resumed allocs. */
+    CAML_EV_COUNTER(EV_C_MAJOR_DIRECT_ALLOCATED_WORDS, my_alloc_direct_count);
+    /* TODO: add counters for suspended and resumed allocs. */
     CAML_EV_COUNTER(EV_C_MAJOR_ALLOCATED_WORK, alloc_work);
     CAML_EV_COUNTER(EV_C_MAJOR_DEPENDENT_WORK, dependent_work);
     CAML_EV_COUNTER(EV_C_MAJOR_EXTRA_WORK, extra_work);


### PR DESCRIPTION
This (now) adds three counters and one span to runtime events.

**`EV_C_MAJOR_DIRECT_ALLOCATED_WORDS`** — `EV_C_MAJOR_ALLOCATED_WORDS` counts words promoted from the minor heap as well as direct major allocations.

This value *can be derived* by observing `EV_C_MAJOR_ALLOCATED_WORDS` and subtracting the `EV_C_MINOR_PROMOTED_WORDS` reported for the same domain since the previous major slice, so this is not new information, but the documentation for `EV_C_MAJOR_ALLOCATED_WORDS` does not currently state that relationship. Emitting it directly is useful for consumers like `olly`.

**`EV_C_MAJOR_SUSPENDED_ALLOCATED_WORDS`, `EV_C_MAJOR_RESUMED_ALLOCATED_WORDS` and `EV_EXPLICIT_GC_RAMP_UP`** — `Gc.ramp_up` suspends the collection work that new allocations would otherwise incur, and `Gc.ramp_down` returns some of it. The span covers the calls and the two counters report the words suspended and the words returned.

~~EV_C_MAJOR_ALLOCATED_WORDS counts words promoted from the minor heap as well as direct major allocations, so the two cannot be told apart. The runtime already tracks allocated_words_direct but never reported it.~~

~~This value *can be derived* by observing EV_C_MAJOR_ALLOCATED_WORDS and subtracting the EV_C_MINOR_PROMOTED_WORDS reported for the same domain since the previous major slice. The documentation for EV_C_MAJOR_ALLOCATED_WORDS currently doesn't state this relationship. Emitting a direct counter for this event would be useful for runtime events consumers like `olly`, equally this isn't new information.~~

~~**IF** accepted this would be useful to backport (5.3, 5.4, and 5.5) all track this value.~~
