### PR TITLE
Fix two bugs in the Win32 implementation of `Unix.select`

### DIFF
--- a/Changes
+++ b/Changes
@@ -343,6 +343,11 @@ Working version
   a custom event does not allocate in the usual single-threaded case.
   (Anil Madhavapeddy, review by Thomas Leonard and Sadiq Jaffer)
 
+- #15025: Fix two bugs in the Win32 version of `Unix.select` that could result
+  in failure or incorrect results being returned when the same file descriptor
+  appeared more than one input list or more than once in a single input list.
+  (Nicolás Ojeda Bär, report by Zhang Rui)
+
 ### Tools:
 
 - #14318, #14709, ocamldoc: use "Module_name (Library name)" rather than

--- a/Changes
+++ b/Changes
@@ -346,7 +346,7 @@ Working version
 - #15025: Fix two bugs in the Win32 version of `Unix.select` that could result
   in failure or incorrect results being returned when the same file descriptor
   appeared more than one input list or more than once in a single input list.
-  (Nicolás Ojeda Bär, report by Zhang Rui)
+  (Nicolás Ojeda Bär, report by Zhang Rui, review by Antonin Décimo)
 
 ### Tools:
 

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -125,21 +125,11 @@ typedef enum _SELECTTYPE {
   SELECT_TYPE_SOCKET        /* Classic select */
 } SELECTTYPE;
 
-/* Data structure for results */
-typedef struct _SELECTRESULT {
-  LIST       lst;
-  SELECTMODE EMode;
-  int        lpOrigIdx;
-} SELECTRESULT;
-
-typedef SELECTRESULT *LPSELECTRESULT;
-
 /* Data structure for query */
 typedef struct _SELECTQUERY {
   LIST         lst;
   SELECTMODE   EMode;
   HANDLE       hFileDescr;
-  int          lpOrigIdx;
   unsigned int uFlagsFd; /* Copy of filedescr->flags_fd */
 } SELECTQUERY;
 
@@ -148,11 +138,13 @@ typedef SELECTQUERY *LPSELECTQUERY;
 typedef struct _SELECTDATA {
   LIST             lst;
   SELECTTYPE       EType;
-  /* Sockets may generate a result for all three lists from one single
-     query object
-   */
-  SELECTRESULT     aResults[MAXIMUM_SELECT_OBJECTS * 3];
-  DWORD            nResultsCount;
+  /* Sockets may generate results for all three lists from one query. */
+  SELECTHANDLESET  readResults;
+  HANDLE           aReadResults[MAXIMUM_SELECT_OBJECTS];
+  SELECTHANDLESET  writeResults;
+  HANDLE           aWriteResults[MAXIMUM_SELECT_OBJECTS];
+  SELECTHANDLESET  exceptResults;
+  HANDLE           aExceptResults[MAXIMUM_SELECT_OBJECTS];
   /* Data following are dedicated to APC like call, they
      will be initialized if required.
      */
@@ -190,7 +182,12 @@ static LPSELECTDATA select_data_new (LPSELECTDATA lpSelectData,
   caml_win32_list_init((LPLIST)res);
   caml_win32_list_next_set((LPLIST)res, (LPLIST)lpSelectData);
   res->EType         = EType;
-  res->nResultsCount = 0;
+  handle_set_init(&res->readResults, res->aReadResults,
+                  MAXIMUM_SELECT_OBJECTS);
+  handle_set_init(&res->writeResults, res->aWriteResults,
+                  MAXIMUM_SELECT_OBJECTS);
+  handle_set_init(&res->exceptResults, res->aExceptResults,
+                  MAXIMUM_SELECT_OBJECTS);
 
 
   /* Data following are dedicated to APC like call, they
@@ -218,38 +215,36 @@ static void select_data_free (LPSELECTDATA lpSelectData)
     lpSelectData->lpWorker = NULL;
   };
 
-  /* Make sure results/queries cannot be accessed */
-  lpSelectData->nResultsCount = 0;
+  /* Make sure queries cannot be accessed */
   lpSelectData->nQueriesCount = 0;
 
   caml_stat_free(lpSelectData);
 }
 
-/* Add a result to select data, return zero if something goes wrong. */
-static DWORD select_data_result_add (LPSELECTDATA lpSelectData,
-                                     SELECTMODE EMode, int lpOrigIdx)
+/* Add a result to select data. */
+static void select_data_result_add (LPSELECTDATA lpSelectData,
+                                    SELECTMODE EMode, HANDLE hFileDescr)
 {
-  DWORD res;
-  DWORD i;
-
-  res = 0;
-  if (lpSelectData->nResultsCount < MAXIMUM_SELECT_OBJECTS * 3)
+  switch (EMode)
   {
-    i = lpSelectData->nResultsCount;
-    lpSelectData->aResults[i].EMode  = EMode;
-    lpSelectData->aResults[i].lpOrigIdx = lpOrigIdx;
-    lpSelectData->nResultsCount++;
-    res = 1;
+    case SELECT_MODE_READ:
+      handle_set_add(&lpSelectData->readResults, hFileDescr);
+      break;
+    case SELECT_MODE_WRITE:
+      handle_set_add(&lpSelectData->writeResults, hFileDescr);
+      break;
+    case SELECT_MODE_EXCEPT:
+      handle_set_add(&lpSelectData->exceptResults, hFileDescr);
+      break;
+    case SELECT_MODE_NONE:
+      CAMLunreachable();
   }
-
-  return res;
 }
 
 /* Add a query to select data, return zero if something goes wrong */
 static DWORD select_data_query_add (LPSELECTDATA lpSelectData,
                                     SELECTMODE EMode,
                                     HANDLE hFileDescr,
-                                    int lpOrigIdx,
                                     unsigned int uFlagsFd)
 {
   DWORD res;
@@ -261,7 +256,6 @@ static DWORD select_data_query_add (LPSELECTDATA lpSelectData,
     i = lpSelectData->nQueriesCount;
     lpSelectData->aQueries[i].EMode      = EMode;
     lpSelectData->aQueries[i].hFileDescr = hFileDescr;
-    lpSelectData->aQueries[i].lpOrigIdx  = lpOrigIdx;
     lpSelectData->aQueries[i].uFlagsFd   = uFlagsFd;
     lpSelectData->nQueriesCount++;
     res = 1;
@@ -349,7 +343,8 @@ static void read_console_poll(HANDLE hStop, void *_data)
       record.Event.KeyEvent.bKeyDown &&
       record.Event.KeyEvent.uChar.AsciiChar != 0)
     {
-      select_data_result_add(lpSelectData, lpQuery->EMode, lpQuery->lpOrigIdx);
+      select_data_result_add(lpSelectData, lpQuery->EMode,
+                             lpQuery->hFileDescr);
       lpSelectData->EState = SELECT_STATE_SIGNALED;
       break;
     }
@@ -370,14 +365,13 @@ static void read_console_poll(HANDLE hStop, void *_data)
 static LPSELECTDATA read_console_poll_add (LPSELECTDATA lpSelectData,
                                            SELECTMODE EMode,
                                            HANDLE hFileDescr,
-                                           int lpOrigIdx,
                                            unsigned int uFlagsFd)
 {
   LPSELECTDATA res;
 
   res = select_data_new(lpSelectData, SELECT_TYPE_CONSOLE_READ);
   res->funcWorker = read_console_poll;
-  select_data_query_add(res, SELECT_MODE_READ, hFileDescr, lpOrigIdx, uFlagsFd);
+  select_data_query_add(res, SELECT_MODE_READ, hFileDescr, uFlagsFd);
 
   return res;
 }
@@ -426,7 +420,7 @@ static void read_pipe_poll (HANDLE hStop, void *_data)
       {
         lpSelectData->EState = SELECT_STATE_SIGNALED;
         select_data_result_add(lpSelectData, iterQuery->EMode,
-                               iterQuery->lpOrigIdx);
+                               iterQuery->hFileDescr);
       };
     };
 
@@ -460,7 +454,6 @@ static void read_pipe_poll (HANDLE hStop, void *_data)
 static LPSELECTDATA read_pipe_poll_add (LPSELECTDATA lpSelectData,
                                         SELECTMODE EMode,
                                         HANDLE hFileDescr,
-                                        int lpOrigIdx,
                                         unsigned int uFlagsFd)
 {
   LPSELECTDATA res;
@@ -476,7 +469,7 @@ static LPSELECTDATA read_pipe_poll_add (LPSELECTDATA lpSelectData,
 
   /* Add a new pipe to poll */
   res->funcWorker = read_pipe_poll;
-  select_data_query_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+  select_data_query_add(res, EMode, hFileDescr, uFlagsFd);
 
   return hd;
 }
@@ -563,20 +556,20 @@ static void socket_poll (HANDLE hStop, void *_data)
                    != 0)
             {
               select_data_result_add(lpSelectData, SELECT_MODE_READ,
-                                     iterQuery->lpOrigIdx);
+                                     iterQuery->hFileDescr);
             }
             if ((iterQuery->EMode & SELECT_MODE_WRITE) != 0
                 && (events.lNetworkEvents & (FD_WRITE | FD_CONNECT | FD_CLOSE))
                    != 0)
             {
               select_data_result_add(lpSelectData, SELECT_MODE_WRITE,
-                                     iterQuery->lpOrigIdx);
+                                     iterQuery->hFileDescr);
             }
             if ((iterQuery->EMode & SELECT_MODE_EXCEPT) != 0
                 && (events.lNetworkEvents & FD_OOB) != 0)
             {
               select_data_result_add(lpSelectData, SELECT_MODE_EXCEPT,
-                                     iterQuery->lpOrigIdx);
+                                     iterQuery->hFileDescr);
             }
           }
         }
@@ -607,7 +600,6 @@ static void socket_poll (HANDLE hStop, void *_data)
 static LPSELECTDATA socket_poll_add (LPSELECTDATA lpSelectData,
                                      SELECTMODE EMode,
                                      HANDLE hFileDescr,
-                                     int lpOrigIdx,
                                      unsigned int uFlagsFd)
 {
   LPSELECTDATA res;
@@ -685,7 +677,6 @@ static LPSELECTDATA socket_poll_add (LPSELECTDATA lpSelectData,
     }
     aQueries->EMode = EMode;
     aQueries->hFileDescr = hFileDescr;
-    aQueries->lpOrigIdx = lpOrigIdx;
     aQueries->uFlagsFd = uFlagsFd;
     DEBUG_PRINT("Socket %x added", hFileDescr);
   }
@@ -706,7 +697,6 @@ static LPSELECTDATA socket_poll_add (LPSELECTDATA lpSelectData,
 static LPSELECTDATA static_poll_add (LPSELECTDATA lpSelectData,
                                      SELECTMODE EMode,
                                      HANDLE hFileDescr,
-                                     int lpOrigIdx,
                                      unsigned int uFlagsFd)
 {
   LPSELECTDATA res;
@@ -717,8 +707,8 @@ static LPSELECTDATA static_poll_add (LPSELECTDATA lpSelectData,
   res = select_data_job_search(&hd, SELECT_TYPE_STATIC);
 
   /* Add a new query/result */
-  select_data_query_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
-  select_data_result_add(res, EMode, lpOrigIdx);
+  select_data_query_add(res, EMode, hFileDescr, uFlagsFd);
+  select_data_result_add(res, EMode, hFileDescr);
 
   return hd;
 }
@@ -774,7 +764,7 @@ static SELECTHANDLETYPE get_handle_type(value fd)
 /* Choose what to do with given data */
 static LPSELECTDATA select_data_dispatch (LPSELECTDATA lpSelectData,
                                           SELECTMODE EMode,
-                                          value fd, int lpOrigIdx)
+                                          value fd)
 {
   LPSELECTDATA    res;
   HANDLE          hFileDescr;
@@ -806,7 +796,7 @@ static LPSELECTDATA select_data_dispatch (LPSELECTDATA lpSelectData,
       /* Disk is always ready in read/write operation */
       if (EMode == SELECT_MODE_READ || EMode == SELECT_MODE_WRITE)
       {
-        res = static_poll_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+        res = static_poll_add(res, EMode, hFileDescr, uFlagsFd);
       };
       break;
 
@@ -815,12 +805,11 @@ static LPSELECTDATA select_data_dispatch (LPSELECTDATA lpSelectData,
       /* Console is always ready in write operation, need to check for read. */
       if (EMode == SELECT_MODE_READ)
       {
-        res = read_console_poll_add(res, EMode, hFileDescr, lpOrigIdx,
-                                    uFlagsFd);
+        res = read_console_poll_add(res, EMode, hFileDescr, uFlagsFd);
       }
       else if (EMode == SELECT_MODE_WRITE)
       {
-        res = static_poll_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+        res = static_poll_add(res, EMode, hFileDescr, uFlagsFd);
       };
       break;
 
@@ -830,13 +819,13 @@ static LPSELECTDATA select_data_dispatch (LPSELECTDATA lpSelectData,
       if (EMode == SELECT_MODE_READ)
       {
         DEBUG_PRINT("Need to check availability of data on pipe");
-        res = read_pipe_poll_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+        res = read_pipe_poll_add(res, EMode, hFileDescr, uFlagsFd);
       }
       else if (EMode == SELECT_MODE_WRITE)
       {
         DEBUG_PRINT("No need to check availability of data on pipe, "
                     "write operation always possible");
-        res = static_poll_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+        res = static_poll_add(res, EMode, hFileDescr, uFlagsFd);
       };
       break;
 
@@ -850,14 +839,14 @@ static LPSELECTDATA select_data_dispatch (LPSELECTDATA lpSelectData,
           DEBUG_PRINT("Socket is not connected");
           if (EMode == SELECT_MODE_WRITE || EMode == SELECT_MODE_READ)
           {
-            res = static_poll_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+            res = static_poll_add(res, EMode, hFileDescr, uFlagsFd);
             alreadyAdded = TRUE;
           }
         }
       }
       if (!alreadyAdded)
       {
-        res = socket_poll_add(res, EMode, hFileDescr, lpOrigIdx, uFlagsFd);
+        res = socket_poll_add(res, EMode, hFileDescr, uFlagsFd);
       }
       break;
 
@@ -886,38 +875,58 @@ static DWORD caml_list_length (value lst)
   CAMLreturnT(DWORD, res);
 }
 
-static value find_handle(LPSELECTRESULT iterResult, value readfds,
-                         value writefds, value exceptfds)
+static LPSELECTHANDLESET select_data_results(LPSELECTDATA lpSelectData,
+                                             SELECTMODE EMode)
 {
-  CAMLparam3(readfds, writefds, exceptfds);
-  CAMLlocal2(result, list);
-
-  switch( iterResult->EMode )
+  switch (EMode)
   {
     case SELECT_MODE_READ:
-      list = readfds;
-      break;
+      return &lpSelectData->readResults;
     case SELECT_MODE_WRITE:
-      list = writefds;
-      break;
+      return &lpSelectData->writeResults;
     case SELECT_MODE_EXCEPT:
-      list = exceptfds;
-      break;
+      return &lpSelectData->exceptResults;
     case SELECT_MODE_NONE:
       CAMLunreachable();
-  };
+  }
+  return NULL; /* Avoid warning C4715 with MSVC. */
+}
 
-  for(int i=0; list != Val_unit && i < iterResult->lpOrigIdx; ++i )
+static BOOL select_data_result_mem(LPSELECTDATA lpSelectData,
+                                   SELECTMODE EMode, HANDLE hFileDescr)
+{
+  for (; lpSelectData != NULL;
+       lpSelectData = LIST_NEXT(LPSELECTDATA, lpSelectData))
   {
-    list = Field(list, 1);
+    if (handle_set_mem(select_data_results(lpSelectData, EMode), hFileDescr))
+      return TRUE;
+  }
+  return FALSE;
+}
+
+/* Filter an original descriptor list using the results.  Iterating over the
+   original list both returns the exact OCaml values supplied by the caller
+   and preserves duplicate descriptors, as the fd_set implementation does. */
+static value select_data_to_fdlist(value fdlist, LPSELECTDATA lpSelectData,
+                                   SELECTMODE EMode)
+{
+  CAMLparam1(fdlist);
+  CAMLlocal2(res, fd);
+
+  res = Val_emptylist;
+  for (; fdlist != Val_emptylist; fdlist = Field(fdlist, 1))
+  {
+    fd = Field(fdlist, 0);
+    if (select_data_result_mem(lpSelectData, EMode, Handle_val(fd)))
+    {
+      value newres = caml_alloc_small(2, Tag_cons);
+      Field(newres, 0) = fd;
+      Field(newres, 1) = res;
+      res = newres;
+    }
   }
 
-  if (list == Val_unit)
-    caml_failwith ("select.c: original file handle not found");
-
-  result = Field(list, 0);
-
-  CAMLreturn( result );
+  CAMLreturn(res);
 }
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -976,12 +985,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   /* Data for all handles */
   LPSELECTDATA lpSelectData;
   LPSELECTDATA iterSelectData;
-
-  /* Iterator for results */
-  LPSELECTRESULT iterResult;
-
-  /* Iterator */
-  DWORD i;
 
   /* Error status */
   DWORD err;
@@ -1056,7 +1059,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       lpEventsDone   = NULL;
       lpSelectData   = NULL;
       iterSelectData = NULL;
-      iterResult     = NULL;
       hasStaticData  = 0;
       readfds_len    = caml_list_length(readfds);
       writefds_len   = caml_list_length(writefds);
@@ -1081,7 +1083,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
          to watch */
       DEBUG_PRINT("Dispatch read fd");
       handle_set_init(&hds, hdsData, hdsMax);
-      i=0;
       for (l = readfds; l != Val_emptylist; l = Field(l, 1))
         {
           fd = Field(l, 0);
@@ -1089,7 +1090,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
             {
               handle_set_add(&hds, Handle_val(fd));
               lpSelectData = select_data_dispatch(lpSelectData,
-                                                  SELECT_MODE_READ, fd, i++);
+                                                  SELECT_MODE_READ, fd);
             }
           else
             {
@@ -1101,7 +1102,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       DEBUG_PRINT("Dispatch write fd");
       handle_set_init(&hds, hdsData, hdsMax);
-      i=0;
       for (l = writefds; l != Val_emptylist; l = Field(l, 1))
         {
           fd = Field(l, 0);
@@ -1109,7 +1109,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
             {
               handle_set_add(&hds, Handle_val(fd));
               lpSelectData = select_data_dispatch(lpSelectData,
-                                                  SELECT_MODE_WRITE, fd, i++);
+                                                  SELECT_MODE_WRITE, fd);
             }
           else
             {
@@ -1121,7 +1121,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       DEBUG_PRINT("Dispatch exceptional fd");
       handle_set_init(&hds, hdsData, hdsMax);
-      i=0;
       for (l = exceptfds; l != Val_emptylist; l = Field(l, 1))
         {
           fd = Field(l, 0);
@@ -1129,7 +1128,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
             {
               handle_set_add(&hds, Handle_val(fd));
               lpSelectData = select_data_dispatch(lpSelectData,
-                                                  SELECT_MODE_EXCEPT, fd, i++);
+                                                  SELECT_MODE_EXCEPT, fd);
             }
           else
             {
@@ -1237,44 +1236,26 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       /* Build results */
       if (err == 0)
         {
-          DEBUG_PRINT("Building result");
-          read_list = Val_emptylist;
-          write_list = Val_emptylist;
-          except_list = Val_emptylist;
-
           iterSelectData = lpSelectData;
           while (iterSelectData != NULL)
             {
-              for (i = 0; i < iterSelectData->nResultsCount; i++)
-                {
-                  iterResult = &(iterSelectData->aResults[i]);
-                  l = caml_alloc_small(2, Tag_cons);
-                  Field(l, 0) = find_handle(iterResult, readfds, writefds,
-                                            exceptfds);
-                  switch (iterResult->EMode)
-                    {
-                    case SELECT_MODE_READ:
-                      Field(l, 1) =  read_list;
-                      read_list = l;
-                      break;
-                    case SELECT_MODE_WRITE:
-                      Field(l, 1) = write_list;
-                      write_list = l;
-                      break;
-                    case SELECT_MODE_EXCEPT:
-                      Field(l, 1) = except_list;
-                      except_list = l;
-                      break;
-                    case SELECT_MODE_NONE:
-                      CAMLunreachable();
-                    }
-                }
               /* We try to only process the first error, bypass other errors */
               if (err == 0 && iterSelectData->EState == SELECT_STATE_ERROR)
                 {
                   err = iterSelectData->nError;
                 }
               iterSelectData = LIST_NEXT(LPSELECTDATA, iterSelectData);
+            }
+
+          if (err == 0)
+            {
+              DEBUG_PRINT("Building result");
+              read_list = select_data_to_fdlist(readfds, lpSelectData,
+                                                SELECT_MODE_READ);
+              write_list = select_data_to_fdlist(writefds, lpSelectData,
+                                                 SELECT_MODE_WRITE);
+              except_list = select_data_to_fdlist(exceptfds, lpSelectData,
+                                                  SELECT_MODE_EXCEPT);
             }
         }
 

--- a/testsuite/tests/lib-unix/win-select/test.ml
+++ b/testsuite/tests/lib-unix/win-select/test.ml
@@ -27,3 +27,75 @@ let () =
 
   close pr; close pw;
   close s1; close s2
+
+let () =
+  let server = socket PF_INET SOCK_STREAM 0 in
+  bind server (ADDR_INET (inet_addr_loopback, 0));
+  listen server 1;
+  let port =
+    match getsockname server with
+    | ADDR_INET (_, port) -> port
+    | _ -> assert false
+  in
+  let client = socket PF_INET SOCK_STREAM 0 in
+  connect client (ADDR_INET (inet_addr_loopback, port));
+  let accepted, _ = accept server in
+  let pr, pw = pipe () in
+
+  begin match select [pr; client] [client] [] 0.5 with
+  | _, [fd], _ when fd == client ->
+      Printf.printf "SUCCESS: Socket uses the right per-list result.\n"
+  | _ ->
+      Printf.printf "BUG REPRODUCED: Wrong write result.\n"
+  | exception Failure s when s = "select.c: original file handle not found" ->
+      Printf.printf "BUG REPRODUCED: Socket uses an index from another list.\n"
+  end;
+
+  close pr; close pw;
+  close accepted; close client; close server
+
+let () =
+  let server = socket PF_INET SOCK_STREAM 0 in
+  bind server (ADDR_INET (inet_addr_loopback, 0));
+  listen server 1;
+  let port =
+    match getsockname server with
+    | ADDR_INET (_, port) -> port
+    | _ -> assert false
+  in
+  let client = socket PF_INET SOCK_STREAM 0 in
+  connect client (ADDR_INET (inet_addr_loopback, port));
+  let accepted, _ = accept server in
+  let decoy = socket PF_INET SOCK_STREAM 0 in
+  bind decoy (ADDR_INET (inet_addr_loopback, 0));
+  listen decoy 1;
+  let pr, pw = pipe () in
+  (* [client]'s query incorrectly retains index 1 from [readfds]. Put a
+     non-writable listening socket at index 1 in [writefds], so the stale index
+     returns the wrong descriptor instead of being out of bounds. *)
+  begin match select [pr; client] [client; decoy] [] 0.5 with
+  | _, [fd], _ when fd == client ->
+      Printf.printf "SUCCESS: Socket is not confused with another descriptor.\n"
+  | _, [fd], _ when fd == decoy ->
+      Printf.printf "BUG REPRODUCED: Wrong write descriptor returned.\n"
+  | _ ->
+      Printf.printf "BUG REPRODUCED: Unexpected write result.\n"
+  end;
+  close pr; close pw;
+  close decoy;
+  close accepted; close client; close server
+
+let () =
+  let pr, pw = pipe () in
+  let path = Filename.temp_file "win-select" ".tmp" in
+  let file = openfile path [O_RDONLY] 0 in
+
+  begin match select [pr; pr; file] [] [] 0.5 with
+  | [fd], _, _ when fd == file ->
+      Printf.printf "SUCCESS: Descriptor after a duplicate is mapped correctly.\n"
+  | _ ->
+      Printf.printf "BUG REPRODUCED: Duplicate changed a result index.\n"
+  end;
+
+  close file; unlink path;
+  close pr; close pw

--- a/testsuite/tests/lib-unix/win-select/test.reference
+++ b/testsuite/tests/lib-unix/win-select/test.reference
@@ -1,1 +1,4 @@
 SUCCESS: Pipe handle is still tracked.
+BUG REPRODUCED: Socket uses an index from another list.
+BUG REPRODUCED: Wrong write descriptor returned.
+BUG REPRODUCED: Duplicate changed a result index.

--- a/testsuite/tests/lib-unix/win-select/test.reference
+++ b/testsuite/tests/lib-unix/win-select/test.reference
@@ -1,4 +1,4 @@
 SUCCESS: Pipe handle is still tracked.
-BUG REPRODUCED: Socket uses an index from another list.
-BUG REPRODUCED: Wrong write descriptor returned.
-BUG REPRODUCED: Duplicate changed a result index.
+SUCCESS: Socket uses the right per-list result.
+SUCCESS: Socket is not confused with another descriptor.
+SUCCESS: Descriptor after a duplicate is mapped correctly.


### PR DESCRIPTION
This PR fixes two related bugs in the Win32 implementation of `Unix.select`, in the custom path used when the arguments contain non-socket descriptors.

The bugs were reported in #14758 by @z-rui, who also provided reproduction cases and ideas for a fix.

Both bugs concern how native pollling results are mapped back to the OCaml file descriptors passed by the caller. The current implementation stores an index into one of the input lists in each internal polling query. When a query produces a result, its readiness mode selects the corresponding input list and the stored index selects the descriptor to return.

These indices are not accurate in two situations.

### Socket appearing in multiple lists

The implementation monitors sockets using `WSAEventSelect()`, which permits only one event per socket. When a socket appears in multiple input lists, their read, write, and exception interests are therefore combined into a single internal query. Suppose the inputs are: `readfds  = [pipe; socket]`, `writefds = [socket]`.  The query for `socket` is first created while processing `readfds`, so it records index 1. When `writefds` is processed, the existing query is updated to include write readiness, but it retains index 1.

If `socket` becomes writable, the implementation uses index 1 to map the result back into `writefds`, even though `socket` is at index 0 there. This can result in either:

- an out-of-bounds lookup in `writefds`
- a different descriptor being returned if index 1 exists in `writefds`.

### Duplicate descriptors within an input list

Suppose an input list is: `[fd_a; fd_a; fd_b]`. The second occurrence of `fd_a` is discarded when constructing the internal polling queries. In the current code, however, the running index is incremented only when a new, unique handle is dispatched:

https://github.com/ocaml/ocaml/blob/c9160dd3566bfdeac8e690dc6dc62cf60ca5c880/otherlibs/unix/select_win32.c#L1088-L1093

As a result, `fd_b` is recorded with index 1 rather than its actual position, 2. If `fd_b` becomes ready, the implementation looks up position 1 in the original list and returns `fd_a`.

## Fix

The proposed change removes the use of indices altogether. Each polling job now maintains three sets of ready native handles: one each for read, write, and exception results. After polling completes, the implementation constructs the result lists by walking the original OCaml input lists and retaining descriptors whose native handles occur in the corresponding result sets.

This avoids positional bookkeeping altogether, and thus the above two problems.

Three regression cases are added corresponding to the three buggy situations explained above. All fail with the current implementation and pass with the fix.

Fixes #1475