### PR TITLE
Emit fsqrt.d for square root on riscv

### DIFF
--- a/Changes
+++ b/Changes
@@ -181,6 +181,9 @@ Working version
 - #14575: Emit direct assembly for `Atomic.fetch_and_add`
   rather than going through C
   (Zane Hambly, review by Olivier Nicole and KC Sivaramakrishnan)
+
+- #15005: riscv: emit `fsqrt.d` for square root rather than calling into C
+  (Zane Hambly, review by         )
 * #13919: optimize `lazy v` when `v` is a structured constant
   (below a size threshold), so that `Lazy.from_val v` should not be
   necessary anymore in most cases.

--- a/asmcomp/riscv/CSE.ml
+++ b/asmcomp/riscv/CSE.ml
@@ -26,7 +26,7 @@ inherit cse_generic as super
 
 method! class_of_operation op =
   match op with
-  | Ispecific(Imultaddf _ | Imultsubf _) -> Op_pure
+  | Ispecific(Imultaddf _ | Imultsubf _ | Isqrtf) -> Op_pure
   | _ -> super#class_of_operation op
 
 method! is_cheap_operation op =

--- a/asmcomp/riscv/arch.ml
+++ b/asmcomp/riscv/arch.ml
@@ -27,6 +27,7 @@ let command_line_options = []
 type specific_operation =
   | Imultaddf of bool        (* multiply, optionally negate, and add *)
   | Imultsubf of bool        (* multiply, optionally negate, and subtract *)
+  | Isqrtf                   (* floating-point square root *)
 
 (* Addressing modes *)
 
@@ -80,6 +81,8 @@ let print_specific_operation printreg op ppf arg =
   | Imultsubf true ->
       fprintf ppf "-f (%a *f %a -f %a)"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
+  | Isqrtf ->
+      fprintf ppf "sqrtf %a" printreg arg.(0)
 
 (* Specific operations that are pure *)
 

--- a/asmcomp/riscv/arch.mli
+++ b/asmcomp/riscv/arch.mli
@@ -25,6 +25,7 @@ val command_line_options : (string * Arg.spec * string) list
 type specific_operation =
   | Imultaddf of bool        (* multiply, optionally negate, and add *)
   | Imultsubf of bool        (* multiply, optionally negate, and subtract *)
+  | Isqrtf                   (* floating-point square root *)
 
 (* Addressing modes *)
 

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -273,11 +273,13 @@ let name_for_floatop2 = function
   | Idivf -> "fdiv.d"
   | _ -> Misc.fatal_error "Emit.Iopf2"
 
+(* Three-operand specific operations only, [Isqrtf] is emitted directly. *)
 let name_for_specific = function
   | Imultaddf false -> "fmadd.d"
   | Imultaddf true  -> "fnmadd.d"
   | Imultsubf false -> "fmsub.d"
   | Imultsubf true  -> "fnmsub.d"
+  | _ -> Misc.fatal_error "Emit.name_for_specific"
 
 (* Output the assembly code for an instruction *)
 
@@ -536,6 +538,8 @@ let emit_instr env i =
       `	fcvt.l.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, rtz\n`
   | Lop(Iopaque) ->
       assert (i.arg.(0).loc = i.res.(0).loc)
+  | Lop(Ispecific Isqrtf) ->
+      `	fsqrt.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
   | Lop(Ispecific sop) ->
       let instr = name_for_specific sop in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`

--- a/asmcomp/riscv/selection.ml
+++ b/asmcomp/riscv/selection.ml
@@ -20,9 +20,13 @@ open Cmm
 open Arch
 open Mach
 
+(* If you update [inline_ops], you may need to update [is_simple_expr] and/or
+   [effects_of], below. *)
+let inline_ops = [ "sqrt" ]
+
 (* Instruction selection *)
 
-class selector = object
+class selector = object (self)
 
 inherit Selectgen.selector_generic as super
 
@@ -35,6 +39,18 @@ method! is_immediate op n =
   (* sub immediate is turned into add immediate opposite *)
   | Isub -> is_immediate (-n)
   | _ -> super#is_immediate op n
+
+method! is_simple_expr = function
+  (* inlined floating-point ops are simple if their arguments are *)
+  | Cop(Cextcall (fn, _, _, _), args, _) when List.mem fn inline_ops ->
+      List.for_all self#is_simple_expr args
+  | e -> super#is_simple_expr e
+
+method! effects_of e =
+  match e with
+  | Cop(Cextcall (fn, _, _, _), args, _) when List.mem fn inline_ops ->
+      Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
+  | e -> super#effects_of e
 
 method select_addressing _ = function
   | Cop(Cadda, [arg; Cconst_int (n, _)], _) when is_immediate n ->
@@ -57,6 +73,9 @@ method! select_operation op args dbg =
       (Ispecific (Imultsubf true), [arg1; arg2; arg3])
   | (Cnegf, [Cop(Caddf, [Cop(Cmulf, [arg1; arg2], _); arg3], _)]) ->
       (Ispecific (Imultaddf true), [arg1; arg2; arg3])
+  (* Recognize square root *)
+  | (Cextcall("sqrt", _, _, _), [arg]) ->
+      (Ispecific Isqrtf, [arg])
   | (Cstore (Word_int | Word_val as memory_chunk, Assignment), [arg1; arg2]) ->
       (* Use trivial addressing mode for non-initializing stores *)
       (Istore (memory_chunk, Iindexed 0, true), [arg2; arg1])


### PR DESCRIPTION
Hello,

Same idea as #15002, I was in the neighbourhood and did this one as well. The riscv backend doesn't recognise any `Cextcall` idioms at all, so `sqrt` goes out to C where amd64 and arm64 both emit an instruction. This makes it emit `fsqrt.d`.

No feature gating needed. `asmcomp/riscv/NOTES.md` gives the supported platform as RV64G, and the D extension is part of G, so `fsqrt.d` is there on anything the port claims to support.

The byte swaps don't come across from the s390x change. RISC-V has no byte reverse in the base ISA, `rev8` is Zbb and Zbb isn't in G, so there's nothing to emit unconditionally. A shift and mask sequence would run to about a dozen instructions and I don't think that beats the call, so I've left it alone.

Tested on a real riscv64 machine, cfarm95, where it builds `world.opt` and the testsuite is clean at 1622 passed and 0 failed.

Kind regards,
Zane