### PR TITLE
Enable KVM for faster Android emulation in CI

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -277,6 +277,11 @@ jobs:
           cat example.ml
           $HOME/cross/bin/ocamlopt.opt example.ml -o example -verbose
           file example
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run example
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
GitHub's [larger Linux runners support running hardware accelerated emulators](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/). See the Android Emulator Runner Action (https://github.com/reactivecircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners), this snippet is taken straight from the readme. This saves about 40s of run time in the `cross-x86_64-linux-android21` CI job, so here's that.