### PR TITLE
Emit the rounding instructions for Float.round, Float.trunc, ceil and floor on arm64 and power

### DIFF
--- a/Changes
+++ b/Changes
@@ -204,7 +204,7 @@ Working version
 
 - #15017: emit the rounding instructions for `Float.round`, `Float.trunc`,
   `ceil` and `floor` on arm64 and power rather than calling into C
-  (Zane Hambly, review by         )
+  (Zane Hambly, review by Miod Vallat and Nicolás Ojeda Bär)
 
 * #13919: optimize `lazy v` when `v` is a structured constant
   (below a size threshold), so that `Lazy.from_val v` should not be

--- a/Changes
+++ b/Changes
@@ -202,6 +202,10 @@ Working version
   riscv and s390x rather than calling into C
   (Zane Hambly, review by Miod Vallat and Xavier Leroy)
 
+- #15017: emit the rounding instructions for `Float.round`, `Float.trunc`,
+  `ceil` and `floor` on arm64 and power rather than calling into C
+  (Zane Hambly, review by         )
+
 * #13919: optimize `lazy v` when `v` is a structured constant
   (below a size threshold), so that `Lazy.from_val v` should not be
   necessary anymore in most cases.

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -87,6 +87,7 @@ type specific_operation =
   | Imulsubf      (* floating-point multiply and subtract *)
   | Inegmulsubf   (* floating-point negate, multiply and subtract *)
   | Isqrtf        (* floating-point square root *)
+  | Iroundf of float_rounding (* floating-point round to integer *)
   | Ibswap of int (* endianness conversion *)
   | Imove32       (* 32-bit integer move *)
   | Isignext of int (* sign extension *)
@@ -94,6 +95,12 @@ type specific_operation =
 and arith_operation =
     Ishiftadd
   | Ishiftsub
+
+and float_rounding =
+    Rnearest_away                       (* to nearest, ties away from zero *)
+  | Rtoward_zero
+  | Rtoward_pos                         (* toward positive infinity *)
+  | Rtoward_neg                         (* toward negative infinity *)
 
 (* Sizes, endianness *)
 
@@ -192,6 +199,14 @@ let print_specific_operation printreg op ppf arg =
         printreg arg.(2)
   | Isqrtf ->
       fprintf ppf "sqrtf %a"
+        printreg arg.(0)
+  | Iroundf r ->
+      let name = match r with
+        | Rnearest_away -> "roundf"
+        | Rtoward_zero -> "truncf"
+        | Rtoward_pos -> "ceilf"
+        | Rtoward_neg -> "floorf" in
+      fprintf ppf "%s %a" name
         printreg arg.(0)
   | Ibswap n ->
       fprintf ppf "bswap%i %a" n

--- a/asmcomp/arm64/arch.mli
+++ b/asmcomp/arm64/arch.mli
@@ -66,6 +66,7 @@ type specific_operation =
   | Imulsubf      (* floating-point multiply and subtract *)
   | Inegmulsubf   (* floating-point negate, multiply and subtract *)
   | Isqrtf        (* floating-point square root *)
+  | Iroundf of float_rounding (* floating-point round to integer *)
   | Ibswap of int (* endianness conversion *)
   | Imove32       (* 32-bit integer move *)
   | Isignext of int (* sign extension *)
@@ -73,6 +74,12 @@ type specific_operation =
 and arith_operation =
     Ishiftadd
   | Ishiftsub
+
+and float_rounding =
+    Rnearest_away                       (* to nearest, ties away from zero *)
+  | Rtoward_zero
+  | Rtoward_pos                         (* toward positive infinity *)
+  | Rtoward_neg                         (* toward negative infinity *)
 
 (* Sizes, endianness *)
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -531,7 +531,8 @@ module Size = struct
     | Lop (Iintop_imm ((Iadd|Isub), n)) -> addsub_size n
     | Lop (Iintop _) -> 1
     | Lop (Iintop_imm _) -> 1
-    | Lop (Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf) -> 1
+    | Lop (Ifloatofint | Iintoffloat | Iabsf | Inegf
+          | Ispecific (Isqrtf | Iroundf _)) -> 1
     | Lop (Iaddf | Isubf | Imulf | Idivf | Ispecific Inegmulf) -> 1
     | Lop (Iopaque) -> 0
     | Lop (Ispecific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
@@ -979,13 +980,18 @@ let emit_instr env i =
     | Lop(Iintop_imm(op, n)) ->
         let instr = name_for_int_operation op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #{emit_int n}\n`
-    | Lop(Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf as op) ->
+    | Lop(Ifloatofint | Iintoffloat | Iabsf | Inegf
+         | Ispecific (Isqrtf | Iroundf _) as op) ->
         let instr = (match op with
                      | Ifloatofint      -> "scvtf"
                      | Iintoffloat      -> "fcvtzs"
                      | Iabsf            -> "fabs"
                      | Inegf            -> "fneg"
                      | Ispecific Isqrtf -> "fsqrt"
+                     | Ispecific (Iroundf Rnearest_away) -> "frinta"
+                     | Ispecific (Iroundf Rtoward_zero)  -> "frintz"
+                     | Ispecific (Iroundf Rtoward_pos)   -> "frintp"
+                     | Ispecific (Iroundf Rtoward_neg)   -> "frintm"
                      | _                -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
     | Lop(Iaddf | Isubf | Imulf | Idivf | Ispecific Inegmulf as op) ->

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -49,7 +49,8 @@ let is_immediate n =
    [effects_of], below. *)
 let inline_ops =
   [ "sqrt"; "caml_bswap16_direct"; "caml_fma"; "caml_int32_direct_bswap";
-    "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+    "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap";
+    "caml_round"; "caml_trunc"; "ceil"; "floor" ]
 
 let use_direct_addressing _symb =
   (not !Clflags.dlcode) && (not Arch.macosx)
@@ -207,6 +208,16 @@ method! select_operation op args dbg =
       | [arg1; arg2; arg3] -> (Ispecific Imuladdf, [arg3; arg1; arg2])
       | _ -> super#select_operation op args dbg
       end
+  (* Only the unboxed rounding externals pass their argument in a
+     register, hence the argument type. *)
+  | Cextcall("caml_round", _, [XFloat], false) ->
+      (Ispecific (Iroundf Rnearest_away), args)
+  | Cextcall("caml_trunc", _, [XFloat], false) ->
+      (Ispecific (Iroundf Rtoward_zero), args)
+  | Cextcall("ceil", _, [XFloat], false) ->
+      (Ispecific (Iroundf Rtoward_pos), args)
+  | Cextcall("floor", _, [XFloat], false) ->
+      (Ispecific (Iroundf Rtoward_neg), args)
   (* Recognize bswap instructions *)
   | Cextcall("caml_bswap16_direct", _, _, _) ->
       (Ispecific(Ibswap 16), args)

--- a/asmcomp/power/CSE.ml
+++ b/asmcomp/power/CSE.ml
@@ -26,7 +26,7 @@ inherit cse_generic as super
 
 method! class_of_operation op =
   match op with
-  | Ispecific(Imultaddf | Imultsubf) -> Op_pure
+  | Ispecific(Imultaddf | Imultsubf | Iroundf _) -> Op_pure
   | Ispecific(Ialloc_far _) | Ispecific(Ipoll_far _) -> Op_other
   | _ -> super#class_of_operation op
 

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -30,6 +30,7 @@ let command_line_options = []
 type specific_operation =
     Imultaddf                           (* multiply and add *)
   | Imultsubf                           (* multiply and subtract *)
+  | Iroundf of float_rounding           (* round to integer *)
   | Ialloc_far of                       (* allocation in large functions *)
       { bytes : int; dbginfo : Debuginfo.alloc_dbginfo }
   | Ipoll_far of { return_label : cmm_label option }
@@ -37,6 +38,12 @@ type specific_operation =
   | Icheckbound_far                     (* bounds check in large functions *)
   | Icheckbound_imm_far of int          (* bounds check in large functions,
                                            constant 2nd arg (the index) *)
+
+and float_rounding =
+    Rnearest_away                       (* to nearest, ties away from zero *)
+  | Rtoward_zero
+  | Rtoward_pos                         (* toward positive infinity *)
+  | Rtoward_neg                         (* toward negative infinity *)
 
 (* Addressing modes *)
 
@@ -93,6 +100,13 @@ let print_specific_operation printreg op ppf arg =
   | Imultsubf ->
       fprintf ppf "%a *f %a -f %a"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
+  | Iroundf r ->
+      let name = match r with
+        | Rnearest_away -> "roundf"
+        | Rtoward_zero -> "truncf"
+        | Rtoward_pos -> "ceilf"
+        | Rtoward_neg -> "floorf" in
+      fprintf ppf "%s %a" name printreg arg.(0)
   | Ialloc_far { bytes; _ } ->
       fprintf ppf "alloc_far %d" bytes
   | Ipoll_far _ ->

--- a/asmcomp/power/arch.mli
+++ b/asmcomp/power/arch.mli
@@ -28,12 +28,19 @@ val command_line_options : (string * Arg.spec * string) list
 type specific_operation =
     Imultaddf                           (* multiply and add *)
   | Imultsubf                           (* multiply and subtract *)
+  | Iroundf of float_rounding           (* round to integer *)
   | Ialloc_far of                       (* allocation in large functions *)
       { bytes : int; dbginfo : Debuginfo.alloc_dbginfo }
   | Ipoll_far of { return_label : cmm_label option }
                                         (* poll point in large functions *)
   | Icheckbound_far                     (* bounds check in large functions *)
   | Icheckbound_imm_far of int          (* bounds check in large functions *)
+
+and float_rounding =
+    Rnearest_away                       (* to nearest, ties away from zero *)
+  | Rtoward_zero
+  | Rtoward_pos                         (* toward positive infinity *)
+  | Rtoward_neg                         (* toward negative infinity *)
 
 (* Addressing modes *)
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -903,6 +903,13 @@ let emit_instr env i =
         `	ld	{emit_reg i.res.(0)}, -16(1)\n`
     | Lop(Iopaque) ->
         assert (i.arg.(0).loc = i.res.(0).loc)
+    | Lop(Ispecific(Iroundf r)) ->
+        let instr = (match r with
+                     | Rnearest_away -> "frin"
+                     | Rtoward_zero  -> "friz"
+                     | Rtoward_pos   -> "frip"
+                     | Rtoward_neg   -> "frim") in
+        `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
     | Lop(Ispecific sop) ->
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`

--- a/asmcomp/power/scheduling.ml
+++ b/asmcomp/power/scheduling.ml
@@ -37,6 +37,7 @@ method oper_latency = function
   | Imulf -> 5
   | Idivf -> 33
   | Ispecific(Imultaddf | Imultsubf) -> 5
+  | Ispecific(Iroundf _) -> 4
   | _ -> 1
 
 method! reload_retaddr_latency = 12

--- a/asmcomp/power/selection.ml
+++ b/asmcomp/power/selection.ml
@@ -51,7 +51,8 @@ let is_immediate_logical n = n <= 0xFFFF && n >= 0
 
 (* If you update [inline_ops], you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
-let inline_ops = [ "caml_fma" ]
+let inline_ops =
+  [ "caml_fma"; "caml_round"; "caml_trunc"; "ceil"; "floor" ]
 
 class selector = object (self)
 
@@ -109,6 +110,16 @@ method! select_operation op args dbg =
   | (Cextcall("caml_fma", _, [XFloat; XFloat; XFloat], false),
      [arg1; arg2; arg3]) ->
       (Ispecific Imultaddf, [arg1; arg2; arg3])
+  (* Only the unboxed rounding externals pass their argument in a
+     register, hence the argument type. *)
+  | (Cextcall("caml_round", _, [XFloat], false), _) ->
+      (Ispecific (Iroundf Rnearest_away), args)
+  | (Cextcall("caml_trunc", _, [XFloat], false), _) ->
+      (Ispecific (Iroundf Rtoward_zero), args)
+  | (Cextcall("ceil", _, [XFloat], false), _) ->
+      (Ispecific (Iroundf Rtoward_pos), args)
+  | (Cextcall("floor", _, [XFloat], false), _) ->
+      (Ispecific (Iroundf Rtoward_neg), args)
   | _ ->
       super#select_operation op args dbg
 

--- a/testsuite/tests/lib-float/round.ml
+++ b/testsuite/tests/lib-float/round.ml
@@ -1,0 +1,82 @@
+(* TEST *)
+
+(* Rounding to a float integer is exact, so each expected value is the only
+   admissible answer. [Float.round] takes halfway cases away from zero, so 2.5
+   is 3. and not the even 2. opaque_identity stops the arguments folding. *)
+
+let opaque = Sys.opaque_identity
+
+let check name x got want =
+  (* Equality alone treats 0. and -0. as equal. *)
+  let ok =
+    if Float.is_nan want then Float.is_nan got
+    else Int64.bits_of_float got = Int64.bits_of_float want
+  in
+  if not ok then
+    failwith (Printf.sprintf "%s %h: got %h, expected %h" name x got want)
+
+let check_val name x got want =
+  if not (got = want) then
+    failwith (Printf.sprintf "%s %h: got %h, expected %h" name x got want)
+
+let case x ~floor:f ~ceil:c ~trunc:t ~round:r =
+  check "floor" x (Float.floor (opaque x)) f;
+  check "ceil"  x (Float.ceil  (opaque x)) c;
+  check "trunc" x (Float.trunc (opaque x)) t;
+  check "round" x (Float.round (opaque x)) r;
+  check "Stdlib.floor" x (floor (opaque x)) f;
+  check "Stdlib.ceil"  x (ceil  (opaque x)) c
+
+let () =
+  case 0.    ~floor:0.    ~ceil:0.    ~trunc:0.    ~round:0.;
+  case (-0.) ~floor:(-0.) ~ceil:(-0.) ~trunc:(-0.) ~round:(-0.);
+  case 1.    ~floor:1.    ~ceil:1.    ~trunc:1.    ~round:1.;
+  case (-1.) ~floor:(-1.) ~ceil:(-1.) ~trunc:(-1.) ~round:(-1.);
+
+  case 0.5    ~floor:0.    ~ceil:1.    ~trunc:0.    ~round:1.;
+  case (-0.5) ~floor:(-1.) ~ceil:(-0.) ~trunc:(-0.) ~round:(-1.);
+  case 1.5    ~floor:1.    ~ceil:2.    ~trunc:1.    ~round:2.;
+  case (-1.5) ~floor:(-2.) ~ceil:(-1.) ~trunc:(-1.) ~round:(-2.);
+  case 2.5    ~floor:2.    ~ceil:3.    ~trunc:2.    ~round:3.;
+  case (-2.5) ~floor:(-3.) ~ceil:(-2.) ~trunc:(-2.) ~round:(-3.);
+
+  case 0x1.fffffffffffffp-2
+    ~floor:0. ~ceil:1. ~trunc:0. ~round:0.;
+  case (-0x1.fffffffffffffp-2)
+    ~floor:(-1.) ~ceil:(-0.) ~trunc:(-0.) ~round:(-0.);
+
+  case 3.7    ~floor:3.    ~ceil:4.    ~trunc:3.    ~round:4.;
+  case (-3.7) ~floor:(-4.) ~ceil:(-3.) ~trunc:(-3.) ~round:(-4.);
+
+  case 0x1p-1074    ~floor:0.    ~ceil:1.    ~trunc:0.    ~round:0.;
+  case (-0x1p-1074) ~floor:(-1.) ~ceil:(-0.) ~trunc:(-0.) ~round:(-0.);
+
+  case 0x1.fffffffffffffp+51
+    ~floor:4503599627370495. ~ceil:4503599627370496.
+    ~trunc:4503599627370495. ~round:4503599627370496.;
+  case (-0x1.fffffffffffffp+51)
+    ~floor:(-4503599627370496.) ~ceil:(-4503599627370495.)
+    ~trunc:(-4503599627370495.) ~round:(-4503599627370496.);
+
+  case 1e300    ~floor:1e300    ~ceil:1e300    ~trunc:1e300    ~round:1e300;
+  case (-1e300) ~floor:(-1e300) ~ceil:(-1e300) ~trunc:(-1e300) ~round:(-1e300);
+  case max_float
+    ~floor:max_float ~ceil:max_float ~trunc:max_float ~round:max_float;
+
+  case infinity
+    ~floor:infinity ~ceil:infinity ~trunc:infinity ~round:infinity;
+  case neg_infinity
+    ~floor:neg_infinity ~ceil:neg_infinity
+    ~trunc:neg_infinity ~round:neg_infinity;
+  case nan ~floor:nan ~ceil:nan ~trunc:nan ~round:nan;
+
+  for i = -1000 to 1000 do
+    let x = float_of_int i /. 8. in
+    let fdiv a b = if a >= 0 then a / b else - ((- a + b - 1) / b) in
+    let want name v = check_val name x v in
+    want "floor" (Float.floor (opaque x)) (float_of_int (fdiv i 8));
+    want "ceil"  (Float.ceil  (opaque x)) (float_of_int (- (fdiv (- i) 8)));
+    want "trunc" (Float.trunc (opaque x)) (float_of_int (i / 8));
+    want "round" (Float.round (opaque x))
+      (float_of_int (if i >= 0 then (i + 4) / 8 else - ((- i + 4) / 8)))
+  done


### PR DESCRIPTION
Hello,

Float.round, Float.trunc, ceil and floor went out to C everywhere, though arm64
and power have had one instruction for each since ARMv8-A and ISA 2.02. Eight
calls become eight instructions.

riscv needs Zfa and s390x needs z196 for the form that doesn't raise inexact,
so I can't do both, GCC does the same thing.

Tested on cfarm185 and cfarm120.