### PR TITLE
ocamllex: remove generated output on fatal missing-case warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -609,6 +609,10 @@ Working version
   to report as the number of words of minor heap consumed, including headers.
   (Tim McGilchrist, review by Nicolás Ojeda Bär)
 
+- #15048: Remove the generated output file when ocamllex reports a fatal
+  missing-case warning.
+  (cuishuang)
+
 OCaml 5.5.1
 -----------
 

--- a/lex/main.ml
+++ b/lex/main.ml
@@ -71,6 +71,8 @@ let _ =
 
 let exit_code_for_known_error = 3
 
+exception Fatal_warning
+
 let main () =
 
   let source_name = match !source_name with
@@ -100,7 +102,7 @@ let main () =
      | Error ->
          match Exhaustiveness.check ~fatal:true transitions entries with
          | Ok () -> ()
-         | Error () -> exit exit_code_for_known_error);
+         | Error () -> raise Fatal_warning);
     if !ml_automata then begin
       Outputbis.output_lexdef
         ic oc tr
@@ -144,6 +146,7 @@ let main () =
         fprintf stderr
           "File \"%s\":\ntransition table overflow, automaton is too big\n"
           source_name
+    | Fatal_warning -> ()
     | _ ->
         Printexc.raise_with_backtrace exn bt
     end;

--- a/testsuite/tests/tool-lexyacc/fatal_warning.compilers.reference
+++ b/testsuite/tests/tool-lexyacc/fatal_warning.compilers.reference
@@ -1,5 +1,5 @@
 ocamllex fatal warning [missing-case]:
-File "fatal_warning.mll", lines 9-10, characters 20-11: rule "missing_case" is not exhaustive.
+File "fatal_warning.mll", lines 26-27, characters 20-11: rule "missing_case" is not exhaustive.
 Here is an example of nonmatching input:
 ""
 Hint: consider adding '| "" { ... }'

--- a/testsuite/tests/tool-lexyacc/fatal_warning.mll
+++ b/testsuite/tests/tool-lexyacc/fatal_warning.mll
@@ -1,9 +1,26 @@
 (* TEST
-  ocamllex_flags = " -q -w @missing-case ";
-  ocamllex_exit_status = "3";
+  setup-simple-build-env;
+  program = "${ocamlrun} ${ocamlsrcdir}/lex/ocamllex";
+  arguments = "-q -w @missing-case fatal_warning.mll";
+  exit_status = "3";
+  output = "fatal_warning.output";
+  reference = "${test_source_directory}/fatal_warning.compilers.reference";
+  run;
+  check-program-output;
+  script = "sh -c 'test ! -e fatal_warning.ml'";
+  exit_status = "0";
+  script;
+  src = "fatal_warning.mll";
+  dst = "fatal_warning.ml";
+  copy;
+  exit_status = "3";
+  run;
+  check-program-output;
+  exit_status = "0";
+  script;
 *)
 (*
-   Check that making a warning fatal works
+   Check that making a warning fatal works without leaving an output file
 *)
 
 rule missing_case = parse


### PR DESCRIPTION

When `ocamllex` is run with `-w @missing-case`, a non-exhaustive rule causes the command to exit with status 3. 

However, the output file is opened before the exhaustiveness check, so it is created or truncated even though code generation fails.

The direct `exit` on the fatal warning bypasses the cleanup handler.

As a result, `ocamllex` can leave an empty or truncated `.ml` file.


For example: 

```sh
ocamllex -w @missing-case bad.mll
```

The command exits with status 3, but bad.ml remains present. If the file existed beforehand, its contents are lost.

We can raise a local exception for the fatal warning and let the existing exception handler perform the normal cleanup, including removing the generated output file. The exit status and diagnostic output are unchanged.