### PR TITLE
CI: stop testing on macos x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,8 +215,6 @@ jobs:
               {name: 'linux-arm64', os: 'ubuntu-24.04-arm',
                config_arg: '--with-target-sh=exe --enable-runtime-search-target=fallback',
                'test-in-prefix': true},
-              {name: 'macos-x86_64', os: 'macos-15-intel',
-               'test-in-prefix': true},
               {name: 'macos-arm64', os: 'macos-latest',
                config_arg: '--with-relative-libdir --enable-runtime-search',
                'test-in-prefix': true}];

--- a/README.adoc
+++ b/README.adoc
@@ -63,11 +63,11 @@ compiler currently runs on the following platforms:
 |====
 |                |  Tier 1 (actively maintained)   | Tier 2 (maintained when possible)
 
-| x86 64 bits    | Linux, macOS, Windows, FreeBSD  |  NetBSD, OpenBSD, DragonFly, OmniOS (Solaris)
-| ARM 64 bits    | Linux, macOS                    |  FreeBSD, OpenBSD, NetBSD
-| Power 64 bits  | Linux (little-endian, ABIv2)    |  Linux (big-endian, ABIv2)
-| RISC-V 64 bits | Linux                           |
-| IBM Z (s390x)  | Linux                           |
+| x86 64 bits    | Linux, Windows, FreeBSD      |  macOS, NetBSD, OpenBSD, DragonFly, OmniOS (Solaris)
+| ARM 64 bits    | Linux, macOS                 |  FreeBSD, OpenBSD, NetBSD
+| Power 64 bits  | Linux (little-endian, ABIv2) |  Linux (big-endian, ABIv2)
+| RISC-V 64 bits | Linux                        |
+| IBM Z (s390x)  | Linux                        |
 |====
 
 Other operating systems for the processors above have not been tested, but


### PR DESCRIPTION
macOS 27 (~~just~~ soon to be released) removes all support for x86, incl. Rosetta emulation.
[(A source (in French))](https://www.frandroid.com/marques/apple/3229963_fin-de-partie-definitive-pour-les-mac-intel-apple-demande-maintenant-aux-developpeurs-de-lacher-laffaire)

I'm expecting Github to retire Mac x86_64 runners entirely.

No reason to keep testing on this platform.
