### PR TITLE
deprecate Weak.get_copy

### DIFF
--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -321,118 +321,15 @@ CAMLprim value caml_weak_get (value ar, value n)
   return caml_ephe_get_key(ar, n);
 }
 
-/* Copy the contents of an object from `from` to `to` (which is
- * already allocated and has the necessary header word). Darken
- * any pointer fields. */
-
-static void ephe_copy_and_darken(value from, value to)
-{
-  mlsize_t i = 0; /* size of non-scannable prefix */
-
-  CAMLassert(Is_block(from));
-  CAMLassert(Is_block(to));
-  CAMLassert(Tag_val(from) == Tag_val(to));
-  CAMLassert(Tag_val(from) != Infix_tag);
-  CAMLassert(Wosize_val(from) == Wosize_val(to));
-
-  if (!Scannable_val(from)) {
-    i = Wosize_val(to);
-  }
-  else if (Tag_val(from) == Closure_tag) {
-    i = Start_env_closinfo(Closinfo_val(from));
-  }
-
-  /* Copy non-scannable prefix */
-  memcpy (Bp_val(to), Bp_val(from), Bsize_wsize(i));
-
-  /* Copy and darken scannable fields */
-  caml_domain_state* domain_state = Caml_state;
-  while (i < Wosize_val(to)) {
-    value field = Field(from, i);
-    if (caml_marking_started())
-      caml_darken (domain_state, field, 0);
-    Store_field(to, i, field);
-    ++ i;
-  }
-}
-
-static value ephe_get_field_copy (value e, mlsize_t offset)
-{
-  CAMLparam1 (e);
-  CAMLlocal3 (res, val, copy);
-  mlsize_t infix_offs = 0;
-
-  copy = Val_unit;
-  /* Loop in case allocating the copy triggers a GC which modifies the
-   * ephemeron or the value. In the common case, we go around this
-   * loop 1.5 times. */
-  while (1) {
-    clean_field(e, offset);
-    val = Field(e, offset);
-
-    if (val == caml_ephe_none) {
-      res = Val_none;
-      goto out;
-    }
-    infix_offs = 0;
-
-    /* Don't copy immediates */
-    if (!Is_block(val)) {
-      copy = val;
-      goto some;
-    }
-
-    /* Don't copy, but do darken, custom blocks #7279 */
-    if (Tag_val(val) == Custom_tag) {
-      if (caml_marking_started())
-        caml_darken (Caml_state, val, 0);
-      copy = val;
-      goto some;
-    }
-
-    if (Tag_val(val) == Infix_tag) {
-      infix_offs = Infix_offset_val(val);
-      val -= infix_offs;
-    }
-
-    if (copy != Val_unit &&
-        (Tag_val(val) == Tag_val(copy)) &&
-        (Wosize_val(val) == Wosize_val(copy))) {
-      /* The copy we allocated (on a previous iteration) is large
-       * enough and has the right header bits for us to copy the
-       * contents of val into it. Note that we don't care whether val
-       * has changed since we allocated copy. */
-      break;
-    }
-
-    /* This allocation could provoke a GC, which could change the
-       * header or size of val (e.g. in a finalizer). So we go around
-       * the loop to read val again. */
-    copy = caml_alloc (Wosize_val(val), Tag_val(val));
-    val = Val_unit;
-  }
-
-  ephe_copy_and_darken(val, copy);
-
-some:
-  res = caml_alloc_some(copy + infix_offs);
-out:
-  /* run GC and memprof callbacks */
-  caml_process_pending_actions();
-  CAMLreturn(res);
-}
-
 CAMLprim value caml_ephe_get_key_copy (value e, value n)
 {
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
-  if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (e)){
-    caml_invalid_argument ("Weak.get");
-  }
-  return ephe_get_field_copy(e, offset);
+  // This function is now deprecated and an alias of [caml_ephe_get_key].
+  return caml_ephe_get_key(e, n);
 }
 
 CAMLprim value caml_weak_get_copy (value e, value n){
-  return caml_ephe_get_key_copy(e,n);
+  // This function is now deprecated and an alias of [caml_weak_get].
+  return caml_weak_get(e,n);
 }
 
 CAMLprim value caml_ephe_get_data (value e)
@@ -442,7 +339,8 @@ CAMLprim value caml_ephe_get_data (value e)
 
 CAMLprim value caml_ephe_get_data_copy (value e)
 {
-  return ephe_get_field_copy (e, CAML_EPHE_DATA_OFFSET);
+  // This function is now deprecated and an alias of [caml_ephe_get_data].
+  return caml_ephe_get_data(e);
 }
 
 static value ephe_check_field (value e, mlsize_t offset)

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -49,10 +49,7 @@ let get e o =
   raise_if_invalid_offset e o "Weak.get";
   get e o
 
-external get_copy : 'a t -> int -> 'a option = "caml_weak_get_copy"
-let get_copy e o =
-  raise_if_invalid_offset e o "Weak.get_copy";
-  get_copy e o
+let get_copy = get
 
 external check : 'a t -> int -> bool = "caml_weak_check"
 let check e o =

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -62,20 +62,22 @@ val get : 'a t -> int -> 'a option
    0 to {!Weak.length}[ ar - 1].*)
 
 val get_copy : 'a t -> int -> 'a option
-(** [Weak.get_copy ar n] returns None if the [n]th cell of [ar] is
-   empty, [Some x] (where [x] is a (shallow) copy of the value) if
-   it is full.
-   In addition to pitfalls with mutable values, the interesting
-   difference with [get] is that [get_copy] does not prevent
-   the incremental GC from erasing the value in its current cycle
-   ([get] may delay the erasure to the next GC cycle).
-   @raise Invalid_argument if [n] is not in the range
-   0 to {!Weak.length}[ ar - 1].
+[@@ocaml.deprecated
+  "This function was removed and is now an alias to Weak.get. \
+   Use Weak.get or Weak.check instead."]
+(** In OCaml versions up to 5.5, [Weak.get_copy ar n] would return
+    a shallow copy of the weak key when it is still alive; this had
+    the benefit of not forcing the key itself to remain alive, while
+    being able to inspect its value.
 
-   If the element is a custom block it is not copied.
+    Performing a shallow-copy is error-prone and proved to interact
+    badly with other parts of the language (for example
+    mutable values); the performance benefits were often offset by the
+    cost of the copy. This function is now deprecated since OCaml 5.6,
+    and behaves as an alias to [get ar n].
 
-*)
-
+    Note: you can also use {!check} below if you want to check that
+    a key is still set without accessing it. *)
 
 val check : 'a t -> int -> bool
 (** [Weak.check ar n] returns [true] if the [n]th cell of [ar] is


### PR DESCRIPTION
`Weak.get_copy` would perform a shallow copy of the weak key (when alive) to avoid extending its lifetime. This is both a performance footgun and something that plays badly with other language features (mutation, single-use assumptions on continuations (#14988), etc.).

We deprecate `get_copy` and turn it into an alias of `Weak.get`, which performs no copy. The same simplification is also performed in runtime/weak.c. (The primitives are kept around as aliases, to avoid compatibility issue for people using them via `external` declarations.)

`get_copy` was historically introduced to support the implementation of weak hash tables, which at first did not store the hash of their keys in the table; on each comparison in the bucket they would need to retrieve the key temporarily to compare it with the searched key, and `get_copy` was necessary to avoid keeping much more keys alive than intended. The weak hash tables now store the hash of each key (and have done so for years), so they do not require `get_copy` anymore and its usage was removed in #12131.

Suggested-by: Stephen Dolan
Suggested-by: Josh Berdine

(This was suggested and discussed in https://github.com/ocaml/ocaml/pull/14988/#issuecomment-5241059093 )