### PR TITLE
Remove unneeded line continuations between C string literals

### DIFF
--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -244,8 +244,8 @@ static int handle_process_termination(
   if (WIFEXITED(status)) return WEXITSTATUS(status);
 
   if ( !WIFSIGNALED(status) )
-    error("Process %lld neither terminated normally nor received a" \
-          "signal!?", (long long) pid);
+    error("Process %lld neither terminated normally nor received a signal!?",
+          (long long) pid);
 
   /* From here we know that the process terminated due to a signal */
   signal = WTERMSIG(status);

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1242,9 +1242,8 @@ CAMLprim value caml_ml_runtime_events_create_cursor(value path_pid_option) {
         caml_failwith("Runtime_events: could not map underlying runtime_events."
         );
       case E_NO_CURRENT_RING:
-        caml_failwith(
-        "Runtime_events: no ring for current process. \
-         Was runtime_events started?");
+        caml_failwith("Runtime_events: no ring for current process. "
+                      "Was runtime_events started?");
       default:
         caml_failwith("Runtime_events: could not obtain cursor");
     }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -552,7 +552,7 @@ CAMLexport void caml_main(char_os **argv)
       break;
     case WRONG_MAGIC:
       error(
-        "the file '%s' has not the right magic number: "\
+        "the file '%s' has not the right magic number: "
         "expected %s, got %s",
         caml_stat_strdup_of_os(exe_name),
         EXEC_MAGIC,

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.reference
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.reference
@@ -1,4 +1,4 @@
-Runtime_events: no ring for current process.          Was runtime_events started?
+Runtime_events: no ring for current process. Was runtime_events started?
 OK
 OK
 Runtime_events: could not create cursor for specified path.


### PR DESCRIPTION
Contiguous C string literals are concatenated by the compiler, thus the line continuation isn't necessary. In the case of the runtime event snippet, all the leading spaces of the second line were added to the error message.