### PR TITLE
#14898: lambda/Translcore, do not trust GADT equations introduced by a partial match

### DIFF
--- a/Changes
+++ b/Changes
@@ -248,6 +248,10 @@ Working version
   barrier; the default is chosen at configure time and can be overridden.
   (Sebastian Pop and Xavier Leroy, review by Xavier Leroy and Olivier Nicole)
 
+- #14898, #15035: do not trust GADT equations introduced by refutable arguments
+  in the Lambda IR.
+  (Florian Angeletti, report by Nathanaëlle Courant, review by Gabriel Scherer)
+
 ### Standard library:
 
 - #14974 : Add `Sys.filepath_exists` and improve documentation

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -831,13 +831,16 @@ and transl_curried_function ~scopes ~env loc return repr params body =
         in
         Some (param, kind), body
   in
+  (* We freeze local GADTs equations to the set existing before the
+     first partial match that introduces new equations to avoid using equations
+     that are only valid if a match succeeds. *)
   let _, params = List.fold_left_map (fun (local_equations, prev_env) fp ->
-      let local_equations = match local_equations, fp.fp_partial with
-        | Some _ , _ | _, Total -> local_equations
-        | None, Partial -> Some (Env.freeze_local_equations prev_env)
-      in
       let env = match fp.fp_kind with
         | Tparam_pat pat | Tparam_optional_default (pat,_) -> pat.pat_env
+      in
+      let local_equations = match local_equations, fp.fp_partial with
+        | Some _ , _ | _, Total -> local_equations
+        | None, Partial -> Env.freeze_if_new_local_equations ~prev:prev_env env
       in
       (local_equations,env), (fp, local_equations)
     ) (None, env) params in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -838,9 +838,15 @@ and transl_curried_function ~scopes ~env loc return repr params body =
       let env = match fp.fp_kind with
         | Tparam_pat pat | Tparam_optional_default (pat,_) -> pat.pat_env
       in
-      let local_equations = match local_equations, fp.fp_partial with
-        | Some _ , _ | _, Total -> local_equations
-        | None, Partial -> Env.freeze_if_new_local_equations ~prev:prev_env env
+      let local_equations =
+        match local_equations, fp.fp_partial, fp.fp_kind with
+        | Some _, _, _ -> local_equations
+        | None, Total, Tparam_pat _ -> local_equations
+        | None, Partial, _
+        (* in default arguments [?(pat=exp)], [exp] can raise and
+           thus even a [Total] pattern can fail. *)
+        | None, _, Tparam_optional_default _ ->
+                Env.freeze_if_new_local_equations ~prev:prev_env env
       in
       (local_equations,env), (fp, local_equations)
     ) (None, env) params in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -735,7 +735,7 @@ and transl_apply ~scopes
    the function as taking each argument individually (in
    [trans_curried_function]).
 *)
-and transl_function_without_attributes ~scopes loc repr params body =
+and transl_function_without_attributes ~scopes ~env loc repr params body =
   let return =
     match body with
     | Tfunction_body body ->
@@ -746,9 +746,9 @@ and transl_function_without_attributes ~scopes loc repr params body =
         (* With Camlp4/ppx, a pattern matching might be empty *)
         Pgenval
   in
-  transl_tupled_function ~scopes loc return repr params body
+  transl_tupled_function ~scopes ~env loc return repr params body
 
-and transl_tupled_function ~scopes loc return repr params body =
+and transl_tupled_function ~scopes ~env loc return repr params body =
   (* Cases are eligible for flattening if they belong to the only param. *)
   let eligible_cases =
     match params, body with
@@ -772,6 +772,11 @@ and transl_tupled_function ~scopes loc return repr params body =
             (fun {c_lhs; c_guard; c_rhs} ->
               (Matching.flatten_pattern size c_lhs, c_guard, c_rhs))
             cases in
+        (* if the match is partial, we cannot rely on GADT equations *)
+        let local_equations = match partial with
+          | Partial -> Some (Env.freeze_local_equations env)
+          | Total -> None
+        in
         let kinds =
           (* All the patterns might not share the same types. We must take the
              union of the patterns types *)
@@ -779,13 +784,13 @@ and transl_tupled_function ~scopes loc return repr params body =
           | [] -> assert false
           | (pats, _, _) :: cases ->
               let first_case_kinds =
-                List.map (fun pat -> value_kind pat.pat_env pat.pat_type) pats
+                List.map (pattern_kind local_equations) pats
               in
               List.fold_left
                 (fun kinds (pats, _, _) ->
                   List.map2 (fun kind pat ->
                     value_kind_union kind
-                      (value_kind pat.pat_env pat.pat_type))
+                      (pattern_kind local_equations pat))
                     kinds pats)
                 first_case_kinds cases
         in
@@ -797,11 +802,11 @@ and transl_tupled_function ~scopes loc return repr params body =
          Matching.for_tupled_function ~scopes loc params
            (transl_tupled_cases ~scopes pats_expr_list) partial)
     with Matching.Cannot_flatten ->
-      transl_curried_function ~scopes loc return repr params body
+      transl_curried_function ~scopes ~env loc return repr params body
       end
-  | _ -> transl_curried_function ~scopes loc return repr params body
+  | _ -> transl_curried_function ~scopes ~env loc return repr params body
 
-and transl_curried_function ~scopes loc return repr params body =
+and transl_curried_function ~scopes ~env loc return repr params body =
   let cases_param, body =
     match body with
     | Tfunction_body body ->
@@ -826,13 +831,23 @@ and transl_curried_function ~scopes loc return repr params body =
         in
         Some (param, kind), body
   in
+  let _, params = List.fold_left_map (fun (local_equations, prev_env) fp ->
+      let local_equations = match local_equations, fp.fp_partial with
+        | Some _ , _ | _, Total -> local_equations
+        | None, Partial -> Some (Env.freeze_local_equations prev_env)
+      in
+      let env = match fp.fp_kind with
+        | Tparam_pat pat | Tparam_optional_default (pat,_) -> pat.pat_env
+      in
+      (local_equations,env), (fp, local_equations)
+    ) (None, env) params in
   let body, params =
-    List.fold_right (fun fp (body, params) ->
+    List.fold_right (fun (fp, local_equations) (body, params) ->
       let param = fp.fp_param in
       let param_loc = fp.fp_loc in
       match fp.fp_kind with
       | Tparam_pat pat ->
-          let kind = value_kind pat.pat_env pat.pat_type in
+          let kind = pattern_kind local_equations pat in
           let body =
             Matching.for_function ~scopes param_loc None (Lvar param)
               [ pat, body ]
@@ -883,7 +898,8 @@ and transl_function ~scopes e params body =
     event_function ~scopes e
       (function repr ->
          let params, body = fuse_method_arity params body in
-         transl_function_without_attributes ~scopes e.exp_loc repr params body)
+         let env = e.exp_env and loc = e.exp_loc in
+         transl_function_without_attributes ~env ~scopes loc repr params body)
   in
   let attr = function_attribute_disallowing_arity_fusion in
   let loc = of_location ~scopes e.exp_loc in
@@ -1277,7 +1293,7 @@ and transl_letop ~scopes loc env let_ ands param case partial =
         (function repr ->
            let loc = case.c_rhs.exp_loc in
            let ghost_loc = { loc with loc_ghost = true } in
-           transl_function_without_attributes ~scopes loc repr []
+           transl_function_without_attributes ~scopes ~env loc repr []
              (Tfunction_cases
                 { cases = [case]; param; partial; loc = ghost_loc;
                   exp_extra = None; attributes = []; }))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -832,12 +832,9 @@ and transl_curried_function ~scopes ~env loc return repr params body =
         Some (param, kind), body
   in
   (* We freeze local GADTs equations to the set existing before the
-     first partial match that introduces new equations to avoid using equations
-     that are only valid if a match succeeds. *)
+     first partial match to avoid using equations that might be only
+     valid if a match succeeds. *)
   let _, params = List.fold_left_map (fun (local_equations, prev_env) fp ->
-      let env = match fp.fp_kind with
-        | Tparam_pat pat | Tparam_optional_default (pat,_) -> pat.pat_env
-      in
       let local_equations =
         match local_equations, fp.fp_partial, fp.fp_kind with
         | Some _, _, _ -> local_equations
@@ -846,7 +843,10 @@ and transl_curried_function ~scopes ~env loc return repr params body =
         (* in default arguments [?(pat=exp)], [exp] can raise and
            thus even a [Total] pattern can fail. *)
         | None, _, Tparam_optional_default _ ->
-                Env.freeze_if_new_local_equations ~prev:prev_env env
+            Some (Env.freeze_local_equations prev_env)
+      in
+      let env = match fp.fp_kind with
+        | Tparam_pat pat | Tparam_optional_default (pat,_) -> pat.pat_env
       in
       (local_equations,env), (fp, local_equations)
     ) (None, env) params in

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -19,7 +19,7 @@ let curried : type a. a rep -> a -> float = fun Float a -> a +. 1.
 [%%expect {|
 (let
   (curried =
-     (function param[int] a[float] : float
+     (function param[int] a : float
        (if param (raise (makeblock 0 (global Match_failure!) [0: "" 1 48]))
          (+. a 1.))))
   (apply (field_mut 1 (global Toploop!)) "curried" curried))
@@ -39,7 +39,7 @@ let curried_first : type a b. unit list -> (a,float) Type.eq -> b rep -> a -> b 
 [%%expect {|
 (let
   (curried_first =
-     (function param param[int] param[int] a[float] b[float] : float
+     (function param param[int] param[int] a b : float
        (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 6]))
          (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 20]))
            (+. a b)))))

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -1,0 +1,49 @@
+(* TEST
+flags = "-dlambda -dno-locations -dno-unique-ids";
+expect;
+*)
+
+(* Test that we do not use local equation introduced by partial matching when computing
+   the value kinds of function parameters *)
+
+[@@@warning "-8"]
+
+type 'a rep = Float : float rep | Int : int rep
+[%%expect {|
+0
+0
+type 'a rep = Float : float rep | Int : int rep
+|}]
+
+let curried : type a. a rep -> a -> float = fun Float a -> a +. 1.
+[%%expect {|
+(let
+  (curried =
+     (function param[int] a[float] : float
+       (if param (raise (makeblock 0 (global Match_failure!) [0: "" 1 48]))
+         (+. a 1.))))
+  (apply (field_mut 1 (global Toploop!)) "curried" curried))
+val curried : 'a rep -> 'a -> float = <fun>
+|}]
+
+let curried_ok : type a. (a,float) Type.eq -> a -> float = fun Type.Equal a -> a +. 1.
+[%%expect {|
+(let (curried_ok = (function param[int] a[float] : float (+. a 1.)))
+  (apply (field_mut 1 (global Toploop!)) "curried_ok" curried_ok))
+val curried_ok : ('a, float) Type.eq -> 'a -> float = <fun>
+|}]
+
+
+let curried_first : type a b. unit list -> (a,float) Type.eq -> b rep -> a -> b -> float =
+  fun [] Type.Equal Float a b -> a +. b
+[%%expect {|
+(let
+  (curried_first =
+     (function param param[int] param[int] a[float] b[float] : float
+       (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 6]))
+         (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 20]))
+           (+. a b)))))
+  (apply (field_mut 1 (global Toploop!)) "curried_first" curried_first))
+val curried_first :
+  unit list -> ('a, float) Type.eq -> 'b rep -> 'a -> 'b -> float = <fun>
+|}]

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -39,7 +39,7 @@ let curried_first : type a b. unit list -> (a,float) Type.eq -> b rep -> a -> b 
 [%%expect {|
 (let
   (curried_first =
-     (function param param[int] param[int] a b : float
+     (function param param[int] param[int] a[float] b : float
        (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 6]))
          (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 20]))
            (+. a b)))))

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = "-dlambda -dno-locations -dno-unique-ids";
+flags = "-dlambda -dno-locations -dcanonical-ids";
 expect;
 *)
 
@@ -18,32 +18,33 @@ type 'a rep = Float : float rep | Int : int rep
 let curried : type a. a rep -> a -> float = fun Float a -> a +. 1.
 [%%expect {|
 (let
-  (curried =
-     (function param[int] a : float
-       (if param (raise (makeblock 0 (global Match_failure!) [0: "" 1 48]))
-         (+. a 1.))))
-  (apply (field_mut 1 (global Toploop!)) "curried" curried))
+  (curried/0 =
+     (function param/0[int] a/0 : float
+       (if param/0
+         (raise (makeblock 0 (global Match_failure/0!) [0: "" 1 48]))
+         (+. a/0 1.))))
+  (apply (field_mut 1 (global Toploop!)) "curried" curried/0))
 val curried : 'a rep -> 'a -> float = <fun>
 |}]
 
 let opt (type a) ?p:(Type.Equal:(a,float) Type.eq=assert false) (x:a) = 1. +. x
 [%%expect {|
 (let
-  (opt =
-     (function *opt* x : float
+  (opt/0 =
+     (function *opt*/0 x/0 : float
        (let
-         (*match* =
-            (if *opt* (field_imm 0 *opt*)
-              (raise (makeblock 0 (global Assert_failure!) [0: "" 1 50]))))
-         (+. 1. x))))
-  (apply (field_mut 1 (global Toploop!)) "opt" opt))
+         (*match*/0 =
+            (if *opt*/0 (field_imm 0 *opt*/0)
+              (raise (makeblock 0 (global Assert_failure/0!) [0: "" 1 50]))))
+         (+. 1. x/0))))
+  (apply (field_mut 1 (global Toploop!)) "opt" opt/0))
 val opt : ?p:('a, float) Type.eq -> 'a -> float = <fun>
 |}]
 
 let curried_ok : type a. (a,float) Type.eq -> a -> float = fun Type.Equal a -> a +. 1.
 [%%expect {|
-(let (curried_ok = (function param[int] a[float] : float (+. a 1.)))
-  (apply (field_mut 1 (global Toploop!)) "curried_ok" curried_ok))
+(let (curried_ok/0 = (function param/1[int] a/1[float] : float (+. a/1 1.)))
+  (apply (field_mut 1 (global Toploop!)) "curried_ok" curried_ok/0))
 val curried_ok : ('a, float) Type.eq -> 'a -> float = <fun>
 |}]
 
@@ -52,12 +53,14 @@ let curried_first : type a b. unit list -> (a,float) Type.eq -> b rep -> a -> b 
   fun [] Type.Equal Float a b -> a +. b
 [%%expect {|
 (let
-  (curried_first =
-     (function param param[int] param[int] a[float] b : float
-       (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 6]))
-         (if param (raise (makeblock 0 (global Match_failure!) [0: "" 2 20]))
-           (+. a b)))))
-  (apply (field_mut 1 (global Toploop!)) "curried_first" curried_first))
+  (curried_first/0 =
+     (function param/2 param/3[int] param/4[int] a/2[float] b/0 : float
+       (if param/2
+         (raise (makeblock 0 (global Match_failure/0!) [0: "" 2 6]))
+         (if param/4
+           (raise (makeblock 0 (global Match_failure/0!) [0: "" 2 20]))
+           (+. a/2 b/0)))))
+  (apply (field_mut 1 (global Toploop!)) "curried_first" curried_first/0))
 val curried_first :
   unit list -> ('a, float) Type.eq -> 'b rep -> 'a -> 'b -> float = <fun>
 |}]

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -26,6 +26,20 @@ let curried : type a. a rep -> a -> float = fun Float a -> a +. 1.
 val curried : 'a rep -> 'a -> float = <fun>
 |}]
 
+let opt (type a) ?p:(Type.Equal:(a,float) Type.eq=assert false) (x:a) = 1. +. x
+[%%expect {|
+(let
+  (opt =
+     (function *opt* x : float
+       (let
+         (*match* =
+            (if *opt* (field_imm 0 *opt*)
+              (raise (makeblock 0 (global Assert_failure!) [0: "" 1 50]))))
+         (+. 1. x))))
+  (apply (field_mut 1 (global Toploop!)) "opt" opt))
+val opt : ?p:('a, float) Type.eq -> 'a -> float = <fun>
+|}]
+
 let curried_ok : type a. (a,float) Type.eq -> a -> float = fun Type.Equal a -> a +. 1.
 [%%expect {|
 (let (curried_ok = (function param[int] a[float] : float (+. a 1.)))

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -15,6 +15,10 @@ type 'a rep = Float : float rep | Int : int rep
 type 'a rep = Float : float rep | Int : int rep
 |}]
 
+(** Expected kind [int -> any -> float]:
+    Since the match on [Float] can fail, one cannot use the equation [a = Float]
+    to infer the kind [float] for [a].
+*)
 let curried : type a. a rep -> a -> float = fun Float a -> a +. 1.
 [%%expect {|
 (let
@@ -27,6 +31,17 @@ let curried : type a. a rep -> a -> float = fun Float a -> a +. 1.
 val curried : 'a rep -> 'a -> float = <fun>
 |}]
 
+(** Expected kind [any -> any -> float]:
+    The [Type.Equal] pattern is total, however the default expression
+    can raise and thus the pattern match in
+    {[
+      match assert false with
+      | Type.Equal -> ...
+    ]}
+    fails to account for the exception case.
+    Thus once again, we cannot use the equation [a = Float] to infer the kind
+    [float] for [a].
+*)
 let opt (type a) ?p:(Type.Equal:(a,float) Type.eq=assert false) (x:a) = 1. +. x
 [%%expect {|
 (let
@@ -41,6 +56,10 @@ let opt (type a) ?p:(Type.Equal:(a,float) Type.eq=assert false) (x:a) = 1. +. x
 val opt : ?p:('a, float) Type.eq -> 'a -> float = <fun>
 |}]
 
+(** Expected kind: [int -> float -> float]
+    [Type.Equal] is an irrefutable pattern, we can safely use [a=float] to infer
+    [a:float].
+*)
 let curried_ok : type a. (a,float) Type.eq -> a -> float = fun Type.Equal a -> a +. 1.
 [%%expect {|
 (let (curried_ok/0 = (function param/1[int] a/1[float] : float (+. a/1 1.)))
@@ -49,6 +68,17 @@ val curried_ok : ('a, float) Type.eq -> 'a -> float = <fun>
 |}]
 
 
+(** Expected kind: [any -> int -> int -> any -> any -> float],
+    valid optimization [any -> int -> int -> float -> any -> float].
+    The empty list pattern [[]] is an refutable pattern, we are currently refusing
+    to use any GADTs equation after this pattern. However, the equation [a=float]
+    is introduced by an irrefutable pattern without any dependencies on a refutable
+    pattern. We could thus theoretically use this equation to refine the inferred
+    kind for the function to [any -> int -> int -> float -> any].
+    A good first approximation to implement this refinement would be to only freeze
+    the set of GADTs equation when we observe a refutable pattern argument which
+    adds a local equation.
+*)
 let curried_first : type a b. unit list -> (a,float) Type.eq -> b rep -> a -> b -> float =
   fun [] Type.Equal Float a b -> a +. b
 [%%expect {|

--- a/testsuite/tests/typeopt/partial_gadt.ml
+++ b/testsuite/tests/typeopt/partial_gadt.ml
@@ -54,7 +54,7 @@ let curried_first : type a b. unit list -> (a,float) Type.eq -> b rep -> a -> b 
 [%%expect {|
 (let
   (curried_first/0 =
-     (function param/2 param/3[int] param/4[int] a/2[float] b/0 : float
+     (function param/2 param/3[int] param/4[int] a/2 b/0 : float
        (if param/2
          (raise (makeblock 0 (global Match_failure/0!) [0: "" 2 6]))
          (if param/4

--- a/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
+++ b/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
@@ -7,7 +7,7 @@
            (if param
              (raise
                (makeblock 0 (global Match_failure!)
-                 [0: "partial_gadt_native.ml" 11 14]))
+                 [0: "partial_gadt_native.ml" 12 14]))
              (+. param 1.)))))
     (setfield_ptr(root-init) 0 (global Partial_gadt_native!) f))
   0)

--- a/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
+++ b/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
@@ -3,7 +3,7 @@
     (f =
        (function b[int] x[float] : float
          (catch (if b (exit 4 0 (+. x x)) (exit 4 1 (opaque 0)))
-          with (4 param[int] param[float])
+          with (4 param[int] param)
            (if param
              (raise
                (makeblock 0 (global Match_failure!)

--- a/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
+++ b/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
@@ -1,13 +1,13 @@
 (seq
   (let
-    (f =
-       (function b[int] x[float] : float
-         (catch (if b (exit 4 0 (+. x x)) (exit 4 1 (opaque 0)))
-          with (4 param[int] param)
-           (if param
+    (f/0 =
+       (function b/0[int] x/0[float] : float
+         (catch (if b/0 (exit 4 0 (+. x/0 x/0)) (exit 4 1 (opaque 0)))
+          with (4 param/0[int] param/1)
+           (if param/0
              (raise
-               (makeblock 0 (global Match_failure!)
+               (makeblock 0 (global Match_failure/0!)
                  [0: "partial_gadt_native.ml" 12 14]))
-             (+. param 1.)))))
-    (setfield_ptr(root-init) 0 (global Partial_gadt_native!) f))
+             (+. param/1 1.)))))
+    (setfield_ptr(root-init) 0 (global Partial_gadt_native!) f/0))
   0)

--- a/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
+++ b/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
@@ -1,0 +1,13 @@
+(seq
+  (let
+    (f =
+       (function b[int] x[float] : float
+         (catch (if b (exit 4 0 (+. x x)) (exit 4 1 (opaque 0)))
+          with (4 param[int] param[float])
+           (if param
+             (raise
+               (makeblock 0 (global Match_failure!)
+                 [0: "partial_gadt_native.ml" 11 14]))
+             (+. param 1.)))))
+    (setfield_ptr(root-init) 0 (global Partial_gadt_native!) f))
+  0)

--- a/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
+++ b/testsuite/tests/typeopt/partial_gadt_native.compilers.reference
@@ -7,7 +7,7 @@
            (if param/0
              (raise
                (makeblock 0 (global Match_failure/0!)
-                 [0: "partial_gadt_native.ml" 12 14]))
+                 [0: "partial_gadt_native.ml" 19 14]))
              (+. param/1 1.)))))
     (setfield_ptr(root-init) 0 (global Partial_gadt_native!) f/0))
   0)

--- a/testsuite/tests/typeopt/partial_gadt_native.ml
+++ b/testsuite/tests/typeopt/partial_gadt_native.ml
@@ -1,0 +1,12 @@
+(* TEST
+flags="-dlambda -dno-locations -dno-unique-ids";
+native;
+*)
+
+[@@@warning "-8"]
+
+type 'a rep = Float : float rep | Int : int rep
+
+let f b x =
+  let[@local] tuple : type a. a rep * a -> float = fun (Float,a) -> a +. 1. in
+  if b then tuple (Float, (x +. x)) else tuple (Int, (Sys.opaque_identity 0))

--- a/testsuite/tests/typeopt/partial_gadt_native.ml
+++ b/testsuite/tests/typeopt/partial_gadt_native.ml
@@ -1,4 +1,5 @@
 (* TEST
+no-flambda; (* different lambda output *)
 flags="-dlambda -dno-locations -dno-unique-ids";
 native;
 *)

--- a/testsuite/tests/typeopt/partial_gadt_native.ml
+++ b/testsuite/tests/typeopt/partial_gadt_native.ml
@@ -1,6 +1,6 @@
 (* TEST
 no-flambda; (* different lambda output *)
-flags="-dlambda -dno-locations -dno-unique-ids";
+flags="-dlambda -dno-locations -dcanonical-ids";
 native;
 *)
 

--- a/testsuite/tests/typeopt/partial_gadt_native.ml
+++ b/testsuite/tests/typeopt/partial_gadt_native.ml
@@ -8,6 +8,13 @@ native;
 
 type 'a rep = Float : float rep | Int : int rep
 
+(** Expected kind: [ (int * any) -> float]
+    However, this kind will only manifest when trying to avoid a tuple
+    allocation.
+    Typically in this test, this kind appears in the exit condition of
+    the generated static catch, which should be
+    {[with param/0[int] param/1]} and not {[with param/0[int] param/1[float]]}.
+*)
 let f b x =
   let[@local] tuple : type a. a rep * a -> float = fun (Float,a) -> a +. 1. in
   if b then tuple (Float, (x +. x)) else tuple (Int, (Sys.opaque_identity 0))

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2385,6 +2385,23 @@ let freeze_local_equations env = env.local_constraints
 let restrict_local_equations local_constraints env =
   { env with local_constraints }
 
+let freeze_if_new_local_equations ~prev env =
+  let included_in x y =
+    let exception Not_included in
+    let merge _ x y =
+      match x, y with
+      | Some _, None -> raise Not_included
+      | _ -> None
+    in
+    match Path.Map.merge merge x y with
+    | exception Not_included -> false
+    | _ -> true
+  in
+  if prev.local_constraints == env.local_constraints ||
+     included_in env.local_constraints prev.local_constraints
+  then None
+  else Some prev.local_constraints
+
 (* Non-lazy version of scrape_alias *)
 let scrape_alias t mty =
   mty |> Subst.Lazy.of_modtype |> scrape_alias t |> Subst.Lazy.force_modtype

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2380,6 +2380,11 @@ let add_local_constraint path info env =
   { env with
     local_constraints = Path.Map.add path info env.local_constraints }
 
+type local_equations = Types.type_declaration Path.Map.t
+let freeze_local_equations env = env.local_constraints
+let restrict_local_equations local_constraints env =
+  { env with local_constraints }
+
 (* Non-lazy version of scrape_alias *)
 let scrape_alias t mty =
   mty |> Subst.Lazy.of_modtype |> scrape_alias t |> Subst.Lazy.force_modtype

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2385,23 +2385,6 @@ let freeze_local_equations env = env.local_constraints
 let restrict_local_equations local_constraints env =
   { env with local_constraints }
 
-let freeze_if_new_local_equations ~prev env =
-  let included_in x y =
-    let exception Not_included in
-    let merge _ x y =
-      match x, y with
-      | Some _, None -> raise Not_included
-      | _ -> None
-    in
-    match Path.Map.merge merge x y with
-    | exception Not_included -> false
-    | _ -> true
-  in
-  if prev.local_constraints == env.local_constraints ||
-     included_in env.local_constraints prev.local_constraints
-  then None
-  else Some prev.local_constraints
-
 (* Non-lazy version of scrape_alias *)
 let scrape_alias t mty =
   mty |> Subst.Lazy.of_modtype |> scrape_alias t |> Subst.Lazy.force_modtype

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -341,6 +341,7 @@ val add_local_constraint: Path.t -> type_declaration -> t -> t
 
 type local_equations
 val freeze_local_equations: t -> local_equations
+val freeze_if_new_local_equations: prev:t -> t -> local_equations option
 val restrict_local_equations: local_equations -> t -> t
 
 (* Insertion of persistent signatures *)

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -339,6 +339,10 @@ val add_class: Ident.t -> class_declaration -> t -> t
 val add_cltype: Ident.t -> class_type_declaration -> t -> t
 val add_local_constraint: Path.t -> type_declaration -> t -> t
 
+type local_equations
+val freeze_local_equations: t -> local_equations
+val restrict_local_equations: local_equations -> t -> t
+
 (* Insertion of persistent signatures *)
 
 (* [add_persistent_structure id env] is an environment such that

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -341,7 +341,6 @@ val add_local_constraint: Path.t -> type_declaration -> t -> t
 
 type local_equations
 val freeze_local_equations: t -> local_equations
-val freeze_if_new_local_equations: prev:t -> t -> local_equations option
 val restrict_local_equations: local_equations -> t -> t
 
 (* Insertion of persistent signatures *)

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -190,6 +190,13 @@ let value_kind env ty =
         Pgenval
   end
 
+let pattern_kind env_modifier pat =
+  match env_modifier with
+  | None -> value_kind pat.pat_env pat.pat_type
+  | Some local_constraints ->
+      let env = Env.restrict_local_equations local_constraints pat.pat_env in
+      value_kind env pat.pat_type
+
 (** The compilation of the expression [lazy e] depends on the form of e:
     in some cases we optimize it into [let x = e in lazy x], evaluating
     [e] right now (if it is equivalent) and avoiding creating a thunk.

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -28,7 +28,10 @@ val array_kind : Typedtree.expression -> Lambda.array_kind
 val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
+
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
+val pattern_kind:
+  Env.local_equations option -> Typedtree.pattern -> Lambda.value_kind
 
 (** [lazy_summary] describes how the expression [lazy e] must be compiled. *)
 type lazy_summary =


### PR DESCRIPTION
This PR fixes the miscompilation reported by #14898 by making sure that the translation to `Lambda.t` do not use local GADTs equations introduced on a partial match to compute the kind of function parameters.

The origin of the issue is that the typedtree and the lambda translation have different expectations on the typing environment stored in pattern for a partial match. Consider, for instance

```ocaml
type 'a rep = Int: int rep | Float: float rep
let f (type a) (Float:a rep) (x:a) = x +. 1.
```
In this example, the typedtree stores an environment which contains the local equation `(* a=float *)`  along the two parameter nodes
```ocaml
let f (Float:a rep (* a=float *) ) (x:a (* a=float *) ) = x +. 1.
```
even if the equation is only valid if the pattern matching on the first argument succeed.
Those environments are then used by `Translcore` to analyze the kind of the parameters of `f`. Thus, the translation comes to the conclusion that the function `f` should be translated to 
```sexp
(f =
  (function param[int] x[float] : float
    ...
   )
)
```
and misses the fact that the kind of `x` is only conditionally `float`.

This PR fixes this issue by freezing the set of local equations used to analyze the kind of values as soon as we encounter a partial match on a GADT. Thus, in the slightly more contrived case like
```ocaml
let f (type a b) 
  None 
  (Type.Equal:(b,float) Type.eq (* b=float *)) 
  (Float:a rep (* a=float, b = float *)) 
  (x:a (* a=float, b = float *)) 
  (y:b (* a=float, b = float *)) = x +. y
```
we freeze the set of local equations to `(* b=float *)` when we encounter the partial match on `Float`, and restrict
the subsequent parameter environments to only this single equation
```ocaml
let f (type a b)
  None 
  (Type.Equal:(b,float) Type.eq (* b=float *)) 
  (Float:a rep (* b = float *)) 
  (x:a (* b = float *)) 
  (y:b (* b = float *)) = x +. y
```
which allow the translation to keep the kind `float` for `y` without erroneously inferring that the type of `x` is `float`:
```sexp
(f =
  (function param param[int] param[int] x y[float] : float
    ...
  )
)
```
Note that, in general, the restriction of local equations will remove some optimization opportunities that would depend on unconditional and independent GADT local equations which appear after a partial match. But my impression is that this hypothetical scenario do not warrant a more extensive fix. 

-----------------------

In term of implementation, the first commit in the PR adds a test for the current behaviour. There is a native compiler test which seems necessary to exercise the translation of tupled function.

The second commit adds the `Env` functions that allow to freeze the set of local equations, and use them in `Translcore` to freeze the set of equations as soon as there is a partial match.

The third commit refines this freeze to the first partial match that would introduce new local equations and is not strictly necessary as a fix.
