### PR TITLE
Optimize weak.blit

### DIFF
--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -97,7 +97,7 @@ CAMLprim value caml_weak_create (value len)
 
    The dead keys must be removed from the ephemerons and data removed
    when one of the keys is dead. Here we call it cleaning the ephemerons.
-   A specific phase of the GC is dedicated to this, Phase_clean. This
+   A specific phase of the GC is dedicated to this, [Phase_sweep_ephe]. This
    phase is just after the mark phase, so the white values are dead
    values. It iterates the function caml_ephe_clean through all the
    ephemerons.
@@ -116,9 +116,9 @@ CAMLprim value caml_weak_create (value len)
      trigger the cleaning of the ephemerons when the accessed key is
      dead. This test is fast.
 
-     In the case of value getter and value setter, there is no fast
+     In the case of data getter and data setter, there is no fast
      test because the removing of the data depend of the deadliness of the keys.
-     We must always try to clean the ephemerons.
+     We must always try to clean the whole ephemerons.
 
  */
 

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -478,23 +478,22 @@ static value ephe_blit_keys (value es, mlsize_t offset_s,
                              value ed, mlsize_t offset_d, mlsize_t length)
 {
   CAMLparam2(es,ed);
+  /* We only need to clean the destination when it has data,
+     as the keys themselves are going to be replaced. */
+  bool ed_has_data = caml_ephe_check_data(ed);
 
   if (length == 0) CAMLreturn(Val_unit);
 
-  /* We clean the source and destination ephemerons before performing the blit.
-   * This guarantees that none of the keys and the data fields being accessed
-   * during a blit operation is unmarked during [Phase_sweep]. */
-  caml_ephe_clean(es);
-  caml_ephe_clean(ed);
-
   if (offset_d < offset_s) {
     for (long i = 0; i < length; i++) {
-      caml_ephe_await_key(ed, offset_d + i);
+      do_check_key_clean(es, offset_s + i);
+      if (ed_has_data) do_check_key_clean(ed, offset_d + i);
       ephe_modify(ed, offset_d + i, Ephe_key(es, offset_s + i));
     }
   } else {
     for (long i = length - 1; i >= 0; i--) {
-      caml_ephe_await_key(ed, offset_d + i);
+      do_check_key_clean(es, offset_s + i);
+      if (ed_has_data) do_check_key_clean(ed, offset_d + i);
       ephe_modify(ed, offset_d + i, Ephe_key(es, offset_s + i));
     }
   }


### PR DESCRIPTION
If an ephemeron has K keys and we ask to blit a sub-range of keys of
length B, the previous implementation was in O(K) while the new one is
on O(B). This makes a dramatic difference in performance when B is
small -- for example if it is used to move a single key from one
ephemeron to another.

This change is inspired by an older change to the same effect in 4.x,
  https://github.com/ocaml/ocaml/pull/9259
  https://github.com/ocaml/ocaml/commit/b80793118095f5c8dadee43e76c162e6f7d36727

The implementation here is new, and simpler; instead of extending the
function to clean a whole ephemeron (data field included), it reuses
the function to clean a single key.

I use the following synthetic test to exercise a worst case of the
current implementation (repeat `blit` calls of length 1 until some
eventually happen during a `Phase_sweep_ephe`), adapted from the
synthetic test proposed in https://github.com/ocaml/ocaml/pull/9259:

```ocaml
let blit_elementwise arr1 arr2 =
  let rec loop i =
    if i < 0
    then ()
    else (
      Weak.blit arr1 i arr2 i 1;
      loop (i - 1))
  in
  loop (Weak.length arr1 - 1)

let len = 5000
let arr1 = Weak.create len
let arr2 = Weak.create len
let keys = Array.init len (fun i -> ref i)
let () =
  for i = 0 to len - 1 do
    Weak.set arr1 i (Some keys.(i))
  done

let f () =
  blit_elementwise arr1 arr2

let rec loop i =
  if i = 0
  then ()
  else (
    f ();
    loop (i - 1))

(* We iterate a call to [loop] a bunch of times, with many allocations
   in-between each call, to nudge the GC into advancing to different
   phases and eventually call [loop] in phase [Phase_sweep_ephe]. *)
let iters = 50
let allocs = 20_000

let () =
  let old = ref [] in
  let worst = ref 0. in
  for _ = 1 to 50 do
    old := Sys.opaque_identity (List.init allocs Fun.id);
    Gc.major_slice allocs;
    let before = Sys.time () in
    loop 10;
    let after = Sys.time () in
    worst := max !worst (after -. before);
    Printf.printf ".%!";
  done;
  print_newline ();
  Printf.printf "Worst iteration time: %.2gs\n%!" !worst
```

Worst iteration times:
- on 4.14: 0.0023s
- on 5.5: 2.2s
- after this PR: 0.0021s