### PR TITLE
Unmarshaling: guard against overflow when computing header_len + data_len

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,6 +137,11 @@ Working version
   respectively `--disable-largefile` and `--disable-year2038` to configure.
   (Antonin Décimo, review by Miod Vallat)
 
+- #15019: `Marshal.from_{string,bytes}`: guard against overflow in
+  the computation of the total data length.
+  (Xavier Leroy, report by Akshay Singh, review by Nicolás Ojeda Bär
+  and Antonin Décimo)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -843,6 +843,7 @@ struct marshal_header {
   int header_len;
   uintnat data_len;
   uintnat uncompressed_data_len;
+  uintnat total_len;  /* header_len + data_len */
   uintnat num_objects;
   uintnat whsize;
   int compressed;
@@ -901,6 +902,11 @@ static void caml_parse_header(struct caml_intern_state* s,
     break;
   default:
     intern_failwith2(fun_name, "bad object");
+  }
+  h->total_len = h->header_len + h->data_len;
+  if (h->total_len < h->data_len) {
+      intern_failwith2
+        (fun_name, "object too large to be read back on this platform");
   }
 }
 
@@ -1035,7 +1041,8 @@ CAMLexport value caml_input_val_from_bytes(value str, intnat ofs)
   /* Initialize global state */
   intern_init(s, &Byte_u(str, ofs), caml_string_length(str) - ofs, NULL);
   caml_parse_header(s, "input_val_from_string", &h);
-  if (ofs + h.header_len + h.data_len > caml_string_length(str))
+  if (ofs < 0 || ofs + h.total_len < h.total_len ||
+      ofs + h.total_len > caml_string_length(str))
     caml_failwith("input_val_from_string: bad length");
   /* Allocate result */
   intern_alloc_storage(s, h.whsize, h.num_objects);
@@ -1077,7 +1084,7 @@ static value caml_input_value_from_buffer(const char * fun_name,
 
   intern_init(s, src, len, input);
   caml_parse_header(s, fun_name, &h);
-  if (h.header_len + h.data_len > len)
+  if (h.total_len > len)
     intern_failwith2(fun_name, "bad length");
   s->intern_src_end = s->intern_src + h.data_len;
   return input_val_from_block(s, &h);
@@ -1117,7 +1124,7 @@ CAMLprim value caml_marshal_data_size(value buff, value ofs)
 {
   uint32_t magic;
   int header_len;
-  uintnat data_len;
+  uintnat data_len, total_len;
   struct caml_intern_state *s = init_intern_state ();
 
   s->intern_src = &Byte_u(buff, Long_val(ofs));
@@ -1147,7 +1154,12 @@ CAMLprim value caml_marshal_data_size(value buff, value ofs)
   default:
     caml_failwith("Marshal.data_size: bad object");
   }
-  return Val_long((header_len - 16) + data_len);
+  total_len = header_len + data_len;
+  if (total_len < data_len) {
+    caml_failwith("Marshal.data_size: "
+                  "object too large to be read back on this platform");
+  }
+  return Val_long(total_len - 16);
 }
 
 /* Resolution of code pointers */

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -903,10 +903,9 @@ static void caml_parse_header(struct caml_intern_state* s,
   default:
     intern_failwith2(fun_name, "bad object");
   }
-  h->total_len = h->header_len + h->data_len;
-  if (h->total_len < h->data_len) {
-      intern_failwith2
-        (fun_name, "object too large to be read back on this platform");
+  if (caml_uadd_overflow(h->header_len, h->data_len, &h->total_len)) {
+    intern_failwith2
+      (fun_name, "object too large to be read back on this platform");
   }
 }
 
@@ -1154,8 +1153,7 @@ CAMLprim value caml_marshal_data_size(value buff, value ofs)
   default:
     caml_failwith("Marshal.data_size: bad object");
   }
-  total_len = header_len + data_len;
-  if (total_len < data_len) {
+  if (caml_uadd_overflow(header_len, data_len, &total_len)) {
     caml_failwith("Marshal.data_size: "
                   "object too large to be read back on this platform");
   }

--- a/testsuite/tests/lib-marshal/fuzzy.ml
+++ b/testsuite/tests/lib-marshal/fuzzy.ml
@@ -79,6 +79,17 @@ let test ic =
   end;
   Gc.full_major()
 
+(* Same, but use Marshal.from_string instead *)
+
+let test_string ic =
+  In_channel.set_binary_mode ic true;
+  let s = In_channel.input_all ic in
+  begin try
+    ignore (Marshal.from_string s 0)
+  with Failure _ | Invalid_argument _ | Out_of_memory -> ()
+  end;
+  Gc.full_major()
+
 (* Internal fuzzing.  Rather naive. *)
 
 let random_offset b =
@@ -123,7 +134,7 @@ let fuzz1 () =
       end;
       Gc.full_major()
     done;
-    Bytes.set_uint8 b i (Bytes.get_uint8 b i)
+    Bytes.set_uint8 b i (String.get_uint8 d i)
   done
 
 let () =
@@ -135,7 +146,9 @@ let () =
     "-x", Arg.Unit fuzz1,
       "<num iter>  Perform internal fuzzing test (exhaustive 1-byte)";
     "-r", Arg.Unit (fun () -> test stdin),
-      "  Read marshaled data from standard input"
+      "  Read marshaled data from standard input";
+    "-s", Arg.Unit (fun () -> test_string stdin),
+      "  Read marshaled data from standard input via a string"
   ]
   (fun s -> raise (Arg.Bad ("don't know what to do with " ^ s)))
   "Usage: fuzzy [option].\nOptions are:"


### PR DESCRIPTION
Corrupted or malicious marshaled data could trigger an overflow in the computation of the total size of the marshaled data (header_len + data_len), making some bounds checks ineffective.