### PR TITLE
Runtime events corrupt stream

### DIFF
--- a/Changes
+++ b/Changes
@@ -609,6 +609,13 @@ Working version
   to report as the number of words of minor heap consumed, including headers.
   (Tim McGilchrist, review by Nicolás Ojeda Bär)
 
+- #15016, #14151: Fix spurious "Runtime_events: corrupt stream" failures when a
+  consumer falls behind the producer. The consumer now reports an overwritten
+  ring slot as lost events rather than corruption, and write_to_ring publishes
+  the ring head advance before overwriting the slots that advance releases.
+  (Tim McGilchrist, reported by mattiasdrp, review by Sadiq Jaffer and
+   Zane Hambly)
+
 OCaml 5.5.1
 -----------
 

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -506,6 +506,27 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
       if (msg_length > RUNTIME_EVENTS_MAX_MSG_LENGTH
           || ring_masked_pos + msg_length
              > cursor->metadata.ring_size_elements) {
+        /* The header may have been overwritten by the writer wrapping around
+           between the ring_head check above and the read of the header, in
+           which case it is not a header at all. Re-check before reporting
+           corruption, so that an overwrite is reported as lost events. */
+        ring_head =
+          atomic_load_acquire(&runtime_events_buffer_header->ring_head);
+
+        if (ring_head > cursor->current_positions[domain_num]) {
+          int lost_words = ring_head - cursor->current_positions[domain_num];
+          cursor->current_positions[domain_num] = ring_head;
+
+          if (cursor->lost_events) {
+            if( !(cursor->lost_events(domain_num, callback_data,
+                                      lost_words)) ) {
+              early_exit = 1;
+            }
+          }
+
+          continue;
+        }
+
         atomic_store(&cursor->cursor_in_poll, 0);
         return E_CORRUPT_STREAM;
       }

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -509,7 +509,14 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
         /* The header may have been overwritten by the writer wrapping around
            between the ring_head check above and the read of the header, in
            which case it is not a header at all. Re-check before reporting
-           corruption, so that an overwrite is reported as lost events. */
+           corruption, so that an overwrite is reported as lost events.
+
+           The fence keeps the header read above the re-read. An acquire load
+           orders later accesses, not earlier ones, and the control dependency
+           on the header does not order load against load, so without it the
+           re-read could be satisfied first and miss the advance. */
+        atomic_thread_fence(memory_order_acquire);
+
         ring_head =
           atomic_load_acquire(&runtime_events_buffer_header->ring_head);
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -590,6 +590,7 @@ static void write_to_ring(ev_category category, ev_message_type type,
   }
 
   /* First we check if a write would take us over the head */
+  int head_advanced = 0;
   while ((ring_tail + length_with_header_ts + padding_required) - ring_head >=
          ring_size_words) {
     /* The write would over-write some old bit of data. Need to advance the
@@ -600,6 +601,17 @@ static void write_to_ring(ev_category category, ev_message_type type,
 
     // advance the ring head
     atomic_store_release(&domain_ring_header->ring_head, ring_head);
+    head_advanced = 1;
+  }
+
+  if (head_advanced) {
+    /* The head advance must become visible before the stores that overwrite
+       the slots it released. atomic_store_release orders accesses before the
+       store, not after it, so without this fence a consumer can observe the
+       overwriting stores while the old ring_head is still visible. It then
+       reads overwritten data and cannot tell, because the head it re-reads
+       says the slot was never released. */
+    atomic_thread_fence(memory_order_release);
   }
 
   if (padding_required > 0) {


### PR DESCRIPTION
Fixes #14151.

A consumer that falls behind a producer of user events fails with `Failure("Runtime_events: corrupt stream")` instead of being told it lost events. It reproduces on every platform I've tested on (AMD64/Linux, ARM64/Linux and ppc64le/Linux) with a range of memory models.

### Reproducer

The program in #14151 reproduces this, but it needs `mtime` and exercises several profiling modes. The reduction below keeps only the path that matters and has no dependency beyond `runtime_events`. One domain writes a custom span event around each iteration while a second domain polls; a small ring makes the producer lap the consumer continuously, which is the condition the bug needs.

<details>
<summary>overwrite_race_repro.ml</summary>

```ocaml
(* Reproducer for ocaml/ocaml#14151: a consumer that falls behind a fast
   producer of user events gets "corrupt stream" instead of lost events.

   Self-contained: needs only the runtime_events library. One domain writes a
   custom span event around each iteration while a second domain polls. With a
   small ring the producer laps the consumer continuously, which is the
   condition the bug needs.

   Usage: overwrite_race_repro [iterations]        (default 50000)
   Exits 0 on success, non-zero on "corrupt stream". *)

type Runtime_events.User.tag += CustomSpan

type span = Begin | End

let to_int = function Begin -> 0 | End -> 1
let of_int = function 0 -> Begin | 1 -> End | _ -> assert false

let custom_span_encoding =
  let encode buffer (count, span) =
    Bytes.set_int64_ne buffer 0 count;
    Bytes.set_int8 buffer 8 (to_int span);
    9
  in
  let decode buffer _size =
    let count = Bytes.get_int64_ne buffer 0 in
    let span = Bytes.get_int8 buffer 8 |> of_int in
    (count, span)
  in
  Runtime_events.Type.register ~encode ~decode

let count_span =
  Runtime_events.User.register "count.span" CustomSpan custom_span_encoding

let handler _domain_id _ts event value =
  match (Runtime_events.User.tag event, value) with
  | CustomSpan, (_, (Begin | End)) -> ()
  | _ -> ()

let finished = ref false

let read_poll () =
  let cursor = Runtime_events.create_cursor None in
  let callbacks =
    Runtime_events.(
      Callbacks.create () |> Callbacks.add_user_event custom_span_encoding handler)
  in
  fun () ->
    Fun.protect
      ~finally:(fun () ->
        Runtime_events.read_poll cursor callbacks None |> ignore;
        Runtime_events.free_cursor cursor)
      (fun () ->
        while not !finished do
          Runtime_events.read_poll cursor callbacks None |> ignore
        done)

let () =
  let times = try int_of_string Sys.argv.(1) with _ -> 50_000 in
  Runtime_events.start ();
  let d = Domain.spawn (read_poll ()) in
  let res = ref 0 in
  for i = 1 to times do
    Runtime_events.User.write count_span (Int64.of_int i, Begin);
    res := !res + i;
    Runtime_events.User.write count_span (Int64.of_int i, End)
  done;
  finished := true;
  Domain.join d;
  Printf.printf "ok %d\n%!" !res
```

</details>

Built and run from the root of a build tree:

```console
$ ./ocamlopt.opt -nostdlib -I stdlib -I otherlibs/runtime_events \
    otherlibs/runtime_events/runtime_events.cmxa overwrite_race_repro.ml -o repro.exe
$ for i in $(seq 1 400); do OCAMLRUNPARAM=e=8 ./repro.exe 50000; done | grep -c ok
```

```
                       e=6      e=8      e=10
Linux x86-64            276      272      292
Linux aarch64           214      353      361
Linux ppc64le            84      383      397
```

At the default `e=16` it reproduces roughly once in a hundred runs, which is why it presents as intermittent and is likely causing intermittent test suite failures.

### Cause

There are two independent problems I've found, both are required to fix it.

**The consumer treats a recoverable overwrite as fatal.** `read_poll` checks a message header for plausibility before it checks whether the writer overwrote that slot. When the producer laps between the `ring_head` check and the header read, the word read is not a header, the length is implausible, and the function returns `E_CORRUPT_STREAM`. The loop already has the right response a few lines below, treating the overwrite as lost events, and never reaches it. The writer pads rather than splitting a message, so a genuine header can never straddle the ring end, reaching that condition means the word is not a header.

**The producer publishes the head advance too late to help.** `write_to_ring` advances `ring_head` with a release store and then overwrites the slots that advance released:

```c
atomic_store_release(&domain_ring_header->ring_head, ring_head);  /* publish */
...
ring_ptr[ring_tail_offset++] = RUNTIME_EVENTS_HEADER(...);        /* overwrite */
```

A release store orders accesses before it, not after it, so the overwriting stores can reach a consumer while the old `ring_head` is still visible. The consumer then reads overwritten data, re-reads `ring_head`, is told the slot was never released, and reports corruption anyway. The tail does this correctly by contrast, publishing after the writes.

This is why the consumer-side change alone is not enough.

### Fixes

Three commits:

1. Re-check `ring_head` when the plausibility check fails and report an
   overwrite as lost events. Where the check fails and the position was not
   overwritten, the stream really is corrupt and the existing return stands.
2. Fence the head advance ahead of the overwriting stores in `write_to_ring`,
   guarded so the common path where nothing is released takes no barrier.
3. An acquire fence in the consumer ordering the header read before the
   re-read. See the note below.

### Validation

400 runs per ring size per variant, all built from 8cdc85c9db. `racefix` is the consumer re-check alone, `fixed` is the full patch:

```
                        e=6              e=8              e=10
                   base racefix fixed  base racefix fixed  base racefix fixed
Linux x86-64        276    0      0     272    0      0     292    0      0
Linux aarch64       214   78      0     353  318      0     361  356      0
Linux ppc64le        84    8      0     383   87      0     397  268      0
```

`tests/lib-runtime-events` passes 22/22, `test_corrupted.ml` among them, so genuinely corrupt streams are still detected.

### Cost

The producer fence only runs when a write releases a slot. The compiler turns the guard into control flow rather than a test, branching past the barrier when the loop did not run, so a consumer that keeps up executes no extra instructions. One barrier is added per platform: `dmb ish` on arm64, one more `lwsync` on ppc64le.

Timing the worst case, where the ring laps on every write, does not resolve a cost: on ppc64le the patched build measured about 4% *faster*, and the same difference persists with a ring large enough that the fence never executes at all, I'm putting this down to code layout variations rather than the barrier itself. Build-to-build layout noise on this workload is 2 to 4 per cent, which is larger than the cost of a single barrier.

### Note on the third commit

The acquire fence in the consumer is a correctness argument, not one I can measure. An acquire load orders later accesses and not earlier ones, and a control dependency does not order a load against a later load, so the re-read may in principle be satisfied before the header read and miss the advance. With the producer fence in place that window is narrow rather than closed. Dropping the commit measured identically, 0/400 at every size on both weak platforms, so I am happy to drop it if you would rather not carry a barrier that cannot be shown to do anything.

**Impacted versions**: Both the consumer ordering and the producer's head publication are unchanged since runtime_events was introduced, so every 5.x is affected.

**NOTE** The code comments are rather verbose on purpose as the memory model details need to work across different architectures. Happy to trim them if they don't make sense to other people. Ideally needs testing on Windows platforms with MSVC where the `atomic_*` functions might be implemented differently.