### PR TITLE
add Stefan Muenzel as maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ The current list of maintainers is as follows:
 - @OlivierNicole Olivier Nicole
 - @sadiqj Sadiq Jaffer
 - @shindere Sébastien Hinderer
+- @smuenzel Stefan Muenzel
 - @stedolan Stephen Dolan
 - @trefis Thomas Refis
 - @xavierleroy Xavier Leroy


### PR DESCRIPTION
Stefan has had a steady volume of excellent contributions to the compiler over the past years, for example to the compiler backend, and in particular provided much-needed help on the maintenance of the type-checker.

(This change reflects a consensus among existing maintainers, and a decision made during the last maintainer meeting.)