### PR TITLE
Improve global roots debugging

### DIFF
--- a/Changes
+++ b/Changes
@@ -146,6 +146,14 @@ Working version
   (Xavier Leroy, report by Akshay Singh, review by Nicolás Ojeda Bär
   and Antonin Décimo)
 
+- #NNNNN: a debug runtime records what registered each global root, and stamps
+  each skiplist cell with the key it was inserted under, so that a root damaged
+  by a stray write is refused by the scan and reported with its registrant
+  instead of faulting inside the collector. The root being scanned is also left
+  in a thread-local, so that a collector taken down by a root holding something
+  that is no longer a value can still be traced back to what registered it.
+  (Romain Beauxis, review by XXX)
+
 ### Type system:
 
 * #11648, #14766, #14768, #14776, #14801, #14842, #14845: Keep expansion and
@@ -324,6 +332,12 @@ Working version
   tweak the documentation of Uchar.of_char.
   (Fabian Hemmer, suggestion by Daniel Bünzli, review by Daniel Bünzli and
   Nicolás Ojeda Bär)
+
+- #NNNNN: Add Gc.check_roots, which walks the C global roots on demand and
+  fails naming a damaged one, for finding which step of a program broke it
+  rather than waiting for the collection that trips over it. Does nothing
+  outside a runtime built for debugging.
+  (Romain Beauxis, review by XXX)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -359,6 +359,13 @@ Working version
 
 ### Tools:
 
+- #NNNNN: an "ocaml roots" command for the GDB and LLDB plugins, which walks
+  the C global roots of a core or a live process, reports any cell that no
+  longer matches the key it was inserted under together with the code that
+  registered that root, and names the root the collector was following when
+  it faulted. Needs a runtime built for debugging.
+  (Romain Beauxis, review by XXX)
+
 - #14318, #14709, ocamldoc: use "Module_name (Library name)" rather than
    "Library name: Module_name" as the title of html pages.
    (Florian Angeletti, report by Antonin Décimo, review by Nicolás Ojeda Bär)

--- a/manual/src/cmds/native-debugger.etex
+++ b/manual/src/cmds/native-debugger.etex
@@ -172,6 +172,19 @@ $1 = caml:14
 
 \end{verbatim}
 
+The plugin also provides \texttt{ocaml roots}, which walks the C global roots and reports any whose skiplist cell no longer matches the key it was inserted under, along with the code that registered it. This needs a runtime built for debugging (\texttt{-runtime-variant d}), which is what keeps the stamp and the table of registrants; against any other runtime the command says so rather than reporting nothing. It reads a core as readily as a live process, which is the case it is meant for: a root damaged by a stray write takes the collector down long after whoever damaged it returned, so the backtrace names only the collector.
+
+\begin{verbatim}
+(gdb) ocaml roots
+caml_global_roots: cell filed under 0x10000005528a0
+  inserted under      0x5528a0 (metadata_charset)
+  registered by       metadata_open + 39 at stubs.c:76 (0x49966c)
+
+7 roots checked, 1 damaged
+\end{verbatim}
+
+A root left holding something that is no longer a value damages no cell, and the collector faults following it. The command then reports the root that was under the scan, which the runtime leaves in a thread-local for exactly this.
+
 We can also print other kinds of OCaml values. In order to illustrate this, consider the following program:
 
 \begin{caml_example*}{verbatim}
@@ -340,6 +353,8 @@ heap exploration (see 'help ocaml' for more information).
 (value) 41 caml:20
 (lldb)
 \end{verbatim}
+
+The \texttt{ocaml roots} command described in the GDB section above is available here too, and behaves the same way.
 
 Note: above we are using an ARM64 Linux machine, so our first argument is passed in the first register \texttt{x0}.
 

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -23,6 +23,11 @@
 #include "mlvalues.h"
 #include "roots.h"
 
+#ifdef DEBUG
+/* The code that registered [r], or NULL. */
+void * caml_global_root_origin(value * r);
+#endif
+
 void caml_scan_global_roots(scanning_action f, void* fdata);
 void caml_scan_global_young_roots(scanning_action f, void* fdata);
 

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -26,6 +26,9 @@
 #ifdef DEBUG
 /* The code that registered [r], or NULL. */
 void * caml_global_root_origin(value * r);
+
+/* The root this thread is handing to the collector, or NULL. */
+extern CAMLthread_local value * caml_root_being_scanned;
 #endif
 
 void caml_scan_global_roots(scanning_action f, void* fdata);

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -39,8 +39,29 @@ struct skiplist {
 struct skipcell {
   uintnat key;
   uintnat data;
+#ifdef DEBUG
+  uintnat check;                /* key, obfuscated: see caml_skiplist_check */
+#endif
   struct skipcell * forward[]; /* flexible array member */
 };
+
+#ifdef DEBUG
+/* Arbitrary. It has to be non-zero, so that a cell zeroed wholesale fails the
+   check, and it is xored so that the key a cell was inserted with can be had
+   back from the stamp. */
+#define SKIPCELL_STAMP ((uintnat) 0x9E3779B97F4A7C15ULL)
+#define Check_of(k) ((k) ^ SKIPCELL_STAMP)
+#define Skipcell_ok(e) ((e)->check == Check_of((e)->key))
+#define Skipcell_key_of_check(e) Check_of((e)->check)
+
+/* The stamp, as a symbol. */
+extern const uintnat caml_skipcell_stamp;
+
+/* Fail if any cell's key no longer matches what it was inserted with. A key
+   is read as an address by some users, so a write landing on one is found by
+   dereferencing it. */
+extern void caml_skiplist_check(struct skiplist * sk, const char * what);
+#endif
 
 /* Initialize a skip list, statically */
 #define SKIPLIST_STATIC_INITIALIZER { {0, }, 0 }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -104,10 +104,22 @@ void * caml_global_root_origin(value * r)
   return (void *) pc;
 }
 
+/* The key is about to be dereferenced, so a damaged one is worth more than a
+   fault inside the collector. */
+static void check_root(struct skipcell * e, value * r)
+{
+  if (Skipcell_ok(e)) return;
+  caml_fatal_error("global root at %p was registered by %p and now reads %p",
+                   (void *) Skipcell_key_of_check(e),
+                   caml_global_root_origin((value *) Skipcell_key_of_check(e)),
+                   (void *) r);
+}
+
 #else
 
 #define record_root_origin(r, pc) ((void) (pc))
 #define forget_root_origin(r) ((void) 0)
+#define check_root(e, r) ((void) 0)
 
 #endif /* DEBUG */
 
@@ -300,6 +312,7 @@ Caml_inline void caml_iterate_global_roots(scanning_action f,
         caml_skiplist_remove(rootlist, e->key);
       } else {
         value * r = (value *) (e->key);
+        check_root(e, r);
         f(fdata, *r, r);
       }
     })

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -34,6 +34,19 @@ static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 /* Greater than zero when the current thread is scanning the roots */
 static CAMLthread_local int iterating_roots = 0;
 
+#ifdef DEBUG
+/* The root being handed to the collector, or NULL. A root holding a value that
+   is no longer one takes the collector down with it, somewhere that names only
+   the collector; this says which root it was. Per thread, domains scanning at
+   the same time being the normal case. */
+CAMLexport CAMLthread_local value * caml_root_being_scanned = NULL;
+#define Begin_scanning(r) (caml_root_being_scanned = (r))
+#define End_scanning() (caml_root_being_scanned = NULL)
+#else
+#define Begin_scanning(r) ((void) 0)
+#define End_scanning() ((void) 0)
+#endif
+
 enum { ROOT_PRESENT = 0, ROOT_DELETED = 1 };
 
 /* The three global root lists.
@@ -313,7 +326,9 @@ Caml_inline void caml_iterate_global_roots(scanning_action f,
       } else {
         value * r = (value *) (e->key);
         check_root(e, r);
+        Begin_scanning(r);
         f(fdata, *r, r);
+        End_scanning();
       }
     })
 }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -59,6 +59,58 @@ struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
      then neither [caml_global_roots_young] nor [caml_global_roots_old] contain
      it. */
 
+#if defined(DEBUG) && (defined(__GNUC__) || defined(__clang__))
+#define Caller_pc __builtin_return_address(0)
+#else
+#define Caller_pc NULL
+#endif
+
+#ifdef DEBUG
+
+/* Where each root was registered from, so a root found broken can name the
+   code that owns it. */
+static struct skiplist roots_origin = SKIPLIST_STATIC_INITIALIZER;
+
+/* A root registered or removed from inside a scan finds roots_mutex already
+   held; see caml_delete_global_root. */
+Caml_inline void lock_roots(void)
+{
+  if (iterating_roots == 0) caml_plat_lock_blocking(&roots_mutex);
+}
+
+Caml_inline void unlock_roots(void)
+{
+  if (iterating_roots == 0) caml_plat_unlock(&roots_mutex);
+}
+
+static void record_root_origin(value * r, void * pc)
+{
+  lock_roots();
+  caml_skiplist_insert(&roots_origin, (uintnat) r, (uintnat) pc);
+  unlock_roots();
+}
+
+static void forget_root_origin(value * r)
+{
+  lock_roots();
+  caml_skiplist_remove(&roots_origin, (uintnat) r);
+  unlock_roots();
+}
+
+void * caml_global_root_origin(value * r)
+{
+  uintnat pc;
+  if (! caml_skiplist_find(&roots_origin, (uintnat) r, &pc)) return NULL;
+  return (void *) pc;
+}
+
+#else
+
+#define record_root_origin(r, pc) ((void) (pc))
+#define forget_root_origin(r) ((void) 0)
+
+#endif /* DEBUG */
+
 /* Insertion and deletion */
 
 Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
@@ -88,6 +140,7 @@ Caml_inline void caml_delete_global_root(struct skiplist * list, value * r)
 CAMLexport void caml_register_global_root(value *r)
 {
   CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
+  record_root_origin(r, Caller_pc);
   caml_insert_global_root(&caml_global_roots, r);
 }
 
@@ -95,6 +148,7 @@ CAMLexport void caml_register_global_root(value *r)
 
 CAMLexport void caml_remove_global_root(value *r)
 {
+  forget_root_origin(r);
   caml_delete_global_root(&caml_global_roots, r);
 }
 
@@ -117,6 +171,7 @@ CAMLexport void caml_register_generational_global_root(value *r)
 {
   Caml_check_caml_state();
   CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
+  record_root_origin(r, Caller_pc);
 
   switch(classify_gc_root(*r)) {
     case YOUNG:
@@ -133,6 +188,7 @@ CAMLexport void caml_register_generational_global_root(value *r)
 
 CAMLexport void caml_remove_generational_global_root(value *r)
 {
+  forget_root_origin(r);
   switch(classify_gc_root(*r)) {
     case OLD:
       caml_delete_global_root(&caml_global_roots_old, r);

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -318,6 +318,20 @@ Caml_inline void caml_iterate_global_roots(scanning_action f,
     })
 }
 
+/* Walk every root without collecting, so that a caller can find which of its
+   own steps damages one. */
+CAMLprim value caml_check_global_roots(value unit)
+{
+#ifdef DEBUG
+  caml_plat_lock_blocking(&roots_mutex);
+  caml_skiplist_check(&caml_global_roots, "caml_global_roots");
+  caml_skiplist_check(&caml_global_roots_young, "caml_global_roots_young");
+  caml_skiplist_check(&caml_global_roots_old, "caml_global_roots_old");
+  caml_plat_unlock(&roots_mutex);
+#endif
+  return Val_unit;
+}
+
 /* Scan all global roots */
 void caml_scan_global_roots(scanning_action f, void* fdata) {
   caml_plat_lock_blocking(&roots_mutex);

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -28,6 +28,28 @@
 /* Size of struct skipcell, in bytes, without the forward array */
 #define SIZEOF_SKIPCELL sizeof(struct skipcell)
 
+#ifdef DEBUG
+
+/* So that whatever reads a cell back -- a debugger on a core, say -- can have
+   the stamp from the image rather than a copy of it. */
+CAMLexport const uintnat caml_skipcell_stamp = SKIPCELL_STAMP;
+
+#define Set_check(f) ((f)->check = Check_of((f)->key))
+
+void caml_skiplist_check(struct skiplist * sk, const char * what)
+{
+  FOREACH_SKIPLIST_ELEMENT(e, sk, {
+      if (! Skipcell_ok(e))
+        caml_fatal_error("%s: skiplist cell at %p has key %" CAML_PRIxNAT
+                         ", inserted with %" CAML_PRIxNAT,
+                         what, (void *) e, e->key, Skipcell_key_of_check(e));
+    })
+}
+
+#else
+#define Set_check(f) ((void) 0)
+#endif /* DEBUG */
+
 /* Generate a random level for a new node: 0 with probability 3/4,
    1 with probability 3/16, 2 with probability 3/64, etc.
    We use a simple linear congruential PRNG (see Knuth vol 2) instead
@@ -153,6 +175,7 @@ int caml_skiplist_insert(struct skiplist * sk,
     caml_fatal_error("caml_skiplist_insert: out of memory");
   f->key = key;
   f->data = data;
+  Set_check(f);
   for (int i = 0; i <= new_level; i++) {
     f->forward[i] = *update[i];
     *update[i] = f;

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -61,6 +61,7 @@ external major_slice : int -> int = "caml_gc_major_slice"
 external major : unit -> unit = "caml_gc_major"
 external full_major : unit -> unit = "caml_gc_full_major"
 external compact : unit -> unit = "caml_gc_compaction"
+external check_roots : unit -> unit = "caml_check_global_roots"
 external get_minor_free : unit -> int = "caml_get_minor_free"
 
 let eventlog_pause () = ()

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -326,6 +326,17 @@ external compact : unit -> unit = "caml_gc_compaction"
 (** Perform a full major collection and compact the heap.  Note that heap
    compaction is a lengthy operation. *)
 
+external check_roots : unit -> unit = "caml_check_global_roots"
+(** Check the C global roots for damage, and fail naming the root and the code
+    that registered it. What it reads is kept only by a runtime built for
+    debugging; anywhere else it returns without looking.
+
+    A root broken by a stray write is found by the collector walking it, which
+    can be long afterwards; calling this between steps narrows down which one
+    did it.
+
+    @since 5.5 *)
+
 val print_stat : out_channel -> unit
 (** Print the current values of the memory management counters (in
    human-readable form) of the total program into the channel argument. *)

--- a/tools/gdb.py
+++ b/tools/gdb.py
@@ -154,6 +154,11 @@ class GDBTarget:
             if len > 0:
                 return text[:len]
 
+    def source_location(self, address):
+        sal = gdb.find_pc_line(address)
+        if sal.symtab is not None and sal.line != 0:
+            return f'{sal.symtab.filename}:{sal.line}'
+
     def mapping(self, addr):
         # Annoyingly the progspace.solib_name() and
         # objfile_for_address() functions either aren't reliably
@@ -263,6 +268,17 @@ class OCamlFind(gdb.Command):
         ocaml.Finder(target).find(arg, val)
 
 OCamlFind()
+
+class OCamlRoots(gdb.Command):
+    "ocaml roots: report any damaged C global root, and what registered it."
+    def __init__(self):
+        super(OCamlRoots, self).__init__("ocaml roots", gdb.COMMAND_USER)
+
+    def invoke(self, arg, from_tty):
+        self.dont_repeat()
+        ocaml.Roots(GDBTarget()).check()
+
+OCamlRoots()
 
 # A convenience function $Array which casts a value to an array of values.
 

--- a/tools/lldb.py
+++ b/tools/lldb.py
@@ -27,6 +27,10 @@ def __lldb_init_module(d, _internal_dict):
                     f'{__name__}.OCamlFind '
                     'ocaml find'
                     )
+    d.HandleCommand('command script add --class '
+                    f'{__name__}.OCamlRoots '
+                    'ocaml roots'
+                    )
     print("OCaml support module loaded. Values of type 'value' will now\n"
           "print as OCaml values, and an 'ocaml' command is available for\n"
           "heap exploration (see 'help ocaml' for more information).")
@@ -51,6 +55,19 @@ class OCamlFind:
         return "Describe the location of the given OCaml value in the heap."
     def get_long_help(self):
         return "Describe the location of the given OCaml value in the heap."
+
+
+class OCamlRoots:
+    def __init__(self, debugger, internal_dict):
+        super()
+
+    def __call__(self, debugger, command, exe_ctx, result):
+        ocaml.Roots(get_target()).check()
+
+    def get_short_help(self):
+        return "Report any damaged C global root, and what registered it."
+    def get_long_help(self):
+        return self.get_short_help()
 
 
 # These three classes (LLDBType, LLDBValue, LLDBTarget) provide a
@@ -186,6 +203,11 @@ class LLDBTarget:
         addr = lldb.SBAddress(address, self._target)
         if addr.IsValid() and addr.symbol and addr.symbol.name:
             return addr.symbol.name
+
+    def source_location(self, address):
+        entry = lldb.SBAddress(address, self._target).line_entry
+        if entry.IsValid() and entry.file:
+            return f'{entry.file.basename}:{entry.line}'
 
     def mapping(self, addr):
         address = self._address(addr)

--- a/tools/ocaml.py
+++ b/tools/ocaml.py
@@ -33,6 +33,9 @@
 #
 #     symbol(address): the symbol name associated with the given address.
 #
+#     source_location(address): "file:line" for the given code address,
+#         or None when the image carries no line information for it.
+#
 #     mapping(address): a string describing any file mapping
 #         associated with the address, or None. Blocks on the Caml
 #         heap do not have an associated file mapping.
@@ -651,3 +654,141 @@ class Finder:
                 print(f"  {where}")
         else:
             print(f"{expr} {str(val)} not found on heap")
+
+
+# The C global roots.
+#
+# Each list is a skiplist keyed by the address of the root. A runtime built
+# for debugging stamps every cell with the key it was inserted under and
+# records what registered each root, which is what lets a damaged cell be
+# named here rather than faulting the collector later.
+
+GLOBAL_ROOT_LISTS = ('caml_global_roots',
+                     'caml_global_roots_young',
+                     'caml_global_roots_old')
+
+# A damaged forward pointer must not turn the walk into a loop.
+MAX_ROOT_CELLS = 1 << 20
+
+DEBUG_RUNTIME_NEEDED = ("this needs a runtime built for debugging, reached "
+                        "through -runtime-variant d")
+
+
+def _read(thunk, default=None):
+    """Reading a damaged structure raises in some debuggers and returns
+    nonsense in others; neither should end the walk."""
+    try:
+        return thunk()
+    except Exception:
+        return default
+
+
+class Roots:
+    """Check each C global root against the key it was inserted with, and
+    name the code that registered a damaged one."""
+
+    def __init__(self, target):
+        self._target = target
+        self._origins = None
+
+    def stamp(self):
+        """The runtime exports what it stamps cells with, so it is read from
+        the image rather than kept as a second copy here."""
+        v = _read(lambda: self._target.global_variable('caml_skipcell_stamp'))
+        return None if v is None else _read(lambda: v.unsigned())
+
+    def cells(self, name):
+        "Walk one skiplist, yielding (address, fields) per cell."
+        sk = _read(lambda: self._target.global_variable(name))
+        if sk is None:
+            return
+        node = _read(lambda: sk.struct()['forward'].sub(0))
+        for _ in range(MAX_ROOT_CELLS):
+            address = _read(lambda: node.unsigned(), 0) if node else 0
+            if not address:
+                return
+            fields = _read(lambda: node.dereference().struct())
+            if fields is None:
+                print(f"  {name}: truncated, the cell at {address:#x} "
+                      f"is unreadable")
+                return
+            yield address, fields
+            node = _read(lambda: fields['forward'].sub(0))
+
+    def origins(self):
+        "The recorded registrant of each root, keyed by the root's address."
+        if self._origins is None:
+            self._origins = {}
+            for _, fields in self.cells('roots_origin'):
+                key = _read(lambda: fields['key'].unsigned())
+                pc = _read(lambda: fields['data'].unsigned())
+                if key is not None and pc is not None:
+                    self._origins[key] = pc
+        return self._origins
+
+    def registrant(self, root):
+        """Name the call site. The recorded pc is a return address, so the
+        lookup is one byte back, inside the call rather than after it."""
+        pc = self.origins().get(root)
+        if not pc:
+            return "no origin recorded"
+        site = pc - 1
+        who = _read(lambda: self._target.symbol(site)) or "unknown"
+        where = _read(lambda: self._target.source_location(site))
+        if where:
+            return f"{who} at {where} ({pc:#x})"
+        return f"{who} ({pc:#x}), no line info"
+
+    def named(self, address):
+        """A root that lives in a static has a name; one inside a malloc'd
+        table does not."""
+        who = _read(lambda: self._target.symbol(address))
+        return f" ({who})" if who else ""
+
+    def scanning(self):
+        """A root holding something that is no longer a value takes the
+        collector down when it is followed, leaving every cell intact. The
+        variable is per thread, so a core reports the thread that died."""
+        v = _read(lambda:
+                  self._target.global_variable('caml_root_being_scanned'))
+        address = _read(lambda: v.unsigned(), 0) if v is not None else 0
+        if not address:
+            return
+        held = _read(lambda: v.dereference().unsigned())
+        print(f"the collector was following the root at {address:#x}"
+              f"{self.named(address)}")
+        print(f"  it holds             "
+              f"{'unreadable' if held is None else format(held, '#x')}")
+        print(f"  registered by        {self.registrant(address)}")
+        print()
+
+    def check(self):
+        "Report every damaged root, then the root under the scan."
+        stamp = self.stamp()
+        if stamp is None:
+            print(f"no caml_skipcell_stamp: {DEBUG_RUNTIME_NEEDED}")
+            return
+        damaged = 0
+        total = 0
+        for name in GLOBAL_ROOT_LISTS:
+            for address, fields in self.cells(name):
+                if 'check' not in fields:
+                    print(f"cells carry no stamp: {DEBUG_RUNTIME_NEEDED}")
+                    return
+                key = _read(lambda: fields['key'].unsigned())
+                check = _read(lambda: fields['check'].unsigned())
+                if key is None or check is None:
+                    print(f"{name}: unreadable cell at {address:#x}")
+                    damaged += 1
+                    continue
+                total += 1
+                if check == key ^ stamp:
+                    continue
+                damaged += 1
+                was = check ^ stamp
+                print(f"{name}: cell filed under {key:#x}")
+                print(f"  inserted under      {was:#x}{self.named(was)}")
+                print(f"  registered by       {self.registrant(was)}")
+                print()
+        self.scanning()
+        print(f"{total} roots checked, {damaged} damaged")


### PR DESCRIPTION
Debugging GC roots corruption has always been a pain in the arse and I was recently faced with yet another of those.

(full disclosure: these changes were prepared with an automated tool and carefully reviewed before submission).

## The mechanism

This PR introduces several mechanisms to help tracking corrupted GC roots.

First one is used to detected corrupted global roots pointer. The idea is to store a `XOR`'d version of the pointer and compare it with the stored value to catch a memory corruption

It is `XOR`'d so that large memset don't make the check pass by trivially setting both sides to `0`. The change is also reversible.

Second, the location of where a global roots is registered is also tracked using `__builtin_return_address(0)`.

Third, while walking the roots and calling `caml_darken`, the root value currently being scanned is kept in a per-thread value. This makes it possible to report where a root value holding an corrupted value was registered.

## Usage

Demo repo: https://github.com/toots/ocaml-global-root-debugging

---
**Update:** the auditing script was moved into the compiler itself, as an `ocaml roots` command in `tools/`. Nothing to download any more, just load the plugin and run it, on a live process or on a core:

```
$ gdb -q -batch -ex "source tools/gdb.py" -ex "ocaml roots" --core=core ./crash.exe
    caml_global_roots: cell filed under 0x10000005528a0
      inserted under      0x5528a0 (metadata_charset)
      registered by       metadata_open + 39 at stubs.c:76 (0x49966c)

    7 roots checked, 1 damaged
```

The same command covers the case where every cell is intact and the collector went down following a root that no longer holds a value. It reports the root that was under the scan, so a core that only names the collector still says who registered it. Without a debug runtime the command says so and stops, rather than reporting nothing found.

```
$ gdb -q -batch -ex "source tools/gdb.py" -ex "ocaml roots" --core=core ./stale.exe
    the collector was following the root at 0x5528a0 (metadata_charset)
      it holds             0x10
      registered by        metadata_open + 39 at stubs.c:76 (0x49966c)

    7 roots checked, 0 damaged
```

If the runtime has no stamp the command says so and stops, rather than reporting nothing found.

---


These mechanisms make it possible to walk the list of global roots, detect corrupted ones and print their location.

A `Gc.check_roots` function is added that allows to do that at runtime and aborts the program when a corrupted root is found. This makes it possible to do a "bisection" type of debugging where the exact moment of corruption can be precisely pinpointed.

In case of a corrupted root, the program itself prints the faulty global root:

```
   $ ./crash.exe
       a root has been damaged; collecting
       Fatal error: global root at 0x552890 was registered by 0x49962c and now reads 0x1000000552890
```

Even better, with the core dump and `gdb` (or I imagine `lldb`), it possible to re-walk the root values and print the exact code location:

```
   $ coredumpctl dump -o core
   $ gdb -q -batch -x audit_roots.py --core=core ./crash.exe
       caml_global_roots: cell filed under 0x1000000552890
         inserted under      0x552890 (metadata_charset)
         registered by       metadata_open at stubs.c:76 (0x49962c)
       
       7 roots checked, 1 damaged
```

Lastly, with a corrupted global root value, we can retrieved the location of the global roots holding it via `gdb`:

```
   $ ./stale.exe
       the root holds rubbish; collecting
       [no message: killed by SIGSEGV, the fault being inside the collector]
 
   $ gdb -q -batch -x audit_roots.py --core=core ./stale.exe
       the collector was following the root at 0x5528a0 (metadata_charset)
         it holds             0x10
         registered by        metadata_open at stubs.c:76 (0x49966c)
       
       7 roots checked, 0 damaged
   ok

```

(see the repo above for reproduction details).

## Always on?

The PR sets the new debugging features only when `DEBUG` is set. However, it seems arguable that this could be on by default. This would in particular allow for a much better debugging capabilities with actual production program which is great because these errors typically happen at random and can be hard to reproduce in a debugging environment.

Some automatic measurements below:

Measured on aarch64, glibc 2.41, OCaml 5.5.0/trunk.

### Memory: the stamp

`struct skipcell` gains one `uintnat`. What that costs depends on where the
allocator rounds, so it was measured rather than counted:

| skiplist level | plain, usable | stamped, usable | delta |
|---|---|---|---|
| 0 | 24 B | 40 B | **+16 B** |
| 1 | 40 B | 40 B | **0 B** |
| 2 | 40 B | 56 B | **+16 B** |

The extra word frequently falls inside rounding the allocator was doing
anyway; at level 1 it is free. Skiplist levels are geometric with p=1/4, so
about three quarters of cells are level 0: call it **~12 B per root** on
average.

### Memory: the provenance table

A second skiplist, one cell per root, so about **48 B per root** with rounding.
This is the larger half, and unlike the stamp it is not partly absorbed.

### Memory: the breadcrumb

One `value *` in thread-local storage: **8 B per OS thread**, and nothing per
root. It does not appear in the table below and does not scale with anything
the program does.

### Memory: at realistic root counts

Global roots scale with the number of C-side objects alive at once that hold an
OCaml value -- a decoder instance, a server handle, a ctypes closure -- not with
throughput or data volume.

| program | roots | stamp | provenance | total |
|---|---|---|---|---|
| liquidsoap, live, C-heavy | **261** (measured) | ~3 KB | ~13 KB | **~16 KB** |
| something extreme | 10,000 | ~120 KB | ~480 KB | ~600 KB |

261 is a real count, taken by attaching to a running liquidsoap with many
bindings loaded. A program holding 100k live global roots is likelier to have a
leak than a workload.

### Time: how it was measured

Three **release** runtimes built from one tree, the checks un-gated rather than
reached through `-runtime-variant d`, so the comparison is what always-on would
actually ship and not the debug runtime's other assertions:

| runtime | contents |
|---|---|
| stock | 5.5.0 as released |
| +stamp+prov | the cell stamp and the provenance table |
| +breadcrumb | and the thread-local root being scanned |

The same stock `ocamlopt` compiles the benchmark each time; only the runtime
archive is swapped at link. Symbol presence is checked per binary, so a link
that silently kept the stock archive fails loudly instead of reporting no
difference. 15 reps round-robin across the three binaries, pinned to one core,
minimum reported.

The benchmark registers N roots and runs major collections. Roots holding
immediates are the worst case, where `caml_darken` returns at once and the
check has nothing to hide behind; roots holding a heap block each are the
realistic one.

### Time: registering a root

**~130 ns per root**, near enough to double, and flat in N:

| roots | stock | +stamp+prov | per root |
|---|---|---|---|
| 300 | 0.041 ms | 0.077 ms | +120 ns |
| 1,000 | 0.150 ms | 0.270 ms | +120 ns |
| 10,000 | 1.630 ms | 2.886 ms | +126 ns |
| 100,000 | 23.4 ms | 38.0 ms | +146 ns |

This is the provenance skiplist insert. It is paid once per root, so it matters
only where registration itself sits in a loop.

### Time: scanning a root

Per root per scan, roots holding a heap block each:

| roots | stock | +stamp+prov | +breadcrumb | vs stock |
|---|---|---|---|---|
| 300 | 225.0 ns | 234.8 ns | 234.3 ns | +4.1% |
| 1,000 | 120.7 ns | 130.0 ns | 130.5 ns | +8.2% |
| 10,000 | 81.0 ns | 90.0 ns | 90.8 ns | +12.1% |
| 100,000 | 78.2 ns | 93.1 ns | 93.9 ns | +20.2% |

The added cost is **~9-15 ns per root per scan** and roughly constant; the
percentage climbs only because the stock per-root cost falls as the walk warms
up. With roots holding immediates the same absolute figure lands against a
much smaller base, reaching +70% at 100k -- a bound, not a workload.

Those percentages are of the global-root scan, which the benchmark's small heap
inflates relative to a real program. **The transferable number is the ns.** At
liquidsoap's measured 261 roots it is about **2.6 us per major collection**.

### Time: the breadcrumb alone

**+0.5 to +0.9 ns per root**, about **1%** of what the stamp and provenance
table cost together, and below the noise floor at 300 roots, where it measured
negative twice. Two thread-local stores per root were the one thing here that
could have been slow -- a TLS access resolved through `__tls_get_addr` is a
call, not a register offset -- and on this platform they are not.

`Gc.check_roots` costs nothing unless called.



