### PR TITLE
ocamldebug: send full headers when requested.

### DIFF
--- a/.depend
+++ b/.depend
@@ -8530,6 +8530,7 @@ debugger/debugcom.cmo : \
     debugger/int64ops.cmi \
     bytecomp/instruct.cmi \
     debugger/input_handling.cmi \
+    utils/config.cmi \
     debugger/debugcom.cmi
 debugger/debugcom.cmx : \
     debugger/primitives.cmx \
@@ -8537,6 +8538,7 @@ debugger/debugcom.cmx : \
     debugger/int64ops.cmx \
     bytecomp/instruct.cmx \
     debugger/input_handling.cmx \
+    utils/config.cmx \
     debugger/debugcom.cmi
 debugger/debugcom.cmi : \
     debugger/primitives.cmi \

--- a/Changes
+++ b/Changes
@@ -378,7 +378,7 @@ Working version
 
 - #15022: ocamldebug: requesting a header through the debugger protocol now
   returns the full header instead of the low 32 bits.
-  (Vincent Laviron, review by ...)
+  (Vincent Laviron, review by Xavier Leroy)
 
 ### Manual and documentation:
 

--- a/Changes
+++ b/Changes
@@ -376,6 +376,10 @@ Working version
   of nonmatching input if a rule is not exhaustive (Martin Jambon,
   review by David Allsopp and Gabriel Scherer)
 
+- #15022: ocamldebug: requesting a header through the debugger protocol now
+  returns the full header instead of the low 32 bits.
+  (Vincent Laviron, review by ...)
+
 ### Manual and documentation:
 
 - #14598: Add `@since` annotations to `Runtime_events`. (Raphaël Proust)

--- a/debugger/debugcom.ml
+++ b/debugger/debugcom.ml
@@ -260,7 +260,7 @@ let output_remote_value ic v =
 let tag_of_header header =
   Nativeint.to_int (Nativeint.logand header 0xFFn)
 
-let only_non_reserved_bits header =
+let header_without_reserved_bits header =
   if Config.reserved_header_bits > 0 then
     let mask =
       Nativeint.sub
@@ -275,8 +275,8 @@ let input_binary_nativeint ic =
   match Sys.word_size with
   | 32 -> Nativeint.of_int (input_binary_int ic)
   | 64 ->
-      let low = input_binary_int ic in
       let high = input_binary_int ic in
+      let low = input_binary_int ic in
       Nativeint.(add (of_int low) (shift_left (of_int high) 32))
   | _ -> failwith "Unsupported word size"
 
@@ -325,7 +325,7 @@ module Remote_value =
         output_remote_value !conn.io_out v;
         flush !conn.io_out;
         let header = input_binary_nativeint !conn.io_in in
-        let header = only_non_reserved_bits header in
+        let header = header_without_reserved_bits header in
         if tag_of_header header = Obj.double_array_tag && Sys.word_size = 32
         then Nativeint.(to_int (shift_right_logical header 11))
         else Nativeint.(to_int (shift_right_logical header 10))

--- a/debugger/debugcom.ml
+++ b/debugger/debugcom.ml
@@ -257,6 +257,29 @@ let input_remote_value ic =
 let output_remote_value ic v =
   output_substring ic v 0 value_size
 
+let tag_of_header header =
+  Nativeint.to_int (Nativeint.logand header 0xFFn)
+
+let only_non_reserved_bits header =
+  if Config.reserved_header_bits > 0 then
+    let mask =
+      Nativeint.sub
+        (Nativeint.shift_left 1n (Sys.word_size - Config.reserved_header_bits))
+        1n
+    in
+    Nativeint.logand header mask
+  else
+    header
+
+let input_binary_nativeint ic =
+  match Sys.word_size with
+  | 32 -> Nativeint.of_int (input_binary_int ic)
+  | 64 ->
+      let low = input_binary_int ic in
+      let high = input_binary_int ic in
+      Nativeint.(add (of_int low) (shift_left (of_int high) 32))
+  | _ -> failwith "Unsupported word size"
+
 module Remote_value =
   struct
     type t = Remote of string | Local of Obj.t
@@ -292,8 +315,8 @@ module Remote_value =
           output_char !conn.io_out 'H';
           output_remote_value !conn.io_out v;
           flush !conn.io_out;
-          let header = input_binary_int !conn.io_in in
-          header land 0xFF
+          let header = input_binary_nativeint !conn.io_in in
+          tag_of_header header
 
     let size = function
     | Local obj -> Obj.size obj
@@ -301,10 +324,11 @@ module Remote_value =
         output_char !conn.io_out 'H';
         output_remote_value !conn.io_out v;
         flush !conn.io_out;
-        let header = input_binary_int !conn.io_in in
-        if header land 0xFF = Obj.double_array_tag && Sys.word_size = 32
-        then header lsr 11
-        else header lsr 10
+        let header = input_binary_nativeint !conn.io_in in
+        let header = only_non_reserved_bits header in
+        if tag_of_header header = Obj.double_array_tag && Sys.word_size = 32
+        then Nativeint.(to_int (shift_right_logical header 11))
+        else Nativeint.(to_int (shift_right_logical header 10))
 
     let field v n =
       match v with

--- a/debugger/debugcom.ml
+++ b/debugger/debugcom.ml
@@ -277,7 +277,13 @@ let input_binary_nativeint ic =
   | 64 ->
       let high = input_binary_int ic in
       let low = input_binary_int ic in
-      Nativeint.(add (of_int low) (shift_left (of_int high) 32))
+      (* [low] was sent as an unsigned 32-bit integer, but [input_binary_int]
+         sign-extended it. Masking the high bits away recovers the original
+         unsigned number. *)
+      let low_masked =
+        Nativeint.(logand (of_int low) 0xFFFF_FFFFn)
+      in
+      Nativeint.(add low_masked (shift_left (of_int high) 32))
   | _ -> failwith "Unsupported word size"
 
 module Remote_value =

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -655,7 +655,12 @@ void caml_debugger(enum event_kind event, value param)
       break;
     case REQ_GET_HEADER:
       val = getval(dbg_in);
+#ifdef ARCH_SIXTYFOUR
+      caml_putword(dbg_out, (uint32_t) Hd_val(val));
+      caml_putword(dbg_out, (uint32_t) (Hd_val(val) >> 32));
+#else
       caml_putword(dbg_out, Hd_val(val));
+#endif
       caml_flush(dbg_out);
       break;
     case REQ_GET_FIELD:

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -656,8 +656,8 @@ void caml_debugger(enum event_kind event, value param)
     case REQ_GET_HEADER:
       val = getval(dbg_in);
 #ifdef ARCH_SIXTYFOUR
-      caml_putword(dbg_out, (uint32_t) Hd_val(val));
       caml_putword(dbg_out, (uint32_t) (Hd_val(val) >> 32));
+      caml_putword(dbg_out, (uint32_t) Hd_val(val));
 #else
       caml_putword(dbg_out, Hd_val(val));
 #endif

--- a/testsuite/tests/tool-debugger/full_headers/debuggee.ml
+++ b/testsuite/tests/tool-debugger/full_headers/debuggee.ml
@@ -13,6 +13,7 @@ let () = main ()
 *)
 
 (* TEST
+ arch64;
  flags += " -g ";
  debugger_script = "${test_source_directory}/input_script";
  debugger;

--- a/testsuite/tests/tool-debugger/full_headers/debuggee.ml
+++ b/testsuite/tests/tool-debugger/full_headers/debuggee.ml
@@ -1,6 +1,6 @@
 (* TEST_BELOW *)
 
-let arr = Array.make (1 lsl 25) 42
+let arr = Array.make (1 lsl 22) 42
 
 let main () =
   ignore (Sys.opaque_identity arr)

--- a/testsuite/tests/tool-debugger/full_headers/debuggee.ml
+++ b/testsuite/tests/tool-debugger/full_headers/debuggee.ml
@@ -1,0 +1,25 @@
+(* TEST_BELOW *)
+
+let arr = Array.make (1 lsl 25) 42
+
+let main () =
+  ignore (Sys.opaque_identity arr)
+
+let () = main ()
+
+(* This test checks that the debugger gets all the header bits
+   when using the remote protocol (i.e. without fetching the full value).
+   See Github issue #15012 for more details.
+*)
+
+(* TEST
+ flags += " -g ";
+ debugger_script = "${test_source_directory}/input_script";
+ debugger;
+ shared-libraries;
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+ ocamldebug;
+ check-program-output;
+*)

--- a/testsuite/tests/tool-debugger/full_headers/debuggee.reference
+++ b/testsuite/tests/tool-debugger/full_headers/debuggee.reference
@@ -1,0 +1,4 @@
+Loading program... done.
+Breakpoint: 1
+6   <|b|>ignore (Sys.opaque_identity arr)
+arr: int array = [|42; 42; ...|]

--- a/testsuite/tests/tool-debugger/full_headers/input_script
+++ b/testsuite/tests/tool-debugger/full_headers/input_script
@@ -1,0 +1,5 @@
+break @ Debuggee 6
+run
+set print_length 3
+print arr
+quit


### PR DESCRIPTION
Fixes #15012 by implementing (my interpretation of) @xavierleroy's suggestion.

I would argue that this does not deserve to be marked as a breaking change, but I believe that earlybird also uses the protocol directly and will need to be patched (cc @sim642).