### PR TITLE
Fix for runtime events corrupt stream failure

### DIFF
--- a/Changes
+++ b/Changes
@@ -550,6 +550,12 @@ Working version
   module are injective and contractive
   (Jeremy Yallop, review by Jacques Garrigue)
 
+- #15015: Fix "corrupt stream" failures in Runtime_events when a slow
+  consumer reads a ring buffer that the producer has overtaken. The consumer
+  now checks whether the ring head has passed its cursor and retries the read
+  instead of reporting a corrupt message header.
+  (Sadiq Jaffer, review by ???)
+
 OCaml 5.5.1
 -----------
 

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -506,6 +506,19 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
       if (msg_length > RUNTIME_EVENTS_MAX_MSG_LENGTH
           || ring_masked_pos + msg_length
              > cursor->metadata.ring_size_elements) {
+        /* It's possible here that the message header has been
+        overwritten by the producer, the head has moved beyond
+        us. If it has then we restart the loop and call the
+        lost_events callback. */
+
+        /* ring_head read must happen after msg_length read */
+        atomic_thread_fence(memory_order_seq_cst);
+
+        ring_head =
+          atomic_load_acquire(&runtime_events_buffer_header->ring_head);
+        if (ring_head > cursor->current_positions[domain_num]) {
+          continue;
+        }
         atomic_store(&cursor->cursor_in_poll, 0);
         return E_CORRUPT_STREAM;
       }


### PR DESCRIPTION
Fix for the corrupt stream failure issue identified in https://github.com/ocaml/ocaml/issues/14151

It's quite possible that a slow consumer might encounter what seems like a corrupt message header, we should check if this is because the ring's head has passed our cursor and if it has then retry reading the ring.