### PR TITLE
Fix handling of backup thread on Win32

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,12 @@ OCaml 5.5.1
   (Xavier Leroy, report by Akshay Singh, review by Nicolás Ojeda Bär
   and Antonin Décimo)
 
+- #15029: Fix a regression on Windows where an OCaml thread that never
+  yielded voluntarily would keep the runtime lock forever, so that the other
+  threads of its domain never ran. Preemptive switching between systhreads had
+  no effect; only explicit calls to `Thread.yield` or blocking sections would
+  let other threads run.
+  (Nicolás Ojeda Bär, report by Daniel Larraz, review by Antonin Décimo)
 
 OCaml 5.5.0 (19 June 2026)
 -------------------------

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -203,6 +203,7 @@ struct dom_internal {
 typedef struct dom_internal dom_internal;
 
 static CAMLthread_local dom_internal* domain_self;
+static CAMLthread_local bool is_backup_thread;
 
 static struct {
   /* enter barrier for STW sections, participating domains arrive into
@@ -1168,6 +1169,7 @@ backup_thread_func(void* v)
 
   domain_self = di;
   caml_state = di->state;
+  is_backup_thread = true;
 
   msg = atomic_load_acquire (&di->backup_thread_msg);
   while (msg != BT_TERMINATE) {
@@ -2177,8 +2179,7 @@ CAMLexport int caml_bt_is_in_blocking_section(void)
 
 CAMLexport int caml_bt_is_self(void)
 {
-  return caml_plat_thread_equal(domain_self->backup_thread,
-                                caml_plat_thread_self());
+  return is_backup_thread;
 }
 
 CAMLexport intnat caml_domain_is_multicore (void)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -190,7 +190,6 @@ struct dom_internal {
   struct interruptor interruptor;
 
   /* backup thread */
-  caml_plat_thread backup_thread;
   atomic_uintnat backup_thread_msg;
   caml_plat_mutex domain_lock;
   caml_plat_cond domain_cond;
@@ -1224,6 +1223,7 @@ backup_thread_func(void* v)
 static value install_backup_thread_exn (dom_internal* di)
 {
   int err;
+  caml_plat_thread backup_thread;
 #ifndef _WIN32
   sigset_t mask, old_mask;
 #endif
@@ -1246,7 +1246,7 @@ static value install_backup_thread_exn (dom_internal* di)
 #endif
 
   atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
-  err = caml_plat_thread_create(&di->backup_thread, 0, backup_thread_func,
+  err = caml_plat_thread_create(&backup_thread, 0, backup_thread_func,
                                 (void*)di);
 
 #ifndef _WIN32
@@ -1255,7 +1255,7 @@ static value install_backup_thread_exn (dom_internal* di)
 
   if (err != 0)
       return caml_check_error_exn(err, "failed to create domain backup thread");
-  caml_plat_thread_detach(di->backup_thread);
+  caml_plat_thread_detach(backup_thread);
   return Val_unit;
 }
 

--- a/testsuite/tests/lib-systhreads/testpreempt.ml
+++ b/testsuite/tests/lib-systhreads/testpreempt.ml
@@ -1,12 +1,6 @@
 (* TEST
  include systhreads;
  hassysthreads;
-   (*
-     On Windows, we use Sleep(0) for triggering preemption of threads.
-     However, this does not seem very reliable, so that this test fails
-     on some Windows configurations. See GPR #1533.
-   *)
- not-target-windows;
  {
    bytecode;
  }{


### PR DESCRIPTION
The first commit contains a minimal fix for #15028: the field `.backup_thread` which is supposed to maintain a reference to the backup thread handle is in fact invalid under Windows because the backup thread is detached after creation using `CloseHandle`. When this invalid handle is passed to `caml_plat_thread_equal`, it returns `-1` which was being interpreted as a truthy value.

The second commit is a refactoring, getting rid of the `.backup_thread` field altogether to avoid storing an invalid handle in the `dom_internal` structure.

The third commit re-enables a test on Windows which actually would have caught this issue if it had been enabled.

PR made against 5.5 since we will have to cherry-pick the fix.

cc @daniel-larraz: can you confirm the fix?

Fixes #15028 