### PR TITLE
Emit the fused multiply-add for Float.fma on arm64, power, riscv and s390x

### DIFF
--- a/Changes
+++ b/Changes
@@ -194,6 +194,10 @@ Working version
 - #15005: riscv: emit `fsqrt.d` for square root rather than calling into C
   (Zane Hambly, review by Miod Vallat and Xavier Leroy)
 
+- #15008: emit the fused multiply-add for `Float.fma` on arm64, power,
+  riscv and s390x rather than calling into C
+  (Zane Hambly, review by Miod Vallat and Xavier Leroy)
+
 * #13919: optimize `lazy v` when `v` is a structured constant
   (below a size threshold), so that `Lazy.from_val v` should not be
   necessary anymore in most cases.

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -48,7 +48,7 @@ let is_immediate n =
 (* If you update [inline_ops], you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
 let inline_ops =
-  [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+  [ "sqrt"; "caml_bswap16_direct"; "caml_fma"; "caml_int32_direct_bswap";
     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
 
 let use_direct_addressing _symb =
@@ -200,6 +200,13 @@ method! select_operation op args dbg =
   (* Recognize floating-point square root *)
   | Cextcall("sqrt", _, _, _) ->
       (Ispecific Isqrtf, args)
+  (* Only the unboxed [Float.fma] passes floats in registers, hence the
+     argument types. *)
+  | Cextcall("caml_fma", _, [XFloat; XFloat; XFloat], false) ->
+      begin match args with
+      | [arg1; arg2; arg3] -> (Ispecific Imuladdf, [arg3; arg1; arg2])
+      | _ -> super#select_operation op args dbg
+      end
   (* Recognize bswap instructions *)
   | Cextcall("caml_bswap16_direct", _, _, _) ->
       (Ispecific(Ibswap 16), args)

--- a/asmcomp/power/selection.ml
+++ b/asmcomp/power/selection.ml
@@ -49,6 +49,10 @@ let is_immediate_logical n = n <= 0xFFFF && n >= 0
 
 (* Instruction selection *)
 
+(* If you update [inline_ops], you may need to update [is_simple_expr] and/or
+   [effects_of], below. *)
+let inline_ops = [ "caml_fma" ]
+
 class selector = object (self)
 
 inherit Selectgen.selector_generic as super
@@ -67,6 +71,18 @@ method! is_immediate op n =
   | Icheckbound -> 0 <= n && n <= 0x7FFF
     (* twlle takes a 16-bit signed immediate but performs an unsigned compare *)
   | _ -> super#is_immediate op n
+
+method! is_simple_expr = function
+  (* inlined floating-point ops are simple if their arguments are *)
+  | Cop(Cextcall (fn, _, _, _), args, _) when List.mem fn inline_ops ->
+      List.for_all self#is_simple_expr args
+  | e -> super#is_simple_expr e
+
+method! effects_of e =
+  match e with
+  | Cop(Cextcall (fn, _, _, _), args, _) when List.mem fn inline_ops ->
+      Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
+  | e -> super#effects_of e
 
 method select_addressing _chunk exp =
   match select_addr exp with
@@ -88,6 +104,11 @@ method! select_operation op args dbg =
       (Ispecific Imultaddf, [arg1; arg2; arg3])
   | (Csubf, [Cop(Cmulf, [arg1; arg2], _); arg3]) ->
       (Ispecific Imultsubf, [arg1; arg2; arg3])
+  (* Only the unboxed [Float.fma] passes floats in registers, hence the
+     argument types. *)
+  | (Cextcall("caml_fma", _, [XFloat; XFloat; XFloat], false),
+     [arg1; arg2; arg3]) ->
+      (Ispecific Imultaddf, [arg1; arg2; arg3])
   | _ ->
       super#select_operation op args dbg
 

--- a/asmcomp/riscv/selection.ml
+++ b/asmcomp/riscv/selection.ml
@@ -22,7 +22,7 @@ open Mach
 
 (* If you update [inline_ops], you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
-let inline_ops = [ "sqrt" ]
+let inline_ops = [ "sqrt"; "caml_fma" ]
 
 (* Instruction selection *)
 
@@ -76,6 +76,11 @@ method! select_operation op args dbg =
   (* Recognize square root *)
   | (Cextcall("sqrt", _, _, _), [arg]) ->
       (Ispecific Isqrtf, [arg])
+  (* Only the unboxed [Float.fma] passes floats in registers, hence the
+     argument types. *)
+  | (Cextcall("caml_fma", _, [XFloat; XFloat; XFloat], false),
+     [arg1; arg2; arg3]) ->
+      (Ispecific (Imultaddf false), [arg1; arg2; arg3])
   | (Cstore (Word_int | Word_val as memory_chunk, Assignment), [arg1; arg2]) ->
       (* Use trivial addressing mode for non-initializing stores *)
       (Istore (memory_chunk, Iindexed 0, true), [arg2; arg1])

--- a/asmcomp/s390x/selection.ml
+++ b/asmcomp/s390x/selection.ml
@@ -65,7 +65,7 @@ let is_immediate_logical n = n <= 0xFFFF_FFFF && n >= 0
 (* If you update [inline_ops], you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
 let inline_ops =
-  [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
+  [ "sqrt"; "caml_bswap16_direct"; "caml_fma"; "caml_int32_direct_bswap";
     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
 
 class selector = object (self)
@@ -109,6 +109,11 @@ method! select_operation op args dbg =
   (* Recognize square root *)
   | (Cextcall("sqrt", _, _, _), [arg]) ->
       (Ispecific Isqrtf, [arg])
+  (* Only the unboxed [Float.fma] passes floats in registers, hence the
+     argument types. *)
+  | (Cextcall("caml_fma", _, [XFloat; XFloat; XFloat], false),
+     [arg1; arg2; arg3]) ->
+      (Ispecific Imultaddf, [arg1; arg2; arg3])
   (* Recognize byte swaps *)
   | (Cextcall("caml_bswap16_direct", _, _, _), _) ->
       (Ispecific (Ibswap 16), args)

--- a/testsuite/tests/lib-float/fma.ml
+++ b/testsuite/tests/lib-float/fma.ml
@@ -6,10 +6,10 @@
 let opaque = Sys.opaque_identity
 
 let check name got want =
-  (* Equality alone treats 0. and -0. as equal, hence the reciprocals. *)
+  (* Equality alone treats 0. and -0. as equal. *)
   let ok =
     if Float.is_nan want then Float.is_nan got
-    else got = want && 1. /. got = 1. /. want
+    else Int64.bits_of_float got = Int64.bits_of_float want
   in
   if not ok then
     failwith (Printf.sprintf "fma %s: got %h, expected %h" name got want)

--- a/testsuite/tests/lib-float/fma.ml
+++ b/testsuite/tests/lib-float/fma.ml
@@ -1,0 +1,51 @@
+(* TEST *)
+
+(* fma rounds once, so the first block differs from a separate multiply and
+   add. opaque_identity stops the arguments folding. *)
+
+let opaque = Sys.opaque_identity
+
+let check name got want =
+  (* Equality alone treats 0. and -0. as equal, hence the reciprocals. *)
+  let ok =
+    if Float.is_nan want then Float.is_nan got
+    else got = want && 1. /. got = 1. /. want
+  in
+  if not ok then
+    failwith (Printf.sprintf "fma %s: got %h, expected %h" name got want)
+
+let fma x y z = Float.fma (opaque x) (opaque y) (opaque z)
+
+let () =
+  check "(1+2^-52)(1-2^-53)-1"
+    (fma 0x1.0000000000001p+0 0x1.fffffffffffffp-1 (-1.))
+    0x1.ffffffffffffep-54;
+  check "sqrt2*sqrt2-2"
+    (fma 0x1.6a09e667f3bcdp+0 0x1.6a09e667f3bcdp+0 (-2.))
+    0x1.3b3efbf5e2229p-52;
+  check "(1+2^-27)^2-1"
+    (fma 0x1.0000002p+0 0x1.0000002p+0 (-1.))
+    0x1.0000001p-26;
+  check "one ulp apart"
+    (fma (-0x1.4eb5248db40afp-136) (-0x1.5128862c33a4fp+562)
+       0x1.5563dab2cd31ep+398)
+    0x1.b8d170ee322e6p+426;
+
+  check "3*5-15"       (fma 3. 5. (-15.))            0.;
+  check "0*0-0"        (fma 0. 0. (-0.))             0.;
+  check "-0*0-0"       (fma (-0.) 0. (-0.))          (-0.);
+
+  check "overflow"     (fma 1e300 1e300 0.)          infinity;
+  check "denormal"     (fma 0x1p-537 0x1p-537 0.)    0x1p-1074;
+  check "denormal sum" (fma 0x1p-1074 1. 0x1p-1074)  0x1p-1073;
+  check "max_float"    (fma max_float 1. 0.)         max_float;
+
+  check "inf*0"        (fma infinity 0. 1.)          nan;
+  check "inf*0+nan"    (fma infinity 0. nan)         nan;
+  check "inf-inf"      (fma 1. infinity neg_infinity) nan;
+  check "nan*1+1"      (fma nan 1. 1.)               nan;
+
+  for i = 0 to 1000 do
+    let x = float_of_int i in
+    check (string_of_int i ^ "^2+1") (fma x x 1.) (float_of_int (i * i + 1))
+  done


### PR DESCRIPTION
Hello,

`Float.fma` goes out to C everywhere, though arm64, power, riscv and s390x already emit a fused multiply-add for `a *. b +. c`. So we fuse when nobody asked and call libm when someone does. This matches `caml_fma` in selection and reuses the existing `Imuladdf`/`Imultaddf`. amd64 is out since FMA3 isn't baseline x86-64.

I read the manuals again to make sure it's right (I couldn't do it from memory). There's also a new test in `testsuite/tests/lib-float/` that pins it, swap `Float.fma` for a plain multiply and add and it fails.

Built `world.opt` and ran the tests on cfarm185 (aarch64), cfarm120 (ppc64le), cfarm95 (riscv64) and a z15. Each goes from a call into `caml_fma` to a single instruction, `fmadd` on arm64 and power, `fmadd.d` on riscv, `madbr` on s390x.

This touches the same lines as #15002, #15005 and #15006, so it'll want a rebase depending on merge order.