### PR TITLE
CONTRIBUTING.md: retire some inactive maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,6 @@ contribution.
 
 The current list of maintainers is as follows:
 
-- @abbysmal Abigael
-- @alainfrisch Alain Frisch
-- @Armael Armaël Guéneau
 - @avsm Anil Madhavapeddy
 - @chambart Pierre Chambart
 - @damiendoligez Damien Doligez
@@ -71,12 +68,10 @@ The current list of maintainers is as follows:
 - @garrigue Jacques Garrigue
 - @gasche Gabriel Scherer
 - @goldfirere Richard Eisenberg
-- @jhjourdan Jacques-Henri Jourdan
 - @kayceesrk KC Sivaramakrishnan
 - @let-def Frédéric Bour
 - @lpw25 Leo White
 - @lthls Vincent Laviron
-- @maranget Luc Maranget
 - @MisterDA Antonin Décimo
 - @mshinwell Mark Shinwell
 - @NickBarnes Nick Barnes


### PR DESCRIPTION
Currently the set of maintainers is sensibly larger than the set of *active* maintainers, with people who in practice have been inactive maintenance-wise for years. We (OCaml maintainers) would like to gradually migrate to a model where the set of maintainers is closer to the set of active maintainers, by "retiring" some people regularly, possibly inviting them back if they start being active again. This should be good for readability/transparency, and there is also a security aspect.

The present commit retires five maintainers who have not been active in the last years: Abigael Decorne, Alain Frisch, Armaël Guéneau, Jacques-Henri Jourdan and Luc Maranget. Thanks all for your work and contributions!

(There is currently no clearly-defined criterion on what "active" means; some of the people still in the list could reasonably be considered inactive as well, and this is fine.)